### PR TITLE
Adding Taproot transaction tag

### DIFF
--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -16,6 +16,7 @@ export function calcSegwitFeeGains(tx: Transaction) {
     const isP2sh  = vin.prevout.scriptpubkey_type === 'p2sh';
     const isP2wsh = vin.prevout.scriptpubkey_type === 'v0_p2wsh';
     const isP2wpkh = vin.prevout.scriptpubkey_type === 'v0_p2wpkh';
+    const isP2tr  = vin.prevout.scriptpubkey_type === 'v1_p2tr';
 
     const op = vin.scriptsig ? vin.scriptsig_asm.split(' ')[0] : null;
     const isP2sh2Wpkh = isP2sh && !!vin.witness && op === 'OP_PUSHBYTES_22';
@@ -25,6 +26,7 @@ export function calcSegwitFeeGains(tx: Transaction) {
       // Native Segwit - P2WPKH/P2WSH (Bech32)
       case isP2wpkh:
       case isP2wsh:
+      case isP2tr:
         // maximal gains: the scriptSig is moved entirely to the witness part
         realizedGains += witnessSize(vin) * 3;
         // XXX P2WSH output creation is more expensive, should we take this into consideration?

--- a/frontend/src/app/components/tx-features/tx-features.component.html
+++ b/frontend/src/app/components/tx-features/tx-features.component.html
@@ -5,5 +5,6 @@
     <span *ngIf="segwitGains.potentialP2shGains" class="badge badge-danger mr-1" i18n-ngbTooltip="ngbTooltip about missed out gains" ngbTooltip="This transaction could save {{ segwitGains.potentialBech32Gains * 100 | number : '1.0-0' }}% on fees by upgrading to native SegWit-Bech32 or {{ segwitGains.potentialP2shGains * 100 | number:  '1.0-0' }}% by upgrading to SegWit-P2SH" placement="bottom"><del i18n="tx-features.tag.segwit|SegWit">SegWit</del></span>
   </ng-template>
 </ng-template>
+<span *ngIf="isTaproot" class="badge badge-success mr-1" i18n-ngbTooltip="Taproot tooltip" ngbTooltip="This transaction uses Taproot" placement="bottom" i18n="tx-features.tag.taproot">Taproot</span>
 <span *ngIf="isRbfTransaction; else rbfDisabled" class="badge badge-success" i18n-ngbTooltip="RBF tooltip" ngbTooltip="This transaction support Replace-By-Fee (RBF) allowing fee bumping" placement="bottom" i18n="tx-features.tag.rbf|RBF">RBF</span>
 <ng-template #rbfDisabled><span class="badge badge-danger mr-1" i18n-ngbTooltip="RBF disabled tooltip" ngbTooltip="This transaction does NOT support Replace-By-Fee (RBF) and cannot be fee bumped using this method" placement="bottom"><del i18n="tx-features.tag.rbf|RBF">RBF</del></span></ng-template>

--- a/frontend/src/app/components/tx-features/tx-features.component.ts
+++ b/frontend/src/app/components/tx-features/tx-features.component.ts
@@ -17,6 +17,7 @@ export class TxFeaturesComponent implements OnChanges {
     potentialP2shGains: 0,
   };
   isRbfTransaction: boolean;
+  isTaproot: boolean;
 
   constructor() { }
 
@@ -26,5 +27,6 @@ export class TxFeaturesComponent implements OnChanges {
     }
     this.segwitGains = calcSegwitFeeGains(this.tx);
     this.isRbfTransaction = this.tx.vin.some((v) => v.sequence < 0xfffffffe);
+    this.isTaproot = this.tx.vin.some((v) => v.prevout && v.prevout.scriptpubkey_type === 'v1_p2tr');
   }
 }


### PR DESCRIPTION
fixes #914

This PR:
* Adds a Taproot tag with tooltip, on detection
* Treat Taproot-outputs like native segwit to display Segwit and savings

<img width="453" alt="Screen Shot 2021-11-10 at 15 09 16" src="https://user-images.githubusercontent.com/8561090/141102731-544999c8-43d2-4fe6-8914-4fed25f15b34.png">


