### PR TITLE
Fix graph legend bug on resize

### DIFF
--- a/frontend/src/app/components/statistics/chartist.component.ts
+++ b/frontend/src/app/components/statistics/chartist.component.ts
@@ -319,7 +319,11 @@ Chartist.plugins.legend = function (options: any) {
 
       chart.on('created', function (data: any) {
 
-        if (isSelfUpdate)
+        const useLabels = chart instanceof Chartist.Pie && chart.data.labels && chart.data.labels.length;
+        const legendNames = getLegendNames(useLabels);
+        var dirtyChartData = (chart.data.series.length < legendNames.length);
+
+        if (isSelfUpdate || dirtyChartData)
             return;
 
         function removeLegendElement() {
@@ -476,8 +480,6 @@ Chartist.plugins.legend = function (options: any) {
         removeLegendElement();
 
         const legendElement = createLegendElement();
-        const useLabels = chart instanceof Chartist.Pie && chart.data.labels && chart.data.labels.length;
-        const legendNames = getLegendNames(useLabels);
         const seriesMetadata = initSeriesMetadata(useLabels);
         const legends: any = [];
 


### PR DESCRIPTION
I spotted this weird bug on the graph page that if you inactive some legends and then resize the page, all the legends will get disappeared.

This PR will fix it.