### PR TITLE
Display previous output types

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -100,10 +100,16 @@
                         <td i18n="transactions-list.nsequence">nSequence</td>
                         <td style="text-align: left;">{{ formatHex(vin.sequence) }}</td>
                       </tr>
-                      <tr *ngIf="vin.prevout">
-                        <td i18n="transactions-list.previous-output-script">Previous output script</td>
-                        <td style="text-align: left;" [innerHTML]="vin.prevout.scriptpubkey_asm | asmStyler">{{ vin.prevout.scriptpubkey_type ? ('(' + vin.prevout.scriptpubkey_type + ')') : '' }}"</td>
-                      </tr>
+                      <ng-template [ngIf]="vin.prevout">
+                        <tr>
+                          <td i18n="transactions-list.previous-output-script">Previous output script</td>
+                          <td style="text-align: left;" [innerHTML]="vin.prevout.scriptpubkey_asm | asmStyler"></td>
+                        </tr>
+                        <tr>
+                          <td i18n="transactions-list.previous-output-type">Previous output type</td>
+                          <td style="text-align: left;">{{ vin.prevout.scriptpubkey_type?.toUpperCase() }}</td>
+                        </tr>
+                    </ng-template>
                     </tbody>
                   </table>
                 </td>
@@ -176,10 +182,6 @@
                 <td colspan="3" class=" details-container" >
                   <table class="table table-striped table-borderless details-table mb-3">
                     <tbody>
-                      <tr *ngIf="vout.scriptpubkey_type">
-                        <td i18n="transactions-list.vout.scriptpubkey-type">Type</td>
-                        <td style="text-align: left;">{{ vout.scriptpubkey_type.toUpperCase() }}</td>
-                      </tr>
                       <tr>
                         <td i18n="transactions-list.scriptpubkey.asm|ScriptPubKey (ASM)">ScriptPubKey (ASM)</td>
                         <td style="text-align: left;" [innerHTML]="vout.scriptpubkey_asm | asmStyler"></td>
@@ -191,6 +193,10 @@
                       <tr *ngIf="vout.scriptpubkey_type == 'op_return'">
                         <td>OP_RETURN <span i18n="transactions-list.vout.scriptpubkey-type.data">data</span></td>
                         <td style="text-align: left;">{{ vout.scriptpubkey_asm | hex2ascii }}</td>
+                      </tr>
+                      <tr *ngIf="vout.scriptpubkey_type">
+                        <td i18n="transactions-list.vout.scriptpubkey-type">Type</td>
+                        <td style="text-align: left;">{{ vout.scriptpubkey_type.toUpperCase() }}</td>
                       </tr>
                     </tbody>
                   </table>


### PR DESCRIPTION
fixes #917

This PR:

* Adds missing Previous Output Type as a new field on Transaction Inputs
* Moves the Type row to the bottom of the details list to match


<img width="1146" alt="Screen Shot 2021-11-10 at 15 33 33" src="https://user-images.githubusercontent.com/8561090/141111187-eed4d2f5-3dde-4db5-a35e-78b52cdcac75.png">


