### PR TITLE
Pin node version on e2e GHA

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.10.0
-      - run: npm install
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: ${{ matrix.browser }} browser tests (Mempool)
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.10.0
+      - run: npm install
       - name: ${{ matrix.browser }} browser tests (Mempool)
         uses: cypress-io/github-action@v2
         with:


### PR DESCRIPTION
Use the official GHA to setup node and cache dependencies on the Cypress GHA