### PR TITLE
UI/UX: Make x-axis dates human readable.

### DIFF
--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -108,21 +108,21 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
           formatter: (value: string) => {
             const date = new Date(value);
             if (this.template !== 'advanced') {
-              return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+              return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
             }
             switch (this.windowPreference) {
               case '1w':
-                return `${date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' })}`;
+                return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
               case '1m':
-                return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
               case '3m':
-                return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
               case '6m':
-                return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
               case '1y':
-                return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
               default: // 2m, 24h
-                return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+                return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
             }
           }
         },

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -100,29 +100,53 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
       },
       xAxis: {
         type: 'category',
+        axisTick: {
+          alignWithLabel: true,
+          lineStyle: {
+            width: 1,
+          },
+          length: 8
+        },
         axisLabel: {
           interval: this.getAxisLabelInterval(),
           align: 'center',
           fontSize: 11,
           lineHeight: 12,
-          formatter: (value: string) => {
+          margin: 11,
+          formatter: (value: string, index: number) => {
             const date = new Date(value);
             if (this.template !== 'advanced') {
-              return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+              const dayControl = date.getDay();
+              if (index === 0) {
+                return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+              } else {
+                if (dayControl < date.getDay()) {
+                  return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                } else {
+                  return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                }
+              }
             }
             switch (this.windowPreference) {
               case '1w':
                 return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
               case '1m':
-                return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
               case '3m':
                 return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
               case '6m':
-                return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
               case '1y':
                 return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
               default: // 2m, 24h
-                return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                const dayControl = date.getDay();
+                if (index === 0) {
+                  return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                } else {
+                  if (dayControl < date.getDay()) {
+                    return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                  } else {
+                    return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                  }
+                }
             }
           }
         },
@@ -209,7 +233,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
   }
   getAxisLabelInterval() {
     if (this.template !== 'advanced') {
-      return 20;
+      return 25;
     }
     switch (this.windowPreference) {
       case '2h':

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -100,11 +100,32 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
       xAxis: {
         type: 'category',
         axisLabel: {
+          interval: this.getAxisLabelInterval(),
           align: 'center',
           fontSize: 11,
-          lineHeight: 12
+          lineHeight: 12,
+          formatter: (value: string) => {
+            const date = new Date(value);
+            if (this.template !== 'advanced') {
+              return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+            }
+            switch (this.windowPreference) {
+              case '1w':
+                return `${date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' })}`;
+              case '1m':
+                return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+              case '3m':
+                return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+              case '6m':
+                return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+              case '1y':
+                return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+              default: // 2m, 24h
+                return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+            }
+          }
         },
-        data: this.data.labels.map((value: any) => `${formatDate(value, 'M/d', this.locale)}\n${formatDate(value, 'H:mm', this.locale)}`),
+        data: this.data.labels,
       },
       yAxis: {
         type: 'value',
@@ -184,5 +205,28 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         }
       },
     };
+  }
+  getAxisLabelInterval() {
+    if (this.template !== 'advanced') {
+      return 20;
+    }
+    switch (this.windowPreference) {
+      case '2h':
+        return 10;
+      case '24h':
+        return 40;
+      case '1w':
+        return 68;
+      case '1m':
+        return 40;
+      case '3m':
+        return 37;
+      case '6m':
+        return 80;
+      case '1y':
+        return 40;
+      default:
+        return 5;
+    }
   }
 }

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -84,7 +84,8 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         },
         formatter: (params: any) => {
           const colorSpan = (color: string) => `<span class="indicator" style="background-color: ` + color + `"></span>`;
-          let itemFormatted = '<div class="title">' + params[0].axisValue + '</div>';
+          const date = new Date(params[0].axisValue);
+          let itemFormatted = '<div class="title">' + date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' }) + '</div>';
           params.map((item: any, index: number) => {
             if (index < 26) {
               itemFormatted += `<div class="item">

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -51,13 +51,27 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         type: 'inside',
         realtime: true,
         zoomOnMouseWheel: (this.template === 'advanced') ? true : false,
-        maxSpan: 100,
+        maxSpan: (window.innerWidth >= 850 || this.template === 'widget') ? 100 : 40,
         minSpan: 10,
       }, {
         show: (this.template === 'advanced') ? true : false,
         type: 'slider',
         brushSelect: false,
         realtime: true,
+        labelFormatter: (value, valueStr) => {
+          const date = new Date (valueStr);
+          switch (this.windowPreference) {
+            case '1w':
+            case '1m':
+              return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
+            case '3m':
+            case '6m':
+            case '1y':
+              return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
+            default: // 2m, 24h
+              return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+          }
+        },
         selectedDataBackground: {
           lineStyle: {
             color: '#fff',
@@ -111,7 +125,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
           interval: this.getAxisLabelInterval(),
           align: 'center',
           fontSize: 11,
-          lineHeight: 12,
+          lineHeight: 25,
           margin: 11,
           formatter: (value: string, index: number) => {
             const date = new Date(value);
@@ -129,10 +143,9 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
             }
             switch (this.windowPreference) {
               case '1w':
-                return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
               case '1m':
+                return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
               case '3m':
-                return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
               case '6m':
               case '1y':
                 return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
@@ -233,21 +246,21 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
   }
   getAxisLabelInterval() {
     if (this.template !== 'advanced') {
-      return 25;
+      return 30;
     }
     switch (this.windowPreference) {
       case '2h':
-        return 10;
+        return 14;
       case '24h':
         return 40;
       case '1w':
         return 68;
       case '1m':
-        return 40;
+        return 118;
       case '3m':
-        return 37;
+        return 140;
       case '6m':
-        return 80;
+        return 70;
       case '1y':
         return 40;
       default:

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -141,16 +141,9 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
                 }
               }
             }
+            const dayControl = date.getDay();
             switch (this.windowPreference) {
-              case '1w':
-              case '1m':
-                return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
-              case '3m':
-              case '6m':
-              case '1y':
-                return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
-              default: // 2m, 24h
-                const dayControl = date.getDay();
+              case '2h':
                 if (index === 0) {
                   return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
                 } else {
@@ -160,6 +153,23 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
                     return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
                   }
                 }
+              case '24h':
+                if (index === 0) {
+                  return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric' });
+                } else {
+                  if (dayControl < date.getDay()) {
+                    return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric' });
+                  } else {
+                    return date.toLocaleTimeString(this.locale, { hour: 'numeric' });
+                  }
+                }
+              case '1w':
+              case '1m':
+                return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
+              case '3m':
+              case '6m':
+              case '1y':
+                return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
             }
           }
         },
@@ -256,7 +266,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
       case '1w':
         return 68;
       case '1m':
-        return 118;
+        return 112;
       case '3m':
         return 140;
       case '6m':

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -300,29 +300,53 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
           type: 'category',
           boundaryGap: false,
           axisLine: { onZero: true },
+          axisTick: {
+            alignWithLabel: true,
+            lineStyle: {
+              width: 1,
+            },
+            length: 8
+          },
           axisLabel: {
             interval: this.getAxisLabelInterval(),
             align: 'center',
             fontSize: 11,
             lineHeight: 12,
-            formatter: (value: string) => {
+            margin: 11,
+            formatter: (value: string, index: number) => {
               const date = new Date(value);
               if (this.template !== 'advanced') {
-                return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                const dayControl = date.getDay();
+                if (index === 0) {
+                  return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                } else {
+                  if (dayControl < date.getDay()) {
+                    return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                  } else {
+                    return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                  }
+                }
               }
               switch (this.windowPreference) {
                 case '1w':
                   return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
                 case '1m':
-                  return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
                 case '3m':
                   return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
                 case '6m':
-                  return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
                 case '1y':
                   return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
                 default: // 2m, 24h
-                  return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                  const dayControl = date.getDay();
+                  if (index === 0) {
+                    return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                  } else {
+                    if (dayControl < date.getDay()) {
+                      return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' });
+                    } else {
+                      return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+                    }
+                  }
               }
             }
           },
@@ -379,7 +403,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   }
   getAxisLabelInterval() {
     if (this.template !== 'advanced') {
-      return 20;
+      return 25;
     }
     switch (this.windowPreference) {
       case '2h':

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -308,21 +308,21 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
             formatter: (value: string) => {
               const date = new Date(value);
               if (this.template !== 'advanced') {
-                return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+                return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
               }
               switch (this.windowPreference) {
                 case '1w':
-                  return `${date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' })}`;
+                  return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
                 case '1m':
-                  return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                  return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
                 case '3m':
-                  return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                  return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
                 case '6m':
-                  return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                  return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
                 case '1y':
-                  return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                  return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
                 default: // 2m, 24h
-                  return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+                  return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
               }
             }
           },

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -22,7 +22,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   @Input() top: number | string = 20;
   @Input() right: number | string = 10;
   @Input() left: number | string = 75;
-  @Input() template: ('widget' | 'advanced') = 'widget';
+  @Input() template: ('widget' | 'advanced' | 'tv') = 'widget';
   @Input() showZoom = true;
 
   mempoolVsizeFeesData: any;
@@ -85,7 +85,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   generateArray(mempoolStats: OptimizedMempoolStats[]) {
     const finalArray: number[][] = [];
     let feesArray: number[] = [];
-    const limitFeesTemplate = this.template === 'advanced' ? 28 : 21;
+    const limitFeesTemplate = this.template !== 'widget' ? 28 : 21;
     for (let index = limitFeesTemplate; index > -1; index--) {
       feesArray = [];
       mempoolStats.forEach((stats) => {
@@ -160,11 +160,11 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
         trigger: 'axis',
         alwaysShowContent: false,
         position: (pos, params, el, elRect, size) => {
-          const positions = { top: (this.template === 'advanced') ? 0 : -30 };
+          const positions = { top: (this.template !== 'widget') ? 0 : -30 };
           positions[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 60;
           return positions;
         },
-        extraCssText: `width: ${(this.template === 'advanced') ? '275px' : '200px'};
+        extraCssText: `width: ${(this.template !== 'widget') ? '275px' : '200px'};
                       background: transparent;
                       border: none;
                       box-shadow: none;`,
@@ -237,10 +237,12 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
               </td>
             </tr>`);
           });
-          const classActive = (this.template === 'advanced') ? 'fees-wrapper-tooltip-chart-advanced' : '';
+          const classActive = (this.template !== 'widget') ? 'fees-wrapper-tooltip-chart-advanced' : '';
+
+          const date = new Date (params[0].axisValue);
           return `<div class="fees-wrapper-tooltip-chart ${classActive}">
             <div class="title">
-              ${params[0].axisValue}
+              ${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' })}
               <span class="total-value">
                 ${this.vbytesPipe.transform(totalValue, 2, 'vB', 'MvB', false)}
               </span>
@@ -299,11 +301,32 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
           boundaryGap: false,
           axisLine: { onZero: true },
           axisLabel: {
+            interval: this.getAxisLabelInterval(),
             align: 'center',
             fontSize: 11,
             lineHeight: 12,
+            formatter: (value: string) => {
+              const date = new Date(value);
+              if (this.template !== 'advanced') {
+                return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+              }
+              switch (this.windowPreference) {
+                case '1w':
+                  return `${date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' })}`;
+                case '1m':
+                  return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                case '3m':
+                  return `${date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' })}`;
+                case '6m':
+                  return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                case '1y':
+                  return `${date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' })}`;
+                default: // 2m, 24h
+                  return `${date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' })}`;
+              }
+            }
           },
-          data: labels.map((value: any) => `${formatDate(value, 'M/d', this.locale)}\n${formatDate(value, 'H:mm', this.locale)}`),
+          data: labels,
         }
       ],
       yAxis: {
@@ -353,6 +376,29 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       }
     }
     this.chartColorsOrdered =  chartColors.slice(0, this.feeLevelsOrdered.length);
