### PR TITLE
Fix crash issues related to new unconfirmed transactions in bitcoind …

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -147,6 +147,9 @@ class BitcoinApi implements AbstractBitcoinApi {
       esploraTransaction = await this.$calculateFeeFromInputs(esploraTransaction, addPrevout);
     } else {
       esploraTransaction = await this.$appendMempoolFeeData(esploraTransaction);
+      if (addPrevout) {
+        esploraTransaction = await this.$calculateFeeFromInputs(esploraTransaction, addPrevout);
+      }
     }
 
     return esploraTransaction;


### PR DESCRIPTION
This PR solves a few issues related to opening recently broadcasted transactions when running Bitcoind:

* The `prevouts` wasn't appended when opening a transaction that is unconfirmed but not yet was into the backend mempool, causing frontend to crash
* A very recent transaction doesn't contain CPFP data causing frontend TX to have the TX location arrow missing. Added a retry every 2 sec until backend has caught up on the CPFP checking on the transaction.

fixes #391