### PR TITLE
fix native scrolling on iOS devices

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -50,7 +50,6 @@ $dropdown-link-active-bg: #11131f;
 
 html, body {
   height: 100%;
-  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Currently on iOS devices you can't scroll to top and sometimes you'll notice that the page will look frozen or broken.

This change restores the native scrolling and should fix that. 

Tested on Desktop and iOS. Untested on Android phones.