### PR TITLE
Always use local hostname for API examples.

### DIFF
--- a/frontend/src/app/components/api-docs/api-docs.component.html
+++ b/frontend/src/app/components/api-docs/api-docs.component.html
@@ -698,7 +698,7 @@
               </ng-template>
               <ng-template ngbPanelContent>
                 <div class="endpoint">
-                  <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
+                  <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
                 </div>
                 <div class="description">
                   <div class="subtitle" i18n>Description</div>

--- a/frontend/src/app/components/api-docs/api-docs.component.ts
+++ b/frontend/src/app/components/api-docs/api-docs.component.ts
@@ -40,18 +40,6 @@ export class ApiDocsComponent implements OnInit {
 
     this.hostname = `${document.location.protocol}//${this.hostname}`;
 
-    if (document.location.hostname === 'localhost') {
-      if (this.env.BASE_MODULE === 'bisq') {
-        this.hostname = `https://bisq.markets`;
-      }
-      if (this.env.BASE_MODULE === 'liquid') {
-        this.hostname = `https://liquid.network`;
-      }
-      if (this.env.BASE_MODULE === 'mempool') {
-        this.hostname = `https://mempool.space`;
-      }
-    }
-
     this.code = {
       address: {
         codeTemplate: {
@@ -2063,7 +2051,7 @@ export class ApiDocsComponent implements OnInit {
       },
       transactionCpfp: {
         codeTemplate: {
-          curl: `/api/fees/cpfp/%{1}`,
+          curl: `/api/v1/cpfp/%{1}`,
           commonJS: `
         const { %{0}: { fees } } = mempoolJS();
 


### PR DESCRIPTION
This PR does:

* location.hostname is now always used for API examples to click to view api works even in local environments
* Corrected URL to the `/api/tx` endpoint
* Corrected URL to the `/api/v1/cpfp` endpoint