### PR TITLE
Cap extreme vbytes_per_second values

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -320,7 +320,7 @@ class Statistics {
   private getQueryForDays(div: number, interval: string) {
     return `SELECT id, UNIX_TIMESTAMP(added) as added, unconfirmed_transactions,
       tx_per_second,
-      vbytes_per_second,
+      CAST(avg(vbytes_per_second) as FLOAT) as vbytes_per_second,
       vsize_1,
       vsize_2,
       vsize_3,


### PR DESCRIPTION
* [x] Apply AVG() on vbytes_per_second so we can see trends
* [x] Cap extreme vbytes_per_second values so the y-axis scale is too big and we can still see details
  * For 2h/24h/1w chart - Cap to 10x of the median value
  * For longer timeframe - Cap to 4x of the median value
  * Those ratios can be changed easily here https://github.com/nymkappa/mempool/commit/45542d5f06888617f7388db802115c325496b430#diff-42a88bf2b0c6898fd6e3a11fa981beb6b26bb7b292e34c033cbfbd313ce5c77cR172