### PR TITLE
Use block cache when searching or opening a recent block.

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -65,7 +65,6 @@ export class BlockComponent implements OnInit, OnDestroy {
         map((indicators) => indicators['blocktxs-' + this.blockHash] !== undefined ? indicators['blocktxs-' + this.blockHash] : 0)
       );
 
-    
     this.blocksSubscription = this.stateService.blocks$
       .subscribe(([block]) => {
         this.latestBlock = block;
@@ -79,8 +78,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         }
       });
 
-    this.subscription = this.route.paramMap
-    .pipe(
+    this.subscription = this.route.paramMap.pipe(
       switchMap((params: ParamMap) => {
         const blockHash: string = params.get('id') || '';
         this.block = undefined;
@@ -108,8 +106,9 @@ export class BlockComponent implements OnInit, OnDestroy {
         } else {
           this.isLoadingBlock = true;
 
+          let blockInCache: Block;
           if (isBlockHeight) {
-            const blockInCache = this.latestBlocks.find((block) => block.height === parseInt(blockHash, 10));
+            blockInCache = this.latestBlocks.find((block) => block.height === parseInt(blockHash, 10));
             if (blockInCache) {
               return of(blockInCache);
             }
@@ -125,7 +124,7 @@ export class BlockComponent implements OnInit, OnDestroy {
               );
           }
 
-          const blockInCache = this.latestBlocks.find((block) => block.id === this.blockHash);
+          blockInCache = this.latestBlocks.find((block) => block.id === this.blockHash);
           if (blockInCache) {
             return of(blockInCache);
           }
@@ -278,12 +277,14 @@ export class BlockComponent implements OnInit, OnDestroy {
       return;
     }
     const block = this.latestBlocks.find((b) => b.height === this.nextBlockHeight - 2);
-    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + '/block/', block ? block.id : this.block.previousblockhash], { state: { data: { block, blockHeight: this.nextBlockHeight - 2 } } });
+    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + '/block/',
+      block ? block.id : this.block.previousblockhash], { state: { data: { block, blockHeight: this.nextBlockHeight - 2 } } });
   }
 
   navigateToNextBlock() {
     const block = this.latestBlocks.find((b) => b.height === this.nextBlockHeight);
-    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + '/block/', block ? block.id : this.nextBlockHeight], { state: { data: { block, blockHeight: this.nextBlockHeight } } });
+    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + '/block/',
+      block ? block.id : this.nextBlockHeight], { state: { data: { block, blockHeight: this.nextBlockHeight } } });
   }
 
   setNextAndPreviousBlockLink(){

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -65,6 +65,20 @@ export class BlockComponent implements OnInit, OnDestroy {
         map((indicators) => indicators['blocktxs-' + this.blockHash] !== undefined ? indicators['blocktxs-' + this.blockHash] : 0)
       );
 
+    
+    this.blocksSubscription = this.stateService.blocks$
+      .subscribe(([block]) => {
+        this.latestBlock = block;
+        this.latestBlocks.unshift(block);
+        this.latestBlocks = this.latestBlocks.slice(0, this.stateService.env.KEEP_BLOCKS_AMOUNT);
+        this.setNextAndPreviousBlockLink();
+
+        if (block.id === this.blockHash) {
+          this.block = block;
+          this.fees = block.reward / 100000000 - this.blockSubsidy;
+        }
+      });
+
     this.subscription = this.route.paramMap
     .pipe(
       switchMap((params: ParamMap) => {
@@ -95,6 +109,10 @@ export class BlockComponent implements OnInit, OnDestroy {
           this.isLoadingBlock = true;
 
           if (isBlockHeight) {
+            const blockInCache = this.latestBlocks.find((block) => block.height === parseInt(blockHash, 10));
+            if (blockInCache) {
+              return of(blockInCache);
+            }
             return this.electrsApiService.getBlockHashFromHeight$(parseInt(blockHash, 10))
               .pipe(
                 switchMap((hash) => {
@@ -107,12 +125,11 @@ export class BlockComponent implements OnInit, OnDestroy {
               );
           }
 
-          this.stateService.blocks$.subscribe(([block]) => {
-            if (block.id === blockHash) {
-              this.block = block;
-            }
-          });
-          
+          const blockInCache = this.latestBlocks.find((block) => block.id === this.blockHash);
+          if (blockInCache) {
+            return of(blockInCache);
+          }
+
           return this.electrsApiService.getBlock$(blockHash);
         }
       }),
@@ -158,14 +175,6 @@ export class BlockComponent implements OnInit, OnDestroy {
       this.error = error;
       this.isLoadingBlock = false;
     });
-
-    this.blocksSubscription = this.stateService.blocks$
-      .subscribe(([block]) => {
-        this.latestBlock = block;
-        this.latestBlocks.unshift(block);
-        this.latestBlocks = this.latestBlocks.slice(0, this.stateService.env.KEEP_BLOCKS_AMOUNT);
-        this.setNextAndPreviousBlockLink();
-      });
 
     this.networkChangedSubscription = this.stateService.networkChanged$
       .subscribe((network) => this.network = network);

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -12,6 +12,7 @@
     "arrow-parens": false,
     "arrow-return-shorthand": true,
     "curly": true,
+    "no-bitwise": false,
     "deprecation": {
       "severity": "warning"
     },


### PR DESCRIPTION
fixes #715

This PR improves the following things:

- When opening / reloading the page straight to a block, median fee is no longer missing
- When searching for a block height or hash that is in recent cache, use the cache for instant opening