### PR TITLE
Adding current language to network dropdown links

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -58,6 +58,7 @@ import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-poli
 import { TrademarkPolicyComponent } from './components/trademark-policy/trademark-policy.component';
 import { StorageService } from './services/storage.service';
 import { HttpCacheInterceptor } from './services/http-cache.interceptor';
+import { LanguageService } from './services/language.service';
 import { SponsorComponent } from './components/sponsor/sponsor.component';
 import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -128,6 +129,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
     AudioService,
     SeoService,
     StorageService,
+    LanguageService,
     { provide: HTTP_INTERCEPTORS, useClass: HttpCacheInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]

--- a/frontend/src/app/components/bisq-master-page/bisq-master-page.component.html
+++ b/frontend/src/app/components/bisq-master-page/bisq-master-page.component.html
@@ -15,13 +15,13 @@
       <img src="./resources/bisq-logo.png" style="width: 25px; height: 25px;" class="mr-1">
     </button>
     <div ngbDropdownMenu [ngClass]="{'dropdown-menu-right' : isMobile}">
-      <a [href]="env.MEMPOOL_WEBSITE_URL" ngbDropdownItem class="mainnet"><img src="./resources/bitcoin-logo.png" style="width: 30px;" class="mr-1"> Mainnet</a>
-      <a [href]="env.MEMPOOL_WEBSITE_URL + '/signet'" ngbDropdownItem *ngIf="env.SIGNET_ENABLED" class="signet"><img src="./resources/signet-logo.png" style="width: 30px;" class="mr-1"> Signet</a>
-      <a [href]="env.MEMPOOL_WEBSITE_URL + '/testnet'" ngbDropdownItem *ngIf="env.TESTNET_ENABLED" class="testnet"><img src="./resources/testnet-logo.png" style="width: 30px;" class="mr-1"> Testnet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage" ngbDropdownItem class="mainnet"><img src="./resources/bitcoin-logo.png" style="width: 30px;" class="mr-1"> Mainnet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage + '/signet'" ngbDropdownItem *ngIf="env.SIGNET_ENABLED" class="signet"><img src="./resources/signet-logo.png" style="width: 30px;" class="mr-1"> Signet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage + '/testnet'" ngbDropdownItem *ngIf="env.TESTNET_ENABLED" class="testnet"><img src="./resources/testnet-logo.png" style="width: 30px;" class="mr-1"> Testnet</a>
       <h6 class="dropdown-header" i18n="master-page.layer2-networks-header">Layer 2 Networks</h6>
       <button ngbDropdownItem class="mainnet active" routerLink="/"><img src="./resources/bisq-logo.png" style="width: 30px;" class="mr-1"> Bisq</button>
-      <a [href]="env.LIQUID_WEBSITE_URL" ngbDropdownItem *ngIf="env.LIQUID_ENABLED" class="liquid"><img src="./resources/liquid-logo.png" style="width: 30px;" class="mr-1"> Liquid</a>
-      <a [href]="env.LIQUID_WEBSITE_URL + '/testnet'" ngbDropdownItem *ngIf="env.LIQUID_TESTNET_ENABLED" class="liquidtestnet"><img src="./resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1"> Liquid Testnet</a>
+      <a [href]="env.LIQUID_WEBSITE_URL + urlLanguage" ngbDropdownItem *ngIf="env.LIQUID_ENABLED" class="liquid"><img src="./resources/liquid-logo.png" style="width: 30px;" class="mr-1"> Liquid</a>
+      <a [href]="env.LIQUID_WEBSITE_URL + urlLanguage + '/testnet'" ngbDropdownItem *ngIf="env.LIQUID_TESTNET_ENABLED" class="liquidtestnet"><img src="./resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1"> Liquid Testnet</a>
     </div>
   </div>
 

--- a/frontend/src/app/components/bisq-master-page/bisq-master-page.component.ts
+++ b/frontend/src/app/components/bisq-master-page/bisq-master-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Env, StateService } from '../../services/state.service';
 import { Observable } from 'rxjs';
