### PR TITLE
Handle database disabled config when running Liquid

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -143,7 +143,7 @@ class Server {
     if (this.wss) {
       websocketHandler.setWebsocketServer(this.wss);
     }
-    if (config.MEMPOOL.NETWORK === 'liquid') {
+    if (config.MEMPOOL.NETWORK === 'liquid' && config.DATABASE.ENABLED) {
       blocks.setNewBlockCallback(async () => {
         try {
           await elementsParser.$parse();
@@ -270,7 +270,7 @@ class Server {
       ;
     }
 
-    if (config.MEMPOOL.NETWORK === 'liquid') {
+    if (config.MEMPOOL.NETWORK === 'liquid' && config.DATABASE.ENABLED) {
       this.app
         .get(config.MEMPOOL.API_URL_PREFIX + 'liquid/pegs/month', routes.$getElementsPegsByMonth)
       ;


### PR DESCRIPTION
fixes #962

* Disables the elements peg in/out parse script that requires the database when database is disabled
* Disables the liquid/pegs/month API endpoint that requires the database when database is disabled

Note that the peg endpoint just like the statistics endpoint will return 404 if database is required and the dashboard will display loading spinners... which is a separate issue.
