### PR TITLE
Handle recent difficulty adjustment estimate gracefully

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -724,14 +724,16 @@ class Routes {
       const nextRetargetHeight = blockHeight + remainingBlocks;
 
       let difficultyChange = 0;
-      if (blocksInEpoch > 0) {
-        difficultyChange = (600 / (diff / blocksInEpoch ) - 1) * 100;
-      }
-      if (difficultyChange > 300) {
-        difficultyChange = 300;
-      }
-      if (difficultyChange < -75) {
-        difficultyChange = -75;
+      if (remainingBlocks < 1870) {
+        if (blocksInEpoch > 0) {
+          difficultyChange = (600 / (diff / blocksInEpoch ) - 1) * 100;
+        }
+        if (difficultyChange > 300) {
+          difficultyChange = 300;
+        }
+        if (difficultyChange < -75) {
+          difficultyChange = -75;
+        }
       }
 
       const timeAvgDiff = difficultyChange * 0.1;

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -242,7 +242,7 @@
           </div>
           <div class="item">
             <h5 class="card-title" i18n="difficulty-box.estimate">Estimate</h5>
-            <div class="card-text" [ngStyle]="{'color': epochData.colorAdjustments}">
+            <div *ngIf="epochData.remainingBlocks < 1870; else recentlyAdjusted" class="card-text" [ngStyle]="{'color': epochData.colorAdjustments}">
               <span *ngIf="epochData.change > 0; else arrowDownDifficulty" >
                 <fa-icon class="retarget-sign" [icon]="['fas', 'caret-up']" [fixedWidth]="true"></fa-icon>
               </span>
@@ -252,6 +252,9 @@
               {{ epochData.change | absolute | number: '1.2-2' }}
               <span class="symbol">%</span>
             </div>
+            <ng-template #recentlyAdjusted>
+              <div class="card-text">&#8212;</div>
+            </ng-template>
             <div class="symbol">
               <span i18n="difficulty-box.previous">Previous</span>:
               <span [ngStyle]="{'color': epochData.colorPreviousAdjustments}">

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -144,14 +144,16 @@ export class DashboardComponent implements OnInit {
           const newDifficultyHeight = block.height + remainingBlocks;
 
           let change = 0;
-          if (blocksInEpoch > 0) {
-            change = (600 / (diff / blocksInEpoch ) - 1) * 100;
-          }
-          if (change > 300) {
-            change = 300;
-          }
-          if (change < -75) {
-            change = -75;
+          if (remainingBlocks < 1870) {
+            if (blocksInEpoch > 0) {
+              change = (600 / (diff / blocksInEpoch ) - 1) * 100;
+            }
+            if (change > 300) {
+              change = 300;
+            }
+            if (change < -75) {
+              change = -75;
+            }
           }
 
           const timeAvgDiff = change * 0.1;


### PR DESCRIPTION
fixes #927

This PR changes so that during the first 144 blocks ( ~24 hours ) the estimated difficulty adjustment will be interpreted as 0, and the Dashboard will hide the number 0 and show a dash instead.

Dashboard after a recent adjustment:
<img width="563" alt="Screen Shot 2021-11-17 at 12 51 00" src="https://user-images.githubusercontent.com/8561090/142170814-062ccdb6-d55b-4718-850f-0b29c10a42cf.png">

API response:
`"progressPercent":0.0992063492063492,"difficultyChange":0,`

