### PR TITLE
Remodeling how historical fees are stored and presented.

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -85,17 +85,14 @@ class Statistics {
       250, 300, 350, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000];
 
     const weightVsizeFees: { [feePerWU: number]: number } = {};
+    const lastItem = logFees.length - 1;
 
     memPoolArray.forEach((transaction) => {
       for (let i = 0; i < logFees.length; i++) {
         if (
-          (config.MEMPOOL.NETWORK === 'liquid'
-            && ((logFees[i] === 2000 && transaction.effectiveFeePerVsize * 10 >= 2000)
-            || transaction.effectiveFeePerVsize * 10 <= logFees[i]))
+          (config.MEMPOOL.NETWORK === 'liquid' && (i === lastItem || transaction.effectiveFeePerVsize * 10 < logFees[i + 1]))
           ||
-          (config.MEMPOOL.NETWORK !== 'liquid'
-            && ((logFees[i] === 2000 && transaction.effectiveFeePerVsize >= 2000)
-            || transaction.effectiveFeePerVsize <= logFees[i]))
+          (config.MEMPOOL.NETWORK !== 'liquid' && (i === lastItem || transaction.effectiveFeePerVsize < logFees[i + 1]))
         ) {
           if (weightVsizeFees[logFees[i]]) {
             weightVsizeFees[logFees[i]] += transaction.vsize;

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -90,11 +90,6 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
     const labels = mempoolStats.map(stats => stats.added);
     const finalArrayVByte = this.generateArray(mempoolStats);
 
-    // Only Liquid has lower than 1 sat/vb transactions
-    if (this.stateService.network !== 'liquid') {
-      finalArrayVByte.shift();
-    }
-
     return {
       labels: labels,
       series: finalArrayVByte
@@ -104,10 +99,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   generateArray(mempoolStats: OptimizedMempoolStats[]) {
     const finalArray: number[][] = [];
     let feesArray: number[] = [];
-    let limitFeesTemplate = this.template === 'advanced' ? 28 : 21;
-    if (this.stateService.network === 'liquid') {
-      limitFeesTemplate = this.template === 'advanced' ? 26 : 20;
-    }
+    let limitFeesTemplate = this.template === 'advanced' ? 26 : 20;
     for (let index = limitFeesTemplate; index > -1; index--) {
       feesArray = [];
       mempoolStats.forEach((stats) => {
@@ -370,18 +362,10 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
         this.feeLimitIndex = i;
       }
       if (feeLevels[i] <= this.limitFee) {
-        if (i === 0) {
-          if (this.stateService.network === 'liquid') {
-            this.feeLevelsOrdered.push('0 - 0.1');
-          } else {
-            this.feeLevelsOrdered.push('0 - 1');
-          }
+        if (this.stateService.network === 'liquid') {
+          this.feeLevelsOrdered.push(`${(feeLevels[i] / 10).toFixed(1)} - ${(feeLevels[i + 1]  / 10).toFixed(1)}`);
         } else {
-          if (this.stateService.network === 'liquid') {
-            this.feeLevelsOrdered.push(`${feeLevels[i - 1] / 10} - ${feeLevels[i] / 10}`);
-          } else {
-            this.feeLevelsOrdered.push(`${feeLevels[i - 1]} - ${feeLevels[i]}`);
-          }
+          this.feeLevelsOrdered.push(`${feeLevels[i]} - ${feeLevels[i + 1]}`);
         }
       }
     }

--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -42,26 +42,15 @@
                 <div class="dropdown-fees" ngbDropdownMenu aria-labelledby="dropdownFees">
                   <ul>
                     <ng-template ngFor let-fee let-i="index" [ngForOf]="feeLevels">
-                      <ng-template [ngIf]="fee === 1">
-                        <li (click)="filterFees(fee)" [class]="filterFeeIndex > fee ? 'inactive' : ''">
-                          <ng-template [ngIf]="inverted">
-                            <span class="square" [ngStyle]="{'backgroundColor': chartColors[i]}"></span>
-                          </ng-template>
-                          <ng-template [ngIf]="!inverted">
-                            <span class="square" [ngStyle]="{'backgroundColor': chartColors[i - 1]}"></span>
-                          </ng-template>
-                          <span class="fee-text" >0 - {{ fee }}</span>
-                        </li>
-                      </ng-template>
-                      <ng-template [ngIf]="fee <= 500 && fee !== 1">
+                      <ng-template [ngIf]="fee <= 400">
                         <li (click)="filterFees(fee)" [class]="filterFeeIndex > fee ? 'inactive' : ''">
                         <ng-template [ngIf]="inverted">
                           <span class="square" [ngStyle]="{'backgroundColor': chartColors[i]}"></span>
-                          <span class="fee-text" >{{feeLevels[i - 1]}} - {{ fee }}</span>
+                          <span class="fee-text" >{{feeLevels[i]}} - {{ feeLevels[i + 1] }}</span>
                         </ng-template>
                         <ng-template [ngIf]="!inverted">
                           <span class="square" [ngStyle]="{'backgroundColor': chartColors[i - 1]}"></span>
-                          <span class="fee-text" >{{feeLevels[i + 1]}} - {{ fee }}</span>
+                          <span class="fee-text" >{{feeLevels[i]}} - {{ feeLevels[i - 1] }}</span>
                         </ng-template>
                       </li>
                       </ng-template>


### PR DESCRIPTION
fixes #908

**What this PR does:**
* Changes the way fee stats is saved in the database.
  - Previous: 0 - 1 was saved in the first column, 1.001 to 2 in the second and so on
  - Currently: < 2 is saved in the first one (1 - 1.999), < 3 (2 - 2.999) in the second one and so on
* The 0 - 1 fee level is removed from the front end and it starts with 1 - 2

**BEFORE:**

<img width="272" alt="Screen Shot 2021-12-01 at 18 02 38" src="https://user-images.githubusercontent.com/8561090/144248301-ee2386d5-2705-4fd4-97c7-07e5e8e659de.png">

**AFTER:**

<img width="269" alt="Screen Shot 2021-12-01 at 18 02 27" src="https://user-images.githubusercontent.com/8561090/144248314-0153dc60-089f-424a-a2b4-3269c79acc32.png">

Snapshot from Jochen:


<img width="144" alt="Screen Shot 2021-12-01 at 18 02 48" src="https://user-images.githubusercontent.com/8561090/144248350-b7773d9a-3d36-478d-8e3f-6f3606e24995.png">

Which translates to:

10-12 0,06 MvB
8-10 21,933 MvB
7-8 0,921
6-7 0.926 MvB
5-6 0,718 MvB
4-5 0,138 MvB
3-4 0,206 MvB
2-3 0,888 MvB
1-2 6,072 MvB

So it is clear how the 8+ data now falls under the 8-10 instead of the 7-8 like before, and it looks more similar to the Jochen numbers in general.

**IMPORTANT NOTE:** Database migration is required for old data with the following SQL query:
`UPDATE statistics SET vsize_1 = vsize_1 + vsize_2, vsize_2 = vsize_3, vsize_3 = vsize_4, vsize_4 = vsize_5, vsize_5 = vsize_6, vsize_6 = vsize_8, vsize_8 = vsize_10, vsize_10 = vsize_12, vsize_12 = vsize_15, vsize_15 = vsize_20, vsize_20 = vsize_30, vsize_30 = vsize_40, vsize_40 = vsize_50, vsize_50 = vsize_60, vsize_60 = vsize_70, vsize_70 = vsize_80, vsize_80 = vsize_90, vsize_90 = vsize_100, vsize_100 = vsize_125, vsize_125 = vsize_150, vsize_150 = vsize_175, vsize_175 = vsize_200, vsize_200 = vsize_250, vsize_250 = vsize_300, vsize_300 = vsize_350, vsize_350 = vsize_400, vsize_400 = vsize_500, vsize_500 = vsize_600, vsize_600 = vsize_700, vsize_700 = vsize_800, vsize_800 = vsize_900, vsize_900 = vsize_1000, vsize_1000 = vsize_1200, vsize_1200 = vsize_1400, vsize_1400 = vsize_1800, vsize_1800 = vsize_2000`

All backend databases needs to be migrated _except_ for Liquid.

**To migrate:**
1. Turn off backend.
2. Run SQL migration.
3. Upgrade backend to new version.
4. Start backend.