### PR TITLE
Align loading component in the center.

### DIFF
--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -1,6 +1,6 @@
 <div class="container-graph">
   <div>
-    <div *ngIf="loading">
+    <div *ngIf="loading" class="loading">
       <div class="text-center">
         <h3 i18n="statistics.loading-graphs">Loading graphs...</h3>
         <br>

--- a/frontend/src/app/components/statistics/statistics.component.scss
+++ b/frontend/src/app/components/statistics/statistics.component.scss
@@ -46,6 +46,6 @@
   display: flex;
   flex-direction: column;
   text-align: center;
-  height: 85vh;
+  height: 80vh;
   justify-content: center;
 }

--- a/frontend/src/app/components/statistics/statistics.component.scss
+++ b/frontend/src/app/components/statistics/statistics.component.scss
@@ -41,3 +41,11 @@
     }
   }
 }
+
+.loading{
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  height: 85vh;
+  justify-content: center;
+}


### PR DESCRIPTION
Centralizes the loading component in the `/graph` url.

![image](https://user-images.githubusercontent.com/5798170/119196609-d2b88e00-ba5c-11eb-9979-93f167193f18.png)
