### PR TITLE
Change total sum column to fixed color.

### DIFF
--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -226,7 +226,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
               </td>
               <td class="total-progress-sum-bar">
                 <span class="total-percentage-bar-background">
-                  <span style="width: ${progressPercentageSum.toFixed(2)}%; background-color: ${this.chartColorsOrdered[index]}"></span>
+                  <span style="width: ${progressPercentageSum.toFixed(2)}%; background-color: ${this.chartColorsOrdered[3]}"></span>
                 </span>
               </td>
             </tr>`);

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -533,6 +533,9 @@ html:lang(ru) .card-title {
       }
     }
   }
+  .total-percentage-bar-background {
+    background-color: #282d47;
+  }
 }
 
 .tx-wrapper-tooltip-chart-advanced {


### PR DESCRIPTION
## Description
The idea here is to leave the columns with the summed values in the same color.

The intention is to convey the idea that we are adding values up to that range. 
If we leave different colors, it can give the wrong idea that the value is not a sum, but the absolute value of that range.

I took the opportunity to add a background color to highlight the color value.

## Preview
### Actual behaviour
![image](https://user-images.githubusercontent.com/5798170/135095172-7c03c322-34bc-44aa-8da5-d125359a8a40.png)

### New behaviour
![image](https://user-images.githubusercontent.com/5798170/135095078-89f4739f-6110-409b-a15c-83695651d3df.png)
