### PR TITLE
Fix tv only

### DIFF
--- a/frontend/cypress/integration/mainnet/mainnet.spec.ts
+++ b/frontend/cypress/integration/mainnet/mainnet.spec.ts
@@ -35,8 +35,9 @@ describe('Mainnet', () => {
             cy.viewport('macbook-16');
             cy.visit('/');
             cy.get('li:nth-of-type(4) > a').click().then(() => {
+                cy.viewport('macbook-16');
                 cy.wait(1000);
-                cy.get('.tv-only').should('not.be.visible');
+                cy.get('.blockchain-wrapper').should('be.visible');
             });
         });
 
@@ -45,7 +46,7 @@ describe('Mainnet', () => {
             cy.get('li:nth-of-type(4) > a').click().then(() => {
                 cy.viewport('iphone-6');
                 cy.wait(1000);
-                cy.get('.tv-only').should('be.visible');
+                cy.get('.blockchain-wrapper').should('not.be.visible');
             });
         });
     });

--- a/frontend/src/app/components/television/television.component.html
+++ b/frontend/src/app/components/television/television.component.html
@@ -4,8 +4,6 @@
     <div class="spinner-border text-light"></div>
   </div>
 
-  <div class="tv-only" i18n="television.tv-only">TV only</div>
-
   <div class="tv-container" *ngIf="!loading">
 
     <div class="chart-holder" *ngIf="mempoolStats.length">

--- a/frontend/src/app/components/television/television.component.scss
+++ b/frontend/src/app/components/television/television.component.scss
@@ -31,6 +31,10 @@
 
 .blockchain-wrapper {
 
+  display: flex;
+  height: 100%;
+  min-height: 240px;
+
   .position-container {
     position: absolute;
     left: 50%;
@@ -79,6 +83,7 @@
 .tv-container {
   display: flex;
   margin-top: 0px;
+  flex-direction: column;
   @media(max-height: 720px) {
     .blockchain-wrapper{
       display: none !important;

--- a/frontend/src/app/components/television/television.component.scss
+++ b/frontend/src/app/components/television/television.component.scss
@@ -34,7 +34,12 @@
   display: flex;
   height: 100%;
   min-height: 240px;
-
+  position: relative;
+  top: -20px;
+  @media(min-height: 800px) {
+    top: 10px;
+  }
+  
   .position-container {
     position: absolute;
     left: 50%;
@@ -84,7 +89,7 @@
   display: flex;
   margin-top: 0px;
   flex-direction: column;
-  @media(max-height: 720px) {
+  @media(max-height: 700px) {
     .blockchain-wrapper{
       display: none !important;
     }

--- a/frontend/src/app/components/television/television.component.scss
+++ b/frontend/src/app/components/television/television.component.scss
@@ -76,29 +76,12 @@
   }
 }
 
-.tv-only {
-  display: block;    
-  height: 100vh;
-  width: 100%;
-  position: relative;
-  display: flex;
-  text-align: center;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  @media(min-width: 768px) {
-    display: none;
-  }
-  @media(max-height: 720px) {
-    display: flex;
-  }
-}
 .tv-container {
-  display: none;
-  @media(min-width: 768px) {
-    display: flex;
-  }
+  display: flex;
+  margin-top: 0px;
   @media(max-height: 720px) {
-    display: none;
+    .blockchain-wrapper{
+      display: none !important;
+    }
   }
 }


### PR DESCRIPTION
Fix #591.

## preview
Hide the `blockchain-wrapper` when the window screen is smaller than `700px` so that it can show graphics at lower TV resolutions.

![tx-only-fix](https://user-images.githubusercontent.com/5798170/123816370-a26ed580-d8cd-11eb-8a5c-71bc3152c598.gif)

