### PR TITLE
Fixing missing assets data for Liquid Testnet native asset

### DIFF
--- a/frontend/src/app/components/asset/asset.component.html
+++ b/frontend/src/app/components/asset/asset.component.html
@@ -31,7 +31,7 @@
                 <td i18n="asset.issuer|Liquid Asset issuer">Issuer</td>
                 <td><a target="_blank" href="{{ 'http://' + assetContract[0] }}">{{ assetContract[0] }}</a></td>
               </tr>
-              <tr *ngIf="!isNativeAsset">
+              <tr *ngIf="asset.issuance_txin">
                 <td i18n="asset.issuance-tx|Liquid Asset issuance TX">Issuance TX</td>
                 <td><a [routerLink]="['/tx/' | relativeUrl, asset.issuance_txin.txid]">{{ asset.issuance_txin.txid | shortenString : 13 }}</a> <app-clipboard class="d-none d-sm-inline-block" [text]="asset.issuance_txin.txid"></app-clipboard></td>
               </tr>
@@ -42,15 +42,15 @@
         <div class="col">
           <table class="table table-borderless table-striped">
             <tbody>
-              <tr *ngIf="isNativeAsset">
+              <tr *ngIf="isNativeAsset && asset.chain_stats.peg_in_amount">
                 <td i18n="asset.pegged-in|Liquid Asset pegged-in amount">Pegged in</td>
                 <td>{{ formatAmount(asset.chain_stats.peg_in_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
-              <tr *ngIf="isNativeAsset">
+              <tr *ngIf="isNativeAsset && asset.chain_stats.peg_out_amount">
                 <td i18n="asset.pegged-out|Liquid Asset pegged-out amount">Pegged out</td>
                 <td>{{ formatAmount(asset.chain_stats.peg_out_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
-              <tr *ngIf="!isNativeAsset">
+              <tr *ngIf="asset.chain_stats.issued_amount">
                 <td i18n="asset.issued-amount|Liquid Asset issued amount">Issued amount</td>
                 <td *ngIf="!blindedIssuance; else confidentialTd">{{ formatAmount(asset.chain_stats.issued_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
@@ -58,11 +58,11 @@
                 <td i18n="asset.burned-amount|Liquid Asset burned amount">Burned amount</td>
                 <td *ngIf="!blindedIssuance; else confidentialTd">{{ formatAmount(asset.chain_stats.burned_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
-              <tr *ngIf="!isNativeAsset">
+              <tr *ngIf="asset.chain_stats.issued_amount">
                 <td i18n="asset.circulating-amount|Liquid Asset circulating amount">Circulating amount</td>
                 <td *ngIf="!blindedIssuance; else confidentialTd">{{ formatAmount(asset.chain_stats.issued_amount - asset.chain_stats.burned_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
-              <tr *ngIf="isNativeAsset">
+              <tr *ngIf="isNativeAsset && asset.chain_stats.peg_in_amount">
                 <td i18n="asset.circulating-amount|Liquid Asset circulating amount">Circulating amount</td>
                 <td>{{ formatAmount(asset.chain_stats.peg_in_amount - asset.chain_stats.burned_amount - asset.chain_stats.peg_out_amount, assetContract[3]) | number: '1.0-' + assetContract[3] }} {{ assetContract[1] }}</td>
               </tr>
@@ -78,7 +78,7 @@
     <div class="title-tx">
       <h2>
         <ng-template [ngIf]="transactions?.length" i18n="asset.M_of_N">{{ (transactions?.length | number) || '?' }} of {{ txCount | number }}&nbsp;</ng-template>
-        <ng-template [ngIf]="isNativeAsset" [ngIfElse]="defaultAsset" i18n="Liquid native asset transactions title">Peg In/Out and Burn Transactions</ng-template>
+        <ng-template [ngIf]="isNativeAsset && network === 'liquid'" [ngIfElse]="defaultAsset" i18n="Liquid native asset transactions title">Peg In/Out and Burn Transactions</ng-template>
         <ng-template #defaultAsset i18n="Default asset transactions title">Issuance and Burn Transactions</ng-template>
       </h2>
     </div>

--- a/frontend/src/app/services/assets.service.ts
+++ b/frontend/src/app/services/assets.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { shareReplay, switchMap } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { StateService } from './state.service';
 
 @Injectable({
@@ -29,6 +29,13 @@ export class AssetsService {
     this.getAssetsMinimalJson$ = this.stateService.networkChanged$
     .pipe(
       switchMap(() => this.httpClient.get(`${apiBaseUrl}/resources/assets${this.stateService.network === 'liquidtestnet' ? '-testnet' : ''}.minimal.json`)),
+      map((assetsMinimal) => {
+        if (this.stateService.network === 'liquidtestnet') {
+          // Hard coding the Liquid Testnet native asset
+          assetsMinimal['144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49'] = [null, "tL-BTC", "Test Liquid Bitcoin", 8];
+        }
+        return assetsMinimal;
+      }),
       shareReplay(1),
     );
     this.getMiningPools$ = this.httpClient.get(apiBaseUrl + '/resources/pools.json').pipe(shareReplay(1));


### PR DESCRIPTION
fixes #1068

Handling the native Liquid Testnet asset which is native but yet behaves like a regular issuance transaction and is not pegged in/out.

<img width="1168" alt="Screen Shot 2022-01-04 at 05 23 28" src="https://user-images.githubusercontent.com/8561090/147997661-52fe44cd-142b-4d9d-9090-81b40b5aa898.png">
