### PR TITLE
Revamp docs layout

### DIFF
--- a/frontend/cypress/integration/bisq/bisq.spec.ts
+++ b/frontend/cypress/integration/bisq/bisq.spec.ts
@@ -59,9 +59,8 @@ describe('Bisq', () => {
             cy.visit(`${basePath}`);
             cy.waitForSkeletonGone();
             cy.get('li:nth-of-type(5) > a').click().then(() => {
-                cy.get('.card').should('have.length.at.least', 1);
-                cy.get('.card').first().click();
-                cy.get('.card-body');
+                cy.get('.section-header').should('have.length.at.least', 1);
+                cy.get('.endpoint-container').should('have.length.at.least', 1);
             });
         });
 

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, fa
   faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown, faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl } from '@fortawesome/free-solid-svg-icons';
 import { ApiDocsComponent } from './components/docs/api-docs.component';
 import { DocsComponent } from './components/docs/docs.component';
+import { ApiDocsNavComponent } from './components/docs/api-docs-nav.component';
 import { CodeTemplateComponent } from './components/docs/code-template.component';
 import { TermsOfServiceComponent } from './components/terms-of-service/terms-of-service.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
@@ -101,6 +102,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
     SponsorComponent,
     PushTransactionComponent,
     DocsComponent,
+    ApiDocsNavComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -47,7 +47,7 @@ import { FeesBoxComponent } from './components/fees-box/fees-box.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, faChartArea, faCogs, faCubes, faDatabase, faExchangeAlt, faInfoCircle,
-  faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown, faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook } from '@fortawesome/free-solid-svg-icons';
+  faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown, faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl } from '@fortawesome/free-solid-svg-icons';
 import { ApiDocsComponent } from './components/docs/api-docs.component';
 import { DocsComponent } from './components/docs/docs.component';
 import { CodeTemplateComponent } from './components/docs/code-template.component';