+  }
+  getAxisLabelInterval() {
+    if (this.template !== 'advanced') {
+      return 20;
+    }
+    switch (this.windowPreference) {
+      case '2h':
+        return 10;
+      case '24h':
+        return 40;
+      case '1w':
+        return 68;
+      case '1m':
+        return 40;
+      case '3m':
+        return 37;
+      case '6m':
+        return 80;
+      case '1y':
+        return 40;
+      default:
+        return 5;
+    }
   }
 }
 

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -270,7 +270,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
         type: 'inside',
         realtime: true,
         zoomOnMouseWheel: (this.template === 'advanced') ? true : false,
-        maxSpan: 100,
+        maxSpan: (window.innerWidth >= 850 || this.template === 'widget') ? 100 : 40,
         minSpan: 10,
       }, {
         show: (this.template === 'advanced' && this.showZoom) ? true : false,
@@ -278,6 +278,20 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
         brushSelect: false,
         realtime: true,
         bottom: 0,
+        labelFormatter: (value, valueStr) => {
+          const date = new Date (valueStr);
+          switch (this.windowPreference) {
+            case '1w':
+            case '1m':
+              return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
+            case '3m':
+            case '6m':
+            case '1y':
+              return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
+            default: // 2m, 24h
+              return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
+          }
+        },
         selectedDataBackground: {
           lineStyle: {
             color: '#fff',
@@ -311,8 +325,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
             interval: this.getAxisLabelInterval(),
             align: 'center',
             fontSize: 11,
-            lineHeight: 12,
-            margin: 11,
+            lineHeight: 25,
             formatter: (value: string, index: number) => {
               const date = new Date(value);
               if (this.template !== 'advanced') {
@@ -329,10 +342,9 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
               }
               switch (this.windowPreference) {
                 case '1w':
-                  return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
                 case '1m':
+                  return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
                 case '3m':
-                  return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
                 case '6m':
                 case '1y':
                   return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
@@ -403,21 +415,21 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   }
   getAxisLabelInterval() {
     if (this.template !== 'advanced') {
-      return 25;
+      return 30;
     }
     switch (this.windowPreference) {
       case '2h':
-        return 10;
+        return 14;
       case '24h':
         return 40;
       case '1w':
         return 68;
       case '1m':
-        return 40;
+        return 118;
       case '3m':
-        return 37;
+        return 140;
       case '6m':
-        return 80;
+        return 70;
       case '1y':
         return 40;
       default:
@@ -425,4 +437,3 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
     }
   }
 }
-

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -340,16 +340,9 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
                   }
                 }
               }
