### PR TITLE
fixed connection refused on local network

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -144,7 +144,7 @@ http {
 	}
 
 	server {
-		listen 127.0.0.1:80;
+		listen 80;
 		include /etc/nginx/nginx-mempool.conf;
 	}
 }


### PR DESCRIPTION
when hosting mempool on my local network it gave me a 'connection refused' except for `curl localhost` on the host. i search the internet for fixes and this one did the trick for me