### PR TITLE
Exempt LAN addresses from all rate limits in nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -54,10 +54,16 @@ http {
 	proxy_cache_path /var/cache/nginx keys_zone=cache:20m levels=1:2 inactive=600s max_size=500m;
 	types_hash_max_size 2048;
 
-	# exempt localhost from rate limit
+	# exempt localhost and local networks from rate limits
 	geo $limited_ip {
 		default		1;
-		127.0.0.1	0;
+		127.0.0.0/8	0;
+		10.0.0.0/8	0;
+		172.16.0.0/12	0;
+		192.168.0.0/16  0;
+		169.254.0.0/16  0;
+		fc00::/7        0;
+		fe80::/10       0;
 	}
 	map $limited_ip $limited_ip_key {
 		1 $binary_remote_addr;


### PR DESCRIPTION
A user recently reported they were rate limited when querying their home node running on a RPI. This PR exempts all LAN addresses from rate limits.

@knorrium since this needs testing on Umbrel / RaspiBlitz / MyNode before merging, I'll tag `v2.3.0-dev1` from this commit, and then we can easily set our RPIs to install that Docker image