### PR TITLE
update legend state after chart update

### DIFF
--- a/frontend/src/app/components/statistics/chartist.component.ts
+++ b/frontend/src/app/components/statistics/chartist.component.ts
@@ -314,6 +314,13 @@ Chartist.plugins.legend = function (options: any) {
 
     return function legend(chart: any) {
 
+      var isClicked = false;
+
+      chart.on('created', function (data: any) {
+
+        if (isClicked)
+            return;
+
         function removeLegendElement() {
           const legendElement = chart.container.querySelector('.ct-legend');
             if (legendElement) {
@@ -442,7 +449,9 @@ Chartist.plugins.legend = function (options: any) {
                     chart.data.labels = newLabels;
                 }
 
+                isClicked = true;
                 chart.update();
+                isClicked = false;
 
                 if (options.onClick) {
                     options.onClick(chart, e);
@@ -480,14 +489,13 @@ Chartist.plugins.legend = function (options: any) {
             });
         });
 
-        chart.on('created', function (data: any) {
-            appendLegendToDOM(legendElement);
-        });
+        appendLegendToDOM(legendElement);
 
         if (options.clickable) {
             setSeriesClassNames();
             addClickHandler(legendElement, legends, seriesMetadata, useLabels);
         }
+      });
     };
 };
 


### PR DESCRIPTION
Hello,

In the Graphs tab, after changing the time span from the default, if you click on the legends on the side, the chart goes back to the default time span. It's because the legend plugin was not updated after the chart was updated.

This pull request fixes this, so that you can work with the legends after changing the time span.