### PR TITLE
Improve scrolling between routes

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -298,7 +298,9 @@ if (browserWindowEnv && browserWindowEnv.OFFICIAL_BISQ_MARKETS) {
 
 @NgModule({
   imports: [RouterModule.forRoot(routes, {
-    initialNavigation: 'enabled'
+    initialNavigation: 'enabled',
+    scrollPositionRestoration: 'enabled',
+    anchorScrolling: 'enabled'
 })],
   exports: [RouterModule]
 })

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -1,6 +1,6 @@
 <div class="container-xl">
 
-  <div class="title-block">
+  <div class="title-block" id="block">
     <h1><ng-template [ngIf]="blockHeight === 0" i18n="block.genesis">Genesis </ng-template><ng-template [ngIf]="blockHeight" i18n="block.block">Block <a [routerLink]="['/block/' | relativeUrl, blockHash]">{{ blockHeight }}</a></ng-template></h1>
     <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
   </div>
@@ -80,7 +80,7 @@
       </div>
     </div>
 
-    <div [hidden]="!showDetails">
+    <div [hidden]="!showDetails" id="details">
       <br>
 
       <div class="box">

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -192,6 +192,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         relativeTo: this.route,
         queryParams: { showDetails: false },
         queryParamsHandling: 'merge',
+        fragment: 'block'
       });
     } else {
       this.showDetails = true;
@@ -199,6 +200,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         relativeTo: this.route,
         queryParams: { showDetails: true },
         queryParamsHandling: 'merge',
+        fragment: 'details'
       });
     }
   }


### PR DESCRIPTION
Potential fix for #493 

Uses `scrollPositionRestoration` and `anchorScrolling` to improve scrolling and state between routes. The block viewer page was also scrolling to top after clicking on the `Details` button because it's technically a route change, so setting anchors will keep the position relatively the same between changes.

Reference: https://angular.io/api/router/ExtraOptions#scrollPositionRestoration

