### PR TITLE
UI/UX: Mempool Charts fixes.

### DIFF
--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.html
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.html
@@ -1,1 +1,7 @@
-<div echarts class="echarts" (chartInit)="onChartReady($event)" [initOpts]="mempoolVsizeFeesInitOptions" [options]="mempoolVsizeFeesOptions"></div>
+<div
+  echarts
+  class="echarts"
+  (chartInit)="onChartReady($event)"
+  [initOpts]="mempoolVsizeFeesInitOptions"
+  [options]="mempoolVsizeFeesOptions"
+></div>

--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -36,6 +36,7 @@
                 <input ngbButton type="radio" [value]="'1y'" [routerLink]="['/graphs' | relativeUrl]" fragment="1y"> 1Y
               </label>
             </div>
+            <!-- <button (click)="invertGraph()" class="btn btn-primary btn-sm ml-2 d-none d-md-inline"><fa-icon [icon]="['fas', 'exchange-alt']" [rotate]="90" [fixedWidth]="true" i18n-title="statistics.component-invert.title" title="Invert"></fa-icon></button> -->
           </form>
         </div>
         <div class="card-body">
@@ -43,9 +44,10 @@
             <app-mempool-graph
               dir="ltr"
               [template]="'advanced'"
-              [limitFee]="500"
+              [limitFee]="200"
               [height]="500"
-              [left]="65"
+              [left]="145"
+              [right]="10"
               [data]="mempoolStats"
             ></app-mempool-graph>
           </div>

--- a/frontend/src/app/components/statistics/statistics.component.ts
+++ b/frontend/src/app/components/statistics/statistics.component.ts
@@ -31,6 +31,7 @@ export class StatisticsComponent implements OnInit {
 
   radioGroupForm: FormGroup;
   graphWindowPreference: String;
+  inverted: boolean;
 
   constructor(
     @Inject(LOCALE_ID) private locale: string,
@@ -44,6 +45,7 @@ export class StatisticsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    this.inverted = this.storageService.getValue('inverted-graph') === 'true';
     this.seoService.setTitle($localize`:@@5d4f792f048fcaa6df5948575d7cb325c9393383:Graphs`);
     this.stateService.networkChanged$.subscribe((network) => this.network = network);
     this.graphWindowPreference = this.storageService.getValue('graphWindowPreference') ? this.storageService.getValue('graphWindowPreference').trim() : '2h';
@@ -123,5 +125,10 @@ export class StatisticsComponent implements OnInit {
 
   saveGraphPreference() {
     this.storageService.setValue('graphWindowPreference', this.radioGroupForm.controls.dateSpan.value);
+  }
+
+  invertGraph() {
+    this.storageService.setValue('inverted-graph', !this.inverted);
+    document.location.reload();
   }
 }

--- a/frontend/src/app/components/television/television.component.html
+++ b/frontend/src/app/components/television/television.component.html
@@ -8,9 +8,9 @@
     <div class="chart-holder">
       <app-mempool-graph
         [template]="'advanced'"
-        [limitFee]="500"
+        [limitFee]="350"
         [height]="600"
-        [left]="60"
+        [left]="150"
         [data]="mempoolStats"
         [showZoom]="false"
       ></app-mempool-graph>

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -50,7 +50,7 @@
             <div class="mempool-graph" *ngIf="(mempoolStats$ | async) as mempoolStats; else loadingSpinner">
               <app-mempool-graph
                 [template]="'widget'"
-                [limitFee]="150"
+                [limitFee]="50"
                 [data]="mempoolStats.mempool"
               ></app-mempool-graph>
             </div>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -453,7 +453,7 @@ html:lang(ru) .card-title {
 .fees-wrapper-tooltip-chart-advanced,
 .tx-wrapper-tooltip-chart-advanced {
   background: rgba(#1d1f31, 0.98);
-  width: 250px;
+  width: 310px;
 
   thead {
     th {
@@ -470,44 +470,49 @@ html:lang(ru) .card-title {
     margin-bottom: 5px;
   }
   .item {
-    line-height: 1;
+    line-height: 1.4;
+    font-size: 12px;
+    font-weight: 400;
     .value {
-      width: 60px;
+      width: 80px;
       .symbol {
         font-size: 10px !important;
       }
     }
     .total-partial {
-      font-size: 10px;
-      width: 58px;
+      font-size: 16px;
+      width: 75px;
       text-align: right;
     }
     .total-progress-percentage {
-      width: 65px;
-      height: 4px;
+      width: 75px;
+      height: 6px;
       padding: 0px 5px;
       display: table-cell !important;
-      border-radius: 4px;
+      border-radius: 6px;
     }
     .total-progress-sum {
-      width: 65px;
-      height: 4px;
+      width: 75px;
+      height: 10px;
       padding: 0px 5px;
-      border-radius: 4px;
+      border-radius: 5px;
+    }
+    .total-percentage-bar-background {
+      background-color: #2d3047;
     }
     .total-progress-percentage-bar,
     .total-progress-sum-bar {
-      width: 35px;
-      height: 4px;
+      width: 40px;
+      height: 5px;
       div {
-        width: 100%;
-        border-radius: 4px;
+        width: 50%;
+        border-radius: 5px;
         display: block;
         background: #29324c94;
       }
       span {
-        height: 4px;
-        border-radius: 4px;
+        height: 5px;
+        border-radius: 5px;
         display: block;
       }
     }
@@ -523,7 +528,8 @@ html:lang(ru) .card-title {
     text-align: right;
     margin: 5px auto 5px;
     span {
-      font-size: 10px;
+      font-size: 14px;
+      font-weight: 400;
     }
     .total-percentage-bar {
       width: 100%;


### PR DESCRIPTION
## Tasks
- [x] Turn animations on.
- [x] Fix blinking stacks on mouseover.
- [x] Limit dashboard mempool chart to 50 vbytes.
- [x] Add filtering legends.
- [x] Set tooltip chart bigger on advanced template.
- [x] Set fixed color to bar at tooltip.

### Coming soon
- [ ] Inverse ordering filtering legends. (coming soon)
- [ ] Invert chart button. (coming soon)
- [ ] Replace and merge new data. (coming soon)