### PR TITLE
Improve docker images and add a makefile for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: backend init frontend up down build
+.DEFAULT_GOAL := build
+
+compose := sudo docker-compose
+
+tag ?= latest
+
+init:
+	docker/init.sh $(tag)
+
+frontend backend: init
+	sudo docker build -f docker/$@/Dockerfile -t mempool/$@:$(tag) $@
+
+build: frontend backend
+
+up:
+	$(compose) up -d
+
+down:
+	$(compose) down

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,6 +11,11 @@ RUN npm run build
 
 FROM node:12-buster-slim
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 WORKDIR /backend
 
 COPY --from=builder /build/ .


### PR DESCRIPTION
Please consider this PR a suggestion for a couple of improvements. If you like any of them, please let me know and I'll change as requested.

1. The backend image doesn't have a proper PID entrypoint. Just a CMD. Because of this, for example, when you try to kill it with `docker-compose down` it hangs for a while (it's not forwarding signals properly. So I've added [TINI](https://github.com/krallin/tini). If you prefer another handler let me know. Also, if you prefer to just add TINI (it's just a `sh` file) to the repo, instead of downloading it from an external source, I'd be happy to do that as well.
2. I've added a simple Makefile for building locally. I couldn't find the instructions for how to do so and had to dig into the GitHub CI yaml. This makes it easier for those who want to build from source and run on their own instead of pulling for docker hub.

