### PR TITLE
fix directory issue in rsync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Install mempool dependencies from npm and build the frontend static HTML/CSS/JS:
 Install the output into nginx webroot folder:
 
 ```bash
-  sudo rsync -av --delete dist/mempool/ /var/www/
+  sudo rsync -av --delete dist/ /var/www/
 ```
 
 ## nginx + certbot


### PR DESCRIPTION
the command that's now in the readme create the locale and resource folders in `/var/www/browser/`

now it corresponds with https://github.com/mempool/mempool/blob/master/nginx-mempool.conf#L4

after fix
```
$ ls /var/www/mempool/browser/
ar  cs  en-US  fa  fr  hi  it  ka  mk  nl  pt         ro  sl  th  uk  zh
ca  de  es     fi  he  hu  ja  ko  nb  pl  resources  ru  sv  tr  vi
```