### PR TITLE
Remove vbytesPipe from series data.

### DIFF
--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -133,7 +133,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
             color: chartColors[index],
             opacity: 1,
           },
-          data: this.vbytesPipe.transform(value, 2, 'vB', 'MvB', true)
+          data: value
         };
       }
     });


### PR DESCRIPTION
Optimize mempool charts series data.
We don't need the `vbytesPipe`, since we already formatting the data on the yAxis formatter option.