@@ -58,6 +58,7 @@ import { StorageService } from './services/storage.service';
 import { HttpCacheInterceptor } from './services/http-cache.interceptor';
 import { SponsorComponent } from './components/sponsor/sponsor.component';
 import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [
@@ -109,6 +110,7 @@ import { PushTransactionComponent } from './components/push-transaction/push-tra
     BrowserAnimationsModule,
     InfiniteScrollModule,
     NgbTypeaheadModule,
+    NgbModule,
     FontAwesomeModule,
     SharedModule,
     NgxEchartsModule.forRoot({
@@ -159,5 +161,6 @@ export class AppModule {
     library.addIcons(faAngleRight);
     library.addIcons(faAngleLeft);
     library.addIcons(faBook);
+    library.addIcons(faListUl);
   }
 }

--- a/frontend/src/app/components/clipboard/clipboard.component.html
+++ b/frontend/src/app/components/clipboard/clipboard.component.html
@@ -1,5 +1,5 @@
 <span #buttonWrapper [attr.data-tlite]="copiedMessage" style="position: relative;">
-  <button #btn class="btn btn-sm btn-link pt-0" style="line-height: 0.9;" [attr.data-clipboard-text]="text">
+  <button #btn class="btn btn-sm btn-link pt-0" style="line-height: 0.9;" [attr.data-clipboard-text]="text"> 
     <img src="./resources/clippy.svg" width="13">
   </button>
 </span>

--- a/frontend/src/app/components/clipboard/clipboard.component.html
+++ b/frontend/src/app/components/clipboard/clipboard.component.html
@@ -1,5 +1,5 @@
 <span #buttonWrapper [attr.data-tlite]="copiedMessage" style="position: relative;">
-  <button #btn class="btn btn-sm btn-link pt-0" style="line-height: 0.9;" [attr.data-clipboard-text]="text"> 
+  <button #btn class="btn btn-sm btn-link pt-0" style="line-height: 0.9;" [attr.data-clipboard-text]="text">
     <img src="./resources/clippy.svg" width="13">
   </button>
 </span>

--- a/frontend/src/app/components/docs/api-docs-nav.component.html
+++ b/frontend/src/app/components/docs/api-docs-nav.component.html
@@ -1,0 +1,63 @@
+<p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
+<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment</a>
+
+<p *ngIf="network.val === 'bisq'">Markets</p>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies">GET Market Currencies</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth">GET Market Depth</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc">GET Market HLOC</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets">GET Markets</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers">GET Market Offers</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker">GET Market Ticker</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades">GET Market Trades</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes">GET Market Volumes</a>
+
+<p *ngIf="network.val === 'bisq'">General</p>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats">GET Stats</a>
+
+<p>Addresses</p>
+<a [routerLink]="['./']" fragment="get-address">GET Address</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions">GET Address Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-chain">GET Address Transactions Chain</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool">GET Address Transactions Mempool</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo">GET Address UTXO</a>
+
+<p *ngIf="network.val === 'liquid'">Assets</p>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets">GET Assets</a>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions">GET Asset Transactions</a>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply">GET Asset Supply</a>
+
+<p>Blocks</p>
+<a [routerLink]="['./']" fragment="get-block">GET Block</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-header">GET Block Header</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-height">GET Block Height</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-raw">GET Block Raw</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-status">GET Block Status</a>
+<a [routerLink]="['./']" fragment="get-block-tip-height">GET Block Tip Height</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-tip-hash">GET Block Tip Hash</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id">GET Block Transaction ID</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids">GET Block Transaction IDs</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions">GET Block Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
+
+<p *ngIf="network.val !== 'bisq'">Fees</p>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees">GET Mempool Blocks Fees</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees">GET Recommended Fees</a>
+
+<p *ngIf="network.val !== 'bisq'">Mempool</p>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool">GET Mempool</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids">GET Mempool Transaction IDs</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent">GET Mempool Recent</a>
+
+<p>Transactions</p>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp">GET Children Pay for Parent</a>
+<a [routerLink]="['./']" fragment="get-transaction">GET Transaction</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-hex">GET Transaction Hex</a>
+<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof">GET Transaction Merkleblock Proof</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-merkle-proof">GET Transaction Merkle Proof</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspend">GET Transaction Outspend</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspends">GET Transaction Outspends</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-raw">GET Transaction Raw</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-status">GET Transaction Status</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-transactions">GET Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="post-transaction">POST Transaction</a>

--- a/frontend/src/app/components/docs/api-docs-nav.component.html
+++ b/frontend/src/app/components/docs/api-docs-nav.component.html
@@ -1,18 +1,24 @@
-<p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
-<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment" (click)="collapseItem.toggle()">GET Difficulty Adjustment</a>
+<ng-template [ngIf]="network.val !== 'bisq' && network.val !== 'liquid'">
+  <p>General</p>
+  <a [routerLink]="['./']" fragment="get-difficulty-adjustment" (click)="collapseItem.toggle()">GET Difficulty Adjustment</a>
+</ng-template>
 
-<p *ngIf="network.val === 'bisq'">Markets</p>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies" (click)="collapseItem.toggle()">GET Market Currencies</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth" (click)="collapseItem.toggle()">GET Market Depth</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc" (click)="collapseItem.toggle()">GET Market HLOC</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets" (click)="collapseItem.toggle()">GET Markets</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers" (click)="collapseItem.toggle()">GET Market Offers</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker" (click)="collapseItem.toggle()">GET Market Ticker</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades" (click)="collapseItem.toggle()">GET Market Trades</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes" (click)="collapseItem.toggle()">GET Market Volumes</a>
+<ng-template [ngIf]="network.val === 'bisq'">
+  <p>Markets</p>
+  <a [routerLink]="['./']" fragment="get-market-currencies" (click)="collapseItem.toggle()">GET Market Currencies</a>
+  <a [routerLink]="['./']" fragment="get-market-depth" (click)="collapseItem.toggle()">GET Market Depth</a>
+  <a [routerLink]="['./']" fragment="get-market-hloc" (click)="collapseItem.toggle()">GET Market HLOC</a>
+  <a [routerLink]="['./']" fragment="get-markets" (click)="collapseItem.toggle()">GET Markets</a>
+  <a [routerLink]="['./']" fragment="get-market-offers" (click)="collapseItem.toggle()">GET Market Offers</a>
+  <a [routerLink]="['./']" fragment="get-market-ticker" (click)="collapseItem.toggle()">GET Market Ticker</a>
+  <a [routerLink]="['./']" fragment="get-market-trades" (click)="collapseItem.toggle()">GET Market Trades</a>
+  <a [routerLink]="['./']" fragment="get-market-volumes" (click)="collapseItem.toggle()">GET Market Volumes</a>
+</ng-template>
 
-<p *ngIf="network.val === 'bisq'">General</p>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats" (click)="collapseItem.toggle()">GET Stats</a>
+<ng-template [ngIf]="network.val === 'bisq'">
+  <p>General</p>
+  <a [routerLink]="['./']" fragment="get-stats" (click)="collapseItem.toggle()">GET Stats</a>
+</ng-template>
 
 <p>Addresses</p>
 <a [routerLink]="['./']" fragment="get-address" (click)="collapseItem.toggle()">GET Address</a>
@@ -21,10 +27,12 @@
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool" (click)="collapseItem.toggle()">GET Address Transactions Mempool</a>
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo" (click)="collapseItem.toggle()">GET Address UTXO</a>
 
-<p *ngIf="network.val === 'liquid'">Assets</p>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets" (click)="collapseItem.toggle()">GET Assets</a>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions" (click)="collapseItem.toggle()">GET Asset Transactions</a>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply" (click)="collapseItem.toggle()">GET Asset Supply</a>
+<ng-template [ngIf]="network.val === 'liquid'">
+  <p>Assets</p>
+  <a [routerLink]="['./']" fragment="get-assets" (click)="collapseItem.toggle()">GET Assets</a>
+  <a [routerLink]="['./']" fragment="get-asset-transactions" (click)="collapseItem.toggle()">GET Asset Transactions</a>
+  <a [routerLink]="['./']" fragment="get-asset-supply" (click)="collapseItem.toggle()">GET Asset Supply</a>
+</ng-template>
 
 <p>Blocks</p>
 <a [routerLink]="['./']" fragment="get-block" (click)="collapseItem.toggle()">GET Block</a>
@@ -37,17 +45,20 @@
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id" (click)="collapseItem.toggle()">GET Block Transaction ID</a>
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids" (click)="collapseItem.toggle()">GET Block Transaction IDs</a>
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions" (click)="collapseItem.toggle()">GET Block Transactions</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks" (click)="collapseItem.toggle()">GET Blocks</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks" (click)="collapseItem.toggle()">GET Blocks</a>
+<a [routerLink]="['./']" fragment="get-blocks" (click)="collapseItem.toggle()">GET Blocks</a>
 
-<p *ngIf="network.val !== 'bisq'">Fees</p>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees" (click)="collapseItem.toggle()">GET Mempool Blocks Fees</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees" (click)="collapseItem.toggle()">GET Recommended Fees</a>
+<ng-template [ngIf]="network.val !== 'bisq'">
+  <p>Fees</p>
+  <a [routerLink]="['./']" fragment="get-mempool-blocks-fees" (click)="collapseItem.toggle()">GET Mempool Blocks Fees</a>
+  <a [routerLink]="['./']" fragment="get-recommended-fees" (click)="collapseItem.toggle()">GET Recommended Fees</a>
+</ng-template>
 
-<p *ngIf="network.val !== 'bisq'">Mempool</p>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool" (click)="collapseItem.toggle()">GET Mempool</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids" (click)="collapseItem.toggle()">GET Mempool Transaction IDs</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent" (click)="collapseItem.toggle()">GET Mempool Recent</a>
+<ng-template [ngIf]="network.val !== 'bisq'">
+  <p>Mempool</p>
+  <a [routerLink]="['./']" fragment="get-mempool" (click)="collapseItem.toggle()">GET Mempool</a>
+  <a [routerLink]="['./']" fragment="get-mempool-transaction-ids" (click)="collapseItem.toggle()">GET Mempool Transaction IDs</a>
+  <a [routerLink]="['./']" fragment="get-mempool-recent" (click)="collapseItem.toggle()">GET Mempool Recent</a>
+</ng-template>
 
 <p>Transactions</p>
 <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp" (click)="collapseItem.toggle()">GET Children Pay for Parent</a>

--- a/frontend/src/app/components/docs/api-docs-nav.component.html
+++ b/frontend/src/app/components/docs/api-docs-nav.component.html
@@ -1,63 +1,63 @@
 <p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
-<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment</a>
+<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment" (click)="collapseItem.toggle()">GET Difficulty Adjustment</a>
 
 <p *ngIf="network.val === 'bisq'">Markets</p>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies">GET Market Currencies</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth">GET Market Depth</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc">GET Market HLOC</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets">GET Markets</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers">GET Market Offers</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker">GET Market Ticker</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades">GET Market Trades</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes">GET Market Volumes</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies" (click)="collapseItem.toggle()">GET Market Currencies</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth" (click)="collapseItem.toggle()">GET Market Depth</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc" (click)="collapseItem.toggle()">GET Market HLOC</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets" (click)="collapseItem.toggle()">GET Markets</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers" (click)="collapseItem.toggle()">GET Market Offers</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker" (click)="collapseItem.toggle()">GET Market Ticker</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades" (click)="collapseItem.toggle()">GET Market Trades</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes" (click)="collapseItem.toggle()">GET Market Volumes</a>
 
 <p *ngIf="network.val === 'bisq'">General</p>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats">GET Stats</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats" (click)="collapseItem.toggle()">GET Stats</a>
 
 <p>Addresses</p>
-<a [routerLink]="['./']" fragment="get-address">GET Address</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions">GET Address Transactions</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-chain">GET Address Transactions Chain</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool">GET Address Transactions Mempool</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo">GET Address UTXO</a>
+<a [routerLink]="['./']" fragment="get-address" (click)="collapseItem.toggle()">GET Address</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions" (click)="collapseItem.toggle()">GET Address Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-chain" (click)="collapseItem.toggle()">GET Address Transactions Chain</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool" (click)="collapseItem.toggle()">GET Address Transactions Mempool</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo" (click)="collapseItem.toggle()">GET Address UTXO</a>
 
 <p *ngIf="network.val === 'liquid'">Assets</p>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets">GET Assets</a>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions">GET Asset Transactions</a>
-<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply">GET Asset Supply</a>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets" (click)="collapseItem.toggle()">GET Assets</a>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions" (click)="collapseItem.toggle()">GET Asset Transactions</a>
+<a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply" (click)="collapseItem.toggle()">GET Asset Supply</a>
 
 <p>Blocks</p>
-<a [routerLink]="['./']" fragment="get-block">GET Block</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-header">GET Block Header</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-height">GET Block Height</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-raw">GET Block Raw</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-status">GET Block Status</a>
-<a [routerLink]="['./']" fragment="get-block-tip-height">GET Block Tip Height</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-tip-hash">GET Block Tip Hash</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id">GET Block Transaction ID</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids">GET Block Transaction IDs</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions">GET Block Transactions</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
+<a [routerLink]="['./']" fragment="get-block" (click)="collapseItem.toggle()">GET Block</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-header" (click)="collapseItem.toggle()">GET Block Header</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-height" (click)="collapseItem.toggle()">GET Block Height</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-raw" (click)="collapseItem.toggle()">GET Block Raw</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-status" (click)="collapseItem.toggle()">GET Block Status</a>
+<a [routerLink]="['./']" fragment="get-block-tip-height" (click)="collapseItem.toggle()">GET Block Tip Height</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-tip-hash" (click)="collapseItem.toggle()">GET Block Tip Hash</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id" (click)="collapseItem.toggle()">GET Block Transaction ID</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids" (click)="collapseItem.toggle()">GET Block Transaction IDs</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions" (click)="collapseItem.toggle()">GET Block Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks" (click)="collapseItem.toggle()">GET Blocks</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks" (click)="collapseItem.toggle()">GET Blocks</a>
 
 <p *ngIf="network.val !== 'bisq'">Fees</p>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees">GET Mempool Blocks Fees</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees">GET Recommended Fees</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees" (click)="collapseItem.toggle()">GET Mempool Blocks Fees</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees" (click)="collapseItem.toggle()">GET Recommended Fees</a>
 
 <p *ngIf="network.val !== 'bisq'">Mempool</p>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool">GET Mempool</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids">GET Mempool Transaction IDs</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent">GET Mempool Recent</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool" (click)="collapseItem.toggle()">GET Mempool</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids" (click)="collapseItem.toggle()">GET Mempool Transaction IDs</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent" (click)="collapseItem.toggle()">GET Mempool Recent</a>
 
 <p>Transactions</p>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp">GET Children Pay for Parent</a>
-<a [routerLink]="['./']" fragment="get-transaction">GET Transaction</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-hex">GET Transaction Hex</a>
-<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof">GET Transaction Merkleblock Proof</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-merkle-proof">GET Transaction Merkle Proof</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspend">GET Transaction Outspend</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspends">GET Transaction Outspends</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-raw">GET Transaction Raw</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-status">GET Transaction Status</a>
-<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-transactions">GET Transactions</a>
-<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="post-transaction">POST Transaction</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp" (click)="collapseItem.toggle()">GET Children Pay for Parent</a>
+<a [routerLink]="['./']" fragment="get-transaction" (click)="collapseItem.toggle()">GET Transaction</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-hex" (click)="collapseItem.toggle()">GET Transaction Hex</a>
+<a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof" (click)="collapseItem.toggle()">GET Transaction Merkleblock Proof</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-merkle-proof" (click)="collapseItem.toggle()">GET Transaction Merkle Proof</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspend" (click)="collapseItem.toggle()">GET Transaction Outspend</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspends" (click)="collapseItem.toggle()">GET Transaction Outspends</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-raw" (click)="collapseItem.toggle()">GET Transaction Raw</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-status" (click)="collapseItem.toggle()">GET Transaction Status</a>
+<a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-transactions" (click)="collapseItem.toggle()">GET Transactions</a>
+<a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="post-transaction" (click)="collapseItem.toggle()">POST Transaction</a>

--- a/frontend/src/app/components/docs/api-docs-nav.component.scss
+++ b/frontend/src/app/components/docs/api-docs-nav.component.scss
@@ -1,0 +1,17 @@
+p {
+  color: #4a68b9;
+  font-weight: 700;
+  margin: 10px 0;
+  margin: 15px 0 10px 0;
+}
+
+p:first-child {
+  margin-top: 0
+}
+
+a {
+  color: #fff;
+  text-decoration: none;
+  display: block;
+  margin: 5px 0;
+}

--- a/frontend/src/app/components/docs/api-docs-nav.component.ts
+++ b/frontend/src/app/components/docs/api-docs-nav.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-api-docs-nav',
+  templateUrl: './api-docs-nav.component.html',
+  styleUrls: ['./api-docs-nav.component.scss']
+})
+export class ApiDocsNavComponent implements OnInit {
+
+  @Input() network: any;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/frontend/src/app/components/docs/api-docs-nav.component.ts
+++ b/frontend/src/app/components/docs/api-docs-nav.component.ts
@@ -8,6 +8,7 @@ import { Component, OnInit, Input } from '@angular/core';
 export class ApiDocsNavComponent implements OnInit {
 
   @Input() network: any;
+  @Input() collapseItem: any;
 
   constructor() { }
 

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -76,11 +76,9 @@
         <p>Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
-          
-	        <h4 i18n="api-docs.tab.general|API Docs tab for General">General</h4>
 
           <div class="endpoint-container" id="difficultyAdjustment">
-            <a class="section-header" [routerLink]="['./']" fragment="difficultyAdjustment">GET Difficulty Adjustment</a>
+            <a class="section-header" [routerLink]="['./']" fragment="difficultyAdjustment">GET Difficulty Adjustment <span>General</span></a>
             <div class="difficulty">
               <div class="endpoint">
                 <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
@@ -97,11 +95,9 @@
         </div>
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
-        
-          <h4 i18n="Bisq All Markets">Markets</h4>
 
           <div class="endpoint-container" id="bisqMarketsCurrencies">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsCurrencies">GET Market Currencies</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsCurrencies">GET Market Currencies <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
@@ -114,7 +110,7 @@
           </div>
 
           <div class="endpoint-container" id="marketDepth">
-            <a class="section-header" [routerLink]="['./']" fragment="marketDepth">GET Market Depth</a>
+            <a class="section-header" [routerLink]="['./']" fragment="marketDepth">GET Market Depth <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
@@ -127,7 +123,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsHloc">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsHloc">GET Market HLOC</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsHloc">GET Market HLOC <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
@@ -140,7 +136,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsMarkets">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsMarkets">GET Markets</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsMarkets">GET Markets <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
@@ -153,7 +149,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsOffers">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsOffers">GET Market Offers</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsOffers">GET Market Offers <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
@@ -166,7 +162,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsTicker">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTicker">GET Market Ticker</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTicker">GET Market Ticker <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
@@ -179,7 +175,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsTrades">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Market Trades</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Market Trades <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
@@ -192,7 +188,7 @@
           </div>
 
           <div class="endpoint-container" id="bisqMarketsVolumes">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsVolumes">GET Market Volumes</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsVolumes">GET Market Volumes <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
@@ -207,11 +203,9 @@
         </div>
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
-        
-          <h4 i18n="api-docs.tab.bsq|API Docs tab for BSQ">General</h4>
 
           <div class="endpoint-container" id="bisqStats">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqStats">GET Stats</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqStats">GET Stats <span>General</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
@@ -226,11 +220,9 @@
         </div>
 
         <div class="api-category">
-        
-          <h4 i18n="api-docs.tab.addresses|API Docs tab for Addresses">Addresses</h4>
 
           <div class="endpoint-container" id="address">
-            <a class="section-header" [routerLink]="['./']" fragment="address">GET Address</a>
+            <a class="section-header" [routerLink]="['./']" fragment="address">GET Address <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
@@ -243,7 +235,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactions">
-            <a class="section-header" [routerLink]="['./']" fragment="addressTransactions">GET Address Transactions</a>
+            <a class="section-header" [routerLink]="['./']" fragment="addressTransactions">GET Address Transactions <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
@@ -256,7 +248,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
-            <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsChain">GET Address Transactions Chain</a>
+            <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsChain">GET Address Transactions Chain <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
@@ -269,7 +261,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
-              <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsMempool">GET Address Transactions Mempool</a>
+              <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsMempool">GET Address Transactions Mempool <span>Addresses</span></a>
               <div class="endpoint">
                 <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
                 <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
@@ -282,7 +274,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressUTXO">
-            <a class="section-header" [routerLink]="['./']" fragment="addressUTXO">GET Address UTXO</a>
+            <a class="section-header" [routerLink]="['./']" fragment="addressUTXO">GET Address UTXO <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
@@ -297,11 +289,9 @@
         </div>
 
         <div class="api-category" *ngIf="network.val === 'liquid'">
-        
-          <h4 i18n="api-docs.tab.assets|API Docs tab for Assets">Assets</h4>
 
           <div class="endpoint-container" id="assets">
-            <a class="section-header" [routerLink]="['./']" fragment="assets">GET Assets</a>
+            <a class="section-header" [routerLink]="['./']" fragment="assets">GET Assets <span>Assets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
@@ -314,7 +304,7 @@
           </div>
 
           <div class="endpoint-container" id="assetTransactions">
-            <a class="section-header" [routerLink]="['./']" fragment="assetTransactions">GET Asset Transactions</a>
+            <a class="section-header" [routerLink]="['./']" fragment="assetTransactions">GET Asset Transactions <span>Assets</span></a>
             <div class="endpoint">
               <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
             </div>
@@ -326,7 +316,7 @@
           </div>
 
           <div class="endpoint-container" id="assetSupply">
-            <a class="section-header" [routerLink]="['./']" fragment="assetSupply">GET Asset Supply</a>
+            <a class="section-header" [routerLink]="['./']" fragment="assetSupply">GET Asset Supply <span>Assets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
@@ -341,11 +331,9 @@
         </div>
 
         <div class="api-category">
-        
-          <h4 i18n="api-docs.tab.blocks|API Docs tab for Blocks">Blocks</h4>
 
           <div class="endpoint-container" id="block">
-            <a class="section-header" [routerLink]="['./']" fragment="block">GET Block</a>
+            <a class="section-header" [routerLink]="['./']" fragment="block">GET Block <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
@@ -358,7 +346,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeader">
-            <a class="section-header" [routerLink]="['./']" fragment="blockHeader">GET Block Header</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockHeader">GET Block Header <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
@@ -371,7 +359,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeight">
-            <a class="section-header" [routerLink]="['./']" fragment="blockHeight">GET Block Height</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockHeight">GET Block Height <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
@@ -384,7 +372,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockRaw">
-            <a class="section-header" [routerLink]="['./']" fragment="blockRaw">GET Block Raw</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockRaw">GET Block Raw <span>Blocks</span></a>
             <div class="endpoint">
               <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
             </div>
@@ -396,7 +384,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockStatus">
-            <a class="section-header" [routerLink]="['./']" fragment="blockStatus">GET Block Status</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockStatus">GET Block Status <span>Blocks</span></a>
             <div class="title">Get Block Status</div>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
@@ -410,7 +398,7 @@
           </div>
 
           <div class="endpoint-container" id="blockTipHeight">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTipHeight">GET Block Tip Height</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockTipHeight">GET Block Tip Height <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
@@ -423,7 +411,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTipHash">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTipHash">GET Block Tip Hash</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockTipHash">GET Block Tip Hash <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
@@ -436,7 +424,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxId">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxId">GET Block Transaction ID</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxId">GET Block Transaction ID <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
@@ -449,7 +437,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxIds">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxIds">GET Block Transaction IDs</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxIds">GET Block Transaction IDs <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
@@ -462,7 +450,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxs">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxs">GET Block Transactions</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxs">GET Block Transactions <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
@@ -475,7 +463,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blocks">
-            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
@@ -488,7 +476,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="blocks">
-            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks</a>
+            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
@@ -503,11 +491,9 @@
         </div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
-        
-          <h4 i18n="api-docs.tab.fees|API Docs tab for Fees">Fees</h4>
 
           <div class="endpoint-container" id="feeMempoolBlocks">
-            <a class="section-header" [routerLink]="['./']" fragment="feeMempoolBlocks">GET Mempool Blocks Fees</a>
+            <a class="section-header" [routerLink]="['./']" fragment="feeMempoolBlocks">GET Mempool Blocks Fees <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
@@ -520,7 +506,7 @@
           </div>
 
           <div class="endpoint-container" id="feeRecommended">
-            <a class="section-header" [routerLink]="['./']" fragment="feeRecommended">GET Recommended Fees</a>
+            <a class="section-header" [routerLink]="['./']" fragment="feeRecommended">GET Recommended Fees <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
@@ -535,11 +521,9 @@
         </div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
-        
-          <h4 i18n="api-docs.tab.mempool|API Docs tab for Mempool">Mempool</h4>
 
           <div class="endpoint-container" id="mempool">
-            <a class="section-header" [routerLink]="['./']" fragment="mempool">GET Mempool</a>
+            <a class="section-header" [routerLink]="['./']" fragment="mempool">GET Mempool <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
@@ -552,7 +536,7 @@
           </div>
 
           <div class="endpoint-container" id="mempoolTxs">
-            <a class="section-header" [routerLink]="['./']" fragment="mempoolTxs">GET Mempool Transactions IDs</a>
+            <a class="section-header" [routerLink]="['./']" fragment="mempoolTxs">GET Mempool Transactions IDs <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
@@ -565,7 +549,7 @@
           </div>
 
           <div class="endpoint-container" id="mempoolRecent">
-            <a class="section-header" [routerLink]="['./']" fragment="mempoolRecent">GET Mempool Recent</a>
+            <a class="section-header" [routerLink]="['./']" fragment="mempoolRecent">GET Mempool Recent <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
@@ -581,10 +565,8 @@
 
         <div class="api-category">
 
-          <h4 i18n="api-docs.tab.transactions|API Docs tab for Transactions">Transactions</h4>
-
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="cpfp">
-            <a class="section-header" [routerLink]="['./']" fragment="cpfp">GET Children Pay for Parent</a>            
+            <a class="section-header" [routerLink]="['./']" fragment="cpfp">GET Children Pay for Parent <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
@@ -597,7 +579,7 @@
           </div>
 
           <div class="endpoint-container" id="transaction">
-            <a class="section-header" [routerLink]="['./']" fragment="transaction">GET Transaction</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transaction">GET Transaction <span>Transactions</span></a>
             <div class="endpoint">
               <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
             </div>
@@ -605,11 +587,11 @@
               <div class="subtitle" i18n>Description</div>
               <div i18n>Returns details about a transaction. Available fields: <code>txid</code>, <code>version</code>, <code>locktime</code>, <code>size</code>, <code>weight</code>, <code>fee</code>, <code>vin</code>, <code>vout</code>, and <code>status</code>.</div>
             </div>
-            <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>            
+            <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionHex">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Transaction Hex</a>
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Transaction Hex <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
                 <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
@@ -622,7 +604,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleBlockProof">GET Transaction Merkleblock Proof</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleBlockProof">GET Transaction Merkleblock Proof <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
@@ -635,7 +617,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleProof">GET Transaction Merkle Proof</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleProof">GET Transaction Merkle Proof <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
@@ -648,7 +630,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspend">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspend">GET Transaction Outspend</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspend">GET Transaction Outspend <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
@@ -661,7 +643,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspends">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspends">GET Transaction Outspends</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspends">GET Transaction Outspends <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
@@ -674,7 +656,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionRaw">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionRaw">GET Transaction Raw</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionRaw">GET Transaction Raw <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
@@ -687,7 +669,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionStatus">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionStatus">GET Transaction Status</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionStatus">GET Transaction Status <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
@@ -700,7 +682,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="transactionsBisq">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionsBisq">GET Transactions</a>
+            <a class="section-header" [routerLink]="['./']" fragment="transactionsBisq">GET Transactions <span>Transactions</span></a>
             <div class="title">Get Mempool Txids</div>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
@@ -714,7 +696,7 @@
           </div>
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="postTransaction">
-            <a class="section-header" [routerLink]="['./']" fragment="postTransaction">POST Transaction</a>
+            <a class="section-header" [routerLink]="['./']" fragment="postTransaction">POST Transaction <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <div>POST /api/tx</div>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -3,852 +3,860 @@
 
     <div id="restAPI" *ngIf="restTabActivated">
 
-      <p>Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
+      <div class="doc-nav-desktop">
+        <p>Placeholder.</p>
+      </div>
 
-      <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
-        <h4 i18n="api-docs.tab.general|API Docs tab for General">General</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark">
+      <div class="doc-content">
 
-          <ngb-panel id="difficultyAdjustment" *ngIf="network.val !== 'liquid'">
-            <ng-template ngbPanelTitle>
-              <span>GET Difficulty Adjustment</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="difficulty">
+        <p>Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
+
+        <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
+          <h4 i18n="api-docs.tab.general|API Docs tab for General">General</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark">
+
+            <ngb-panel id="difficultyAdjustment" *ngIf="network.val !== 'liquid'">
+              <ng-template ngbPanelTitle>
+                <span>GET Difficulty Adjustment</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="difficulty">
+                  <div class="endpoint">
+                    <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                    <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
+                  </div>
+                  <div class="description">
+                    <div class="subtitle" i18n>Description</div>
+                      <div i18n>Returns details about difficulty adjustment.</div>
+                  </div>
+                  <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
+                </div>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category" *ngIf="network.val === 'bisq'">
+          <h4 i18n="Bisq All Markets">Markets</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel id="bisqMarketsCurrencies">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Currencies</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
                 <div class="endpoint">
                   <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
+                  <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
                 </div>
                 <div class="description">
                   <div class="subtitle" i18n>Description</div>
-                    <div i18n>Returns details about difficulty adjustment.</div>
+                  <div i18n>Provides list of available currencies for a given base currency. </div>
                 </div>
-                <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
-              </div>
-            </ng-template>
-          </ngb-panel>
+                <app-code-template [hostname]="hostname" [code]="code.marketsCurrencies" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category" *ngIf="network.val === 'bisq'">
-        <h4 i18n="Bisq All Markets">Markets</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="bisqMarketsCurrencies">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Currencies</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides list of available currencies for a given base currency. </div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketsCurrencies" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="marketDepth">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Depth</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides list of open offer prices for a single market.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketDepth" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsHloc">
-            <ng-template ngbPanelTitle>
-              <span>GET Market HLOC</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides hi/low/open/close data for a given market. This can be used to generate a candlestick chart.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketHloc" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsMarkets">
-            <ng-template ngbPanelTitle>
-              <span>GET Markets</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides list of available markets.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.markets" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsOffers">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Offers</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides list of open offer details for a single market.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketOffers" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsTicker">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Ticker</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides 24 hour price ticker for single market or all markets</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketTicker" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsTrades">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Trades</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides list of completed trades for a single market.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketTrades" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="bisqMarketsVolumes">
-            <ng-template ngbPanelTitle>
-              <span>GET Market Volumes</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Provides periodic volume data in terms of base currency for one or all markets.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.marketVolumes" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category" *ngIf="network.val === 'bisq'">
-        <h4 ngbNavLink i18n="api-docs.tab.bsq|API Docs tab for BSQ">General</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="bisqStats">
-            <ng-template ngbPanelTitle>
-              <span>GET Stats</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns statistics about all Bisq transactions.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.stats" [network]="network.val"></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category">
-        <h4 i18n="api-docs.tab.addresses|API Docs tab for Addresses">Addresses</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="address">
-            <ng-template ngbPanelTitle>
-              <span>GET Address</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns details about an address. Available fields: <code>address</code>, <code>chain_stats</code>, and <code>mempool_stats</code>. {{ '{' }}chain,mempool{{ '}' }}_stats each contain an object with <code>tx_count</code>, <code>funded_txo_count</code>, <code>funded_txo_sum</code>, <code>spent_txo_count</code>, and <code>spent_txo_sum</code>.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.address" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'"  id="addressTransactions">
-            <ng-template ngbPanelTitle>
-              <span>GET Address Transactions</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using <code>:last_seen_txid</code> (see below).</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.addressTransactions" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
-            <ng-template ngbPanelTitle>
-              <span>GET Address Transactions Chain</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Get confirmed transaction history for the specified address/scripthash, sorted with newest first. Returns 25 transactions per page. More can be requested by specifying the last txid seen by the previous query.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.addressTransactionsChain" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
-            <ng-template ngbPanelTitle>
-              <span>GET Address Transactions Mempool</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Get unconfirmed transaction history for the specified address/scripthash. Returns up to 50 transactions (no paging).</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.addressTransactionsMempool" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="addressUTXO">
-            <ng-template ngbPanelTitle>
-              <span>GET Address UTXO</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Get the list of unspent transaction outputs associated with the address/scripthash. Available fields: <code>txid</code>, <code>vout</code>, <code>value</code>, and <code>status</code> (with the status of the funding tx).<ng-container *ngIf="network.val === 'liquid'">There is also a <code>valuecommitment</code> field that may appear in place of <code>value</code>, plus the following additional fields: <code>asset</code>/<code>assetcommitment</code>, <code>nonce</code>/<code>noncecommitment</code>, <code>surjection_proof</code>, and <code>range_proof</code>.</ng-container></div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.addressUTXO" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category" *ngIf="network.val === 'liquid'">
-        <h4 i18n="api-docs.tab.assets|API Docs tab for Assets">Assets</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="assets">
-            <ng-template ngbPanelTitle>
-              <span>GET Assets</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns information about a Liquid asset.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.assets" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="assetTransactions">
-            <ng-template ngbPanelTitle>
-              <span>GET Asset Transactions</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns transactions associated with the specified Liquid asset. For the network's native asset, returns a list of peg in, peg out, and burn transactions. For user-issued assets, returns a list of issuance, reissuance, and burn transactions. Does not include regular transactions transferring this asset.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.assetTransactions" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="assetSupply">
-            <ng-template ngbPanelTitle>
-              <span>GET Asset Supply</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Get the current total supply of the specified asset. For the native asset (L-BTC), this is calculated as [chain,mempool]_stats.peg_in_amount - [chain,mempool]_stats.peg_out_amount - [chain,mempool]_stats.burned_amount. For issued assets, this is calculated as [chain,mempool]_stats.issued_amount - [chain,mempool]_stats.burned_amount. Not available for assets with blinded issuances. If /decimal is specified, returns the supply as a decimal according to the asset's divisibility. Otherwise, returned in base units.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.assetSupply" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category">
-        <h4 i18n="api-docs.tab.blocks|API Docs tab for Blocks">Blocks</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="block">
-            <ng-template ngbPanelTitle>
-              <span>GET Block</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns details about a block. Available fields: <code>id</code>, <code>height</code>, <code>version</code>, <code>timestamp</code>, <code>bits</code>, <code>nonce</code>, <code>merkle_root</code>, <code>tx_count</code>, <code>size</code>, <code>weight</code>,<ng-container *ngIf="network.val === 'liquid'"> <code>proof</code>,</ng-container> and <code>previousblockhash</code>.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.block" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeader">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Header</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the hex-encoded block header.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockHeader" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeight">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Height</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the hash of the block currently at <code>:height</code>.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockHeight" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockRaw">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Raw</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the raw block representation in binary.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockRaw" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockStatus">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Status</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="title">Get Block Status</div>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the confirmation status of a block. Available fields: <code>in_best_chain</code> (boolean, false for orphaned blocks), <code>next_best</code> (the hash of the next block, only available for blocks in the best chain).</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockStatus" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="blockTipHeight">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Tip Height</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the height of the last block.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockTipHeight" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTipHash">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Tip Hash</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the hash of the last block.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockTipHash" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxId">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Transaction ID</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the transaction at index <code>:index</code> within the specified block.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockTxId" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxIds">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Transaction IDs</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a list of all txids in the block.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockTxIds" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxs">
-            <ng-template ngbPanelTitle>
-              <span>GET Block Transactions</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a list of transactions in the block (up to 25 transactions beginning at <code>start_index</code>). Transactions returned here do not have the <code>status</code> field, since all the transactions share the same block and confirmation status.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blockTxs" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="blocks">
-            <ng-template ngbPanelTitle>
-              <span>GET Blocks</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blocks" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val === 'bisq'" id="blocks">
-            <ng-template ngbPanelTitle>
-              <span>GET Blocks</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.blocksBisq" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category" *ngIf="network.val !== 'bisq'">
-        <h4 i18n="api-docs.tab.fees|API Docs tab for Fees">Fees</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark">
-
-          <ngb-panel id="feeMempoolBlocks">
-            <ng-template ngbPanelTitle>
-              <span>GET Mempool Blocks Fees</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.fees.mempool-blocks|API Docs for /api/v1/fees/mempool-blocks">Returns current mempool as projected blocks.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.feeMempoolBlocks" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="feeRecommended">
-            <ng-template ngbPanelTitle>
-              <span>GET Recommended Fees</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.fees.recommended|API Docs for /api/v1/fees/recommended">Returns our currently suggested fees for new transactions.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.feeRecommended" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category" *ngIf="network.val !== 'bisq'">
-        <h4 i18n="api-docs.tab.mempool|API Docs tab for Mempool">Mempool</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel id="mempool">
-            <ng-template ngbPanelTitle>
-              <span>GET Mempool</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.mempool.mempool|API Docs for /api/mempool">Returns current mempool backlog statistics.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.mempool" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="mempoolTxs">
-            <ng-template ngbPanelTitle>
-              <span>GET Mempool Transactions IDs</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.mempool.txids|API Docs for /api/mempool/txids">Get the full list of txids in the mempool as an array. The order of the txids is arbitrary and does not match bitcoind.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.mempoolTxs" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="mempoolRecent">
-            <ng-template ngbPanelTitle>
-              <span>GET Mempool Recent</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.mempool.recent|API Docs for /api/mempool/recent">Get a list of the last 10 transactions to enter the mempool. Each transaction object contains simplified overview data, with the following fields: <code>txid</code>, <code>fee</code>, <code>vsize</code>, and <code>value</code>.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.mempoolRecent" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-        </ngb-accordion>
-      </div>
-
-      <div class="api-category">
-        <h4 i18n="api-docs.tab.transactions|API Docs tab for Transactions">Transactions</h4>
-        <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="cpfp">
-            <ng-template ngbPanelTitle>
-              <span>GET Children Pay for Parent</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n="api-docs.fees.cpfp|API Docs for /api/v1/fees/cpfp">Returns the ancestors and the best descendant fees for a transaction.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionCpfp" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel id="transaction">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns details about a transaction. Available fields: <code>txid</code>, <code>version</code>, <code>locktime</code>, <code>size</code>, <code>weight</code>, <code>fee</code>, <code>vin</code>, <code>vout</code>, and <code>status</code>.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
-
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionHex">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Hex</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
+            <ngb-panel id="marketDepth">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Depth</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
                 </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a transaction serialized as hex.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionHex" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides list of open offer prices for a single market.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketDepth" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Merkleblock Proof</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://bitcoin.org/en/glossary/merkle-block">bitcoind's merkleblock</a> format.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionMerkleBlockProof" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsHloc">
+              <ng-template ngbPanelTitle>
+                <span>GET Market HLOC</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides hi/low/open/close data for a given market. This can be used to generate a candlestick chart.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketHloc" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Merkle Proof</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get-merkle">Electrum's blockchain.transaction.get_merkle format.</a></div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionMerkleProof" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsMarkets">
+              <ng-template ngbPanelTitle>
+                <span>GET Markets</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides list of available markets.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.markets" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspend">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Outspend</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the spending status of a transaction output. Available fields: <code>spent</code> (boolean), <code>txid</code> (optional), <code>vin</code> (optional), and <code>status</code> (optional, the status of the spending tx).</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionOutspend" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsOffers">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Offers</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides list of open offer details for a single market.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketOffers" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspends">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Outspends</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the spending status of all transaction outputs.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionOutspends" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsTicker">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Ticker</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides 24 hour price ticker for single market or all markets</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketTicker" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionRaw">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Raw</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns a transaction as binary data.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionRaw" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsTrades">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Trades</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides list of completed trades for a single market.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketTrades" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionStatus">
-            <ng-template ngbPanelTitle>
-              <span>GET Transaction Status</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns the confirmation status of a transaction. Available fields: <code>confirmed</code> (boolean), <code>block_height</code> (optional), and <code>block_hash</code> (optional).</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionStatus" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+            <ngb-panel id="bisqMarketsVolumes">
+              <ng-template ngbPanelTitle>
+                <span>GET Market Volumes</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Provides periodic volume data in terms of base currency for one or all markets.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.marketVolumes" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
 
-          <ngb-panel *ngIf="network.val === 'bisq'" id="transactionsBisq">
-            <ng-template ngbPanelTitle>
-              <span>GET Transactions</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="title">Get Mempool Txids</div>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Returns :length of latest Bisq transactions, starting from :index.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.transactionsBisq" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+          </ngb-accordion>
+        </div>
 
-          <ngb-panel *ngIf="network.val !== 'bisq'" id="postTransaction">
-            <ng-template ngbPanelTitle>
-              <span>POST Transaction</span>
-            </ng-template>
-            <ng-template ngbPanelContent>
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <div>POST /api/tx</div>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                <div i18n>Broadcast a raw transaction to the network. The transaction should be provided as hex in the request body. The <code>txid</code> will be returned on success.</div>
-              </div>
-              <app-code-template [method]="'post'" [hostname]="hostname" [code]="code.transactionPost" [network]="network.val" ></app-code-template>
-            </ng-template>
-          </ngb-panel>
+        <div class="api-category" *ngIf="network.val === 'bisq'">
+          <h4 ngbNavLink i18n="api-docs.tab.bsq|API Docs tab for BSQ">General</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-        </ngb-accordion>
+            <ngb-panel id="bisqStats">
+              <ng-template ngbPanelTitle>
+                <span>GET Stats</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns statistics about all Bisq transactions.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.stats" [network]="network.val"></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category">
+          <h4 i18n="api-docs.tab.addresses|API Docs tab for Addresses">Addresses</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel id="address">
+              <ng-template ngbPanelTitle>
+                <span>GET Address</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                    <div i18n>Returns details about an address. Available fields: <code>address</code>, <code>chain_stats</code>, and <code>mempool_stats</code>. {{ '{' }}chain,mempool{{ '}' }}_stats each contain an object with <code>tx_count</code>, <code>funded_txo_count</code>, <code>funded_txo_sum</code>, <code>spent_txo_count</code>, and <code>spent_txo_sum</code>.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.address" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'"  id="addressTransactions">
+              <ng-template ngbPanelTitle>
+                <span>GET Address Transactions</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using <code>:last_seen_txid</code> (see below).</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.addressTransactions" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
+              <ng-template ngbPanelTitle>
+                <span>GET Address Transactions Chain</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Get confirmed transaction history for the specified address/scripthash, sorted with newest first. Returns 25 transactions per page. More can be requested by specifying the last txid seen by the previous query.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.addressTransactionsChain" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
+              <ng-template ngbPanelTitle>
+                <span>GET Address Transactions Mempool</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Get unconfirmed transaction history for the specified address/scripthash. Returns up to 50 transactions (no paging).</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.addressTransactionsMempool" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressUTXO">
+              <ng-template ngbPanelTitle>
+                <span>GET Address UTXO</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Get the list of unspent transaction outputs associated with the address/scripthash. Available fields: <code>txid</code>, <code>vout</code>, <code>value</code>, and <code>status</code> (with the status of the funding tx).<ng-container *ngIf="network.val === 'liquid'">There is also a <code>valuecommitment</code> field that may appear in place of <code>value</code>, plus the following additional fields: <code>asset</code>/<code>assetcommitment</code>, <code>nonce</code>/<code>noncecommitment</code>, <code>surjection_proof</code>, and <code>range_proof</code>.</ng-container></div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.addressUTXO" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category" *ngIf="network.val === 'liquid'">
+          <h4 i18n="api-docs.tab.assets|API Docs tab for Assets">Assets</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel id="assets">
+              <ng-template ngbPanelTitle>
+                <span>GET Assets</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns information about a Liquid asset.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.assets" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="assetTransactions">
+              <ng-template ngbPanelTitle>
+                <span>GET Asset Transactions</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns transactions associated with the specified Liquid asset. For the network's native asset, returns a list of peg in, peg out, and burn transactions. For user-issued assets, returns a list of issuance, reissuance, and burn transactions. Does not include regular transactions transferring this asset.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.assetTransactions" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="assetSupply">
+              <ng-template ngbPanelTitle>
+                <span>GET Asset Supply</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Get the current total supply of the specified asset. For the native asset (L-BTC), this is calculated as [chain,mempool]_stats.peg_in_amount - [chain,mempool]_stats.peg_out_amount - [chain,mempool]_stats.burned_amount. For issued assets, this is calculated as [chain,mempool]_stats.issued_amount - [chain,mempool]_stats.burned_amount. Not available for assets with blinded issuances. If /decimal is specified, returns the supply as a decimal according to the asset's divisibility. Otherwise, returned in base units.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.assetSupply" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category">
+          <h4 i18n="api-docs.tab.blocks|API Docs tab for Blocks">Blocks</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel id="block">
+              <ng-template ngbPanelTitle>
+                <span>GET Block</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns details about a block. Available fields: <code>id</code>, <code>height</code>, <code>version</code>, <code>timestamp</code>, <code>bits</code>, <code>nonce</code>, <code>merkle_root</code>, <code>tx_count</code>, <code>size</code>, <code>weight</code>,<ng-container *ngIf="network.val === 'liquid'"> <code>proof</code>,</ng-container> and <code>previousblockhash</code>.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.block" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeader">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Header</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the hex-encoded block header.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockHeader" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeight">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Height</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the hash of the block currently at <code>:height</code>.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockHeight" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockRaw">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Raw</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the raw block representation in binary.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockRaw" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockStatus">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Status</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="title">Get Block Status</div>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the confirmation status of a block. Available fields: <code>in_best_chain</code> (boolean, false for orphaned blocks), <code>next_best</code> (the hash of the next block, only available for blocks in the best chain).</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockStatus" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="blockTipHeight">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Tip Height</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the height of the last block.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockTipHeight" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTipHash">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Tip Hash</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the hash of the last block.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockTipHash" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxId">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Transaction ID</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the transaction at index <code>:index</code> within the specified block.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockTxId" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxIds">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Transaction IDs</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a list of all txids in the block.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockTxIds" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxs">
+              <ng-template ngbPanelTitle>
+                <span>GET Block Transactions</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a list of transactions in the block (up to 25 transactions beginning at <code>start_index</code>). Transactions returned here do not have the <code>status</code> field, since all the transactions share the same block and confirmation status.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blockTxs" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="blocks">
+              <ng-template ngbPanelTitle>
+                <span>GET Blocks</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blocks" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val === 'bisq'" id="blocks">
+              <ng-template ngbPanelTitle>
+                <span>GET Blocks</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.blocksBisq" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category" *ngIf="network.val !== 'bisq'">
+          <h4 i18n="api-docs.tab.fees|API Docs tab for Fees">Fees</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark">
+
+            <ngb-panel id="feeMempoolBlocks">
+              <ng-template ngbPanelTitle>
+                <span>GET Mempool Blocks Fees</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.fees.mempool-blocks|API Docs for /api/v1/fees/mempool-blocks">Returns current mempool as projected blocks.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.feeMempoolBlocks" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="feeRecommended">
+              <ng-template ngbPanelTitle>
+                <span>GET Recommended Fees</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.fees.recommended|API Docs for /api/v1/fees/recommended">Returns our currently suggested fees for new transactions.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.feeRecommended" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category" *ngIf="network.val !== 'bisq'">
+          <h4 i18n="api-docs.tab.mempool|API Docs tab for Mempool">Mempool</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel id="mempool">
+              <ng-template ngbPanelTitle>
+                <span>GET Mempool</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.mempool.mempool|API Docs for /api/mempool">Returns current mempool backlog statistics.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.mempool" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="mempoolTxs">
+              <ng-template ngbPanelTitle>
+                <span>GET Mempool Transactions IDs</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.mempool.txids|API Docs for /api/mempool/txids">Get the full list of txids in the mempool as an array. The order of the txids is arbitrary and does not match bitcoind.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.mempoolTxs" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="mempoolRecent">
+              <ng-template ngbPanelTitle>
+                <span>GET Mempool Recent</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.mempool.recent|API Docs for /api/mempool/recent">Get a list of the last 10 transactions to enter the mempool. Each transaction object contains simplified overview data, with the following fields: <code>txid</code>, <code>fee</code>, <code>vsize</code>, and <code>value</code>.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.mempoolRecent" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+        </div>
+
+        <div class="api-category">
+          <h4 i18n="api-docs.tab.transactions|API Docs tab for Transactions">Transactions</h4>
+          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="cpfp">
+              <ng-template ngbPanelTitle>
+                <span>GET Children Pay for Parent</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n="api-docs.fees.cpfp|API Docs for /api/v1/fees/cpfp">Returns the ancestors and the best descendant fees for a transaction.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionCpfp" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel id="transaction">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns details about a transaction. Available fields: <code>txid</code>, <code>version</code>, <code>locktime</code>, <code>size</code>, <code>weight</code>, <code>fee</code>, <code>vin</code>, <code>vout</code>, and <code>status</code>.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionHex">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Hex</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                    <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
+                  </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a transaction serialized as hex.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionHex" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Merkleblock Proof</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://bitcoin.org/en/glossary/merkle-block">bitcoind's merkleblock</a> format.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionMerkleBlockProof" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Merkle Proof</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get-merkle">Electrum's blockchain.transaction.get_merkle format.</a></div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionMerkleProof" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspend">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Outspend</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the spending status of a transaction output. Available fields: <code>spent</code> (boolean), <code>txid</code> (optional), <code>vin</code> (optional), and <code>status</code> (optional, the status of the spending tx).</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionOutspend" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspends">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Outspends</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the spending status of all transaction outputs.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionOutspends" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionRaw">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Raw</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns a transaction as binary data.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionRaw" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionStatus">
+              <ng-template ngbPanelTitle>
+                <span>GET Transaction Status</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns the confirmation status of a transaction. Available fields: <code>confirmed</code> (boolean), <code>block_height</code> (optional), and <code>block_hash</code> (optional).</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionStatus" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val === 'bisq'" id="transactionsBisq">
+              <ng-template ngbPanelTitle>
+                <span>GET Transactions</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="title">Get Mempool Txids</div>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns :length of latest Bisq transactions, starting from :index.</div>
+                </div>
+                <app-code-template [hostname]="hostname" [code]="code.transactionsBisq" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+            <ngb-panel *ngIf="network.val !== 'bisq'" id="postTransaction">
+              <ng-template ngbPanelTitle>
+                <span>POST Transaction</span>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <div class="endpoint">
+                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                  <div>POST /api/tx</div>
+                </div>
+                <div class="description">
+                  <div class="subtitle" i18n>Description</div>
+                  <div i18n>Broadcast a raw transaction to the network. The transaction should be provided as hex in the request body. The <code>txid</code> will be returned on success.</div>
+                </div>
+                <app-code-template [method]="'post'" [hostname]="hostname" [code]="code.transactionPost" [network]="network.val" ></app-code-template>
+              </ng-template>
+            </ngb-panel>
+
+          </ngb-accordion>
+
+        </div>
       </div>
     </div>
 
@@ -866,14 +874,6 @@
           <app-code-template [method]="'websocket'" [hostname]="hostname" [code]="code.websocket" [network]="network.val" ></app-code-template>
         </div>
       </div>
-    </div>
-
-    <br>
-
-    <div class="text-center">
-      <a [routerLink]="['/terms-of-service']" i18n="shared.terms-of-service|Terms of Service">Terms of Service</a>
-      |
-      <a [routerLink]="['/privacy-policy']" i18n="shared.privacy-policy|Privacy Policy">Privacy Policy</a>
     </div>
 
   </div>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -3,8 +3,8 @@
 
     <div id="restAPI" *ngIf="restTabActivated">
 
-      <div class="doc-nav-desktop">
-        <p>Placeholder.</p>
+      <div class="doc-nav-desktop" [ngClass]="docsNavPosition">
+        Placeholder.
       </div>
 
       <div class="doc-content">

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -3,7 +3,7 @@
 
     <div id="restAPI" *ngIf="restTabActivated">
 
-      <div class="doc-nav-desktop" [ngClass]="docsNavPosition">
+      <div class="doc-nav-desktop hide-on-mobile" [ngClass]="desktopDocsNavPosition">
 
         <p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
         <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment</a>
@@ -73,7 +73,18 @@
 
       <div class="doc-content">
 
-        <p>Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
+        <p class="hide-on-mobile">Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
+
+        <div class="doc-nav-mobile hide-on-desktop" [ngClass]="mobileDocsNavPosition">
+          <button id="doc-nav-mobile-toggle" type="button" class="btn btn-outline-primary" [ngClass]="mobileDocsNavPosition" (click)="collapse.toggle()" [attr.aria-expanded]="mobileMenuOpen" aria-controls="collapseExample"><fa-icon [icon]="['fas', 'list-ul']" [fixedWidth]="true"></fa-icon> {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} REST API Overview</button>
+          <div #collapse="ngbCollapse" [(ngbCollapse)]="mobileMenuOpen">
+            <div class="card">
+              <div class="card-body">
+                <p>Placeholder.</p>
+              </div>
+            </div>
+          </div>
+        </div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
 

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -79,17 +79,15 @@
 
           <div class="endpoint-container" id="difficultyAdjustment">
             <a class="section-header" [routerLink]="['./']" fragment="difficultyAdjustment">GET Difficulty Adjustment <span>General</span></a>
-            <div class="difficulty">
-              <div class="endpoint">
-                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
-              </div>
-              <div class="description">
-                <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns details about difficulty adjustment.</div>
-              </div>
-              <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
             </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+                <div i18n>Returns details about difficulty adjustment.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
           </div>
 
         </div>
@@ -374,6 +372,7 @@
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockRaw">
             <a class="section-header" [routerLink]="['./']" fragment="blockRaw">GET Block Raw <span>Blocks</span></a>
             <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
             </div>
             <div class="description">
@@ -385,7 +384,6 @@
 
           <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockStatus">
             <a class="section-header" [routerLink]="['./']" fragment="blockStatus">GET Block Status <span>Blocks</span></a>
-            <div class="title">Get Block Status</div>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
@@ -581,6 +579,7 @@
           <div class="endpoint-container" id="transaction">
             <a class="section-header" [routerLink]="['./']" fragment="transaction">GET Transaction <span>Transactions</span></a>
             <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
             </div>
             <div class="description">
@@ -683,7 +682,6 @@
 
           <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="transactionsBisq">
             <a class="section-header" [routerLink]="['./']" fragment="transactionsBisq">GET Transactions <span>Transactions</span></a>
-            <div class="title">Get Mempool Txids</div>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -6,68 +6,68 @@
       <div class="doc-nav-desktop" [ngClass]="docsNavPosition">
 
         <p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
-        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" href="#">GET Difficulty Adjustment</a>
+        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment</a>
 
         <p *ngIf="network.val === 'bisq'">Markets</p>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Currencies</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Depth</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market HLOC</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Markets</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Offers</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Ticker</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Trades</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Market Volumes</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies">GET Market Currencies</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth">GET Market Depth</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc">GET Market HLOC</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets">GET Markets</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers">GET Market Offers</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker">GET Market Ticker</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades">GET Market Trades</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes">GET Market Volumes</a>
 
         <p *ngIf="network.val === 'bisq'">General</p>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Stats</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats">GET Stats</a>
 
         <p>Addresses</p>
-        <a href="#">GET Address</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions Chain</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions Mempool</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Address UTXO</a>
+        <a [routerLink]="['./']" fragment="get-address">GET Address</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions">GET Address Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-chain">GET Address Transactions Chain</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool">GET Address Transactions Mempool</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo">GET Address UTXO</a>
 
         <p *ngIf="network.val === 'liquid'">Assets</p>
-        <a *ngIf="network.val === 'liquid'" href="#">GET Assets</a>
-        <a *ngIf="network.val === 'liquid'" href="#">GET Asset Transactions</a>
-        <a *ngIf="network.val === 'liquid'" href="#">GET Asset Supply</a>
+        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets">GET Assets</a>
+        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions">GET Asset Transactions</a>
+        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply">GET Asset Supply</a>
 
         <p>Blocks</p>
-        <a href="#">GET Block</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Header</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Height</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Raw</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Status</a>
-        <a href="#">GET Block Tip Height</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Tip Hash</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transaction ID</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transaction IDs</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Blocks</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Blocks</a>
+        <a [routerLink]="['./']" fragment="get-block">GET Block</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-header">GET Block Header</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-height">GET Block Height</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-raw">GET Block Raw</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-status">GET Block Status</a>
+        <a [routerLink]="['./']" fragment="get-block-tip-height">GET Block Tip Height</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-tip-hash">GET Block Tip Hash</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id">GET Block Transaction ID</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids">GET Block Transaction IDs</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions">GET Block Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
 
         <p *ngIf="network.val !== 'bisq'">Fees</p>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Blocks Fees</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Recommended Fees</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees">GET Mempool Blocks Fees</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees">GET Recommended Fees</a>
 
         <p *ngIf="network.val !== 'bisq'">Mempool</p>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Transaction IDs</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Recent</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool">GET Mempool</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids">GET Mempool Transaction IDs</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent">GET Mempool Recent</a>
 
         <p>Transactions</p>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Children Pay for Parent</a>
-        <a href="#">GET Transaction</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Hex</a>
-        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" href="#">GET Transaction Merkleblock Proof</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Merkle Proof</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Outspend</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Outspends</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Raw</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Status</a>
-        <a *ngIf="network.val === 'bisq'" href="#">GET Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" href="#">POST Transaction</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp">GET Children Pay for Parent</a>
+        <a [routerLink]="['./']" fragment="get-transaction">GET Transaction</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-hex">GET Transaction Hex</a>
+        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof">GET Transaction Merkleblock Proof</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-merkle-proof">GET Transaction Merkle Proof</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspend">GET Transaction Outspend</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspends">GET Transaction Outspends</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-raw">GET Transaction Raw</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-status">GET Transaction Status</a>
+        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-transactions">GET Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="post-transaction">POST Transaction</a>
 
       </div>
 
@@ -77,8 +77,8 @@
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
 
-          <div class="endpoint-container" id="difficultyAdjustment">
-            <a class="section-header" [routerLink]="['./']" fragment="difficultyAdjustment">GET Difficulty Adjustment <span>General</span></a>
+          <div class="endpoint-container" id="get-difficulty-adjustment">
+            <a class="section-header" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment <span>General</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
@@ -94,8 +94,8 @@
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
 
-          <div class="endpoint-container" id="bisqMarketsCurrencies">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsCurrencies">GET Market Currencies <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-currencies">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-currencies">GET Market Currencies <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
@@ -107,8 +107,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketsCurrencies" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="marketDepth">
-            <a class="section-header" [routerLink]="['./']" fragment="marketDepth">GET Market Depth <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-depth">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-depth">GET Market Depth <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
@@ -120,8 +120,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketDepth" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsHloc">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsHloc">GET Market HLOC <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-hloc">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-hloc">GET Market HLOC <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
@@ -133,8 +133,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketHloc" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsMarkets">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsMarkets">GET Markets <span>Markets</span></a>
+          <div class="endpoint-container" id="get-markets">
+            <a class="section-header" [routerLink]="['./']" fragment="get-markets">GET Markets <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
@@ -146,8 +146,8 @@
             <app-code-template [hostname]="hostname" [code]="code.markets" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsOffers">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsOffers">GET Market Offers <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-offers">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-offers">GET Market Offers <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
@@ -159,8 +159,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketOffers" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsTicker">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTicker">GET Market Ticker <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-ticker">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-ticker">GET Market Ticker <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
@@ -172,8 +172,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketTicker" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsTrades">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Market Trades <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-trades">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-trades">GET Market Trades <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
@@ -185,8 +185,8 @@
             <app-code-template [hostname]="hostname" [code]="code.marketTrades" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="bisqMarketsVolumes">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsVolumes">GET Market Volumes <span>Markets</span></a>
+          <div class="endpoint-container" id="get-market-volumes">
+            <a class="section-header" [routerLink]="['./']" fragment="get-market-volumes">GET Market Volumes <span>Markets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
@@ -202,8 +202,8 @@
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
 
-          <div class="endpoint-container" id="bisqStats">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqStats">GET Stats <span>General</span></a>
+          <div class="endpoint-container" id="get-stats">
+            <a class="section-header" [routerLink]="['./']" fragment="get-stats">GET Stats <span>General</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
@@ -219,8 +219,8 @@
 
         <div class="api-category">
 
-          <div class="endpoint-container" id="address">
-            <a class="section-header" [routerLink]="['./']" fragment="address">GET Address <span>Addresses</span></a>
+          <div class="endpoint-container" id="get-address">
+            <a class="section-header" [routerLink]="['./']" fragment="get-address">GET Address <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
@@ -232,8 +232,8 @@
             <app-code-template [hostname]="hostname" [code]="code.address" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactions">
-            <a class="section-header" [routerLink]="['./']" fragment="addressTransactions">GET Address Transactions <span>Addresses</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-address-transactions">
+            <a class="section-header" [routerLink]="['./']" fragment="get-address-transactions">GET Address Transactions <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
@@ -245,8 +245,8 @@
             <app-code-template [hostname]="hostname" [code]="code.addressTransactions" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
-            <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsChain">GET Address Transactions Chain <span>Addresses</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-address-transactions-chain">
+            <a class="section-header" [routerLink]="['./']" fragment="get-address-transactions-chain">GET Address Transactions Chain <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
@@ -258,8 +258,8 @@
             <app-code-template [hostname]="hostname" [code]="code.addressTransactionsChain" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
-              <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsMempool">GET Address Transactions Mempool <span>Addresses</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-address-transactions-mempool">
+              <a class="section-header" [routerLink]="['./']" fragment="get-address-transactions-mempool">GET Address Transactions Mempool <span>Addresses</span></a>
               <div class="endpoint">
                 <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
                 <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
@@ -271,8 +271,8 @@
               <app-code-template [hostname]="hostname" [code]="code.addressTransactionsMempool" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressUTXO">
-            <a class="section-header" [routerLink]="['./']" fragment="addressUTXO">GET Address UTXO <span>Addresses</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-address-utxo">
+            <a class="section-header" [routerLink]="['./']" fragment="get-address-utxo">GET Address UTXO <span>Addresses</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
@@ -288,8 +288,8 @@
 
         <div class="api-category" *ngIf="network.val === 'liquid'">
 
-          <div class="endpoint-container" id="assets">
-            <a class="section-header" [routerLink]="['./']" fragment="assets">GET Assets <span>Assets</span></a>
+          <div class="endpoint-container" id="get-assets">
+            <a class="section-header" [routerLink]="['./']" fragment="get-assets">GET Assets <span>Assets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
@@ -301,8 +301,8 @@
             <app-code-template [hostname]="hostname" [code]="code.assets" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="assetTransactions">
-            <a class="section-header" [routerLink]="['./']" fragment="assetTransactions">GET Asset Transactions <span>Assets</span></a>
+          <div class="endpoint-container" id="get-asset-transactions">
+            <a class="section-header" [routerLink]="['./']" fragment="get-asset-transactions">GET Asset Transactions <span>Assets</span></a>
             <div class="endpoint">
               <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
             </div>
@@ -313,8 +313,8 @@
             <app-code-template [hostname]="hostname" [code]="code.assetTransactions" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="assetSupply">
-            <a class="section-header" [routerLink]="['./']" fragment="assetSupply">GET Asset Supply <span>Assets</span></a>
+          <div class="endpoint-container" id="get-asset-supply">
+            <a class="section-header" [routerLink]="['./']" fragment="get-asset-supply">GET Asset Supply <span>Assets</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
@@ -330,8 +330,8 @@
 
         <div class="api-category">
 
-          <div class="endpoint-container" id="block">
-            <a class="section-header" [routerLink]="['./']" fragment="block">GET Block <span>Blocks</span></a>
+          <div class="endpoint-container" id="get-block">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block">GET Block <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
@@ -343,8 +343,8 @@
             <app-code-template [hostname]="hostname" [code]="code.block" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeader">
-            <a class="section-header" [routerLink]="['./']" fragment="blockHeader">GET Block Header <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-header">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-header">GET Block Header <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
@@ -356,8 +356,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockHeader" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeight">
-            <a class="section-header" [routerLink]="['./']" fragment="blockHeight">GET Block Height <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-height">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-height">GET Block Height <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
@@ -369,8 +369,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockHeight" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockRaw">
-            <a class="section-header" [routerLink]="['./']" fragment="blockRaw">GET Block Raw <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-raw">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-raw">GET Block Raw <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
@@ -382,8 +382,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockRaw" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockStatus">
-            <a class="section-header" [routerLink]="['./']" fragment="blockStatus">GET Block Status <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-status">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-status">GET Block Status <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
@@ -395,8 +395,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockStatus" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="blockTipHeight">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTipHeight">GET Block Tip Height <span>Blocks</span></a>
+          <div class="endpoint-container" id="get-block-tip-height">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-tip-height">GET Block Tip Height <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
@@ -408,8 +408,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockTipHeight" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTipHash">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTipHash">GET Block Tip Hash <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-tip-hash">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-tip-hash">GET Block Tip Hash <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
@@ -421,8 +421,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockTipHash" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxId">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxId">GET Block Transaction ID <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-transaction-id">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-transaction-id">GET Block Transaction ID <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
@@ -434,8 +434,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockTxId" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxIds">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxIds">GET Block Transaction IDs <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-transaction-ids">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-transaction-ids">GET Block Transaction IDs <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
@@ -447,8 +447,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockTxIds" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxs">
-            <a class="section-header" [routerLink]="['./']" fragment="blockTxs">GET Block Transactions <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-block-transactions">
+            <a class="section-header" [routerLink]="['./']" fragment="get-block-transactions">GET Block Transactions <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
@@ -460,8 +460,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blockTxs" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blocks">
-            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-blocks">
+            <a class="section-header" [routerLink]="['./']" fragment="get-blocks">GET Blocks <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
@@ -473,8 +473,8 @@
             <app-code-template [hostname]="hostname" [code]="code.blocks" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="blocks">
-            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks <span>Blocks</span></a>
+          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="get-blocks">
+            <a class="section-header" [routerLink]="['./']" fragment="get-blocks">GET Blocks <span>Blocks</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
@@ -490,8 +490,8 @@
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
 
-          <div class="endpoint-container" id="feeMempoolBlocks">
-            <a class="section-header" [routerLink]="['./']" fragment="feeMempoolBlocks">GET Mempool Blocks Fees <span>Fees</span></a>
+          <div class="endpoint-container" id="get-mempool-blocks-fees">
+            <a class="section-header" [routerLink]="['./']" fragment="get-mempool-blocks-fees">GET Mempool Blocks Fees <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
@@ -503,8 +503,8 @@
             <app-code-template [hostname]="hostname" [code]="code.feeMempoolBlocks" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="feeRecommended">
-            <a class="section-header" [routerLink]="['./']" fragment="feeRecommended">GET Recommended Fees <span>Fees</span></a>
+          <div class="endpoint-container" id="get-recommended-fees">
+            <a class="section-header" [routerLink]="['./']" fragment="get-recommended-fees">GET Recommended Fees <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
@@ -520,8 +520,8 @@
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
 
-          <div class="endpoint-container" id="mempool">
-            <a class="section-header" [routerLink]="['./']" fragment="mempool">GET Mempool <span>Fees</span></a>
+          <div class="endpoint-container" id="get-mempool">
+            <a class="section-header" [routerLink]="['./']" fragment="get-mempool">GET Mempool <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
@@ -533,8 +533,8 @@
             <app-code-template [hostname]="hostname" [code]="code.mempool" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="mempoolTxs">
-            <a class="section-header" [routerLink]="['./']" fragment="mempoolTxs">GET Mempool Transactions IDs <span>Fees</span></a>
+          <div class="endpoint-container" id="get-mempool-transaction-ids">
+            <a class="section-header" [routerLink]="['./']" fragment="get-mempool-transaction-ids">GET Mempool Transactions IDs <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
@@ -546,8 +546,8 @@
             <app-code-template [hostname]="hostname" [code]="code.mempoolTxs" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="mempoolRecent">
-            <a class="section-header" [routerLink]="['./']" fragment="mempoolRecent">GET Mempool Recent <span>Fees</span></a>
+          <div class="endpoint-container" id="get-mempool-recent">
+            <a class="section-header" [routerLink]="['./']" fragment="get-mempool-recent">GET Mempool Recent <span>Fees</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
@@ -563,8 +563,8 @@
 
         <div class="api-category">
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="cpfp">
-            <a class="section-header" [routerLink]="['./']" fragment="cpfp">GET Children Pay for Parent <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-cpfp">
+            <a class="section-header" [routerLink]="['./']" fragment="get-cpfp">GET Children Pay for Parent <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
@@ -576,8 +576,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionCpfp" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" id="transaction">
-            <a class="section-header" [routerLink]="['./']" fragment="transaction">GET Transaction <span>Transactions</span></a>
+          <div class="endpoint-container" id="get-transaction">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction">GET Transaction <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
@@ -589,8 +589,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionHex">
-            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Transaction Hex <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-hex">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-hex">GET Transaction Hex <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
                 <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
@@ -602,8 +602,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionHex" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleBlockProof">GET Transaction Merkleblock Proof <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="get-transaction-merkleblock-proof">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof">GET Transaction Merkleblock Proof <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
@@ -615,8 +615,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionMerkleBlockProof" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleProof">GET Transaction Merkle Proof <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-merkle-proof">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-merkle-proof">GET Transaction Merkle Proof <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
@@ -628,8 +628,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionMerkleProof" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspend">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspend">GET Transaction Outspend <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-outspend">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-outspend">GET Transaction Outspend <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
@@ -641,8 +641,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionOutspend" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspends">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspends">GET Transaction Outspends <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-outspends">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-outspends">GET Transaction Outspends <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
@@ -654,8 +654,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionOutspends" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionRaw">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionRaw">GET Transaction Raw <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-raw">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-raw">GET Transaction Raw <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
@@ -667,8 +667,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionRaw" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionStatus">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionStatus">GET Transaction Status <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="get-transaction-status">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transaction-status">GET Transaction Status <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
@@ -680,8 +680,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionStatus" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="transactionsBisq">
-            <a class="section-header" [routerLink]="['./']" fragment="transactionsBisq">GET Transactions <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="get-transactions">
+            <a class="section-header" [routerLink]="['./']" fragment="get-transactions">GET Transactions <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>
@@ -693,8 +693,8 @@
             <app-code-template [hostname]="hostname" [code]="code.transactionsBisq" [network]="network.val" ></app-code-template>
           </div>
 
-          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="postTransaction">
-            <a class="section-header" [routerLink]="['./']" fragment="postTransaction">POST Transaction <span>Transactions</span></a>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="post-transaction">
+            <a class="section-header" [routerLink]="['./']" fragment="post-transaction">POST Transaction <span>Transactions</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <div>POST /api/tx</div>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -3,24 +3,26 @@
 
     <div id="restAPI" *ngIf="restTabActivated">
 
-      <div class="doc-nav-desktop hide-on-mobile" [ngClass]="desktopDocsNavPosition">
+      <div id="doc-nav-desktop" class="hide-on-mobile" [ngClass]="desktopDocsNavPosition">
         <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
       </div>
 
       <div class="doc-content">
 
-        <p class="hide-on-mobile">Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
+        <p class="hide-on-mobile no-bottom-space">Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
 
-        <div class="doc-nav-mobile hide-on-desktop" [ngClass]="mobileDocsNavPosition">
-          <button id="doc-nav-mobile-toggle" type="button" class="btn btn-outline-primary" [ngClass]="mobileDocsNavPosition" (click)="collapse.toggle()" [attr.aria-expanded]="mobileMenuOpen" aria-controls="collapseExample"><fa-icon [icon]="['fas', 'list-ul']" [fixedWidth]="true"></fa-icon> {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} REST API Overview</button>
+        <div id="doc-nav-mobile" class="hide-on-desktop" *ngIf="showFloatingDocsNav">
+          <button type="button" class="btn btn-outline-primary" (click)="collapse.toggle()" [attr.aria-expanded]="mobileMenuOpen" aria-controls="collapseExample"><fa-icon [icon]="['fas', 'list-ul']" [fixedWidth]="true"></fa-icon> {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} REST API Overview</button>
           <div #collapse="ngbCollapse" [(ngbCollapse)]="mobileMenuOpen">
             <div class="card">
               <div class="card-body">
-                <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
+                <app-api-docs-nav [collapseItem]="collapse" [network]="{ val: network$ | async }"></app-api-docs-nav>
               </div>
             </div>
           </div>
         </div>
+
+        <div id="mobile-top-doc-nav" class="hide-on-desktop"><app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav></div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
 

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -4,7 +4,71 @@
     <div id="restAPI" *ngIf="restTabActivated">
 
       <div class="doc-nav-desktop" [ngClass]="docsNavPosition">
-        Placeholder.
+
+        <p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
+        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" href="#">GET Difficulty Adjustment</a>
+
+        <p *ngIf="network.val === 'bisq'">Markets</p>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Currencies</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Depth</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market HLOC</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Markets</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Offers</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Ticker</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Trades</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Market Volumes</a>
+
+        <p *ngIf="network.val === 'bisq'">General</p>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Stats</a>
+
+        <p>Addresses</p>
+        <a href="#">GET Address</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions Chain</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Address Transactions Mempool</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Address UTXO</a>
+
+        <p *ngIf="network.val === 'liquid'">Assets</p>
+        <a *ngIf="network.val === 'liquid'" href="#">GET Assets</a>
+        <a *ngIf="network.val === 'liquid'" href="#">GET Asset Transactions</a>
+        <a *ngIf="network.val === 'liquid'" href="#">GET Asset Supply</a>
+
+        <p>Blocks</p>
+        <a href="#">GET Block</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Header</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Height</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Raw</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Status</a>
+        <a href="#">GET Block Tip Height</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Tip Hash</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transaction ID</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transaction IDs</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Block Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Blocks</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Blocks</a>
+
+        <p *ngIf="network.val !== 'bisq'">Fees</p>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Blocks Fees</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Recommended Fees</a>
+
+        <p *ngIf="network.val !== 'bisq'">Mempool</p>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Transaction IDs</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Mempool Recent</a>
+
+        <p>Transactions</p>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Children Pay for Parent</a>
+        <a href="#">GET Transaction</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Hex</a>
+        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" href="#">GET Transaction Merkleblock Proof</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Merkle Proof</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Outspend</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Outspends</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Raw</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">GET Transaction Status</a>
+        <a *ngIf="network.val === 'bisq'" href="#">GET Transactions</a>
+        <a *ngIf="network.val !== 'bisq'" href="#">POST Transaction</a>
+
       </div>
 
       <div class="doc-content">

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -4,71 +4,7 @@
     <div id="restAPI" *ngIf="restTabActivated">
 
       <div class="doc-nav-desktop hide-on-mobile" [ngClass]="desktopDocsNavPosition">
-
-        <p *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">General</p>
-        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-difficulty-adjustment">GET Difficulty Adjustment</a>
-
-        <p *ngIf="network.val === 'bisq'">Markets</p>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-currencies">GET Market Currencies</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-depth">GET Market Depth</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-hloc">GET Market HLOC</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-markets">GET Markets</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-offers">GET Market Offers</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-ticker">GET Market Ticker</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-trades">GET Market Trades</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-market-volumes">GET Market Volumes</a>
-
-        <p *ngIf="network.val === 'bisq'">General</p>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-stats">GET Stats</a>
-
-        <p>Addresses</p>
-        <a [routerLink]="['./']" fragment="get-address">GET Address</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions">GET Address Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-chain">GET Address Transactions Chain</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-transactions-mempool">GET Address Transactions Mempool</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-address-utxo">GET Address UTXO</a>
-
-        <p *ngIf="network.val === 'liquid'">Assets</p>
-        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-assets">GET Assets</a>
-        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-transactions">GET Asset Transactions</a>
-        <a *ngIf="network.val === 'liquid'" [routerLink]="['./']" fragment="get-asset-supply">GET Asset Supply</a>
-
-        <p>Blocks</p>
-        <a [routerLink]="['./']" fragment="get-block">GET Block</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-header">GET Block Header</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-height">GET Block Height</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-raw">GET Block Raw</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-status">GET Block Status</a>
-        <a [routerLink]="['./']" fragment="get-block-tip-height">GET Block Tip Height</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-tip-hash">GET Block Tip Hash</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-id">GET Block Transaction ID</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transaction-ids">GET Block Transaction IDs</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-block-transactions">GET Block Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-blocks">GET Blocks</a>
-
-        <p *ngIf="network.val !== 'bisq'">Fees</p>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-blocks-fees">GET Mempool Blocks Fees</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-recommended-fees">GET Recommended Fees</a>
-
-        <p *ngIf="network.val !== 'bisq'">Mempool</p>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool">GET Mempool</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-transaction-ids">GET Mempool Transaction IDs</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-mempool-recent">GET Mempool Recent</a>
-
-        <p>Transactions</p>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-cpfp">GET Children Pay for Parent</a>
-        <a [routerLink]="['./']" fragment="get-transaction">GET Transaction</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-hex">GET Transaction Hex</a>
-        <a *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" [routerLink]="['./']" fragment="get-transaction-merkleblock-proof">GET Transaction Merkleblock Proof</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-merkle-proof">GET Transaction Merkle Proof</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspend">GET Transaction Outspend</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-outspends">GET Transaction Outspends</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-raw">GET Transaction Raw</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="get-transaction-status">GET Transaction Status</a>
-        <a *ngIf="network.val === 'bisq'" [routerLink]="['./']" fragment="get-transactions">GET Transactions</a>
-        <a *ngIf="network.val !== 'bisq'" [routerLink]="['./']" fragment="post-transaction">POST Transaction</a>
-
+        <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
       </div>
 
       <div class="doc-content">
@@ -80,7 +16,7 @@
           <div #collapse="ngbCollapse" [(ngbCollapse)]="mobileMenuOpen">
             <div class="card">
               <div class="card-body">
-                <p>Placeholder.</p>
+                <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
               </div>
             </div>
           </div>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -76,849 +76,655 @@
         <p>Reference for the {{ network.val === '' ? 'Bitcoin' : network.val.charAt(0).toUpperCase() + network.val.slice(1) }} <ng-container i18n="api-docs.title">API service</ng-container>.</p>
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
-          <h4 i18n="api-docs.tab.general|API Docs tab for General">General</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark">
+          
+	        <h4 i18n="api-docs.tab.general|API Docs tab for General">General</h4>
 
-            <ngb-panel id="difficultyAdjustment" *ngIf="network.val !== 'liquid'">
-              <ng-template ngbPanelTitle>
-                <span>GET Difficulty Adjustment</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="difficulty">
-                  <div class="endpoint">
-                    <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                    <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
-                  </div>
-                  <div class="description">
-                    <div class="subtitle" i18n>Description</div>
-                      <div i18n>Returns details about difficulty adjustment.</div>
-                  </div>
-                  <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
-                </div>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="difficultyAdjustment">
+            <a class="section-header" [routerLink]="['./']" fragment="difficultyAdjustment">GET Difficulty Adjustment</a>
+            <div class="difficulty">
+              <div class="endpoint">
+                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                <a [href]="wrapUrl(network.val, code.difficulty)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/difficulty-adjustment</a>
+              </div>
+              <div class="description">
+                <div class="subtitle" i18n>Description</div>
+                  <div i18n>Returns details about difficulty adjustment.</div>
+              </div>
+              <app-code-template [hostname]="hostname" [code]="code.difficulty" [network]="network.val" ></app-code-template>
+            </div>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
+        
           <h4 i18n="Bisq All Markets">Markets</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel id="bisqMarketsCurrencies">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Currencies</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides list of available currencies for a given base currency. </div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketsCurrencies" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsCurrencies">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsCurrencies">GET Market Currencies</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketsCurrencies)" target="_blank">GET {{ baseNetworkUrl }}/api/currencies</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides list of available currencies for a given base currency. </div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketsCurrencies" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="marketDepth">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Depth</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides list of open offer prices for a single market.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketDepth" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="marketDepth">
+            <a class="section-header" [routerLink]="['./']" fragment="marketDepth">GET Market Depth</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketDepth)" target="_blank">GET {{ baseNetworkUrl }}/api/depth?market=[:market]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides list of open offer prices for a single market.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketDepth" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsHloc">
-              <ng-template ngbPanelTitle>
-                <span>GET Market HLOC</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides hi/low/open/close data for a given market. This can be used to generate a candlestick chart.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketHloc" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsHloc">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsHloc">GET Market HLOC</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketHloc)" target="_blank">GET {{ baseNetworkUrl }}/api/hloc?market=[:market]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides hi/low/open/close data for a given market. This can be used to generate a candlestick chart.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketHloc" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsMarkets">
-              <ng-template ngbPanelTitle>
-                <span>GET Markets</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides list of available markets.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.markets" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsMarkets">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsMarkets">GET Markets</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.markets)" target="_blank">GET {{ baseNetworkUrl }}/api/markets</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides list of available markets.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.markets" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsOffers">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Offers</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides list of open offer details for a single market.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketOffers" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsOffers">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsOffers">GET Market Offers</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketOffers)" target="_blank">GET {{ baseNetworkUrl }}/api/offers?market=[:market]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides list of open offer details for a single market.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketOffers" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsTicker">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Ticker</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides 24 hour price ticker for single market or all markets</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketTicker" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsTicker">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTicker">GET Market Ticker</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketTicker)" target="_blank">GET {{ baseNetworkUrl }}/api/ticker?market=[:market]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides 24 hour price ticker for single market or all markets</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketTicker" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsTrades">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Trades</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides list of completed trades for a single market.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketTrades" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsTrades">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Market Trades</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketTrades)" target="_blank">GET {{ baseNetworkUrl }}/api/trades?market=[:market]&limit=[:limit]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides list of completed trades for a single market.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketTrades" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="bisqMarketsVolumes">
-              <ng-template ngbPanelTitle>
-                <span>GET Market Volumes</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Provides periodic volume data in terms of base currency for one or all markets.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.marketVolumes" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqMarketsVolumes">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsVolumes">GET Market Volumes</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.marketVolumes)" target="_blank">GET {{ baseNetworkUrl }}/api/volumes?basecurrency=[:basecurrency]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Provides periodic volume data in terms of base currency for one or all markets.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.marketVolumes" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category" *ngIf="network.val === 'bisq'">
-          <h4 ngbNavLink i18n="api-docs.tab.bsq|API Docs tab for BSQ">General</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
+        
+          <h4 i18n="api-docs.tab.bsq|API Docs tab for BSQ">General</h4>
 
