### PR TITLE
Very basic desktop notifications implementation

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -44,7 +44,7 @@ import { FeesBoxComponent } from './components/fees-box/fees-box.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faAngleDown, faAngleUp, faBolt, faChartArea, faCogs, faCubes, faDatabase, faExchangeAlt, faInfoCircle,
-  faLink, faList, faSearch, faTachometerAlt, faThList, faTint, faTv } from '@fortawesome/free-solid-svg-icons';
+  faLink, faList, faSearch, faTachometerAlt, faThList, faTint, faTv, faBell, faBellSlash } from '@fortawesome/free-solid-svg-icons';
 import { ApiDocsComponent } from './components/api-docs/api-docs.component';
 import { TermsOfServiceComponent } from './components/terms-of-service/terms-of-service.component';
 import { StorageService } from './services/storage.service';
@@ -125,5 +125,7 @@ export class AppModule {
     library.addIcons(faAngleDown);
     library.addIcons(faAngleUp);
     library.addIcons(faExchangeAlt);
+    library.addIcons(faBell);
+    library.addIcons(faBellSlash);
   }
 }

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -43,10 +43,10 @@
 
     <br>
     <ng-template [ngIf]="hasNotificationPermission">
-      <button (click)="toggleNotifications(false)">disable notifications</button>
+      <button (click)="toggleNotifications(false)"><span i18n="address.disable-desktop-notifications">Disable desktop notifications</span></button>
     </ng-template>
     <ng-template [ngIf]="!hasNotificationPermission">
-      <button (click)="toggleNotifications(true)">notify me when a transaction happens</button>
+      <button (click)="toggleNotifications(true)"><span i18n="address.enable-desktop-notifications">Enable desktop notifications</span></button>
     </ng-template>
     <br>
     <br>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -43,14 +43,16 @@
 
     <br>
 
-    <div class="float-right">
-      <ng-template [ngIf]="sendNotifications">
-        <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(false)"><fa-icon [icon]="['fas', 'bell-slash']"></fa-icon> &nbsp; <span i18n="address.disable-desktop-notifications">Disable desktop notifications</span></button>
-      </ng-template>
-      <ng-template [ngIf]="!sendNotifications">
-        <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(true)"><fa-icon [icon]="['fas', 'bell']"></fa-icon> &nbsp; <span i18n="address.enable-desktop-notifications">Enable desktop notifications</span></button>
-      </ng-template>
-    </div>
+    <ng-template [ngIf]="hasNotificationSupport()">
+      <div class="float-right">
+        <ng-template [ngIf]="sendNotifications">
+          <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(false)"><fa-icon [icon]="['fas', 'bell-slash']"></fa-icon> &nbsp; <span i18n="address.disable-desktop-notifications">Disable desktop notifications</span></button>
+        </ng-template>
+        <ng-template [ngIf]="!sendNotifications">
+          <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(true)"><fa-icon [icon]="['fas', 'bell']"></fa-icon> &nbsp; <span i18n="address.enable-desktop-notifications">Enable desktop notifications</span></button>
+        </ng-template>
+      </div>
+    </ng-template>
 
     <h2>
       <ng-template [ngIf]="!transactions?.length">&nbsp;</ng-template>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -42,14 +42,15 @@
     </div>
 
     <br>
-    <ng-template [ngIf]="hasNotificationPermission">
-      <button (click)="toggleNotifications(false)"><span i18n="address.disable-desktop-notifications">Disable desktop notifications</span></button>
-    </ng-template>
-    <ng-template [ngIf]="!hasNotificationPermission">
-      <button (click)="toggleNotifications(true)"><span i18n="address.enable-desktop-notifications">Enable desktop notifications</span></button>
-    </ng-template>
-    <br>
-    <br>
+
+    <div class="float-right">
+      <ng-template [ngIf]="sendNotifications">
+        <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(false)"><fa-icon [icon]="['fas', 'bell-slash']"></fa-icon> &nbsp; <span i18n="address.disable-desktop-notifications">Disable desktop notifications</span></button>
+      </ng-template>
+      <ng-template [ngIf]="!sendNotifications">
+        <button class="btn btn-sm btn-outline-info" (click)="toggleNotifications(true)"><fa-icon [icon]="['fas', 'bell']"></fa-icon> &nbsp; <span i18n="address.enable-desktop-notifications">Enable desktop notifications</span></button>
+      </ng-template>
+    </div>
 
     <h2>
       <ng-template [ngIf]="!transactions?.length">&nbsp;</ng-template>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -42,6 +42,14 @@
     </div>
 
     <br>
