### PR TITLE
Adding version and locktime to transaction details

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -206,26 +206,44 @@
       <h2 i18n="transaction.details">Details</h2>
     </div>
     <div class="box">
-      <table class="table table-borderless table-striped">
-        <tbody>
-          <tr>
-            <td i18n="transaction.size|Transaction Size">Size</td>
-            <td [innerHTML]="'&lrm;' + (tx.size | bytes: 2)"></td>
-          </tr>
-          <tr>
-            <td i18n="transaction.vsize|Transaction Virtual Size">Virtual size</td>
-            <td [innerHTML]="'&lrm;' + (tx.weight / 4 | vbytes: 2)"></td>
-          </tr>
-          <tr>
-            <td i18n="transaction.weight|Transaction Weight">Weight</td>
-            <td [innerHTML]="'&lrm;' + (tx.weight | wuBytes: 2)"></td>
-          </tr>
-          <tr>
-            <td i18n="transaction.hex">Transaction Hex</td>
-            <td><a target="_blank" href="{{ network === '' ? '' : '/' + network }}/api/tx/{{ txId }}/hex"><fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true"></fa-icon></a></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="row">
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td i18n="transaction.size|Transaction Size">Size</td>
+                <td [innerHTML]="'&lrm;' + (tx.size | bytes: 2)"></td>
+              </tr>
+              <tr>
+                <td i18n="transaction.vsize|Transaction Virtual Size">Virtual size</td>
+                <td [innerHTML]="'&lrm;' + (tx.weight / 4 | vbytes: 2)"></td>
+              </tr>
+              <tr>
+                <td i18n="transaction.weight|Transaction Weight">Weight</td>
+                <td [innerHTML]="'&lrm;' + (tx.weight | wuBytes: 2)"></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td i18n="transaction.version">Version</td>
+                <td [innerHTML]="'&lrm;' + (tx.version | number)"></td>
+              </tr>
+              <tr>
+                <td i18n="transaction.locktime">Locktime</td>
+                <td [innerHTML]="'&lrm;' + (tx.locktime | number)"></td>
+              </tr>
+              <tr>
+                <td i18n="transaction.hex">Transaction Hex</td>
+                <td><a target="_blank" href="{{ network === '' ? '' : '/' + network }}/api/tx/{{ txId }}/hex"><fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true"></fa-icon></a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
 
   </ng-template>
@@ -286,22 +304,44 @@
 
     <h2 i18n="transaction.details">Details</h2>
     <div class="box">
-      <table class="table table-borderless table-striped">
-        <tbody>
-          <tr>
-            <td><span class="skeleton-loader"></span></td>
-            <td><span class="skeleton-loader"></span></td>
-          </tr>
-          <tr>
-            <td><span class="skeleton-loader"></span></td>
-            <td><span class="skeleton-loader"></span></td>
-          </tr>
-          <tr>
-            <td><span class="skeleton-loader"></span></td>
-            <td><span class="skeleton-loader"></span></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="row">
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
 
   </ng-template>

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -110,7 +110,7 @@
 		}
 		&:last-child {
 			text-align: right;
-			@media (min-width: 768px) {
+			@media (min-width: 850px) {
 			text-align: left;
 			}
 		}


### PR DESCRIPTION
fixes #929

In this PR:
* Adding missing Version and Locktime to Transaction Details
* Splitting up the transaction "Details" section into 2 columns

New look:
<img width="1174" alt="Screen Shot 2021-11-15 at 11 47 52" src="https://user-images.githubusercontent.com/8561090/141744172-049bd942-f8a3-4442-9be5-f7c8e56efa20.png">


Mobile:
<img width="515" alt="Screen Shot 2021-11-15 at 11 48 06" src="https://user-images.githubusercontent.com/8561090/141744182-49334752-47a1-42b7-864e-afe0c19004b9.png">