-            <ngb-panel id="bisqStats">
-              <ng-template ngbPanelTitle>
-                <span>GET Stats</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns statistics about all Bisq transactions.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.stats" [network]="network.val"></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="bisqStats">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqStats">GET Stats</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.stats)" target="_blank'" target="_blank">GET {{ baseNetworkUrl }}/api/stats</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns statistics about all Bisq transactions.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.stats" [network]="network.val"></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category">
+        
           <h4 i18n="api-docs.tab.addresses|API Docs tab for Addresses">Addresses</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel id="address">
-              <ng-template ngbPanelTitle>
-                <span>GET Address</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                    <div i18n>Returns details about an address. Available fields: <code>address</code>, <code>chain_stats</code>, and <code>mempool_stats</code>. {{ '{' }}chain,mempool{{ '}' }}_stats each contain an object with <code>tx_count</code>, <code>funded_txo_count</code>, <code>funded_txo_sum</code>, <code>spent_txo_count</code>, and <code>spent_txo_sum</code>.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.address" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="address">
+            <a class="section-header" [routerLink]="['./']" fragment="address">GET Address</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.address)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+                <div i18n>Returns details about an address. Available fields: <code>address</code>, <code>chain_stats</code>, and <code>mempool_stats</code>. {{ '{' }}chain,mempool{{ '}' }}_stats each contain an object with <code>tx_count</code>, <code>funded_txo_count</code>, <code>funded_txo_sum</code>, <code>spent_txo_count</code>, and <code>spent_txo_sum</code>.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.address" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'"  id="addressTransactions">
-              <ng-template ngbPanelTitle>
-                <span>GET Address Transactions</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using <code>:last_seen_txid</code> (see below).</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.addressTransactions" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactions">
+            <a class="section-header" [routerLink]="['./']" fragment="addressTransactions">GET Address Transactions</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.addressTransactions)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using <code>:last_seen_txid</code> (see below).</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.addressTransactions" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
-              <ng-template ngbPanelTitle>
-                <span>GET Address Transactions Chain</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Get confirmed transaction history for the specified address/scripthash, sorted with newest first. Returns 25 transactions per page. More can be requested by specifying the last txid seen by the previous query.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.addressTransactionsChain" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsChain">
+            <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsChain">GET Address Transactions Chain</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.addressTransactionsChain)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/chain</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Get confirmed transaction history for the specified address/scripthash, sorted with newest first. Returns 25 transactions per page. More can be requested by specifying the last txid seen by the previous query.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.addressTransactionsChain" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
-              <ng-template ngbPanelTitle>
-                <span>GET Address Transactions Mempool</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Get unconfirmed transaction history for the specified address/scripthash. Returns up to 50 transactions (no paging).</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.addressTransactionsMempool" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressTransactionsMempool">
+              <a class="section-header" [routerLink]="['./']" fragment="addressTransactionsMempool">GET Address Transactions Mempool</a>
+              <div class="endpoint">
+                <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                <a [href]="wrapUrl(network.val, code.addressTransactionsMempool)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/txs/mempool</a>
+              </div>
+              <div class="description">
+                <div class="subtitle" i18n>Description</div>
+                <div i18n>Get unconfirmed transaction history for the specified address/scripthash. Returns up to 50 transactions (no paging).</div>
+              </div>
+              <app-code-template [hostname]="hostname" [code]="code.addressTransactionsMempool" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="addressUTXO">
-              <ng-template ngbPanelTitle>
-                <span>GET Address UTXO</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Get the list of unspent transaction outputs associated with the address/scripthash. Available fields: <code>txid</code>, <code>vout</code>, <code>value</code>, and <code>status</code> (with the status of the funding tx).<ng-container *ngIf="network.val === 'liquid'">There is also a <code>valuecommitment</code> field that may appear in place of <code>value</code>, plus the following additional fields: <code>asset</code>/<code>assetcommitment</code>, <code>nonce</code>/<code>noncecommitment</code>, <code>surjection_proof</code>, and <code>range_proof</code>.</ng-container></div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.addressUTXO" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="addressUTXO">
+            <a class="section-header" [routerLink]="['./']" fragment="addressUTXO">GET Address UTXO</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.addressUTXO)" target="_blank">GET {{ baseNetworkUrl }}/api/address/:address/utxo</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Get the list of unspent transaction outputs associated with the address/scripthash. Available fields: <code>txid</code>, <code>vout</code>, <code>value</code>, and <code>status</code> (with the status of the funding tx).<ng-container *ngIf="network.val === 'liquid'">There is also a <code>valuecommitment</code> field that may appear in place of <code>value</code>, plus the following additional fields: <code>asset</code>/<code>assetcommitment</code>, <code>nonce</code>/<code>noncecommitment</code>, <code>surjection_proof</code>, and <code>range_proof</code>.</ng-container></div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.addressUTXO" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category" *ngIf="network.val === 'liquid'">
+        
           <h4 i18n="api-docs.tab.assets|API Docs tab for Assets">Assets</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel id="assets">
