### PR TITLE
Handle new type of Electrum Server error.

### DIFF
--- a/backend/src/api/bitcoin/electrum-api.ts
+++ b/backend/src/api/bitcoin/electrum-api.ts
@@ -87,11 +87,8 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
         },
         'electrum': true,
       };
-    } catch (e) {
-      if (e === 'failed to get confirmed status') {
-        e = 'The number of transactions on this address exceeds the Electrum server limit';
-      }
-      throw new Error(typeof e === 'string' ? e : 'Error');
+    } catch (e: any) {
+      throw new Error(typeof e === 'string' ? e : e && e.message || e);
     }
   }
 
@@ -124,12 +121,9 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
       }
 
       return transactions;
-    } catch (e) {
+    } catch (e: any) {
       loadingIndicators.setProgress('address-' + address, 100);
-      if (e === 'failed to get confirmed status') {
-        e = 'The number of transactions on this address exceeds the Electrum server limit';
-      }
-      throw new Error(typeof e === 'string' ? e : 'Error');
+      throw new Error(typeof e === 'string' ? e : e && e.message || e);
     }
   }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -613,7 +613,7 @@ class Routes {
       const addressData = await bitcoinApi.$getAddress(req.params.address);
       res.json(addressData);
     } catch (e) {
-      if (e instanceof Error && e.message && e.message.indexOf('exceeds') > 0) {
+      if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
         return res.status(413).send(e instanceof Error ? e.message : e);
       }
       res.status(500).send(e instanceof Error ? e.message : e);
@@ -630,7 +630,7 @@ class Routes {
       const transactions = await bitcoinApi.$getAddressTransactions(req.params.address, req.params.txId);
       res.json(transactions);
     } catch (e) {
-      if (e instanceof Error && e.message && e.message.indexOf('exceeds') > 0) {
+      if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
         return res.status(413).send(e instanceof Error ? e.message : e);
       }
       res.status(500).send(e instanceof Error ? e.message : e);

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -122,10 +122,11 @@
   </ng-template>
 
   <ng-template [ngIf]="error">
+    <br>
     <div class="text-center">
       <span i18n="address.error.loading-address-data">Error loading address data.</span>
       <br>
-      <ng-template #displayServerError><i>{{ error.error }}</i></ng-template>
+      <ng-template #displayServerError><i class="small">({{ error.error }})</i></ng-template>
       <ng-template [ngIf]="error.status === 413 || error.status === 405" [ngIfElse]="displayServerError">
         <ng-container i18n="Electrum server limit exceeded error">
           <i>The number of transactions on this address exceeds the Electrum server limit</i>
@@ -136,6 +137,8 @@
         <a href="https://mempool.space/address/{{ addressString }}" target="_blank">https://mempool.space/address/{{ addressString }}</a>
         <br>
         <a href="http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/address/{{ addressString }}" target="_blank">http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/address/{{ addressString }}</a>
+        <br><br>
+        <i class="small">({{ error.error }})</i>
       </ng-template>
     </div>
   </ng-template>


### PR DESCRIPTION
fixes #872

Handle new and old romanz/electrs error response.

Default random error message:
<img width="346" alt="Screen Shot 2021-10-23 at 11 45 47" src="https://user-images.githubusercontent.com/8561090/138547635-923c5be2-1005-4619-972a-7fdfd46cff5a.png">

Address limit exceeded detected and replaced with the i18n-translated error message, along with the original error:
<img width="706" alt="Screen Shot 2021-10-23 at 11 43 26" src="https://user-images.githubusercontent.com/8561090/138547648-9d10fd50-6696-46cf-bd36-8e35048e09e0.png">

