### PR TITLE
Show fee tiles on mobile

### DIFF
--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -32,7 +32,6 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   ) { }
 
   ngOnInit(): void {
-    const showLegend = !this.isMobile && this.showLegend;
     let labelHops = !this.showLegend ? 48 : 24;
     if (this.small) {
       labelHops = labelHops / 2;
@@ -73,12 +72,12 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       },
       axisY: {
         labelInterpolationFnc: (value: number): any => this.vbytesPipe.transform(value, 2),
-        offset: showLegend ? 160 : 60,
+        offset: this.showLegend ? 160 : 60,
       },
       plugins: this.inverted ? [Chartist.plugins.ctTargetLine({ value: 1000000 })] : []
     };
 
-    if (showLegend) {
+    if (this.showLegend) {
       this.mempoolVsizeFeesOptions.plugins.push(
         Chartist.plugins.legend({
           legendNames: [1, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200,

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -81,9 +81,6 @@ body {
   .box {
     padding: 0.75rem;
   }
-  .ct-legend {
-    display: none;
-  }
 }
 
 .navbar-nav.liquid > .active {


### PR DESCRIPTION
It was setting display to none when the screen width was being set to <= 767.98px (So basically mobile)

This makes the screen a tad cramped. But since these tiles have a useful function now, trading appearance for usability seems ok to me.
