### PR TITLE
Add the Commons Clause License Condition v1.0 to our MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
-MIT License
+MIT License with Commons Clause License Condition v1.0
 
-Copyright (c) 2019 Simon Lindh
+Copyright (c) 2019-2020 The Mempool Open Source Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+to use, copy, modify, merge, publish, distribute, and/or sublicense
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
@@ -19,3 +19,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Commons Clause License Condition v1.0
+
+Without limiting other conditions in the License, the grant of rights under
+the License will not include, and the License does not grant to you, the
+right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the
+rights granted to you under the License to provide to third parties, for a
+fee or other consideration (including without limitation fees for hosting or
+consulting/ support services related to the Software), a product or service
+whose value derives, entirely or substantially, from the functionality of
+the Software. Any license notice or attribution required by the License must
+also include this Commons Cause License Condition notice.


### PR DESCRIPTION
In order to keep the Mempool software freely available for the benefit of the Bitcoin community, I propose to add the Commons Clause as a condition to our MIT License to prevent others from forking our software and charging users to install or use it. The mempool should be free for everyone.

More information: https://commonsclause.com/