### PR TITLE
Adding Core Contributors on the About page

### DIFF
--- a/frontend/src/app/components/about/about.component.html
+++ b/frontend/src/app/components/about/about.component.html
@@ -159,20 +159,32 @@
       </a>
     </div>
   </div>
-
-  <div class="contributors">
-    <h3 i18n="about.contributors">Project Contributors</h3>
-    <div class="wrapper">
-      <ng-container *ngIf="contributors$ | async as contributors; else loadingSponsors">
-        <ng-template ngFor let-contributor [ngForOf]="contributors">
+  
+  <ng-container *ngIf="allContributors$ | async as contributors else loadingSponsors">
+    <div class="contributors">
+      <h3 i18n="about.contributors">Project Contributors</h3>
+      <div class="wrapper">
+        <ng-template ngFor let-contributor [ngForOf]="contributors.regular">
           <a [href]="'https://github.com/' + contributor.name" target="_blank" [title]="contributor.name">
             <img class="image" [src]="'/api/v1/contributors/images/' + contributor.id" />
             <span>{{ contributor.name }}</span>
           </a>
         </ng-template>
-      </ng-container>
+      </div>
     </div>
-  </div>
+
+    <div class="maintainers" *ngIf="contributors.core.length">
+      <h3 i18n="about.core_contributors">Core Contributors</h3>
+      <div class="wrapper">
+        <ng-template ngFor let-contributor [ngForOf]="contributors.core">
+          <a [href]="'https://github.com/' + contributor.name" target="_blank" [title]="contributor.name">
+            <img class="image" [src]="'/api/v1/contributors/images/' + contributor.id" />
+            <span>{{ contributor.name }}</span>
+          </a>
+        </ng-template>
+      </div>
+    </div>
+  </ng-container>
 
   <div class="maintainers">
     <h3 i18n="about.maintainers">Project Maintainers</h3>

--- a/frontend/src/app/components/about/about.component.ts
+++ b/frontend/src/app/components/about/about.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { ApiService } from 'src/app/services/api.service';
 import { IBackendInfo } from 'src/app/interfaces/websocket.interface';
 import { Router } from '@angular/router';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-about',
@@ -16,7 +17,7 @@ import { Router } from '@angular/router';
 export class AboutComponent implements OnInit {
   backendInfo$: Observable<IBackendInfo>;
   sponsors$: Observable<any>;
-  contributors$: Observable<any>;
+  allContributors$: Observable<any>;
   frontendGitCommitHash = this.stateService.env.GIT_COMMIT_HASH;
   packetJsonVersion = this.stateService.env.PACKAGE_JSON_VERSION;
   officialMempoolSpace = this.stateService.env.OFFICIAL_MEMPOOL_SPACE;
@@ -37,7 +38,14 @@ export class AboutComponent implements OnInit {
     this.websocketService.want(['blocks']);
 
     this.sponsors$ = this.apiService.getDonation$();
-    this.contributors$ = this.apiService.getContributor$();
+    this.allContributors$ = this.apiService.getContributor$().pipe(
+      map((contributors) => {
+        return {
+          regular: contributors.filter((user) => !user.core_constributor),
+          core: contributors.filter((user) => user.core_constributor),
+        };
+      })
+    );
   }
 
   sponsor() {


### PR DESCRIPTION
The new updated Service backend is required for the new Core Contributors separation to be visible.
It should work seamlessly even with old service backend, and old mempool about pages should handle the new service backend as well.

<img width="955" alt="Screen Shot 2021-12-07 at 18 00 56" src="https://user-images.githubusercontent.com/8561090/145042845-fc58ea53-dd9a-48b9-b8a5-0ad824843adf.png">
