### PR TITLE
Handle changes to address RPC api in bitcoin core 22

### DIFF
--- a/backend/src/api/bisq/interfaces.ts
+++ b/backend/src/api/bisq/interfaces.ts
@@ -71,7 +71,7 @@ interface BisqScriptPubKey {
   addresses: string[];
   asm: string;
   hex: string;
-  reqSigs: number;
+  reqSigs?: number;
   type: string;
 }
 

--- a/backend/src/api/bitcoin/bitcoin-api.interface.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.interface.ts
@@ -90,9 +90,10 @@ export namespace IBitcoinApi {
     scriptPubKey: {                  //  (json object)
       asm: string;                   //  (string) the asm
       hex: string;                   //  (string) the hex
-      reqSigs: number;               //  (numeric) The required sigs
+      reqSigs?: number;              //  (numeric) The required sigs
       type: string;                  //  (string) The type, eg 'pubkeyhash'
-      addresses: string[]            //  (string) bitcoin address
+      addresses?: string[]           //  (string) bitcoin addresses
+      address?: string              //  (string) bitcoin address
     };
   }
 

--- a/backend/src/api/bitcoin/bitcoin-api.interface.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.interface.ts
@@ -92,8 +92,8 @@ export namespace IBitcoinApi {
       hex: string;                   //  (string) the hex
       reqSigs?: number;              //  (numeric) The required sigs
       type: string;                  //  (string) The type, eg 'pubkeyhash'
-      addresses?: string[]           //  (string) bitcoin addresses
-      address?: string              //  (string) bitcoin address
+      addresses?: string[];           //  (string) bitcoin addresses
+      address?: string;              //  (string) bitcoin address
     };
   }
 

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -123,7 +123,8 @@ class BitcoinApi implements AbstractBitcoinApi {
       return {
         value: vout.value * 100000000,
         scriptpubkey: vout.scriptPubKey.hex,
-        scriptpubkey_address: vout.scriptPubKey && vout.scriptPubKey.addresses ? vout.scriptPubKey.addresses[0] : '',
+        scriptpubkey_address: vout.scriptPubKey && vout.scriptPubKey.address ? vout.scriptPubKey.address
+          : vout.scriptPubKey.addresses ? vout.scriptPubKey.addresses[0] : '',
         scriptpubkey_asm: vout.scriptPubKey.asm ? this.convertScriptSigAsm(vout.scriptPubKey.asm) : '',
         scriptpubkey_type: this.translateScriptPubKeyType(vout.scriptPubKey.type),
       };

--- a/frontend/src/app/bisq/bisq.interfaces.ts
+++ b/frontend/src/app/bisq/bisq.interfaces.ts
@@ -71,7 +71,7 @@ interface BisqScriptPubKey {
   addresses: string[];
   asm: string;
   hex: string;
-  reqSigs: number;
+  reqSigs?: number;
   type: string;
 }
 


### PR DESCRIPTION
fixes #778

This fix handles both the new core 22.0 and older version style of bitcoin addresses in the RPC API. 

This only happens when running with bitcoind as main backend.