### PR TITLE
Remove circle symbols when hovering the series.

### DIFF
--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -66,8 +66,10 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   }
 
   onChartReady(myChart: any) {
-    myChart.on('mouseover', 'series', (serie: any) => {
-      this.hoverIndexSerie = serie.seriesIndex;
+    myChart.getZr().on('mousemove', e => {
+      if (e.target !== undefined) {
+        this.hoverIndexSerie = e.target.parent.parent.__ecComponentInfo.index;
+      }
     });
   }
 
@@ -109,7 +111,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
         return {
           name: this.feeLevelsOrdered[index],
           type: 'line',
-          stack: 'total',
+          stack: 'fees',
           smooth: false,
           markPoint: {
             symbol: 'rect',
@@ -118,8 +120,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
             width: 0,
             opacity: 0,
           },
-          symbolSize: (this.template === 'advanced') ? 10 : 10,
-          showSymbol: false,
+          symbol: 'none',
           emphasis: {
             focus: 'none',
             areaStyle: {


### PR DESCRIPTION
Hey @Xekyo! 

I've managed to find a way to get the highlighted stack when you hover the mempool chart! :)

I've removed the circle buttons and catched the mouse movements checking if they are hovering the stacked area, selecting the fee range in the tooltip. 

I think I finally got a cool user experience! What do you think?

Fix #829 and #780.

## Tasks
- [x] Remove circle symbols when hovering the series.
- [x] Fix selected index when hovering the series.

## Preview
![hover-without-circles](https://user-images.githubusercontent.com/5798170/135178009-083fdffa-10d7-4a9d-a146-6921dd80dc32.gif)

