### PR TITLE
add script to pull digests from docker images

### DIFF
--- a/docker/scripts/get_image_digest.sh
+++ b/docker/scripts/get_image_digest.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+VERSION=$1
+IMAGE=""
+
+if [ -z "${VERSION}" ]; then
+    echo "no version provided (i.e, v2.2.0), using latest tag"
+    VERSION="latest"
+fi
+
+for package in backend frontend; do
+  PACKAGE=mempool/"$package"
+  IMAGE="$PACKAGE":"$VERSION"
+  HASH=`docker pull $IMAGE > /dev/null && docker inspect $IMAGE | sed -n '/RepoDigests/{n;p;}' | grep -o '[0-9a-f]\{64\}'`
+  if [ -n "${HASH}" ]; then
+    echo "$IMAGE" "$HASH"
+  fi
+done 
+
+


### PR DESCRIPTION
helper script to fetch the digest from a given docker image

```
$ sh get_image_digest.sh 
no version provided, using latest tag
mempool/backend:latest 2e5690772451526286897d147cd064b35558bb8d1a03d79cb8d7efcb2404b9de
mempool/frontend:latest 01a546e28d77988b930519f9162c63b89933c4f968fcf1b66ddd000535209e90

```

```
$ sh get_image_digest.sh v2.2.0
mempool/backend:v2.2.0 5eb38b094288a6f12ac2e738ff5cff9257eaa8522ebf1d23827edebe4730ebf1
mempool/frontend:v2.2.0 e3c3dd393c99018a69068b0a924dd24cf8de47389cb6ef2cfd0fe2d31d77f931
```

```
$ sh get_image_digest.sh v6.6.6
Error response from daemon: manifest for mempool/backend:v6.6.6 not found: manifest unknown: manifest unknown
Error response from daemon: manifest for mempool/frontend:v6.6.6 not found: manifest unknown: manifest unknown
```