### PR TITLE
Display correct amount of mempool blocks on mobile

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -184,7 +184,8 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
   }
 
   reduceMempoolBlocksToFitScreen(blocks: MempoolBlock[]): MempoolBlock[] {
-    const blocksAmount = Math.min(this.stateService.env.MEMPOOL_BLOCKS_AMOUNT, Math.floor(window.innerWidth / 2 / (this.blockWidth + this.blockPadding)));
+    const innerWidth = this.stateService.env.BASE_MODULE !== 'liquid' && window.innerWidth <= 767.98 ? window.innerWidth : window.innerWidth / 2;
+    const blocksAmount = Math.min(this.stateService.env.MEMPOOL_BLOCKS_AMOUNT, Math.floor(innerWidth / (this.blockWidth + this.blockPadding)));
     while (blocks.length > blocksAmount) {
       const block = blocks.pop();
       const lastBlock = blocks[blocks.length - 1];


### PR DESCRIPTION
fixes #854

The width to fit the mempool blocks wasn't calculated correctly due to how we move the white separator when on mobile.

After this fix:

Liquid:
<img width="367" alt="Screen Shot 2021-10-05 at 15 41 00" src="https://user-images.githubusercontent.com/8561090/136016129-9fad1804-7a4e-4813-bbb4-3199db9cddff.png">


Mainnet

<img width="362" alt="Screen Shot 2021-10-05 at 15 41 42" src="https://user-images.githubusercontent.com/8561090/136016138-dd344979-1f64-48f3-b9b2-5f4177fbc2c5.png">


