### PR TITLE
Updated address regex to handle all types of addresses.

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -82,7 +82,11 @@ class WebsocketHandler {
           if (parsedMessage && parsedMessage['track-address']) {
             if (/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100})$/
               .test(parsedMessage['track-address'])) {
-              client['track-address'] = parsedMessage['track-address'];
+              let matchedAddress = parsedMessage['track-address'];
+              if (/^[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}$/.test(parsedMessage['track-address'])) {
+                matchedAddress = matchedAddress.toLowerCase();
+              }
+              client['track-address'] = matchedAddress;
             } else {
               client['track-address'] = null;
             }

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -80,7 +80,7 @@ class WebsocketHandler {
           }
 
           if (parsedMessage && parsedMessage['track-address']) {
-            if (/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,87})$/
+            if (/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100})$/
               .test(parsedMessage['track-address'])) {
               client['track-address'] = parsedMessage['track-address'];
             } else {

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -69,6 +69,9 @@ export class AddressComponent implements OnInit, OnDestroy {
           this.transactions = null;
           document.body.scrollTo(0, 0);
           this.addressString = params.get('id') || '';
+          if (/^[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}$/.test(this.addressString)) {
+            this.addressString = this.addressString.toLowerCase();
+          }
           this.seoService.setTitle($localize`:@@address.component.browser-title:Address: ${this.addressString}:INTERPOLATION:`);
 
           return merge(

--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -23,7 +23,7 @@ export class SearchFormComponent implements OnInit {
   searchForm: FormGroup;
   @Output() searchTriggered = new EventEmitter();
 
-  regexAddress = /^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[bB]?[a-z]{2,5}1[ac-hj-np-z02-9]{8,87})$/;
+  regexAddress = /^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100})$/;
   regexBlockhash = /^[0]{8}[a-fA-F0-9]{56}$/;
   regexTransaction = /^[a-fA-F0-9]{64}$/;
   regexBlockheight = /^[0-9]+$/;


### PR DESCRIPTION
fixes #301
fixes #750

This PR fixes the following bugs:
* All Liquid address types are now accepted as valid in the search box.
 Examples:
 1. lq1qqgddwun5n54jq8za4rkddalngqtcc6skcelg7mquc40ayscr285ksaxs3a72pf6knc4zrx7pk7ggwueu0lkdw009cvvwhqel2
 2. VJL8eyC5Hux6khmKNLDKTqhkihUkupeDhU8DjbFctmRWs2b5PwE2VnuqEUmdPYwXTPTSjWrkvxJJvUbH
 3. GuHku7sQRYQqSqvyWGd2Vobq3WLXBpEzZU
* Uppercase Bc1 addresses now works in the search box.
Example: BC1Q0QFZUGE7VR5S2XKCZRJKCCMXEMLYYN8MHX298V

Uppercase bc1 addresses also gets converted to lower case in the UX.

Make sure that tx-tracking still works in the address view, especially for uppercase segwit addresses. Note that tracking of some Liquid address types still doesn't work.