### PR TITLE
Update README with repository checkout guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ You should see mempool starting up, which takes over an hour (needs 8 blocks). W
 
 ## Checking out release tag
 ```bash
-  git clone https://github.com/mempool-space/mempool.space
-  cd mempool.space
-  git checkout v1.0.0 # put latest release tag here
+  git clone https://github.com/mempool/mempool
+  cd mempool
+  latestrelease=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  git checkout $latestrelease
 ```
 
 ## Bitcoin Core (bitcoind)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You should see mempool starting up, which takes over an hour (needs 8 blocks). W
 ```bash
   git clone https://github.com/mempool/mempool
   cd mempool
-  latestrelease=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  latestrelease=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
   git checkout $latestrelease
 ```
 


### PR DESCRIPTION
- Changed repository to clone based on updated organization
- Determine latest release from github api call.  An alternative form being `latestrelease=$(git describe --exact-match --abbrev=0)` to yield the most recent tag name.