-              <ng-template ngbPanelTitle>
-                <span>GET Assets</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns information about a Liquid asset.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.assets" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="assets">
+            <a class="section-header" [routerLink]="['./']" fragment="assets">GET Assets</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.assets)" target="_blank">GET /liquid/api/asset/:asset_id</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns information about a Liquid asset.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.assets" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="assetTransactions">
-              <ng-template ngbPanelTitle>
-                <span>GET Asset Transactions</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns transactions associated with the specified Liquid asset. For the network's native asset, returns a list of peg in, peg out, and burn transactions. For user-issued assets, returns a list of issuance, reissuance, and burn transactions. Does not include regular transactions transferring this asset.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.assetTransactions" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="assetTransactions">
+            <a class="section-header" [routerLink]="['./']" fragment="assetTransactions">GET Asset Transactions</a>
+            <div class="endpoint">
+              <a [href]="wrapUrl(network.val, code.assetTransactions)" target="_blank">GET /liquid/api/asset/:asset_id/txs[/mempool|/chain]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns transactions associated with the specified Liquid asset. For the network's native asset, returns a list of peg in, peg out, and burn transactions. For user-issued assets, returns a list of issuance, reissuance, and burn transactions. Does not include regular transactions transferring this asset.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.assetTransactions" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="assetSupply">
-              <ng-template ngbPanelTitle>
-                <span>GET Asset Supply</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Get the current total supply of the specified asset. For the native asset (L-BTC), this is calculated as [chain,mempool]_stats.peg_in_amount - [chain,mempool]_stats.peg_out_amount - [chain,mempool]_stats.burned_amount. For issued assets, this is calculated as [chain,mempool]_stats.issued_amount - [chain,mempool]_stats.burned_amount. Not available for assets with blinded issuances. If /decimal is specified, returns the supply as a decimal according to the asset's divisibility. Otherwise, returned in base units.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.assetSupply" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="assetSupply">
+            <a class="section-header" [routerLink]="['./']" fragment="assetSupply">GET Asset Supply</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.assetSupply)" target="_blank">GET /liquid/api/asset/:asset_id/supply[/decimal]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Get the current total supply of the specified asset. For the native asset (L-BTC), this is calculated as [chain,mempool]_stats.peg_in_amount - [chain,mempool]_stats.peg_out_amount - [chain,mempool]_stats.burned_amount. For issued assets, this is calculated as [chain,mempool]_stats.issued_amount - [chain,mempool]_stats.burned_amount. Not available for assets with blinded issuances. If /decimal is specified, returns the supply as a decimal according to the asset's divisibility. Otherwise, returned in base units.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.assetSupply" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category">
+        
           <h4 i18n="api-docs.tab.blocks|API Docs tab for Blocks">Blocks</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel id="block">
