### PR TITLE
Utilize gettxout to display spent/unspent

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -12,6 +12,7 @@ export interface AbstractBitcoinApi {
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
   $getAddressPrefix(prefix: string): string[];
   $sendRawTransaction(rawTransaction: string): Promise<string>;
+  $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]>;
 }
 export interface BitcoinRpcCredentials {
   host: string;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -102,6 +102,18 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.sendRawTransaction(rawTransaction);
   }
 
+  async $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]> {
+    const outSpends: IEsploraApi.Outspend[] = [];
+    const tx = await this.$getRawTransaction(txId, true, false);
+    for (let i = 0; i < tx.vout.length; i++) {
+      const txOut = await this.bitcoindClient.getTxOut(txId, i);
+      outSpends.push({
+        spent: txOut === null,
+      });
+    }
+    return outSpends;
+  }
+
   protected async $convertTransaction(transaction: IBitcoinApi.Transaction, addPrevout: boolean): Promise<IEsploraApi.Transaction> {
     let esploraTransaction: IEsploraApi.Transaction = {
       txid: transaction.txid,

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -113,9 +113,9 @@ export namespace IEsploraApi {
 
   export interface Outspend {
     spent: boolean;
-    txid: string;
-    vin: number;
-    status: Status;
+    txid?: string;
+    vin?: number;
+    status?: Status;
   }
 
   export interface Asset {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -60,6 +60,10 @@ class ElectrsApi implements AbstractBitcoinApi {
   $sendRawTransaction(rawTransaction: string): Promise<string> {
     throw new Error('Method not implemented.');
   }
+
+  $getOutspends(): Promise<IEsploraApi.Outspend[]> {
+    throw new Error('Method not implemented.');
+  }
 }
 
 export default ElectrsApi;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -716,8 +716,13 @@ class Routes {
     }
   }
 
-  public getTransactionOutspends(req: Request, res: Response) {
-    res.status(501).send('Not implemented');
+  public async getTransactionOutspends(req: Request, res: Response) {
+    try {
+      const result = await bitcoinApi.$getOutspends(req.params.txId);
+      res.json(result);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
   }
 
   public getDifficultyChange(req: Request, res: Response) {

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -189,9 +189,14 @@
                       <fa-icon [icon]="['fas', 'arrow-alt-circle-right']" [fixedWidth]="true"></fa-icon>
                     </span>
                     <ng-template #spent>
-                      <a [routerLink]="['/tx/' | relativeUrl, outspends[i][vindex].txid]" class="red">
+                      <a *ngIf="outspends[i][vindex].txid else outputNoTxId" [routerLink]="['/tx/' | relativeUrl, outspends[i][vindex].txid]" class="red">
                         <fa-icon [icon]="['fas', 'arrow-alt-circle-right']" [fixedWidth]="true"></fa-icon>
                       </a>
+                      <ng-template #outputNoTxId>
+                        <span class="red">
+                          <fa-icon [icon]="['fas', 'arrow-alt-circle-right']" [fixedWidth]="true"></fa-icon>
+                        </span>
+                      </ng-template>
                     </ng-template>
                   </ng-template>
                 </td>


### PR DESCRIPTION
fixes #1088

Unlike with esplora the red spent is not clickable, but at least we are showing if UTXOs are spent or not, and we get rid of the 501 error message.

Before:
<img width="465" alt="Screen Shot 2022-01-15 at 22 10 35" src="https://user-images.githubusercontent.com/8561090/149632955-07e2198e-323c-4da7-a96f-511b354acac0.png">

<img width="563" alt="Screen Shot 2022-01-15 at 22 07 29" src="https://user-images.githubusercontent.com/8561090/149632920-eed5d328-6ef9-437e-869d-f9ab256b151f.png">

After:
<img width="564" alt="Screen Shot 2022-01-15 at 22 07 23" src="https://user-images.githubusercontent.com/8561090/149632923-3c8c7451-62a2-46a2-a641-7d2377862f04.png">


