### PR TITLE
Fix for fee rounding not using locale

### DIFF
--- a/frontend/src/app/shared/pipes/fee-rounding/fee-rounding.pipe.ts
+++ b/frontend/src/app/shared/pipes/fee-rounding/fee-rounding.pipe.ts
@@ -1,15 +1,20 @@
-import { Pipe, PipeTransform } from "@angular/core";
+import { formatNumber } from "@angular/common";
+import { Inject, LOCALE_ID, Pipe, PipeTransform } from "@angular/core";
 
 @Pipe({
   name: "feeRounding",
 })
 export class FeeRoundingPipe implements PipeTransform {
+  constructor(
+    @Inject(LOCALE_ID) private locale: string,
+  ) {}
+
   transform(fee: number): string {
     if (fee >= 100) {
-      return fee.toFixed(0);
+      return formatNumber(fee, this.locale, '1.0-0')
     } else if (fee < 10) {
-      return fee.toFixed(2);
+      return formatNumber(fee, this.locale, '1.2-2')
     }
-    return fee.toFixed(1);
+    return formatNumber(fee, this.locale, '1.1-1')
   }
 }


### PR DESCRIPTION
fixes #796

All display of fee and the fee rounding should now take the locale into account.

Locale is determined by the language selected on the site, to test, change language on the site from default english `/` to for example Swedish `/sv`

The minimum fee on the dashboard for example should show as `1.00` on default english-us but `1,00` on the Swedish site.