### PR TITLE
Bugfix: Fix mempool-info-data misalignment when reloading the page.

### DIFF
--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -53,6 +53,7 @@
 }
 
 .mempool-info-data {
+  min-height: 56px;
   display: block;
   @media (min-width: 485px) {
     display: flex;


### PR DESCRIPTION
Fix mempool-info-data misalignment when reloading the page.

### Actual behaviour
![mempool-info-data-alignment-erro](https://user-images.githubusercontent.com/5798170/126059548-e9d96e81-9666-4239-a7a2-b9e59f0bb2c3.gif)

### Expected behaviour
![mempool-info-data-alignment](https://user-images.githubusercontent.com/5798170/126059550-ef8a7db4-c709-47a0-94cd-daef629eb6f7.gif)
