### PR TITLE
Fixing broken RBF alert

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -20,8 +20,6 @@
         <app-clipboard [text]="txId"></app-clipboard>
       </span>
 
-      <span class="grow"></span>
-
       <div class="container-buttons">
         <ng-template [ngIf]="tx?.status?.confirmed">
           <button *ngIf="latestBlock" type="button" class="btn btn-sm btn-success">

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -3,25 +3,11 @@
 }
 
 .container-buttons {
-	text-align: right;
-  align-self: start;
-  width: auto;
-  margin-right: 15px;
-  right: 0;
-  position: absolute;
-	@media (min-width: 650px) {
-    right: auto;
-    margin-right: auto;
-    position: relative;
-  }
-	@media (min-width: 768px) {
-    align-self: center;
-		float: right;
-	}
+  align-self: center;
 }
 
 .title-block {
-  flex-direction: column;
+	flex-wrap: wrap;
   @media (min-width: 650px) {
     flex-direction: row;
   }
@@ -32,6 +18,7 @@
 }
 .tx-link {
   display: flex;
+	flex-grow: 1;
   margin-bottom: 0px;
   margin-top: 8px;
 	@media (min-width: 650px) {
@@ -44,6 +31,9 @@
     margin-bottom: 0px;
     top: 1px;
     position: relative;
+	}
+	@media (max-width: 768px) {
+	  order: 3;
 	}
 }
 


### PR DESCRIPTION
fixes #516

Fixing the CSS flexbox code so that elements are positioned properly. Screenshot provided with Dev Tools visuals enabled.

Desktop:
<img width="1155" alt="Screen Shot 2021-12-15 at 01 14 35" src="https://user-images.githubusercontent.com/8561090/146080536-84f6508b-61f3-42fc-9720-ed0143238344.png">

Mobile:
<img width="401" alt="Screen Shot 2021-12-15 at 01 16 01" src="https://user-images.githubusercontent.com/8561090/146080602-2be707c7-4c71-4fee-809e-9dcc8d709157.png">