-              <ng-template ngbPanelTitle>
-                <span>GET Block</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns details about a block. Available fields: <code>id</code>, <code>height</code>, <code>version</code>, <code>timestamp</code>, <code>bits</code>, <code>nonce</code>, <code>merkle_root</code>, <code>tx_count</code>, <code>size</code>, <code>weight</code>,<ng-container *ngIf="network.val === 'liquid'"> <code>proof</code>,</ng-container> and <code>previousblockhash</code>.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.block" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="block">
+            <a class="section-header" [routerLink]="['./']" fragment="block">GET Block</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.block)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns details about a block. Available fields: <code>id</code>, <code>height</code>, <code>version</code>, <code>timestamp</code>, <code>bits</code>, <code>nonce</code>, <code>merkle_root</code>, <code>tx_count</code>, <code>size</code>, <code>weight</code>,<ng-container *ngIf="network.val === 'liquid'"> <code>proof</code>,</ng-container> and <code>previousblockhash</code>.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.block" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeader">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Header</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the hex-encoded block header.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockHeader" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeader">
+            <a class="section-header" [routerLink]="['./']" fragment="blockHeader">GET Block Header</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/header</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the hex-encoded block header.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockHeader" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockHeight">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Height</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the hash of the block currently at <code>:height</code>.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockHeight" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockHeight">
+            <a class="section-header" [routerLink]="['./']" fragment="blockHeight">GET Block Height</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockHeader)" target="_blank">GET {{ baseNetworkUrl }}/api/block-height/:height</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the hash of the block currently at <code>:height</code>.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockHeight" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockRaw">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Raw</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the raw block representation in binary.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockRaw" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockRaw">
+            <a class="section-header" [routerLink]="['./']" fragment="blockRaw">GET Block Raw</a>
+            <div class="endpoint">
+              <a [href]="wrapUrl(network.val, code.blockRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/raw</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the raw block representation in binary.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockRaw" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockStatus">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Status</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="title">Get Block Status</div>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the confirmation status of a block. Available fields: <code>in_best_chain</code> (boolean, false for orphaned blocks), <code>next_best</code> (the hash of the next block, only available for blocks in the best chain).</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockStatus" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockStatus">
+            <a class="section-header" [routerLink]="['./']" fragment="blockStatus">GET Block Status</a>
+            <div class="title">Get Block Status</div>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/status</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the confirmation status of a block. Available fields: <code>in_best_chain</code> (boolean, false for orphaned blocks), <code>next_best</code> (the hash of the next block, only available for blocks in the best chain).</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockStatus" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="blockTipHeight">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Tip Height</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the height of the last block.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockTipHeight" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="blockTipHeight">
+            <a class="section-header" [routerLink]="['./']" fragment="blockTipHeight">GET Block Tip Height</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockTipHeight)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/height</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the height of the last block.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockTipHeight" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTipHash">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Tip Hash</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the hash of the last block.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockTipHash" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTipHash">
+            <a class="section-header" [routerLink]="['./']" fragment="blockTipHash">GET Block Tip Hash</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockTipHash)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/tip/hash</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the hash of the last block.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockTipHash" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxId">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Transaction ID</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the transaction at index <code>:index</code> within the specified block.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockTxId" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxId">
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxId">GET Block Transaction ID</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockTxId)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txid/:index</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the transaction at index <code>:index</code> within the specified block.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockTxId" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxIds">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Transaction IDs</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a list of all txids in the block.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockTxIds" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxIds">
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxIds">GET Block Transaction IDs</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockTxIds)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txids</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a list of all txids in the block.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockTxIds" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blockTxs">
-              <ng-template ngbPanelTitle>
-                <span>GET Block Transactions</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a list of transactions in the block (up to 25 transactions beginning at <code>start_index</code>). Transactions returned here do not have the <code>status</code> field, since all the transactions share the same block and confirmation status.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blockTxs" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blockTxs">
+            <a class="section-header" [routerLink]="['./']" fragment="blockTxs">GET Block Transactions</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blockTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/block/:hash/txs[/:start_index]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a list of transactions in the block (up to 25 transactions beginning at <code>start_index</code>). Transactions returned here do not have the <code>status</code> field, since all the transactions share the same block and confirmation status.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blockTxs" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="blocks">
-              <ng-template ngbPanelTitle>
-                <span>GET Blocks</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blocks" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="blocks">
+            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blocks)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks[/:start_height]</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blocks" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val === 'bisq'" id="blocks">
-              <ng-template ngbPanelTitle>
-                <span>GET Blocks</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.blocksBisq" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="blocks">
+            <a class="section-header" [routerLink]="['./']" fragment="blocks">GET Blocks</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.blocksBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/blocks/:index/:length</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the 10 newest blocks starting at the tip or at <code>:start_height</code> if specified.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.blocksBisq" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
+        
           <h4 i18n="api-docs.tab.fees|API Docs tab for Fees">Fees</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark">
 
