### PR TITLE
Resume tx tracking when network goes offline.

### DIFF
--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -25,6 +25,7 @@ export class WebsocketService {
   private goneOffline = false;
   private lastWant: string | null = null;
   private isTrackingTx = false;
+  private trackingTxId: string;
   private latestGitCommit = '';
   private onlineCheckTimeout: number;
   private onlineCheckTimeoutTwo: number;
@@ -97,6 +98,9 @@ export class WebsocketService {
           if (this.lastWant) {
             this.want(JSON.parse(this.lastWant), true);
           }
+          if (this.isTrackingTx) {
+            this.startMultiTrackTransaction(this.trackingTxId);
+          }
           this.stateService.connectionState$.next(2);
         }
 
@@ -119,11 +123,13 @@ export class WebsocketService {
     }
     this.websocketSubject.next({ 'track-tx': txId });
     this.isTrackingTx = true;
+    this.trackingTxId = txId;
   }
 
   startMultiTrackTransaction(txId: string) {
     this.websocketSubject.next({ 'track-tx': txId, 'watch-mempool': true });
     this.isTrackingTx = true;
+    this.trackingTxId = txId;
   }
 
   stopTrackingTransaction() {


### PR DESCRIPTION
fixes #609

### This PR fix the following 2 cases that is broken currently:

A). Start tracking a unconfirmed transaction. Let your websocket connection disconnect... and back online again.. TX tracking should now be resumed and TX confirmation will be notified as expected

B) Start tracking a unconfirmed transaction. Let your websocket connection disconnect. While disconnected, your transaction is mined in a block. Resume websocket connection. The client is now notified and transaction moves to confirmed into the new block.

Worth noting that this should be tested both on `esplora` and `bitcoind` backend as the TX tracking behavior have been affected and behave differently depending on backend.