### PR TITLE
Catch getMempoolInfo errors gracefully to not break general main loop

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -14,7 +14,7 @@ class Mempool {
   private inSync: boolean = false;
   private mempoolCache: { [txId: string]: TransactionExtended } = {};
   private mempoolInfo: IBitcoinApi.MempoolInfo = { loaded: false, size: 0, bytes: 0, usage: 0,
-                                                    maxmempool: 0, mempoolminfee: 0, minrelaytxfee: 0 };
+                                                    maxmempool: 300000000, mempoolminfee: 0.00001000, minrelaytxfee: 0.00001000 };
   private mempoolChangedCallback: ((newMempool: {[txId: string]: TransactionExtended; }, newTransactions: TransactionExtended[],
     deletedTransactions: TransactionExtended[]) => void) | undefined;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -111,7 +111,16 @@ class Server {
 
   async runMainUpdateLoop() {
     try {
-      await memPool.$updateMemPoolInfo();
+      try {
+        await memPool.$updateMemPoolInfo();
+      } catch (e) {
+        const msg = `updateMempoolInfo: ${(e.message || e)}`;
+        if (config.CORE_RPC_MINFEE.ENABLED) {
+          logger.warn(msg);
+        } else {
+          logger.debug(msg);
+        }
+      }
       await blocks.$updateBlocks();
       await memPool.$updateMempool();
       setTimeout(this.runMainUpdateLoop.bind(this), config.MEMPOOL.POLL_RATE_MS);


### PR DESCRIPTION
**NOTE**
The issue reported is not a "crash bug" as errors are handled, and I don't think the backend gets "totally stuck", it just halted the main loop.

This fix handles getMempoolInfo errors separately and will now throw a warn on first error if using a separate RPC server config, as opposed to after 5 tries for general main loop errors.

fixes #411