### PR TITLE
Post TX API for HTML forms

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -170,6 +170,7 @@ class Server {
       .get(config.MEMPOOL.API_URL_PREFIX + 'backend-info', routes.getBackendInfo)
       .get(config.MEMPOOL.API_URL_PREFIX + 'init-data', routes.getInitData)
       .get(config.MEMPOOL.API_URL_PREFIX + 'validate-address/:address', routes.validateAddress)
+      .post(config.MEMPOOL.API_URL_PREFIX + 'tx/push', routes.$postTransactionForm)
       .get(config.MEMPOOL.API_URL_PREFIX + 'donations', async (req, res) => {
         try {
           const response = await axios.get('https://mempool.space/api/v1/donations', { responseType: 'stream', timeout: 10000 });

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -781,6 +781,22 @@ class Routes {
         : (e.message || 'Error'));
     }
   }
+
+  public async $postTransactionForm(req: Request, res: Response) {
+    res.setHeader('content-type', 'text/plain');
+    const matches = /tx=([a-z0-9]+)/.exec(req.body);
+    let txHex = '';
+    if (matches && matches[1]) {
+      txHex = matches[1];
+    }
+    try {
+      const txIdResult = await bitcoinClient.sendRawTransaction(txHex);
+      res.send(txIdResult);
+    } catch (e: any) {
+      res.status(400).send(e.message && e.code ? 'sendrawtransaction RPC error: ' + JSON.stringify({ code: e.code, message: e.message })
+        : (e.message || 'Error'));
+    }
+  }
 }
 
 export default new Routes();


### PR DESCRIPTION
This adds a new NodeJS backend endpoint at `POST /api/v1/tx/push` that parses a `tx` form data and passes the value to the Bitcoin sendRawTransaction API.