### PR TITLE
Remove unused fields from statistics queries since we don't use them in the front end

### DIFF
--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -247,9 +247,8 @@ class Statistics {
   }
 
   private getQueryForDaysAvg(div: number, interval: string) {
-    return `SELECT id, UNIX_TIMESTAMP(added) as added,
-      CAST(avg(unconfirmed_transactions) as DOUBLE) as unconfirmed_transactions,
-      CAST(avg(tx_per_second) as DOUBLE) as tx_per_second,
+    return `SELECT
+      UNIX_TIMESTAMP(added) as added,
       CAST(avg(vbytes_per_second) as DOUBLE) as vbytes_per_second,
       CAST(avg(vsize_1) as DOUBLE) as vsize_1,
       CAST(avg(vsize_2) as DOUBLE) as vsize_2,
@@ -296,8 +295,8 @@ class Statistics {
   }
 
   private getQueryForDays(div: number, interval: string) {
-    return `SELECT id, UNIX_TIMESTAMP(added) as added, unconfirmed_transactions,
-      tx_per_second,
+    return `SELECT
+      UNIX_TIMESTAMP(added) as added,
       CAST(avg(vbytes_per_second) as DOUBLE) as vbytes_per_second,
       vsize_1,
       vsize_2,
@@ -477,10 +476,7 @@ class Statistics {
   private mapStatisticToOptimizedStatistic(statistic: Statistic[]): OptimizedStatistic[] {
     return statistic.map((s) => {
       return {
-        id: s.id || 0,
         added: s.added,
-        unconfirmed_transactions: s.unconfirmed_transactions,
-        tx_per_second: s.tx_per_second,
         vbytes_per_second: s.vbytes_per_second,
         mempool_byte_weight: s.mempool_byte_weight,
         total_fee: s.total_fee,

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -128,10 +128,7 @@ export interface Statistic {
 }
 
 export interface OptimizedStatistic {
-  id: number;
   added: string;
-  unconfirmed_transactions: number;
-  tx_per_second: number;
   vbytes_per_second: number;
   total_fee: number;
   mempool_byte_weight: number;

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -1,8 +1,5 @@
 export interface OptimizedMempoolStats {
-  id: number;
   added: number;
-  unconfirmed_transactions: number;
-  tx_per_second: number;
   vbytes_per_second: number;
   total_fee: number;
   mempool_byte_weight: number;


### PR DESCRIPTION
Remove `id`, `unconfirmed_transactions` and `tx_per_second` from the statistics queries since we don't use them in the front end