### PR TITLE
Display missing taproot inner script

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -299,6 +299,11 @@ class BitcoinApi implements AbstractBitcoinApi {
       const witnessScript = vin.witness[vin.witness.length - 1];
       vin.inner_witnessscript_asm = this.convertScriptSigAsm(bitcoinjs.script.toASM(Buffer.from(witnessScript, 'hex')));
     }
+
+    if (vin.prevout.scriptpubkey_type === 'v1_p2tr' && vin.witness && vin.witness.length > 1) {
+      const witnessScript = vin.witness[vin.witness.length - 2];
+      vin.inner_witnessscript_asm = this.convertScriptSigAsm(bitcoinjs.script.toASM(Buffer.from(witnessScript, 'hex')));
+    }
   }
 
 }


### PR DESCRIPTION
fixes #973

This PR reveals the inner spending script on a taproot transaction.
This does _only_ fix the missing spend script for the backend when running `bitcoind` and not when using `esplora` as blockstream/electrs needs to implement this natively just like with other output types.

Some open questions remains to be tested/answered:
* Will this work on all types of Taproot-transactions
* Should it be called `P2WSH witness script`?

**Before:**
<img width="1135" alt="Screen Shot 2021-12-05 at 23 54 10" src="https://user-images.githubusercontent.com/8561090/144762116-a4cc002c-4b2f-4e62-aad6-623acdfda46c.png">

**After:**

<img width="1129" alt="Screen Shot 2021-12-05 at 23 54 34" src="https://user-images.githubusercontent.com/8561090/144762129-0346b488-2f82-49e4-89e0-b7b13b1f3ac1.png">

