### PR TITLE
Increase graphs data resolution

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -407,7 +407,7 @@ class Statistics {
   public async $list1W(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDaysAvg(600, '1 WEEK'); // 10m interval
+      const query = this.getQueryForDaysAvg(300, '1 WEEK'); // 5m interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -420,7 +420,7 @@ class Statistics {
   public async $list1M(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDaysAvg(3600, '1 MONTH'); // 1h interval
+      const query = this.getQueryForDaysAvg(1800, '1 MONTH'); // 30m interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -433,7 +433,7 @@ class Statistics {
   public async $list3M(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDaysAvg(14400, '3 MONTH'); // 4h interval
+      const query = this.getQueryForDaysAvg(7200, '3 MONTH'); // 2h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -446,7 +446,7 @@ class Statistics {
   public async $list6M(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDaysAvg(21600, '6 MONTH'); // 6h interval 
+      const query = this.getQueryForDaysAvg(10800, '6 MONTH'); // 3h interval 
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -459,7 +459,7 @@ class Statistics {
   public async $list1Y(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDays(43200, '1 YEAR'); // 12h interval
+      const query = this.getQueryForDays(28800, '1 YEAR'); // 8h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -472,7 +472,7 @@ class Statistics {
   public async $list2Y(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDays(86400, "2 YEAR"); // 1d interval
+      const query = this.getQueryForDays(28800, "2 YEAR"); // 8h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -485,7 +485,7 @@ class Statistics {
   public async $list3Y(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = this.getQueryForDays(86400, "3 YEAR"); // 1d interval
+      const query = this.getQueryForDays(43200, "3 YEAR"); // 12h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);


### PR DESCRIPTION
Data size in kB at the time of this PR, for reference only

| Timespan | Local | Prod | ~Compression | Applied resolution | New Local | New Prod (?) |
|-|-|-|-|-|-|-|
| 2h | 38.2kB | 10.3kB | 3.7x | Unchanged, already 1 min tick | N/A | N/A |
| 24h | 456kB | 115kB | 3.9x | Unchanged, already 1 min tick | N/A | N/A |
| 1w | 319kB | 105kB | 3x | 10min -> 5min | 618kB | 206kB (?) |
| 1M | 226kB | 91kB | 2.4x | 1h -> 30min | 440kB | 183kB (?) |
| 3M | 196kB | 77.1kB | 2.5x | 4h -> 2h | 383kB | 153kB (?) |
| 6M | 274kB | 107kB | 2.5x | 6h -> 3h |  534kB | 213kB (?) |
| 1Y | 128kB | 75kB | 1.7x | 12h -> 8h | 325kB | 191kB (?) |
| 2Y | 212kB | 73.8kB | 2.8x | 1d -> 8h |  636kB | 227kB (?) |
| 3Y | 303kB | 102kB | 2.9x | 1d -> 12h |  605kB | 208kB (?) |