+    <ng-template [ngIf]="hasNotificationPermission">
+      <button (click)="toggleNotifications(false)">disable notifications</button>
+    </ng-template>
+    <ng-template [ngIf]="!hasNotificationPermission">
+      <button (click)="toggleNotifications(true)">notify me when a transaction happens</button>
+    </ng-template>
+    <br>
+    <br>
 
     <h2>
       <ng-template [ngIf]="!transactions?.length">&nbsp;</ng-template>

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -160,7 +160,7 @@ export class AddressComponent implements OnInit, OnDestroy {
           if (this.activeNotification) {
             this.activeNotification.close();
           }
-          this.activeNotification = new Notification(this.addressString, { body: 'Got a transaction' });
+          this.activeNotification = new Notification(this.addressString, { body: $localize`:@@address.new-transaction-notification-body:A new transaction was seen` });
 
           document.addEventListener('visibilitychange', () => {
             if (document.visibilityState === 'visible') {

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -209,6 +209,10 @@ export class AddressComponent implements OnInit, OnDestroy {
     }
   }
 
+  hasNotificationSupport() {
+    return NotificationService.supportsNotifications();
+  }
+
   updateChainStats() {
     this.receieved = this.address.chain_stats.funded_txo_sum + this.address.mempool_stats.funded_txo_sum;
     this.sent = this.address.chain_stats.spent_txo_sum + this.address.mempool_stats.spent_txo_sum;

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -35,7 +35,6 @@ export class AddressComponent implements OnInit, OnDestroy {
   sent = 0;
 
   sendNotifications = false;
-  activeNotification: Notification;
 
   private tempTransactions: Transaction[];
   private timeTxIndexes: number[];
@@ -158,15 +157,8 @@ export class AddressComponent implements OnInit, OnDestroy {
           this.audioService.playSound('chime');
         }
 
-        if (this.sendNotifications && this.notificationService.hasNotificationPermission() && document.visibilityState !== 'visible') {
+        if (this.sendNotifications && this.notificationService.hasNotificationPermission()) {
           this.notificationService.sendNotification(this.addressString, $localize`:@@address.new-transaction-notification-body:A new transaction was seen`);
-
-          document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'visible') {
-              // The tab has become visible so clear the now-stale Notification.
-              this.notificationService.closeNotification();
-            }
-          });
         }
 
         transaction.vin.forEach((vin) => {

--- a/frontend/src/app/services/notification.service.ts
+++ b/frontend/src/app/services/notification.service.ts
@@ -1,0 +1,59 @@
+import {Injectable} from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationService {
+  activeNotification: Notification;
+
+  constructor() {
+  }
+
+  private static supportsNotifications() {
+    if (!window || !('Notification' in window)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public async askForNotificationPermission() {
+    if (!NotificationService.supportsNotifications()) {
+      return false;
+    }
+
+    await Notification.requestPermission();
+
+    return this.hasNotificationPermission();
+  }
+
+  public hasNotificationPermission() {
+    if (!NotificationService.supportsNotifications()) {
+      return false;
+    }
+
+    return (window.Notification.permission === 'granted');
+  }
+
+  public sendNotification(title, body) {
+    if (!NotificationService.supportsNotifications()) {
+      return false;
+    }
+
+    this.closeNotification();
+
+    this.activeNotification = new Notification(title, { body });
+
+    return true;
+  }
+
+  public closeNotification() {
+    if (!NotificationService.supportsNotifications()) {
+      return false;
+    }
+
+    if (this.activeNotification) {
+      this.activeNotification.close();
+    }
+  }
+}

--- a/frontend/src/app/services/notification.service.ts
+++ b/frontend/src/app/services/notification.service.ts
@@ -10,7 +10,7 @@ export class NotificationService implements OnDestroy {
     document.addEventListener('visibilitychange', this.onVisibilityChange.bind(this));
   }
 
-  private static supportsNotifications() {
+  public static supportsNotifications() {
     if (!window || !('Notification' in window)) {
       return false;
     }

--- a/frontend/src/app/services/notification.service.ts
+++ b/frontend/src/app/services/notification.service.ts
@@ -1,12 +1,13 @@
-import {Injectable} from '@angular/core';
+import {Injectable, OnDestroy} from '@angular/core';
 
 @Injectable({
   providedIn: 'root'
 })
-export class NotificationService {
+export class NotificationService implements OnDestroy {
   activeNotification: Notification;
 
   constructor() {
+    document.addEventListener('visibilitychange', this.onVisibilityChange.bind(this));
   }
 
   private static supportsNotifications() {
@@ -15,6 +16,13 @@ export class NotificationService {
     }
 
     return true;
+  }
+
+  private onVisibilityChange() {
+    if (document.visibilityState === 'visible') {
+      // The tab has become visible so clear the now-stale Notification.
+      this.closeNotification();
+    }
   }
 
   public async askForNotificationPermission() {
@@ -42,18 +50,30 @@ export class NotificationService {
 
     this.closeNotification();
 
-    this.activeNotification = new Notification(title, { body });
+    if (document.visibilityState !== 'visible') {
+      this.activeNotification = new Notification(title, { body });
 
-    return true;
+      return true;
+    }
+
+    return false;
   }
 
   public closeNotification() {
-    if (!NotificationService.supportsNotifications()) {
-      return false;
+    if (this.activeNotification) {
+      if (!NotificationService.supportsNotifications()) {
+        return false;
+      }
+
+      this.activeNotification.close();
+
+      return true;
     }
 
-    if (this.activeNotification) {
-      this.activeNotification.close();
-    }
+    return false;
+  }
+
+  ngOnDestroy() {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange.bind(this));
   }
 }


### PR DESCRIPTION
Minimum viable implementation

Probably needs:

- [x] Tweak the source English strings and add i18n tags
- [x] Maybe centralize notification API for re-use
- [x] Better placement of button
- [x] Actually design the button or make it not a button or whatever

For now hides notification when tab becomes visible, and does not send notifications if the tab is already visible. Does not ask any permissions until button is pressed. Browsing away from the address page will disable notifications.