### PR TITLE
Display lower <1 s/vB fee rate tiers for Liquid

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -3,6 +3,7 @@ import { DB } from '../database';
 import logger from '../logger';
 
 import { Statistic, TransactionExtended, OptimizedStatistic } from '../mempool.interfaces';
+import config from '../config';
 
 class Statistics {
   protected intervalTimer: NodeJS.Timer | undefined;
@@ -87,7 +88,15 @@ class Statistics {
 
     memPoolArray.forEach((transaction) => {
       for (let i = 0; i < logFees.length; i++) {
-        if ((logFees[i] === 2000 && transaction.effectiveFeePerVsize >= 2000) || transaction.effectiveFeePerVsize <= logFees[i]) {
+        if (
+          (config.MEMPOOL.NETWORK === 'liquid'
+            && ((logFees[i] === 2000 && transaction.effectiveFeePerVsize * 10 >= 2000)
+            || transaction.effectiveFeePerVsize * 10 <= logFees[i]))
+          ||
+          (config.MEMPOOL.NETWORK !== 'liquid'
+            && ((logFees[i] === 2000 && transaction.effectiveFeePerVsize >= 2000)
+            || transaction.effectiveFeePerVsize <= logFees[i]))
+        ) {
           if (weightVsizeFees[logFees[i]]) {
             weightVsizeFees[logFees[i]] += transaction.vsize;
           } else {

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -349,9 +349,17 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       }
       if (feeLevels[i] <= this.limitFee) {
         if (i === 0) {
-          this.feeLevelsOrdered.push('0 - 1');
+          if (this.stateService.network === 'liquid') {
+            this.feeLevelsOrdered.push('0 - 0.1');
+          } else {
+            this.feeLevelsOrdered.push('0 - 1');
+          }
         } else {
-          this.feeLevelsOrdered.push(`${feeLevels[i - 1]} - ${feeLevels[i]}`);
+          if (this.stateService.network === 'liquid') {
+            this.feeLevelsOrdered.push(`${feeLevels[i - 1] / 10} - ${feeLevels[i] / 10}`);
+          } else {
+            this.feeLevelsOrdered.push(`${feeLevels[i - 1]} - ${feeLevels[i]}`);
+          }
         }
       }
     }


### PR DESCRIPTION
fixes #859

This PR does:

* Liquid fee ranges 0.1, 0.2, 0.3 sat/vB etc are now stored in the 1, 2, 3 respective database fields
* The frontend adapt and display 1/10 the size of fee levels 
 
<img width="815" alt="Screen Shot 2021-11-09 at 23 55 33" src="https://user-images.githubusercontent.com/8561090/140996684-c0aa97b9-6d67-4a22-a713-8de276d97ab4.png">
e 