-            <ngb-panel id="feeMempoolBlocks">
-              <ng-template ngbPanelTitle>
-                <span>GET Mempool Blocks Fees</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.fees.mempool-blocks|API Docs for /api/v1/fees/mempool-blocks">Returns current mempool as projected blocks.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.feeMempoolBlocks" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="feeMempoolBlocks">
+            <a class="section-header" [routerLink]="['./']" fragment="feeMempoolBlocks">GET Mempool Blocks Fees</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.feeMempoolBlocks)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/mempool-blocks</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.fees.mempool-blocks|API Docs for /api/v1/fees/mempool-blocks">Returns current mempool as projected blocks.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.feeMempoolBlocks" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="feeRecommended">
-              <ng-template ngbPanelTitle>
-                <span>GET Recommended Fees</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.fees.recommended|API Docs for /api/v1/fees/recommended">Returns our currently suggested fees for new transactions.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.feeRecommended" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="feeRecommended">
+            <a class="section-header" [routerLink]="['./']" fragment="feeRecommended">GET Recommended Fees</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.feeRecommended)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/fees/recommended</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.fees.recommended|API Docs for /api/v1/fees/recommended">Returns our currently suggested fees for new transactions.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.feeRecommended" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq'">
+        
           <h4 i18n="api-docs.tab.mempool|API Docs tab for Mempool">Mempool</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel id="mempool">
