### PR TITLE
Rename API endpoints in frontend and nginx.conf to match blockstream

### DIFF
--- a/frontend/src/app/components/about/about.component.html
+++ b/frontend/src/app/components/about/about.component.html
@@ -73,7 +73,7 @@
     </tr>
     <tr>
       <td style="border: 0;">
-          <input class="form-control" type="text" value="wss://mempool.space/ws" readonly>
+          <input class="form-control" type="text" value="wss://mempool.space/api/v1/ws" readonly>
       </td>
     </tr>
   </table>

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -4,7 +4,7 @@ import { OptimizedMempoolStats } from '../interfaces/node-api.interface';
 import { Observable } from 'rxjs';
 import { StateService } from './state.service';
 
-const API_BASE_URL = '/api{network}/v1';
+const API_BASE_URL = '{network}/api/v1';
 
 @Injectable({
   providedIn: 'root'

--- a/frontend/src/app/services/electrs-api.service.ts
+++ b/frontend/src/app/services/electrs-api.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { Block, Transaction, Address, Outspend, Recent, Asset } from '../interfaces/electrs.interface';
 import { StateService } from './state.service';
 
-const API_BASE_URL = document.location.protocol + '//' + document.location.hostname + ':' + document.location.port + '/electrs';
+const API_BASE_URL = '{network}/api';
 
 @Injectable({
   providedIn: 'root'
@@ -16,9 +16,9 @@ export class ElectrsApiService {
     private httpClient: HttpClient,
     private stateService: StateService,
   ) {
-    this.apiBaseUrl = API_BASE_URL;
+    this.apiBaseUrl = API_BASE_URL.replace('{network}', '');
     this.stateService.networkChanged$.subscribe((network) => {
-      this.apiBaseUrl = API_BASE_URL + '/' + network;
+      this.apiBaseUrl = API_BASE_URL.replace('{network}', network ? '/' + network : '');
     });
   }
 

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -6,7 +6,7 @@ import { Block, Transaction } from '../interfaces/electrs.interface';
 import { Subscription } from 'rxjs';
 
 const WEB_SOCKET_PROTOCOL = (document.location.protocol === 'https:') ? 'wss:' : 'ws:';
-const WEB_SOCKET_URL = WEB_SOCKET_PROTOCOL + '//' + document.location.hostname + ':' + document.location.port + '/ws';
+const WEB_SOCKET_URL = WEB_SOCKET_PROTOCOL + '//' + document.location.hostname + ':' + document.location.port + '{network}/api/v1/ws';
 
 const OFFLINE_RETRY_AFTER_MS = 10000;
 const OFFLINE_PING_CHECK_AFTER_MS = 30000;
@@ -30,7 +30,7 @@ export class WebsocketService {
     private stateService: StateService,
   ) {
     this.network = this.stateService.network;
-    this.websocketSubject = webSocket<WebsocketResponse | any>(WEB_SOCKET_URL + '/' + this.network);
+    this.websocketSubject = webSocket<WebsocketResponse | any>(WEB_SOCKET_URL.replace('{network}', this.network ? '/' + this.network : ''));
     this.startSubscription();
 
     this.stateService.networkChanged$.subscribe((network) => {
@@ -45,7 +45,7 @@ export class WebsocketService {
 
       this.websocketSubject.complete();
       this.subscription.unsubscribe();
-      this.websocketSubject = webSocket<WebsocketResponse | any>(WEB_SOCKET_URL + '/' + network);
+      this.websocketSubject = webSocket<WebsocketResponse | any>(WEB_SOCKET_URL.replace('{network}', this.network ? '/' + this.network : ''));
 
       this.startSubscription();
     });

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -172,64 +172,56 @@ http {
 			proxy_pass http://127.0.0.1:2222/;
 		}
 
-		location /api {
-			proxy_pass http://127.0.0.1:8999/api;
-		}
-
-		location /api/mainnet {
-			proxy_pass http://127.0.0.1:8999/api;
-		}
-
-		location /api/liquid {
-			proxy_pass http://127.0.0.1:8998/api;
-		}
-
-		location /api/testnet {
-			proxy_pass http://127.0.0.1:8997/api;
-		}
-
-		location /electrs/ {
-			proxy_pass http://[::1]:3000/;
-		}
-
-		location /electrs/mainnet/ {
-			proxy_pass http://[::1]:3000/;
-		}
-
-		location /electrs/liquid/ {
-			proxy_pass http://[::1]:3001/;
-		}
-
-		location /electrs/testnet/ {
-			proxy_pass http://[::1]:3002/;
-		}
-
-		location /ws {
+		location /api/v1/ws {
 			proxy_pass http://127.0.0.1:8999/;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 		}
+		location /api/v1 {
+			proxy_pass http://127.0.0.1:8999/api/v1;
+		}
+		location /api/ {
+			proxy_pass http://[::1]:3000/;
+		}
 
-		location /ws/mainnet {
+		location /mainnet/api/v1/ws {
 			proxy_pass http://127.0.0.1:8999/;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 		}
+		location /mainnet/api/v1 {
+			proxy_pass http://127.0.0.1:8999/api/v1;
+		}
+		location /mainnet/api/ {
+			proxy_pass http://[::1]:3000/;
+		}
 
-		location /ws/liquid {
+		location /liquid/api/v1/ws {
 			proxy_pass http://127.0.0.1:8998/;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 		}
+		location /liquid/api/v1 {
+			proxy_pass http://127.0.0.1:8998/api/v1;
+		}
+		location /liquid/api/ {
+			proxy_pass http://[::1]:3001/;
+		}
 
-		location /ws/testnet {
+		location /testnet/api/v1/ws {
 			proxy_pass http://127.0.0.1:8997/;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
+		}
+		location /testnet/api/v1 {
+			proxy_pass http://127.0.0.1:8997/api/v1;
+		}
+		location /testnet/api/ {
+			proxy_pass http://[::1]:3002/;
 		}
 	}
 }


### PR DESCRIPTION
Feature request by @6102bitcoin 
Running live on https://node210.bitcoin.wiz.biz/ for testing