### PR TITLE
Bugfix: Change mempool block time precision.

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -77,7 +77,6 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
         this.mempoolBlocks = this.reduceMempoolBlocksToFitScreen(JSON.parse(stringifiedBlocks));
         this.updateMempoolBlockStyles();
         this.calculateTransactionPosition();
-        this.now = new Date().getTime();
         return this.mempoolBlocks;
       })
     );
@@ -90,6 +89,7 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
           this.stateService.lastDifficultyAdjustment$
         ])),
         map(([block, DATime]) => {
+          this.now = new Date().getTime();
           const now = new Date().getTime() / 1000;
           const diff = now - DATime;
           const blocksInEpoch = block.height % 2016;

--- a/frontend/src/app/components/time-since/time-since.component.ts
+++ b/frontend/src/app/components/time-since/time-since.component.ts
@@ -56,7 +56,7 @@ export class TimeSinceComponent implements OnInit, OnChanges, OnDestroy {
     if (seconds < 60) {
       return $localize`:@@date-base.just-now:Just now`;
     }
-    let counter;
+    let counter: number;
     for (const i in this.intervals) {
       if (this.intervals.hasOwnProperty(i)) {
         counter = Math.floor(seconds / this.intervals[i]);

--- a/frontend/src/app/components/time-span/time-span.component.ts
+++ b/frontend/src/app/components/time-span/time-span.component.ts
@@ -56,7 +56,7 @@ export class TimeSpanComponent implements OnInit, OnChanges, OnDestroy {
     if (seconds < 60) {
       return $localize`:@@date-base.just-now:Just now`;
     }
-    let counter;
+    let counter: number;
     for (const i in this.intervals) {
       if (this.intervals.hasOwnProperty(i)) {
         counter = Math.floor(seconds / this.intervals[i]);

--- a/frontend/src/app/components/time-until/time-until.component.ts
+++ b/frontend/src/app/components/time-until/time-until.component.ts
@@ -58,16 +58,20 @@ export class TimeUntilComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   calculate() {
-    const seconds = Math.floor((+new Date(this.time) - +new Date()) / 1000);
+    const seconds = (+new Date(this.time) - +new Date()) / 1000;
 
     if (seconds < 60) {
       const dateStrings = dates(1);
       return $localize`:@@time-until:In ~${dateStrings.i18nMinute}:DATE:`;
     }
-    let counter;
+    let counter: number;
     for (const i in this.intervals) {
       if (this.intervals.hasOwnProperty(i)) {
-        counter = Math.floor(seconds / this.intervals[i]);
+        if (i === 'minute') {
+          counter = Math.round(seconds / this.intervals[i]);
+        } else {
+          counter = Math.floor(seconds / this.intervals[i]);
+        }
         const dateStrings = dates(counter);
         if (counter > 0) {
           if (counter === 1) {

--- a/frontend/src/app/components/time-until/time-until.component.ts
+++ b/frontend/src/app/components/time-until/time-until.component.ts
@@ -67,7 +67,7 @@ export class TimeUntilComponent implements OnInit, OnChanges, OnDestroy {
     let counter;
     for (const i in this.intervals) {
       if (this.intervals.hasOwnProperty(i)) {
-        counter = Math.round(seconds / this.intervals[i]);
+        counter = Math.floor(seconds / this.intervals[i]);
         const dateStrings = dates(counter);
         if (counter > 0) {
           if (counter === 1) {

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -117,10 +117,10 @@
                       </ng-template>
                       <ng-template #belowBlockLimit>
                         <ng-template [ngIf]="network === 'liquid'" [ngIfElse]="timeEstimateDefault">
-                          <ng-container *ngTemplateOutlet="1 * txInBlockIndex + 1 === 1 ? nextBlockEta : nextBlockEtaPlural; context:{ $implicit: 1 * txInBlockIndex + 1 }"></ng-container>&nbsp;<i><span class="symbol">(<ng-container *ngTemplateOutlet="txInBlockIndex === 0 ? blocksSingular : blocksPlural; context: {$implicit: txInBlockIndex + 1 }"></ng-container>)</span></i>
+                          <app-time-until [time]="(60 * 1000 * txInBlockIndex) + now" [fastRender]="false" [fixedRender]="true"></app-time-until>
                         </ng-template>
                         <ng-template #timeEstimateDefault>
-                          <ng-container *ngTemplateOutlet="nextBlockEtaPlural; context:{ $implicit: 10 * txInBlockIndex + 10 }"></ng-container>&nbsp;<i><span class="symbol">(<ng-container *ngTemplateOutlet="txInBlockIndex === 0 ? blocksSingular : blocksPlural; context: {$implicit: txInBlockIndex + 1 }"></ng-container>)</span></i>
+                          <app-time-until *ngIf="(timeAvg$ | async) as timeAvg;" [time]="(timeAvg * txInBlockIndex) + now + timeAvg" [fastRender]="false" [fixedRender]="true"></app-time-until>
                         </ng-template>
                       </ng-template>
                     </ng-template>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -67,6 +67,7 @@ export class TransactionComponent implements OnInit, OnDestroy {
           this.stateService.lastDifficultyAdjustment$
         ])),
         map(([block, DATime]) => {
+          this.now = new Date().getTime();
           const now = new Date().getTime() / 1000;
           const diff = now - DATime;
           const blocksInEpoch = block.height % 2016;


### PR DESCRIPTION
### Description

The blocks of mempool were rounding up and it was making a confusion about the precision of the block time.

### Actual Behaviour
![image](https://user-images.githubusercontent.com/5798170/126348504-aa7c8947-a1f0-40c4-a083-eb09f9ab9e8b.png)
`Math.round`

### New Behaviour
![image](https://user-images.githubusercontent.com/5798170/126348444-17e0eacc-42f6-4531-8ebd-086f0888c643.png)
`Math.floor`
