### PR TITLE
Reduce backend heap size setting to 2G since cache memory usage was optimized

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
     "ng": "./node_modules/@angular/cli/bin/ng",
     "tsc": "./node_modules/typescript/bin/tsc",
     "build": "npm run tsc",
-    "start": "node --max-old-space-size=4096 dist/index.js",
+    "start": "node --max-old-space-size=2048 dist/index.js",
+    "start-production": "node --max-old-space-size=4096 dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/production/mempool-start-all
+++ b/production/mempool-start-all
@@ -4,8 +4,5 @@ source "$NVM_DIR/nvm.sh"
 for site in mainnet liquid testnet bisq
 do
     cd "${HOME}/${site}/backend/"
-    screen -dmS "${site}" sh -c 'while true;do npm run start;sleep 1;done'
+    screen -dmS "${site}" sh -c 'while true;do npm run start-production;sleep 1;done'
 done
-
-#cd "${HOME}/webhook/"
-#screen -dmS webhook ./start


### PR DESCRIPTION
On powerful servers, nodejs automatically sets the limit at 4GB
```
% node -e 'console.log(`node heap limit = ${require("v8").getHeapStatistics().heap_size_limit / (1024 * 1024)} Mb`)'
node heap limit = 4144 Mb
```

On a Raspberry Pi with 8GB RAM, nodejs automatically sets the limit at 1GB
```
% node -e 'console.log(`node heap limit = ${require("v8").getHeapStatistics().heap_size_limit / (1024 * 1024)} Mb`)'
node heap limit = 1048 Mb
```

On a Raspberry Pi with 4GB RAM, nodejs automatically sets the limit at 740MB
```
% node -e 'console.log(`node heap limit = ${require("v8").getHeapStatistics().heap_size_limit / (1024 * 1024)} Mb`)'
node heap limit = 739.4694900512695 Mb
```

After testing with manually setting the limit to 768MB, mempool starts
up fine, but crashes when saving the cache when the mempool is quite
large (over 400MB with custom bitcoin.conf setting).

So it's probably safe to reduce the 4GB limit setting to 2GB for
all devices and and just use the automatically set values, now that the
backend's disk cache memory usage was recently optimized.

However, a new npm script for `npm run start-production` will be added
so we can keep our production mempool.space servers running with a very
large bitcoin.conf mempool