-              <ng-template ngbPanelTitle>
-                <span>GET Mempool</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.mempool.mempool|API Docs for /api/mempool">Returns current mempool backlog statistics.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.mempool" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="mempool">
+            <a class="section-header" [routerLink]="['./']" fragment="mempool">GET Mempool</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.mempool)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.mempool.mempool|API Docs for /api/mempool">Returns current mempool backlog statistics.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.mempool" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="mempoolTxs">
-              <ng-template ngbPanelTitle>
-                <span>GET Mempool Transactions IDs</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.mempool.txids|API Docs for /api/mempool/txids">Get the full list of txids in the mempool as an array. The order of the txids is arbitrary and does not match bitcoind.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.mempoolTxs" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="mempoolTxs">
+            <a class="section-header" [routerLink]="['./']" fragment="mempoolTxs">GET Mempool Transactions IDs</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.mempoolTxs)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/txids</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.mempool.txids|API Docs for /api/mempool/txids">Get the full list of txids in the mempool as an array. The order of the txids is arbitrary and does not match bitcoind.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.mempoolTxs" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="mempoolRecent">
-              <ng-template ngbPanelTitle>
-                <span>GET Mempool Recent</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.mempool.recent|API Docs for /api/mempool/recent">Get a list of the last 10 transactions to enter the mempool. Each transaction object contains simplified overview data, with the following fields: <code>txid</code>, <code>fee</code>, <code>vsize</code>, and <code>value</code>.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.mempoolRecent" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="mempoolRecent">
+            <a class="section-header" [routerLink]="['./']" fragment="mempoolRecent">GET Mempool Recent</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.mempoolRecent)" target="_blank">GET {{ baseNetworkUrl }}/api/mempool/recent</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.mempool.recent|API Docs for /api/mempool/recent">Get a list of the last 10 transactions to enter the mempool. Each transaction object contains simplified overview data, with the following fields: <code>txid</code>, <code>fee</code>, <code>vsize</code>, and <code>value</code>.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.mempoolRecent" [network]="network.val" ></app-code-template>
+          </div>
 
-          </ngb-accordion>
         </div>
 
         <div class="api-category">
+
           <h4 i18n="api-docs.tab.transactions|API Docs tab for Transactions">Transactions</h4>
-          <ngb-accordion [closeOthers]="true" animated="true" type="dark" >
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="cpfp">
-              <ng-template ngbPanelTitle>
-                <span>GET Children Pay for Parent</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n="api-docs.fees.cpfp|API Docs for /api/v1/fees/cpfp">Returns the ancestors and the best descendant fees for a transaction.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionCpfp" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="cpfp">
+            <a class="section-header" [routerLink]="['./']" fragment="cpfp">GET Children Pay for Parent</a>            
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionCpfp)" target="_blank">GET {{ baseNetworkUrl }}/api/v1/cpfp/:txid</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n="api-docs.fees.cpfp|API Docs for /api/v1/fees/cpfp">Returns the ancestors and the best descendant fees for a transaction.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionCpfp" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel id="transaction">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns details about a transaction. Available fields: <code>txid</code>, <code>version</code>, <code>locktime</code>, <code>size</code>, <code>weight</code>, <code>fee</code>, <code>vin</code>, <code>vout</code>, and <code>status</code>.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" id="transaction">
+            <a class="section-header" [routerLink]="['./']" fragment="transaction">GET Transaction</a>
+            <div class="endpoint">
+              <a [href]="wrapUrl(network.val, code.transaction)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns details about a transaction. Available fields: <code>txid</code>, <code>version</code>, <code>locktime</code>, <code>size</code>, <code>weight</code>, <code>fee</code>, <code>vin</code>, <code>vout</code>, and <code>status</code>.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transaction" [network]="network.val" ></app-code-template>            
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionHex">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Hex</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                    <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
-                  </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a transaction serialized as hex.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionHex" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionHex">
+            <a class="section-header" [routerLink]="['./']" fragment="bisqMarketsTrades">GET Transaction Hex</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+                <a [href]="wrapUrl(network.val, code.transactionHex)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/hex</a>
+              </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a transaction serialized as hex.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionHex" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Merkleblock Proof</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://bitcoin.org/en/glossary/merkle-block">bitcoind's merkleblock</a> format.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionMerkleBlockProof" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'" id="transactionMerkleBlockProof">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleBlockProof">GET Transaction Merkleblock Proof</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionMerkleBlockProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkleblock-proof</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://bitcoin.org/en/glossary/merkle-block">bitcoind's merkleblock</a> format.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionMerkleBlockProof" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Merkle Proof</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get-merkle">Electrum's blockchain.transaction.get_merkle format.</a></div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionMerkleProof" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionMerkleProof">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionMerkleProof">GET Transaction Merkle Proof</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionMerkleProof)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/merkle-proof</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a merkle inclusion proof for the transaction using <a href="https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-transaction-get-merkle">Electrum's blockchain.transaction.get_merkle format.</a></div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionMerkleProof" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspend">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Outspend</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the spending status of a transaction output. Available fields: <code>spent</code> (boolean), <code>txid</code> (optional), <code>vin</code> (optional), and <code>status</code> (optional, the status of the spending tx).</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionOutspend" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspend">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspend">GET Transaction Outspend</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionOutspend)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspend/:vout</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the spending status of a transaction output. Available fields: <code>spent</code> (boolean), <code>txid</code> (optional), <code>vin</code> (optional), and <code>status</code> (optional, the status of the spending tx).</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionOutspend" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionOutspends">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Outspends</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the spending status of all transaction outputs.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionOutspends" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionOutspends">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionOutspends">GET Transaction Outspends</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionOutspends)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/outspends</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the spending status of all transaction outputs.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionOutspends" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionRaw">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Raw</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns a transaction as binary data.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionRaw" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionRaw">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionRaw">GET Transaction Raw</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionRaw)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/raw</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns a transaction as binary data.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionRaw" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="transactionStatus">
-              <ng-template ngbPanelTitle>
-                <span>GET Transaction Status</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns the confirmation status of a transaction. Available fields: <code>confirmed</code> (boolean), <code>block_height</code> (optional), and <code>block_hash</code> (optional).</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionStatus" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="transactionStatus">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionStatus">GET Transaction Status</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionStatus)" target="_blank">GET {{ baseNetworkUrl }}/api/tx/:txid/status</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns the confirmation status of a transaction. Available fields: <code>confirmed</code> (boolean), <code>block_height</code> (optional), and <code>block_hash</code> (optional).</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionStatus" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val === 'bisq'" id="transactionsBisq">
-              <ng-template ngbPanelTitle>
-                <span>GET Transactions</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="title">Get Mempool Txids</div>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Returns :length of latest Bisq transactions, starting from :index.</div>
-                </div>
-                <app-code-template [hostname]="hostname" [code]="code.transactionsBisq" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
+          <div class="endpoint-container" *ngIf="network.val === 'bisq'" id="transactionsBisq">
+            <a class="section-header" [routerLink]="['./']" fragment="transactionsBisq">GET Transactions</a>
+            <div class="title">Get Mempool Txids</div>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <a [href]="wrapUrl(network.val, code.transactionsBisq)" target="_blank">GET {{ baseNetworkUrl }}/api/txs/:index/:length</a>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Returns :length of latest Bisq transactions, starting from :index.</div>
+            </div>
+            <app-code-template [hostname]="hostname" [code]="code.transactionsBisq" [network]="network.val" ></app-code-template>
+          </div>
 
