### PR TITLE
Disable graph touch interaction in dashboard on mobile so we can scroll properly

### DIFF
--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -67,7 +67,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         left: this.left,
       },
       animation: false,
-      dataZoom: [{
+      dataZoom: (this.template === 'widget' && this.isMobile()) ? null : [{
         type: 'inside',
         realtime: true,
         zoomLock: (this.template === 'widget') ? true : false,
@@ -93,6 +93,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         },
       }],
       tooltip: {
+        show: !this.isMobile(),
         trigger: 'axis',
         position: (pos, params, el, elRect, size) => {
           const obj = { top: -20 };
@@ -218,5 +219,9 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
         }
       },
     };
+  }
+
+  isMobile() {
+    return window.innerWidth <= 767.98;
   }
 }

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -170,7 +170,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       hover: true,
       color: this.inverted ? [...newColors].reverse() : newColors,
       tooltip: {
-        show: (window.innerWidth >= 768) ? true : false,
+        show: !this.isMobile(),
         trigger: 'axis',
         alwaysShowContent: false,
         position: (pos, params, el, elRect, size) => {
@@ -282,7 +282,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
           </div>`;
         }
       },
-      dataZoom: [{
+      dataZoom: (this.template === 'widget' && this.isMobile()) ? null : [{
         type: 'inside',
         realtime: true,
         zoomLock: (this.template === 'widget') ? true : false,
@@ -381,6 +381,10 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       }
     }
     this.chartColorsOrdered =  chartColors.slice(0, this.feeLevelsOrdered.length);
+  }
+
+  isMobile() {
+    return window.innerWidth <= 767.98;
   }
 }
 


### PR DESCRIPTION
- [X] Can't interact with graphs in the dashboard on mobile only
- [X] Always hide tooltip on vBytes/sec chart on mobile for consistency with the mempool chart which already does not show it
- [X] Can still zoom in/out in `/graphs` view (and therefore the scrolling UX is as before, not so great)
  - For a later PR, need to improve mempool chart performance on mobile, it's terribly slow right now (very hard to use the zoom)