### PR TITLE
better identification of lightning outputs.

### DIFF
--- a/frontend/src/app/components/address-labels/address-labels.component.html
+++ b/frontend/src/app/components/address-labels/address-labels.component.html
@@ -1,2 +1,12 @@
-<span *ngIf="multisig" class="badge badge-pill badge-warning" i18n="address-labels.multisig">multisig {{ multisigM }} of {{ multisigN }}</span>
-<span *ngIf="secondLayerClose" class="badge badge-pill badge-warning" i18n="address-labels.upper-layer-peg-out">Layer{{ network === 'liquid' ? '3' : '2' }} Peg-out</span>
+<span
+  *ngIf="multisig"
+  class="badge badge-pill badge-warning"
+  i18n="address-labels.multisig"
+  >multisig {{ multisigM }} of {{ multisigN }}</span
+>
+<span
+  *ngIf="lightning"
+  class="badge badge-pill badge-warning"
+  i18n="address-labels.upper-layer-peg-out"
+  >Lightning {{ lightning }}</span
+>

--- a/frontend/src/app/components/address-labels/address-labels.component.html
+++ b/frontend/src/app/components/address-labels/address-labels.component.html
@@ -10,3 +10,9 @@
   i18n="address-labels.upper-layer-peg-out"
   >Lightning {{ lightning }}</span
 >
+<span
+  *ngIf="liquid"
+  class="badge badge-pill badge-warning"
+  i18n="address-labels.upper-layer-peg-out"
+  >Liquid {{ liquid }}</span
+>

--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -18,7 +18,7 @@ export class AddressLabelsComponent implements OnInit {
   multisigM: number;
   multisigN: number;
 
-  secondLayerClose = false;
+  lightning = null;
 
   constructor(
     stateService: StateService,
@@ -47,9 +47,17 @@ export class AddressLabelsComponent implements OnInit {
         }
       }
 
-      if (/OP_IF (.+) OP_ELSE (.+) OP_CSV OP_DROP/.test(this.vin.inner_witnessscript_asm)) {
-        this.secondLayerClose = true;
-      }
+      [
+        [/^OP_DUP OP_HASH160/, 'HTLC'],
+        [/^OP_IF OP_PUSHBYTES_33 \w{33} OP_ELSE OP_PUSHBYTES_2 \w{2} OP_CSV OP_DROP/, 'Force Close']
+      ].map(
+        ([re, label]) => {
+          if (re.test(this.vin.inner_witnessscript_asm)) {
+            this.lightning = label;
+            this.multisig = false;
+          }
+        }
+      );
     }
 
     if (this.vin.inner_redeemscript_asm && this.vin.inner_redeemscript_asm.indexOf('OP_CHECKMULTISIG') > -1) {


### PR DESCRIPTION
I couldn't test this and I have zero experience with Angular, but I'm hoping it will work.

If this works we can also identify Lightning penalty transactions, if the HTLC was redeemed or not, or if the HTLC was claimed by the same side that closed the channel just by looking at the script and witness.