### PR TITLE
Order by native `statistics.added` field for better query performances

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -292,7 +292,7 @@ class Statistics {
       FROM statistics \
       WHERE added BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW() \
       GROUP BY UNIX_TIMESTAMP(added) DIV ${div} \
-      ORDER BY added DESC;`;
+      ORDER BY statistics.added DESC;`;
   }
 
   private getQueryForDays(div: number, interval: string) {
@@ -340,7 +340,7 @@ class Statistics {
       FROM statistics \
       WHERE added BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW() \
       GROUP BY UNIX_TIMESTAMP(added) DIV ${div} \
-      ORDER BY added DESC;`;
+      ORDER BY statistics.added DESC;`;
   }
 
   private async $get(id: number): Promise<OptimizedStatistic | undefined> {
@@ -360,7 +360,7 @@ class Statistics {
   public async $list2H(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY added DESC LIMIT 120`;
+      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 120`;
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);
@@ -373,7 +373,7 @@ class Statistics {
   public async $list24H(): Promise<OptimizedStatistic[]> {
     try {
       const connection = await DB.pool.getConnection();
-      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY added DESC LIMIT 1440`;
+      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 1440`;
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
       return this.mapStatisticToOptimizedStatistic(rows);


### PR DESCRIPTION
Replace `ORDER BY added` by `ORDER BY statistics.added` to improve query speed