### PR TITLE
Revert "Set frontend tsconfig to target es2020"

### DIFF
--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -10,7 +10,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2020",
+    "target": "es2015",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
This reverts commit 896a4cbcfc629af64a7cbc8d0c6d0ab3be2b5151 to fix #1042.

While es2020 works great for 99.99% of our users, it broke support for old TVs and presumably other embedded devices.

