### PR TITLE
Fix tx-list load is being constantly triggered.

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -74,7 +74,14 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   }
 
   onScroll() {
-    this.loadMore.emit();
+    const scrollHeight = document.body.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    if(scrollHeight > 0){
+      const percentageScrolled = scrollTop * 100 / scrollHeight;
+      if(percentageScrolled > 90){
+        this.loadMore.emit();
+      }
+    }
   }
 
   getTotalTxOutput(tx: Transaction) {


### PR DESCRIPTION
Fix #526 

Only trigger more tx when the page is +90% scrolled.