### PR TITLE
Removing db-scripts from ls -R output

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ data mysql
 ./data:
 
 ./mysql:
-data  db-scripts
+data
 
 ./mysql/data:
 ```


### PR DESCRIPTION
The output of `ls -R` after creating the directories with the command `mkdir -p data mysql/data` is actually:
```
.:
data  mysql

./data:

./mysql:
data

./mysql/data:

```
The `db-scripts` on the output `ls -R` in this file is kind of misleading.
If the user creates a directory `mysql/db-scripts`, the output of `ls -R` is actually:
```
.:
data  mysql

./data:

./mysql:
data  db-scripts

./mysql/data:

./mysql/db-scripts:

```
This might lead the user to think that `db-scripts` is actually a file. This is the output of `ls -R` when `db-scripts` is a file:
```
.:
data  mysql

./data:

./mysql:
data  db-scripts

./mysql/data:

```
The command `docker-compose up` will fail if `db-scripts` is actually a file. But, it will create the directory if it doesn't exist.
