### PR TITLE
Add 0 as lower bound for block's fees

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -76,7 +76,7 @@ export class BlockComponent implements OnInit, OnDestroy {
 
         if (block.id === this.blockHash) {
           this.block = block;
-          this.fees = block.reward / 100000000 - this.blockSubsidy;
+          this.fees = Math.max(0, block.reward / 100000000 - this.blockSubsidy);
         }
       });
 
@@ -147,7 +147,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         }
         this.setBlockSubsidy();
         if (block.reward !== undefined) {
-          this.fees = block.reward / 100000000 - this.blockSubsidy;
+          this.fees = Math.max(0, block.reward / 100000000 - this.blockSubsidy);
         }
         this.stateService.markBlock$.next({ blockHeight: this.blockHeight });
         this.isLoadingTransactions = true;
@@ -164,7 +164,7 @@ export class BlockComponent implements OnInit, OnDestroy {
     )
     .subscribe((transactions: Transaction[]) => {
       if (this.fees === undefined && transactions[0]) {
-        this.fees = transactions[0].vout.reduce((acc: number, curr: Vout) => acc + curr.value, 0) / 100000000 - this.blockSubsidy;
+        this.fees = Math.max(0, transactions[0].vout.reduce((acc: number, curr: Vout) => acc + curr.value, 0) / 100000000 - this.blockSubsidy);
       }
       if (!this.coinbaseTx && transactions[0]) {
         this.coinbaseTx = transactions[0];


### PR DESCRIPTION
I noticed that block 501726 didn't collect a mining reward and tested it
on a few block explorers. On mempool, it currently shows up as "Total
fees: -₿12.5". Negative fees don't make sense, so I'm introducing a
lower bound of 0 for the displayed value.
![image](https://user-images.githubusercontent.com/4060799/149797159-7117466a-ada2-4b97-a96f-a44146d4c0c4.png)

-----

This is my first code contribution, it seems very likely that I didn't catch all the relevant places or broke something else. Please let me know what else needs to be done or whether you'd rather take over the PR. I'm also not sure whether there should be a test for this, and it seems a bit arduous to sync an instance to block 502k to see whether it was fixed, so ideas how to confirm that the issues was resolved would be welcome. ;)