### PR TITLE
Add instructions on how to contribute to the Frontend codebase

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,50 @@
 # mempool-frontend
 
-## Transifex Project
+## Contributing
+
+This package is used for the https://mempool.space, https://liquid.network and https://bisq.markets websites - there are npm scripts to setup all three, which effectively change how BASE_MODULE is  configured:
+
+```
+$ npm run config:defaults:mempool
+$ npm run config:defaults:liquid
+$ npm run config:defaults:bisq
+```
+
+Changes that affect the frontend codebase only can be done using the production backend so you don't need to spin up the entire Mempool infrastructure. This is very convenient in case you want to quickly improve the UI, fix typos or implement new features that don't require any backend changes.
+
+Make your changes, install the project dependencies and run the frontend server as follows:
+
+```
+$ npm install
+$ npm run serve:local-prod
+```
+
+The frontend will be available at http://localhost:4200/ and all API requests will be proxied to the production server at https://mempool.space
+
+After making your changes, you can run our end-to-end automation suite and check for possible regressions:
+
+Headless:
+
+```
+$ npm run config:defaults:mempool && npm run cypress:run
+```
+
+Interactive:
+
+```
+$ npm run config:defaults:mempool && npm run cypress:open
+```
+
+This will open the Cypress test runner, where you can select any of the test files to run.
+
+If all tests are green, submit your PR and it will be reviewed by someone on the team as soon as possible.
+
+## Translations: Transifex Project
 
 The mempool frontend strings are localized into 20+ locales:
 https://www.transifex.com/mempool/mempool/dashboard/
 
-## Translators
+### Translators
 
 * Arabic @baro0k
 * Czech @pixelmade2


### PR DESCRIPTION
Improve the README to include instructions on how to install the dependencies and run the frontend against the production servers, as well as how to run the e2e automation suite.