+              const dayControl = date.getDay();
               switch (this.windowPreference) {
-                case '1w':
-                case '1m':
-                  return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
-                case '3m':
-                case '6m':
-                case '1y':
-                  return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
-                default: // 2m, 24h
-                  const dayControl = date.getDay();
+                case '2h':
                   if (index === 0) {
                     return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
                   } else {
@@ -359,6 +352,24 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
                       return date.toLocaleTimeString(this.locale, { hour: 'numeric', minute: 'numeric' });
                     }
                   }
+                case '24h':
+                  if (index === 0) {
+                    return date.toLocaleTimeString(this.locale, { month: 'short', day: 'numeric', hour: 'numeric' });
+                  } else {
+                    if (dayControl < date.getDay()) {
+                      return date.toLocaleTimeString(this.locale, { month: 'numeric', day: 'numeric', hour: 'numeric' });
+                    } else {
+                      return date.toLocaleTimeString(this.locale, { hour: 'numeric' });
+                    }
+                  }
+                case '1w':
+                case '1m':
+                  return date.toLocaleDateString(this.locale, { month: 'short', weekday: 'short', day: 'numeric' });
+                case '3m':
+                  return date.toLocaleDateString(this.locale, { month: 'short', day: 'numeric' });
+                case '6m':
+                case '1y':
+                  return date.toLocaleDateString(this.locale, { year: 'numeric', month: 'short' });
               }
             }
           },
