### PR TITLE
preserve the user's network selection on the about page

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -124,6 +124,10 @@ const routes: Routes = [
             path: 'api',
             component: ApiDocsComponent,
           },
+          {
+            path: 'about',
+            component: AboutComponent,
+          },
         ],
       },
       {
@@ -185,6 +189,10 @@ const routes: Routes = [
           {
             path: 'api',
             component: ApiDocsComponent,
+          },
+          {
+            path: 'about',
+            component: AboutComponent,
           },
         ],
       },
@@ -276,6 +284,10 @@ const routes: Routes = [
   {
     path: 'status',
     component: StatusViewComponent
+  },
+  {
+    path: 'about',
+    component: AboutComponent,
   },
   {
     path: '**',

--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -59,7 +59,7 @@
         <a class="nav-link" [routerLink]="['/api' | relativeUrl]" (click)="collapse()"><fa-icon [icon]="['fas', 'cogs']" [fixedWidth]="true" i18n-title="master-page.api" title="API"></fa-icon></a>
       </li>
       <li class="nav-item" routerLinkActive="active">
-        <a class="nav-link" [routerLink]="['/about']" (click)="collapse()"><fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true" i18n-title="master-page.about" title="About"></fa-icon></a>
+        <a class="nav-link" [routerLink]="'/' + network.val + '/about'" (click)="collapse()"><fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true" i18n-title="master-page.about" title="About"></fa-icon></a>
       </li>
     </ul>
     <app-search-form location="top" (searchTriggered)="collapse()"></app-search-form>


### PR DESCRIPTION
The navigation bar was always routing to `/about`, which ends up switching back to the default network.

We will now respect the user's selection.

<img width="1063" alt="liquid" src="https://user-images.githubusercontent.com/100320/115133713-1f70fb00-9fbf-11eb-84c0-db97889ddae5.png">
<img width="1063" alt="bisq" src="https://user-images.githubusercontent.com/100320/115133714-20a22800-9fbf-11eb-8c7a-0924d9a587d9.png">
<img width="1049" alt="testnet" src="https://user-images.githubusercontent.com/100320/115133716-213abe80-9fbf-11eb-9dfb-7adac703f413.png">