-            <ngb-panel *ngIf="network.val !== 'bisq'" id="postTransaction">
-              <ng-template ngbPanelTitle>
-                <span>POST Transaction</span>
-              </ng-template>
-              <ng-template ngbPanelContent>
-                <div class="endpoint">
-                  <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
-                  <div>POST /api/tx</div>
-                </div>
-                <div class="description">
-                  <div class="subtitle" i18n>Description</div>
-                  <div i18n>Broadcast a raw transaction to the network. The transaction should be provided as hex in the request body. The <code>txid</code> will be returned on success.</div>
-                </div>
-                <app-code-template [method]="'post'" [hostname]="hostname" [code]="code.transactionPost" [network]="network.val" ></app-code-template>
-              </ng-template>
-            </ngb-panel>
-
-          </ngb-accordion>
+          <div class="endpoint-container" *ngIf="network.val !== 'bisq'" id="postTransaction">
+            <a class="section-header" [routerLink]="['./']" fragment="postTransaction">POST Transaction</a>
+            <div class="endpoint">
+              <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
+              <div>POST /api/tx</div>
+            </div>
+            <div class="description">
+              <div class="subtitle" i18n>Description</div>
+              <div i18n>Broadcast a raw transaction to the network. The transaction should be provided as hex in the request body. The <code>txid</code> will be returned on success.</div>
+            </div>
+            <app-code-template [method]="'post'" [hostname]="hostname" [code]="code.transactionPost" [network]="network.val" ></app-code-template>
+          </div>
 
         </div>
       </div>

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -22,7 +22,7 @@
           </div>
         </div>
 
-        <div id="mobile-top-doc-nav" class="hide-on-desktop"><app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav></div>
+        <div id="mobile-top-doc-nav" #mobileFixedApiNav class="hide-on-desktop"><app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav></div>
 
         <div class="api-category" *ngIf="network.val !== 'bisq' && network.val !== 'liquid'">
 

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -124,6 +124,14 @@ li.nav-item {
   float: right;
 }
 
+.endpoint-container:before {
+	display: block;
+ 	content: " ";
+  height: 1px;
+  margin-top: -1px;
+  visibility: hidden;
+}
+
 .endpoint-container .section-header {
   display: block;
   background-color: #2d3348;

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -73,27 +73,61 @@ li.nav-item {
 }
 
 .doc-nav-desktop {
-  width: 25%;
+  width: 300px;
 }
 
 .doc-nav-desktop.relative {
   float: left;
+  overflow: hidden;
 }
 
 .doc-nav-desktop.fixed {
   float: unset;
   position: fixed;
   top: 20px;
+  overflow-y: auto;
+  height: calc(100vh - 50px);
+  scrollbar-color: #2d3348 #11131f;
+  scrollbar-width: thin;
+}
+::-webkit-scrollbar {
+  width: 3px;
+}
+::-webkit-scrollbar-track {
+  background: #11131f;
+}
+::-webkit-scrollbar-thumb {
+  background-color: #2d3348;
+  border-radius: 5px;
+  border: none;
+}
+
+.doc-nav-desktop p {
+  color: #4a68b9;
+  font-weight: 700;
+  margin: 10px 0;
+  margin: 15px 0 10px 0;
+}
+.doc-nav-desktop p:first-child {
+  margin-top: 0
+}
+
+.doc-nav-desktop a {
+  color: #fff;
+  text-decoration: none;
+  display: block;
+  margin: 5px 0;
 }
 
 .doc-content {
-  width: 75%;
+  width: calc(100% - 330px);
   float: right;
 }
 
 @media (max-width: 992px){
   .doc-nav-desktop {
     display: none;
+    height: auto;
   }
 
   .doc-content {

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -163,10 +163,38 @@ li.nav-item {
   float: right;
 }
 
-@media (max-width: 992px){
-  .doc-nav-desktop {
+.doc-nav-mobile.relative {
+
+}
+
+.doc-nav-mobile.relative {
+  position: relative;
+}
+
+.doc-nav-mobile.fixed {
+  position: fixed;
+  top: 20px;
+  width: calc(100% - 60px);
+  z-index: 100;
+}
+
+.doc-nav-mobile > div {
+  background-color: #2d3348;
+  z-index: 100;
+  border-radius: 0.25rem;
+}
+
+#doc-nav-mobile-toggle {
+  width: 100%;
+  background-color: #105fb0;
+  color: #fff;
+  border-color: #105fb0;
+}
+
+@media (max-width: 992px) {
+
+  .hide-on-mobile {
     display: none;
-    height: auto;
   }
 
   .doc-content {
@@ -186,3 +214,8 @@ li.nav-item {
   }
 }
 
+@media (min-width: 992px) {
+  .hide-on-desktop {
+    display: none;
+  }
+}

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -22,6 +22,10 @@ li.nav-item {
   }
 }
 
+.no-bottom-space {
+  margin-bottom: 0;
+}
+
 .nav-tabs .nav-link.active {
   border-bottom: 1px solid #fff;
   @media (min-width: 676px){
@@ -72,16 +76,16 @@ li.nav-item {
   padding: 15px;
 }
 
-.doc-nav-desktop {
+#doc-nav-desktop {
   width: 300px;
 }
 
-.doc-nav-desktop.relative {
+#doc-nav-desktop.relative {
   float: left;
   overflow: hidden;
 }
 
-.doc-nav-desktop.fixed {
+#doc-nav-desktop.fixed {
   float: unset;
   position: fixed;
   top: 20px;
@@ -122,12 +126,9 @@ li.nav-item {
   padding: 1rem 1.3rem 1rem 1.3rem;
   font-weight: bold;
   border-radius: 0.25rem;
-  margin: 40px 0 20px 0;
+  margin: 20px 0 20px 0;
   font-size: 24px;
   position: relative;
-}
-.endpoint-container .section-header:first-child {
-  margin-top: 20px;
 }
 .endpoint-container .section-header:hover {
   text-decoration: none;
@@ -146,32 +147,27 @@ li.nav-item {
   float: right;
 }
 
-.doc-nav-mobile.relative {
-
-}
-
-.doc-nav-mobile.relative {
-  position: relative;
-}
-
-.doc-nav-mobile.fixed {
+#doc-nav-mobile {
   position: fixed;
   top: 20px;
   width: calc(100% - 60px);
   z-index: 100;
 }
 
-.doc-nav-mobile > div {
+#doc-nav-mobile > div {
   background-color: #2d3348;
   z-index: 100;
-  border-radius: 0.25rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  height: 55vh;
+  overflow-y: auto;
 }
 
-#doc-nav-mobile-toggle {
+#doc-nav-mobile button {
   width: 100%;
   background-color: #105fb0;
   color: #fff;
   border-color: #105fb0;
+  border-radius: 0.5rem 0.5rem 0 0;
 }
 
 @media (max-width: 992px) {
@@ -195,6 +191,12 @@ li.nav-item {
     left: 0;
     bottom: -50px;
   }
+
+  .endpoint-container:before {
+    height: 30px;
+    margin-top: -12px;
+  }
+
 }
 
 @media (min-width: 992px) {

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -72,6 +72,26 @@ li.nav-item {
   padding: 15px;
 }
 
+.doc-nav-desktop {
+  width: 25%;
+  float: left;
+}
+
+.doc-content {
+  width: 75%;
+  float: right;
+}
+
+@media (max-width: 992px){
+  .doc-nav-desktop {
+    display: none;
+  }
+
+  .doc-content {
+    width: 100%;
+  }
+}
+
 #restAPI .api-category {
   margin: 30px 0;
 }

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -102,23 +102,6 @@ li.nav-item {
   border: none;
 }
 
-.doc-nav-desktop p {
-  color: #4a68b9;
-  font-weight: 700;
-  margin: 10px 0;
-  margin: 15px 0 10px 0;
-}
-.doc-nav-desktop p:first-child {
-  margin-top: 0
-}
-
-.doc-nav-desktop a {
-  color: #fff;
-  text-decoration: none;
-  display: block;
-  margin: 5px 0;
-}
-
 .doc-content {
   width: calc(100% - 330px);
   float: right;

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -74,7 +74,16 @@ li.nav-item {
 
 .doc-nav-desktop {
   width: 25%;
+}
+
+.doc-nav-desktop.relative {
   float: left;
+}
+
+.doc-nav-desktop.fixed {
+  float: unset;
+  position: fixed;
+  top: 20px;
 }
 
 .doc-content {

--- a/frontend/src/app/components/docs/api-docs.component.scss
+++ b/frontend/src/app/components/docs/api-docs.component.scss
@@ -124,6 +124,37 @@ li.nav-item {
   float: right;
 }
 
+.endpoint-container .section-header {
+  display: block;
+  background-color: #2d3348;
+  color: #1bd8f4;
+  padding: 1rem 1.3rem 1rem 1.3rem;
+  font-weight: bold;
+  border-radius: 0.25rem;
+  margin: 40px 0 20px 0;
+  font-size: 24px;
+  position: relative;
+}
+.endpoint-container .section-header:first-child {
+  margin-top: 20px;
+}
+.endpoint-container .section-header:hover {
+  text-decoration: none;
+}
+
+.endpoint-container .section-header span {
+  color: #fff;
+  background-color: #653b9c;
+  font-size: 12px;
+  text-transform: uppercase;
+  font-weight: 400;
+  padding: 8px 10px;
+  letter-spacing: 1px;
+  border-radius: 0.25rem;
+  font-family: monospace;
+  float: right;
+}
+
 @media (max-width: 992px){
   .doc-nav-desktop {
     display: none;
@@ -133,12 +164,17 @@ li.nav-item {
   .doc-content {
     width: 100%;
   }
+
+  .endpoint-container .section-header {
+    margin: 40px 0 70px 0;
+  }
+
+  .endpoint-container .section-header span {
+    float: none;
+    position: absolute;
+    top: unset;
+    left: 0;
+    bottom: -50px;
+  }
 }
 
-#restAPI .api-category {
-  margin: 30px 0;
-}
-
-.api-category h4 {
-  margin-bottom: 15px;
-}

--- a/frontend/src/app/components/docs/api-docs.component.ts
+++ b/frontend/src/app/components/docs/api-docs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
 import { Env, StateService } from 'src/app/services/state.service';
 import { Observable, merge, of } from 'rxjs';
 import { SeoService } from 'src/app/services/seo.service';
@@ -17,6 +17,7 @@ export class ApiDocsComponent implements OnInit {
   code: any;
   baseNetworkUrl = '';
   @Input() restTabActivated: Boolean;
+  @ViewChild( "mobileFixedApiNav", { static: false } ) mobileFixedApiNav: ElementRef;
   desktopDocsNavPosition = "relative";
   showFloatingDocsNav = false;
   mobileMenuOpen = true;
@@ -25,6 +26,16 @@ export class ApiDocsComponent implements OnInit {
     private stateService: StateService,
     private seoService: SeoService,
   ) { }
+
+  ngAfterViewInit() {
+    const that = this;
+    setTimeout( () => {
+      window.addEventListener('scroll', function() {
+        that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
+        that.showFloatingDocsNav = ( window.pageYOffset > ( that.mobileFixedApiNav.nativeElement.offsetHeight + 188 ) ) ? true : false;
+      });
+    }, 1 );
+  }
 
   ngOnInit(): void {
     this.env = this.stateService.env;
@@ -37,13 +48,6 @@ export class ApiDocsComponent implements OnInit {
         return network;
       })
     );
-
-    //to toggle fixed menu for desktop navigation
-    const that = this;
-    window.addEventListener('scroll', function() {
-      that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
-      that.showFloatingDocsNav = ( window.pageYOffset > 1425 ) ? true : false;
-    });
 
     if (document.location.port !== '') {
       this.hostname = `${this.hostname}:${document.location.port}`;

--- a/frontend/src/app/components/docs/api-docs.component.ts
+++ b/frontend/src/app/components/docs/api-docs.component.ts
@@ -17,6 +17,7 @@ export class ApiDocsComponent implements OnInit {
   code: any;
   baseNetworkUrl = '';
   @Input() restTabActivated: Boolean;
+  docsNavPosition = "relative";
 
   constructor(
     private stateService: StateService,
@@ -34,6 +35,16 @@ export class ApiDocsComponent implements OnInit {
         return network;
       })
     );
+
+    //to toggle fixed menu for desktop navigation
+    let that = this;
+    window.addEventListener('scroll', function() {
+      if( window.pageYOffset > 182 ) {
+        that.docsNavPosition = "fixed";
+      } else {
+        that.docsNavPosition = "relative";
+      }
+    });
 
     if (document.location.port !== '') {
       this.hostname = `${this.hostname}:${document.location.port}`;

--- a/frontend/src/app/components/docs/api-docs.component.ts
+++ b/frontend/src/app/components/docs/api-docs.component.ts
@@ -18,7 +18,7 @@ export class ApiDocsComponent implements OnInit {
   baseNetworkUrl = '';
   @Input() restTabActivated: Boolean;
   desktopDocsNavPosition = "relative";
-  mobileDocsNavPosition = "relative";
+  showFloatingDocsNav = false;
   mobileMenuOpen = true;
 
   constructor(
@@ -39,10 +39,10 @@ export class ApiDocsComponent implements OnInit {
     );
 
     //to toggle fixed menu for desktop navigation
-    let that = this;
+    const that = this;
     window.addEventListener('scroll', function() {
       that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
-      that.mobileDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
+      that.showFloatingDocsNav = ( window.pageYOffset > 1425 ) ? true : false;
     });
 
     if (document.location.port !== '') {

--- a/frontend/src/app/components/docs/api-docs.component.ts
+++ b/frontend/src/app/components/docs/api-docs.component.ts
@@ -17,7 +17,9 @@ export class ApiDocsComponent implements OnInit {
   code: any;
   baseNetworkUrl = '';
   @Input() restTabActivated: Boolean;
-  docsNavPosition = "relative";
+  desktopDocsNavPosition = "relative";
+  mobileDocsNavPosition = "relative";
+  mobileMenuOpen = true;
 
   constructor(
     private stateService: StateService,
@@ -39,11 +41,8 @@ export class ApiDocsComponent implements OnInit {
     //to toggle fixed menu for desktop navigation
     let that = this;
     window.addEventListener('scroll', function() {
-      if( window.pageYOffset > 182 ) {
-        that.docsNavPosition = "fixed";
-      } else {
-        that.docsNavPosition = "relative";
-      }
+      that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
+      that.mobileDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
     });
 
     if (document.location.port !== '') {

--- a/frontend/src/app/components/docs/docs.component.html
+++ b/frontend/src/app/components/docs/docs.component.html
@@ -27,5 +27,13 @@
 
     <div id="main-tab-content" [ngbNavOutlet]="nav" class="mt-2"></div>
 
+    <br>
+
+    <div id="footer" class="text-center">
+      <a [routerLink]="['/terms-of-service']" i18n="shared.terms-of-service|Terms of Service">Terms of Service</a>
+      |
+      <a [routerLink]="['/privacy-policy']" i18n="shared.privacy-policy|Privacy Policy">Privacy Policy</a>
+    </div>
+
   </div>
 </div>

--- a/frontend/src/app/components/docs/docs.component.scss
+++ b/frontend/src/app/components/docs/docs.component.scss
@@ -1,6 +1,7 @@
 #main-tab-content {
   text-align: left;
   padding-top: 10px;
+  scroll-behavior: smooth;
 }
 
 #footer {

--- a/frontend/src/app/components/docs/docs.component.scss
+++ b/frontend/src/app/components/docs/docs.component.scss
@@ -2,3 +2,7 @@
   text-align: left;
   padding-top: 10px;
 }
+
+#footer {
+  clear: both;
+}


### PR DESCRIPTION
These changes migrate docs from a simple-but-limited `ngb-accordion`-based layout to something more flexible.

This PR is big but doesn't add or remove any content that is on the site right now.

Results:
- anchor links make every api endpoint linkable
- custom layouts allow for expansion later on as/when needed (e.g., search)
- new layouts show more info on screens with more space
- new layouts should also accommodate faqs and other docs content nicely