@@ -425,9 +436,9 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       case '1w':
         return 68;
       case '1m':
-        return 118;
+        return 112;
       case '3m':
-        return 140;
+        return 35;
       case '6m':
         return 70;
       case '1y':

--- a/frontend/src/app/components/television/television.component.html
+++ b/frontend/src/app/components/television/television.component.html
@@ -7,7 +7,7 @@
   <div class="tv-container" *ngIf="mempoolStats.length">
     <div class="chart-holder">
       <app-mempool-graph
-        [template]="'advanced'"
+        [template]="'tv'"
         [limitFee]="500"
         [height]="600"
         [left]="60"

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -540,7 +540,7 @@ html:lang(ru) .card-title {
 }
 
 .tx-wrapper-tooltip-chart-advanced {
-  width: 115px;
+  width: 145px;
   .indicator-container {
     .indicator {
       margin-right: 5px;


### PR DESCRIPTION
Hey @Xekyo, can you give me a feedback on this PR? :heart: 

### Description
This is my proposal to make x-axis labels with human readable dates:

- timespan 2h: `HH:mm` round to `5 mins`.
- timespan 24h: `HH:mm` round to `30 mins`.
- timespan 1w: `m/d H:mm` round to `1 hour`.
- timespan 1m, 3m, 6m: `MM/dd` round to `1 day`.
- timespan 1y: `m/d/YY` round to `1 day`.

Fix #842 .

### Preview 
#### Dashboard
![image](https://user-images.githubusercontent.com/5798170/137339177-1ad91d5a-677c-4313-bfbc-d782d0ea5777.png)

#### TV View
![image](https://user-images.githubusercontent.com/5798170/137339381-4ee74b63-e8f2-4014-be38-4a369aac4338.png)

#### Graphs - 2H
![image](https://user-images.githubusercontent.com/5798170/137339510-7f58e30b-363d-4054-8b19-a0fea311cc9f.png)

#### Graphs - 24H
![image](https://user-images.githubusercontent.com/5798170/137339568-539a4cde-37e2-4927-ba5d-2f239bc9a4f9.png)

#### Graphs - 1W
![image](https://user-images.githubusercontent.com/5798170/137339640-a7aff4c1-d3c6-4e5d-ab0e-0e5326e0ec6c.png)

#### Graphs - 1M
![image](https://user-images.githubusercontent.com/5798170/137339703-ec9dfaad-7e9c-4d41-ba63-4e1387f5f735.png)

#### Graphs - 3M
![image](https://user-images.githubusercontent.com/5798170/137339811-d3a412ac-54ff-4f53-a711-54077e420a44.png)

#### Graphs - 6M
![image](https://user-images.githubusercontent.com/5798170/137339848-2c72587f-fa3c-4c87-a93a-5183bbc7de07.png)

#### Graphs - 1Y
![image](https://user-images.githubusercontent.com/5798170/137339888-497cfedd-a6c7-4585-a8da-9179627111f3.png)
