### PR TITLE
Handle search for Liquid block hashes in search bar.

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -107,7 +107,12 @@ export class SearchFormComponent implements OnInit {
           this.electrsApiService.getAsset$(searchText)
             .subscribe(
               () => { this.navigate('/asset/', searchText); },
-              () => { this.navigate('/tx/', searchText); }
+              () => {
+                this.electrsApiService.getBlock$(searchText)
+                  .subscribe(
+                    (block) => { this.navigate('/block/', searchText, { state: { data: { block } } }); },
+                    () => { this.navigate('/tx/', searchText); });
+              }
             );
         } else {
           this.navigate('/tx/', searchText);
@@ -118,8 +123,8 @@ export class SearchFormComponent implements OnInit {
     }
   }
 
-  navigate(url: string, searchText: string) {
-    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + url, searchText]);
+  navigate(url: string, searchText: string, extras?: any) {
+    this.router.navigate([(this.network && this.stateService.env.BASE_MODULE === 'mempool' ? '/' + this.network : '') + url, searchText], extras);
     this.searchTriggered.emit();
     this.searchForm.setValue({
       searchText: '',


### PR DESCRIPTION
fixes #797

This PR fixes the bug that it was impossible to search for a Liquid block hash. Liquid TXID, Block and Asset hashes follow the very same pattern.

Try searching with examples:

TXID
fcdf5012156207d1bc6d74a0402553bcfb87b206ebe2dd855ef387db11dd6e87
BLOCK HASH
c24d5201465d2107adb0d3bb7bd2aa750fdef47b5f3b7074409f630b2e938345
ASSET:
a0c358a0f6947864af3a06f3f6a2aeb304df7fd95c922f2f22d7412399ce7691

I am aware that the search component in general needs a full refactor, but the refactor could be in a separate PR, this one is just to fix this annoying bug.