+import { LanguageService } from 'src/app/services/language.service';
 
 @Component({
   selector: 'app-bisq-master-page',
@@ -12,14 +13,17 @@ export class BisqMasterPageComponent implements OnInit {
   navCollapsed = false;
   env: Env;
   isMobile = window.innerWidth <= 767.98;
-  
+  urlLanguage: string;
+
   constructor(
     private stateService: StateService,
+    private languageService: LanguageService,
   ) { }
 
   ngOnInit() {
     this.env = this.stateService.env;
     this.connectionState$ = this.stateService.connectionState$;
+    this.urlLanguage = this.languageService.getLanguageForUrl();
   }
 
   collapse(): void {

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -13,7 +13,6 @@ import { RelativeUrlPipe } from 'src/app/shared/pipes/relative-url/relative-url.
 @Component({
   selector: 'app-block',
   templateUrl: './block.component.html',
-  providers: [RelativeUrlPipe],
   styleUrls: ['./block.component.scss']
 })
 export class BlockComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/components/language-selector/language-selector.component.ts
+++ b/frontend/src/app/components/language-selector/language-selector.component.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { languages } from 'src/app/app.constants';
@@ -14,6 +15,7 @@ export class LanguageSelectorComponent implements OnInit {
   languages = languages;
 
   constructor(
+    @Inject(DOCUMENT) private document: Document,
     private formBuilder: FormBuilder,
     private languageService: LanguageService,
   ) { }
@@ -26,6 +28,9 @@ export class LanguageSelectorComponent implements OnInit {
   }
 
   changeLanguage() {
-    this.languageService.setLanguage(this.languageForm.get('language').value);
+    const newLang = this.languageForm.get('language').value;
+    this.languageService.setLanguage(newLang);
+    const rawUrlPath = this.languageService.stripLanguageFromUrl(null);
+    this.document.location.href = (newLang !== 'en' ? `/${newLang}` : '') + rawUrlPath;
   }
 }

--- a/frontend/src/app/components/language-selector/language-selector.component.ts
+++ b/frontend/src/app/components/language-selector/language-selector.component.ts
@@ -1,8 +1,7 @@
-import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { Language, languages } from 'src/app/app.constants';
-import { StateService } from 'src/app/services/state.service';
+import { languages } from 'src/app/app.constants';
+import { LanguageService } from 'src/app/services/language.service';
 
 @Component({
   selector: 'app-language-selector',
@@ -12,42 +11,21 @@ import { StateService } from 'src/app/services/state.service';
 })
 export class LanguageSelectorComponent implements OnInit {
   languageForm: FormGroup;
-  languages: Language[];
+  languages = languages;
 
   constructor(
     private formBuilder: FormBuilder,
-    private stateService: StateService,
-    @Inject(DOCUMENT) private document: Document
+    private languageService: LanguageService,
   ) { }
 
   ngOnInit() {
-    this.languages = languages;
-
     this.languageForm = this.formBuilder.group({
-      language: ['']
+      language: ['en']
     });
-    this.setLanguageFromUrl();
-  }
-
-  setLanguageFromUrl() {
-    const urlLanguage = this.document.location.pathname.split('/')[1];
-    if (this.languages.map((lang) => lang.code).indexOf(urlLanguage) > -1) {
-      this.languageForm.get('language').setValue(urlLanguage);
-    } else {
-      this.languageForm.get('language').setValue('en');
-    }
+    this.languageForm.get('language').setValue(this.languageService.getLanguage());
   }
 
   changeLanguage() {
-    const language = this.languageForm.get('language').value;
-    try {
-      document.cookie = `lang=${language}; expires=Thu, 18 Dec 2050 12:00:00 UTC; path=/`;
-    } catch (e) { }
-    
-    if (this.stateService.env.BASE_MODULE === 'mempool') {
-      this.document.location.href = `/${language}/${this.stateService.network}`;
-    } else {
-      this.document.location.href = `/${language}`;
-    }
+    this.languageService.setLanguage(this.languageForm.get('language').value);
   }
 }

--- a/frontend/src/app/components/liquid-master-page/liquid-master-page.component.html
+++ b/frontend/src/app/components/liquid-master-page/liquid-master-page.component.html
@@ -16,11 +16,11 @@
       <img src="./resources/{{ network.val === '' ? 'liquid' : network.val }}-logo.png" style="width: 25px; height: 25px;" class="mr-1">
     </button>
     <div ngbDropdownMenu [ngClass]="{'dropdown-menu-right' : isMobile}">
-      <a [href]="env.MEMPOOL_WEBSITE_URL" ngbDropdownItem class="mainnet"><img src="./resources/bitcoin-logo.png" style="width: 30px;" class="mr-1"> Mainnet</a>
-      <a [href]="env.MEMPOOL_WEBSITE_URL + '/signet'" ngbDropdownItem *ngIf="env.SIGNET_ENABLED" class="signet"><img src="./resources/signet-logo.png" style="width: 30px;" class="mr-1"> Signet</a>
-      <a [href]="env.MEMPOOL_WEBSITE_URL + '/testnet'" ngbDropdownItem *ngIf="env.TESTNET_ENABLED" class="testnet"><img src="./resources/testnet-logo.png" style="width: 30px;" class="mr-1"> Testnet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage" ngbDropdownItem class="mainnet"><img src="./resources/bitcoin-logo.png" style="width: 30px;" class="mr-1"> Mainnet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage + '/signet'" ngbDropdownItem *ngIf="env.SIGNET_ENABLED" class="signet"><img src="./resources/signet-logo.png" style="width: 30px;" class="mr-1"> Signet</a>
+      <a [href]="env.MEMPOOL_WEBSITE_URL + urlLanguage + '/testnet'" ngbDropdownItem *ngIf="env.TESTNET_ENABLED" class="testnet"><img src="./resources/testnet-logo.png" style="width: 30px;" class="mr-1"> Testnet</a>
       <h6 class="dropdown-header" i18n="master-page.layer2-networks-header">Layer 2 Networks</h6>
-      <a [href]="env.BISQ_WEBSITE_URL" ngbDropdownItem class="mainnet"><img src="./resources/bisq-logo.png" style="width: 30px;" class="mr-1"> Bisq</a>
+      <a [href]="env.BISQ_WEBSITE_URL + urlLanguage" ngbDropdownItem class="mainnet"><img src="./resources/bisq-logo.png" style="width: 30px;" class="mr-1"> Bisq</a>
       <button ngbDropdownItem class="liquid" [class.active]="network.val === 'liquid'" routerLink="/"><img src="./resources/liquid-logo.png" style="width: 30px;" class="mr-1"> Liquid</button>
       <button ngbDropdownItem *ngIf="env.LIQUID_TESTNET_ENABLED" class="liquidtestnet" [class.active]="network.val === 'liquidtestnet'" routerLink="/testnet"><img src="./resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1"> Liquid Testnet</button>
     </div>

--- a/frontend/src/app/components/liquid-master-page/liquid-master-page.component.ts
+++ b/frontend/src/app/components/liquid-master-page/liquid-master-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Env, StateService } from '../../services/state.service';
 import { merge, Observable, of} from 'rxjs';
+import { LanguageService } from 'src/app/services/language.service';
 
 @Component({
   selector: 'app-liquid-master-page',
@@ -14,15 +15,18 @@ export class LiquidMasterPageComponent implements OnInit {
   isMobile = window.innerWidth <= 767.98;
   officialMempoolSpace = this.stateService.env.OFFICIAL_MEMPOOL_SPACE;
   network$: Observable<string>;
+  urlLanguage: string;
 
   constructor(
     private stateService: StateService,
+    private languageService: LanguageService,
   ) { }
 
   ngOnInit() {
     this.env = this.stateService.env;
     this.connectionState$ = this.stateService.connectionState$;
     this.network$ = merge(of(''), this.stateService.networkChanged$);
+    this.urlLanguage = this.languageService.getLanguageForUrl();
   }
 
   collapse(): void {

--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -20,9 +20,9 @@
       <button ngbDropdownItem *ngIf="env.SIGNET_ENABLED" class="signet" [class.active]="network.val === 'signet'" routerLink="/signet"><img src="./resources/signet-logo.png" style="width: 30px;" class="mr-1"> Signet</button>
       <button ngbDropdownItem *ngIf="env.TESTNET_ENABLED" class="testnet" [class.active]="network.val === 'testnet'" routerLink="/testnet"><img src="./resources/testnet-logo.png" style="width: 30px;" class="mr-1"> Testnet</button>
       <h6 *ngIf="env.LIQUID_ENABLED || env.BISQ_ENABLED" class="dropdown-header" i18n="master-page.layer2-networks-header">Layer 2 Networks</h6>
-      <a [href]="env.BISQ_WEBSITE_URL" ngbDropdownItem *ngIf="env.BISQ_ENABLED" class="bisq"><img src="./resources/bisq-logo.png" style="width: 30px;" class="mr-1"> Bisq</a>
-      <a [href]="env.LIQUID_WEBSITE_URL" ngbDropdownItem *ngIf="env.LIQUID_ENABLED" class="liquid" [class.active]="network.val === 'liquid'"><img src="./resources/liquid-logo.png" style="width: 30px;" class="mr-1"> Liquid</a>
-      <a [href]="env.LIQUID_WEBSITE_URL + '/testnet'" ngbDropdownItem *ngIf="env.LIQUID_TESTNET_ENABLED" class="liquidtestnet" [class.active]="network.val === 'liquid'"><img src="./resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1"> Liquid Testnet</a>
+      <a [href]="env.BISQ_WEBSITE_URL + urlLanguage" ngbDropdownItem *ngIf="env.BISQ_ENABLED" class="bisq"><img src="./resources/bisq-logo.png" style="width: 30px;" class="mr-1"> Bisq</a>
+      <a [href]="env.LIQUID_WEBSITE_URL + urlLanguage" ngbDropdownItem *ngIf="env.LIQUID_ENABLED" class="liquid" [class.active]="network.val === 'liquid'"><img src="./resources/liquid-logo.png" style="width: 30px;" class="mr-1"> Liquid</a>
+      <a [href]="env.LIQUID_WEBSITE_URL + urlLanguage + '/testnet'" ngbDropdownItem *ngIf="env.LIQUID_TESTNET_ENABLED" class="liquidtestnet" [class.active]="network.val === 'liquid'"><img src="./resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1"> Liquid Testnet</a>
     </div>
   </div>
 

--- a/frontend/src/app/components/master-page/master-page.component.ts
+++ b/frontend/src/app/components/master-page/master-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Env, StateService } from '../../services/state.service';
 import { Observable, merge, of } from 'rxjs';
+import { LanguageService } from 'src/app/services/language.service';
 
 @Component({
   selector: 'app-master-page',
@@ -14,15 +15,18 @@ export class MasterPageComponent implements OnInit {
   navCollapsed = false;
   isMobile = window.innerWidth <= 767.98;
   officialMempoolSpace = this.stateService.env.OFFICIAL_MEMPOOL_SPACE;
+  urlLanguage: string;
 
   constructor(
     private stateService: StateService,
+    private languageService: LanguageService,
   ) { }
 
   ngOnInit() {
     this.env = this.stateService.env;
     this.connectionState$ = this.stateService.connectionState$;
     this.network$ = merge(of(''), this.stateService.networkChanged$);
+    this.urlLanguage = this.languageService.getLanguageForUrl();
   }
 
   collapse(): void {

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -12,7 +12,6 @@ import { RelativeUrlPipe } from 'src/app/shared/pipes/relative-url/relative-url.
   selector: 'app-mempool-blocks',
   templateUrl: './mempool-blocks.component.html',
   styleUrls: ['./mempool-blocks.component.scss'],
-  providers: [RelativeUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MempoolBlocksComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -13,7 +13,6 @@ import { RelativeUrlPipe } from 'src/app/shared/pipes/relative-url/relative-url.
   selector: 'app-search-form',
   templateUrl: './search-form.component.html',
   styleUrls: ['./search-form.component.scss'],
-  providers: [RelativeUrlPipe],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SearchFormComponent implements OnInit {

--- a/frontend/src/app/services/language.service.ts
+++ b/frontend/src/app/services/language.service.ts
@@ -11,10 +11,12 @@ export class LanguageService {
   constructor(
     @Inject(DOCUMENT) private document: Document,
     @Inject(LOCALE_ID) private locale: string,
-  ) { }
+  ) {
+    this.language = getLocaleId(this.locale).substring(0, 2);
+  }
 
   getLanguage(): string {
-    return getLocaleId(this.locale).substring(0, 2);
+    return this.language;
   }
 
   stripLanguageFromUrl(urlPath: string) {
@@ -27,12 +29,10 @@ export class LanguageService {
   }
 
   getLanguageForUrl(): string {
-    let lang = this.getLanguage();
-    return lang === 'en' ? '' : '/' + lang;
+    return this.language === 'en' ? '' : '/' + this.language;
   }
 
   setLanguage(language: string): void {
-    this.language = language;
     try {
       document.cookie = `lang=${language}; expires=Thu, 18 Dec 2050 12:00:00 UTC; path=/`;
     } catch (e) { }

--- a/frontend/src/app/services/language.service.ts
+++ b/frontend/src/app/services/language.service.ts
@@ -1,7 +1,6 @@
-import { DOCUMENT } from '@angular/common';
-import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT, getLocaleId } from '@angular/common';
+import { LOCALE_ID, Inject, Injectable } from '@angular/core';
 import { languages } from 'src/app/app.constants';
-import { RelativeUrlPipe } from '../shared/pipes/relative-url/relative-url.pipe';
 
 @Injectable({
   providedIn: 'root'
@@ -11,31 +10,31 @@ export class LanguageService {
   private languages = languages;
   constructor(
     @Inject(DOCUMENT) private document: Document,
-    private relativeUrlPipe: RelativeUrlPipe,
+    @Inject(LOCALE_ID) private locale: string,
   ) { }
 
   getLanguage(): string {
-    return this.language;
+    return getLocaleId(this.locale).substring(0, 2);
   }
 
-  getLanguageForUrl() {
-    return this.language === 'en' ? '' : '/' + this.language;
-  }
-
-  setLocalLanguage() {
+  stripLanguageFromUrl(urlPath: string) {
+    let rawUrlPath = urlPath ? urlPath : document.location.pathname;
     const urlLanguage = this.document.location.pathname.split('/')[1];
-    if (this.languages.map((lang) => lang.code).indexOf(urlLanguage) > -1) {
-      this.language = urlLanguage;
-    } else {
-      this.language = 'en';
+    if (this.languages.map((lang) => lang.code).indexOf(urlLanguage) != -1) {
+      rawUrlPath = rawUrlPath.substring(3);
     }
+    return rawUrlPath;
+  }
+
+  getLanguageForUrl(): string {
+    let lang = this.getLanguage();
+    return lang === 'en' ? '' : '/' + lang;
   }
 
   setLanguage(language: string): void {
+    this.language = language;
     try {
       document.cookie = `lang=${language}; expires=Thu, 18 Dec 2050 12:00:00 UTC; path=/`;
     } catch (e) { }
-
-    this.document.location.href = this.relativeUrlPipe.transform(`/${language}/`);
   }
 }

--- a/frontend/src/app/services/language.service.ts
+++ b/frontend/src/app/services/language.service.ts
@@ -1,0 +1,41 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import { languages } from 'src/app/app.constants';
+import { RelativeUrlPipe } from '../shared/pipes/relative-url/relative-url.pipe';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LanguageService {
+  private language = 'en';
+  private languages = languages;
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private relativeUrlPipe: RelativeUrlPipe,
+  ) { }
+
+  getLanguage(): string {
+    return this.language;
+  }
+
+  getLanguageForUrl() {
+    return this.language === 'en' ? '' : '/' + this.language;
+  }
+
+  setLocalLanguage() {
+    const urlLanguage = this.document.location.pathname.split('/')[1];
+    if (this.languages.map((lang) => lang.code).indexOf(urlLanguage) > -1) {
+      this.language = urlLanguage;
+    } else {
+      this.language = 'en';
+    }
+  }
+
+  setLanguage(language: string): void {
+    try {
+      document.cookie = `lang=${language}; expires=Thu, 18 Dec 2050 12:00:00 UTC; path=/`;
+    } catch (e) { }
+
+    this.document.location.href = this.relativeUrlPipe.transform(`/${language}/`);
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -60,6 +60,7 @@ import { ColoredPriceDirective } from './directives/colored-price.directive';
   ],
   providers: [
     VbytesPipe,
+    RelativeUrlPipe,
   ],
   exports: [
     NgbAccordionModule,


### PR DESCRIPTION
fixes  #1094

This PR solves the following issues:

* Switching network from `mempool.space/sv` to Liquid should take you to `liquid.network/sv`
* Switching language on `liquid.network/testnet` should take you to `liquid.network/sv/testnet` , not root.

Completely untested locally.