### PR TITLE
Fix style on block hover

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -11,6 +11,10 @@
   z-index: 10;
 }
 
+.blockLink:hover {
+  text-decoration: none;
+}
+
 .mined-block {
   position: absolute;
   top: 0px;

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -116,3 +116,7 @@
   left: 0;
   z-index: 10;
 }
+
+.blockLink:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
I found that when you hover over the block there is a small blue line over the s of "sat".

This is just a minor style bug fix