### PR TITLE
Adding POST /tx API to bitcoind mode

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -11,6 +11,7 @@ export interface AbstractBitcoinApi {
   $getAddress(address: string): Promise<IEsploraApi.Address>;
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
   $getAddressPrefix(prefix: string): string[];
+  $sendRawTransaction(rawTransaction: string): Promise<string>;
 }
 export interface BitcoinRpcCredentials {
   host: string;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -98,6 +98,10 @@ class BitcoinApi implements AbstractBitcoinApi {
     return found;
   }
 
+  $sendRawTransaction(rawTransaction: string): Promise<string> {
+    return this.bitcoindClient.sendRawTransaction(rawTransaction);
+  }
+
   protected async $convertTransaction(transaction: IBitcoinApi.Transaction, addPrevout: boolean): Promise<IEsploraApi.Transaction> {
     let esploraTransaction: IEsploraApi.Transaction = {
       txid: transaction.txid,

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -56,6 +56,10 @@ class ElectrsApi implements AbstractBitcoinApi {
   $getAddressPrefix(prefix: string): string[] {
     throw new Error('Method not implemented.');
   }
+
+  $sendRawTransaction(rawTransaction: string): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
 }
 
 export default ElectrsApi;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -246,6 +246,7 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mempool/txids', routes.getMempoolTxIds)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mempool/recent', routes.getRecentMempoolTransactions)
         .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId', routes.getTransaction)
+        .post(config.MEMPOOL.API_URL_PREFIX + 'tx', routes.$postTransaction)
         .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/hex', routes.getRawTransaction)
         .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/status', routes.getTransactionStatus)
         .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/outspends', routes.getTransactionOutspends)

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -764,6 +764,18 @@ class Routes {
       res.status(500).send(e instanceof Error ? e.message : e);
     }
   }
+
+  public async $postTransaction(req: Request, res: Response) {
+    res.setHeader('content-type', 'text/plain');
+    try {
+      const rawtx = Object.keys(req.body)[0];
+      const txIdResult = await bitcoinApi.$sendRawTransaction(rawtx);
+      res.send(txIdResult);
+    } catch (e: any) {
+      res.status(400).send(e.message && e.code ? 'sendrawtransaction RPC error: ' + JSON.stringify({ code: e.code, message: e.message })
+        : (e.message || 'Error'));
+    }
+  }
 }
 
 export default new Routes();

--- a/frontend/src/app/components/api-docs/code-template.component.ts
+++ b/frontend/src/app/components/api-docs/code-template.component.ts
@@ -284,13 +284,13 @@ yarn add @mempool/liquid.js`;
     if (this.env.BASE_MODULE === 'mempool') {
       if (this.network === 'main' || this.network === '') {
         if (this.method === 'post') {
-          return `curl POST -sSLd "${text}"`;
+          return `curl -X POST -sSLd "${text}"`;
         }
         return `curl -sSL "${this.hostname}${text}"`;
       }
       if (this.method === 'post') {
         text = text.replace('/api', `/${this.network}/api`);
-        return `curl POST -sSLd "${text}"`;
+        return `curl -X POST -sSLd "${text}"`;
       }
       return `curl -sSL "${this.hostname}/${this.network}${text}"`;
     }


### PR DESCRIPTION
fixes #777

In the docs, this API URL is `POST /api/tx` but since this is a NodeJS backend API the endpoint is exposed from `/api/v1/tx/` . Is this a problem? Will this be redirected using Nginx on peoples installations to just /api/tx or do we need to expose this directly under /api/tx? @wiz 