### PR TITLE
Fix backend support for 'liquidtestnet' network

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -109,7 +109,8 @@ export class Common {
       totalFees += tx.bestDescendant.fee;
     }
 
-    tx.effectiveFeePerVsize = Math.max(config.MEMPOOL.NETWORK === 'liquid' ? 0.1 : 1, totalFees / (totalWeight / 4));
+    tx.effectiveFeePerVsize = Math.max(config.MEMPOOL.NETWORK === 'liquid'
+      || config.MEMPOOL.NETWORK === 'liquidtestnet' ? 0.1 : 1, totalFees / (totalWeight / 4));
     tx.cpfpChecked = true;
 
     return {

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -127,7 +127,7 @@ class DatabaseMigration {
     const queries: string[] = [];
 
     if (version < 1) {
-      if (config.MEMPOOL.NETWORK !== 'liquid') {
+      if (config.MEMPOOL.NETWORK !== 'liquid' && config.MEMPOOL.NETWORK !== 'liquidtestnet') {
         queries.push(`UPDATE statistics SET
           vsize_1 = vsize_1 + vsize_2, vsize_2 = vsize_3,
           vsize_3 = vsize_4, vsize_4 = vsize_5,

--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -6,7 +6,7 @@ import projectedBlocks from './mempool-blocks';
 class FeeApi {
   constructor() { }
 
-  defaultFee = config.MEMPOOL.NETWORK === 'liquid' ? 0.1 : 1;
+  defaultFee = config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet' ? 0.1 : 1;
 
   public getRecommendedFee() {
     const pBlocks = projectedBlocks.getMempoolBlocks();

--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -90,9 +90,11 @@ class Statistics {
     memPoolArray.forEach((transaction) => {
       for (let i = 0; i < logFees.length; i++) {
         if (
-          (config.MEMPOOL.NETWORK === 'liquid' && (i === lastItem || transaction.effectiveFeePerVsize * 10 < logFees[i + 1]))
+          ((config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet')
+          && (i === lastItem || transaction.effectiveFeePerVsize * 10 < logFees[i + 1]))
           ||
-          (config.MEMPOOL.NETWORK !== 'liquid' && (i === lastItem || transaction.effectiveFeePerVsize < logFees[i + 1]))
+          ((config.MEMPOOL.NETWORK !== 'liquid' && config.MEMPOOL.NETWORK !== 'liquidtestnet')
+          && (i === lastItem || transaction.effectiveFeePerVsize < logFees[i + 1]))
         ) {
           if (weightVsizeFees[logFees[i]]) {
             weightVsizeFees[logFees[i]] += transaction.vsize;

--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -31,7 +31,8 @@ class TransactionUtils {
       // @ts-ignore
       return transaction;
     }
-    const feePerVbytes = Math.max(config.MEMPOOL.NETWORK === 'liquid' ? 0.1 : 1, (transaction.fee || 0) / (transaction.weight / 4));
+    const feePerVbytes = Math.max(config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet' ? 0.1 : 1,
+      (transaction.fee || 0) / (transaction.weight / 4));
     const transactionExtended: TransactionExtended = Object.assign({
       vsize: Math.round(transaction.weight / 4),
       feePerVsize: feePerVbytes,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,7 +96,7 @@ class Server {
       statistics.startStatistics();
     }
 
-    if (config.MEMPOOL.NETWORK === 'liquid') {
+    if (config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet') {
       icons.loadIcons();
     }
 
@@ -156,7 +156,7 @@ class Server {
     if (this.wss) {
       websocketHandler.setWebsocketServer(this.wss);
     }
-    if (config.MEMPOOL.NETWORK === 'liquid' && config.DATABASE.ENABLED) {
+    if ((config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet') && config.DATABASE.ENABLED) {
       blocks.setNewBlockCallback(async () => {
         try {
           await elementsParser.$parse();
@@ -283,14 +283,14 @@ class Server {
       ;
     }
 
-    if (config.MEMPOOL.NETWORK === 'liquid') {
+    if (config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet') {
       this.app
         .get(config.MEMPOOL.API_URL_PREFIX + 'assets/icons', routes.getAllLiquidIcon)
         .get(config.MEMPOOL.API_URL_PREFIX + 'asset/:assetId/icon', routes.getLiquidIcon)
       ;
     }
 
-    if (config.MEMPOOL.NETWORK === 'liquid' && config.DATABASE.ENABLED) {
+    if ((config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet') && config.DATABASE.ENABLED) {
       this.app
         .get(config.MEMPOOL.API_URL_PREFIX + 'liquid/pegs/month', routes.$getElementsPegsByMonth)
       ;

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -55,17 +55,19 @@
                     <ng-container *ngSwitchCase="vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk'">
                       <span>P2PK</span>
                     </ng-container>
-                    <ng-container *ngSwitchCase="!vin.prevout">
-                      <span>{{ vin.issuance ? 'Issuance' : 'UNKNOWN' }}</span>
-                    </ng-container>
                     <ng-container *ngSwitchDefault>
-                      <a [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey_address]" title="{{ vin.prevout.scriptpubkey_address }}">
-                        <span class="d-block d-lg-none">{{ vin.prevout.scriptpubkey_address | shortenString : 16 }}</span>
-                        <span class="d-none d-lg-block">{{ vin.prevout.scriptpubkey_address | shortenString : 35 }}</span>
-                      </a>
-                      <div>
-                        <app-address-labels [vin]="vin"></app-address-labels>
-                      </div>
+                      <ng-template [ngIf]="!vin.prevout" [ngIfElse]="defaultAddress">
+                        <span>{{ vin.issuance ? 'Issuance' : 'UNKNOWN' }}</span>
+                      </ng-template>
+                      <ng-template #defaultAddress>
+                        <a [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey_address]" title="{{ vin.prevout.scriptpubkey_address }}">
+                          <span class="d-block d-lg-none">{{ vin.prevout.scriptpubkey_address | shortenString : 16 }}</span>
+                          <span class="d-none d-lg-block">{{ vin.prevout.scriptpubkey_address | shortenString : 35 }}</span>
+                        </a>
+                        <div>
+                          <app-address-labels [vin]="vin"></app-address-labels>
+                        </div>
+                      </ng-template>
                     </ng-container>
                   </div>
                 </td>


### PR DESCRIPTION
Since we added the new '`liquidtestnet`', all cases where we detect liquid network also needs to check for the liquid testnet network