### PR TITLE
fix the block viewer for liquid

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -96,14 +96,14 @@
                   <td i18n="block.merkle-root">Merkle root</td>
                   <td><p class="break-all">{{ block.merkle_root }}</p></td>
                 </tr>
-                <tr>
+                <tr *ngIf="network !== 'liquid'">
                   <td i18n="block.bits">Bits</td>
                   <td>{{ block.bits | decimal2hex }}</td>
                 </tr>
               </tbody>
             </table>
           </div>
-          <div class="col-sm">
+          <div class="col-sm" *ngIf="network !== 'liquid'">
             <table class="table table-borderless table-striped">
               <tbody>
                 <tr>


### PR DESCRIPTION
`toString()` on `decimal2hex` was throwing an exception because `nonce` and `bits` are not available on Liquid blocks, `Difficulty` is also not available, so remove it as well