### PR TITLE
Correcting CPFP button position on mobile

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -196,7 +196,7 @@
       <h2 i18n="transaction.inputs-and-outputs|Transaction inputs and outputs">Inputs & Outputs</h2>
     </div>
 
-    <button type="button" class="btn btn-outline-info btn-sm float-right" (click)="txList.toggleDetails()" i18n="transaction.details|Transaction Details">Details</button>
+    <button type="button" class="btn btn-outline-info details-button btn-sm float-right" (click)="txList.toggleDetails()" i18n="transaction.details|Transaction Details">Details</button>
 
     <div class="clearfix"></div>
 

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -127,7 +127,6 @@
 	}
 }
 
-
 .title {
   h2 {
     line-height: 1;
@@ -137,7 +136,14 @@
 }
 
 .btn-outline-info {
-  margin-top: -10px;
+	margin-top: 5px;
+	@media (min-width: 768px){
+		margin-top: 0px;
+	}
+}
+
+.details-button {
+  margin-top: -5px;
 	@media (min-width: 768px){
 		display: inline-block;
     margin-top: 0px;


### PR DESCRIPTION
fixes #1006

Adjusted the positioning on the CPFP and the Details button on the Mobile view.
The desktop view should be unaffected.

New mobile look:
<img width="363" alt="Screen Shot 2021-12-15 at 02 15 58" src="https://user-images.githubusercontent.com/8561090/146088146-bfdc5ff2-d59d-4c87-8056-da9b7e0d1a09.png">

