### PR TITLE
Add recommended fee percentile config

### DIFF
--- a/backend/mempool-config.sample.json
+++ b/backend/mempool-config.sample.json
@@ -7,7 +7,8 @@
     "API_URL_PREFIX": "/api/v1/",
     "POLL_RATE_MS": 2000,
     "CACHE_DIR": "./cache",
-    "CLEAR_PROTECTION_MINUTES": 20
+    "CLEAR_PROTECTION_MINUTES": 20,
+    "RECOMMENDED_FEE_PERCENTILE": 50
   },
   "CORE_RPC": {
     "HOST": "127.0.0.1",

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -12,6 +12,13 @@ export class Common {
     return medianNr;
   }
 
+  static percentile(numbers: number[], percentile: number) {
+    if (percentile === 50) return this.median(numbers);
+    const index = Math.ceil(numbers.length * (100 - percentile) * 1e-2);
+    if (index < 0 || index > numbers.length - 1) return 0;
+    return numbers[index];
+  }
+
   static getFeesInRange(transactions: TransactionExtended[], rangeLength: number) {
     const arr = [transactions[transactions.length - 1].feePerVsize];
     const chunk = 1 / (rangeLength - 1);

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -1,5 +1,6 @@
 import { MempoolBlock, TransactionExtended, MempoolBlockWithTransactions } from '../mempool.interfaces';
 import { Common } from './common';
+import config from '../config';
 
 class MempoolBlocks {
   private static DEFAULT_PROJECTED_BLOCKS_AMOUNT = 8;
@@ -76,7 +77,7 @@ class MempoolBlocks {
       blockVSize: blockVSize,
       nTx: transactions.length,
       totalFees: transactions.reduce((acc, cur) => acc + cur.fee, 0),
-      medianFee: Common.median(transactions.map((tx) => tx.feePerVsize)),
+      medianFee: Common.percentile(transactions.map((tx) => tx.feePerVsize), config.MEMPOOL.RECOMMENDED_FEE_PERCENTILE),
       feeRange: Common.getFeesInRange(transactions, rangeLength),
       transactionIds: transactions.map((tx) => tx.txid),
     };

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -10,6 +10,7 @@ interface IConfig {
     POLL_RATE_MS: number;
     CACHE_DIR: string;
     CLEAR_PROTECTION_MINUTES: number;
+    RECOMMENDED_FEE_PERCENTILE: number;
   };
   ESPLORA: {
     REST_API_URL: string;
@@ -64,6 +65,7 @@ const defaults: IConfig = {
     'POLL_RATE_MS': 2000,
     'CACHE_DIR': './cache',
     'CLEAR_PROTECTION_MINUTES': 20,
+    'RECOMMENDED_FEE_PERCENTILE': 50,
   },
   'ESPLORA': {
     'REST_API_URL': 'http://127.0.0.1:3000',


### PR DESCRIPTION
Adds a new config `RECOMMENDED_FEE_PERCENTILE` that modifies the recommended fee by taking the fee at a percentile of the block instead of the median.

Resolves #393 