### PR TITLE
Mining dashboard (1/2) - Import mining pools into the database - Increment db schema to 3

### DIFF
--- a/backend/mempool-config.sample.json
+++ b/backend/mempool-config.sample.json
@@ -14,7 +14,9 @@
     "MEMPOOL_BLOCKS_AMOUNT": 8,
     "PRICE_FEED_UPDATE_INTERVAL": 3600,
     "USE_SECOND_NODE_FOR_MINFEE": false,
-    "EXTERNAL_ASSETS": []
+    "EXTERNAL_ASSETS": [
+      "https://mempool.space/resources/pools.json"
+    ]
   },
   "CORE_RPC": {
     "HOST": "127.0.0.1",

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -3,10 +3,10 @@ import config from '../config';
 import { DB } from '../database';
 import logger from '../logger';
 
-const sleep = (ms: number) => new Promise( res => setTimeout(res, ms));
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 2;
+  private static currentVersion = 3;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -82,6 +82,9 @@ class DatabaseMigration {
       await this.$executeQuery(connection, this.getCreateStatisticsQuery(), await this.$checkIfTableExists('statistics'));
       if (databaseSchemaVersion < 2 && this.statisticsAddedIndexed === false) {
         await this.$executeQuery(connection, `CREATE INDEX added ON statistics (added);`);
+      }
+      if (databaseSchemaVersion < 3) {
+        await this.$executeQuery(connection, this.getCreatePoolsTableQuery(), await this.$checkIfTableExists('pools'));
       }
       connection.release();
     } catch (e) {
@@ -334,6 +337,17 @@ class DatabaseMigration {
       bitcoinindex int(11) NOT NULL,
       final_tx int(11) NOT NULL
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
+  }
+
+  private getCreatePoolsTableQuery(): string {
+    return `CREATE TABLE IF NOT EXISTS pools (
+      id int(11) NOT NULL AUTO_INCREMENT,
+      name varchar(50) NOT NULL,
+      link varchar(255) NOT NULL,
+      addresses text NOT NULL,
+      regexes text NOT NULL,
+      PRIMARY KEY (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`;
   }
 }
 

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -3,10 +3,10 @@ import { DB } from '../database';
 import logger from '../logger';
 
 interface Pool {
-  name: string,
-  link: string,
-  regexes: string[],
-  addresses: string[],
+  name: string;
+  link: string;
+  regexes: string[];
+  addresses: string[];
 }
 
 class PoolsParser {
@@ -18,14 +18,14 @@ class PoolsParser {
     logger.info('Importing pools.json to the database');
 
     // Get existing pools from the db
-    const [existingPools] = await connection.query<any>({ sql: 'SELECT * FROM pools;', timeout: 120000 }); // We clear the table before insertion    
+    const [existingPools] = await connection.query<any>({ sql: 'SELECT * FROM pools;', timeout: 120000 });
 
     logger.info('Open ./pools.json');
-    const fileContent: string = readFileSync('./pools.json','utf8');
+    const fileContent: string = readFileSync('./pools.json', 'utf8');
     const poolsJson: object = JSON.parse(fileContent);
 
     // First we save every entries without paying attention to pool duplication
-    let poolsDuplicated: Pool[] = [];
+    const poolsDuplicated: Pool[] = [];
 
     logger.info('Parse coinbase_tags');
     const coinbaseTags = Object.entries(poolsJson['coinbase_tags']);
@@ -50,7 +50,7 @@ class PoolsParser {
 
     // Then, we find unique mining pool names
     logger.info('Identify unique mining pools');
-    let poolNames : string[] = [];
+    const poolNames: string[] = [];
     for (let i = 0; i < poolsDuplicated.length; ++i) {
       if (poolNames.indexOf(poolsDuplicated[i].name) === -1) {
         poolNames.push(poolsDuplicated[i].name);
@@ -59,47 +59,47 @@ class PoolsParser {
     logger.info(`Found ${poolNames.length} unique mining pools`);
 
     // Finally, we generate the final consolidated pools data
-    let finalPoolDataAdd: Pool[] = [];
-    let finalPoolDataUpdate: Pool[] = [];
+    const finalPoolDataAdd: Pool[] = [];
+    const finalPoolDataUpdate: Pool[] = [];
     for (let i = 0; i < poolNames.length; ++i) {
       let allAddresses: string[] = [];
       let allRegexes: string[] = [];
-      let match = poolsDuplicated.filter((pool: Pool) => pool.name === poolNames[i]);
+      const match = poolsDuplicated.filter((pool: Pool) => pool.name === poolNames[i]);
 
       for (let y = 0; y < match.length; ++y) {
         allAddresses = allAddresses.concat(match[y].addresses);
         allRegexes = allRegexes.concat(match[y].regexes);
       }
 
-      const finalPoolName = poolNames[i].replace("'", "''"); // To support single quote in names when doing db queries
+      const finalPoolName = poolNames[i].replace(`'`, `''`); // To support single quote in names when doing db queries
 
-      if (existingPools.find((pool) => { return pool.name === poolNames[i]}) !== undefined) {
-        logger.debug(`Update '${finalPoolName} mining pool`);
+      if (existingPools.find((pool) => pool.name === poolNames[i]) !== undefined) {
+        logger.debug(`Update '${finalPoolName}' mining pool`);
         finalPoolDataUpdate.push({
           'name': finalPoolName,
           'link': match[0].link,
           'regexes': allRegexes,
           'addresses': allAddresses,
-        })
+        });
       } else {
-        logger.debug(`Add '${finalPoolName} mining pool`);
+        logger.debug(`Add '${finalPoolName}' mining pool`);
         finalPoolDataAdd.push({
           'name': finalPoolName,
           'link': match[0].link,
           'regexes': allRegexes,
           'addresses': allAddresses,
-        })
+        });
       }
     }
 
     // Manually add the 'unknown pool'
-    if (existingPools.find((pool) => { return pool.name === "Uknown"}) !== undefined) {
+    if (existingPools.find((pool) => pool.name === 'Unknown') !== undefined) {
       finalPoolDataAdd.push({
         'name': 'Unknown',
         'link': 'https://learnmeabitcoin.com/technical/coinbase-transaction',
         regexes: [],
         addresses: [],
-      })
+      });
     }
 
     logger.info(`Update pools table now`);
@@ -113,7 +113,7 @@ class PoolsParser {
     queryAdd = queryAdd.slice(0, -1) + ';';
 
     // Add new mining pools into the database
-    let updateQueries: string[] = [];
+    const updateQueries: string[] = [];
     for (let i = 0; i < finalPoolDataUpdate.length; ++i) {
       updateQueries.push(`
         UPDATE pools

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -135,9 +135,9 @@ class PoolsParser {
       if (finalPoolDataAdd.length > 0) {
         await connection.query<any>({ sql: queryAdd, timeout: 120000 });
       }
-      updateQueries.forEach(async query => {
+      for (const query of updateQueries) {
         await connection.query<any>({ sql: query, timeout: 120000 });
-      });
+      }
       await this.insertUnknownPool();
       connection.release();
       logger.info('Mining pools.json import completed');

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -1,0 +1,118 @@
+import {readFileSync} from 'fs';
+import { DB } from '../database';
+import logger from '../logger';
+
+interface Pool {
+  name: string,
+  link: string,
+  regexes: string[],
+  addresses: string[],
+}
+
+class PoolsParser {
+  /**
+   * Parse the pools.json file, consolidate the data and dump it into the database
+   */
+  public async migratePoolsJson() {
+    logger.info('Importing pools.json to the database');
+    let connection = await DB.pool.getConnection();
+
+    // Check if the pools table does not have data already, for now we do not support updating it
+    // but that will come in a later version
+    let [rows] = await connection.query<any>({ sql: 'SELECT count(id) as count from pools;', timeout: 120000 });
+    if (rows[0].count !== 0) {
+      logger.info('Pools table already contain data, updating it is not yet supported, skipping.');
+      connection.release();
+      return;
+    }
+
+    logger.info('Open ../frontend/cypress/fixtures/pools.json');
+    const fileContent: string = readFileSync('../frontend/cypress/fixtures/pools.json','utf8');
+    const poolsJson: object = JSON.parse(fileContent);
+
+    // First we save every entries without paying attention to pool duplication
+    let poolsDuplicated: Pool[] = [];
+
+    logger.info('Parse coinbase_tags');
+    const coinbaseTags = Object.entries(poolsJson['coinbase_tags']);
+    for (let i = 0; i < coinbaseTags.length; ++i) {
+      poolsDuplicated.push({
+        'name': (<Pool>coinbaseTags[i][1]).name,
+        'link': (<Pool>coinbaseTags[i][1]).link,
+        'regexes': [coinbaseTags[i][0]],
+        'addresses': [],
+      });
+    }
+    logger.info('Parse payout_addresses');
+    const addressesTags = Object.entries(poolsJson['payout_addresses']);
+    for (let i = 0; i < addressesTags.length; ++i) {
+      poolsDuplicated.push({
+        'name': (<Pool>addressesTags[i][1]).name,
+        'link': (<Pool>addressesTags[i][1]).link,
+        'regexes': [],
+        'addresses': [addressesTags[i][0]],
+      });
+    }
+
+    // Then, we find unique mining pool names
+    logger.info('Identify unique mining pools');
+    let poolNames : string[] = [];
+    for (let i = 0; i < poolsDuplicated.length; ++i) {
+      if (poolNames.indexOf(poolsDuplicated[i].name) === -1) {
+        poolNames.push(poolsDuplicated[i].name);
+      }
+    }
+    logger.info(`Found ${poolNames.length} unique mining pools`);
+
+    // Finally, we generate the final consolidated pools data
+    let finalPoolData: Pool[] = [];
+    for (let i = 0; i < poolNames.length; ++i) {
+      let allAddresses: string[] = [];
+      let allRegexes: string[] = [];
+      let match = poolsDuplicated.filter((pool: Pool) => pool.name === poolNames[i]);
+
+      for (let y = 0; y < match.length; ++y) {
+        allAddresses = allAddresses.concat(match[y].addresses);
+        allRegexes = allRegexes.concat(match[y].regexes);
+      }
+
+      finalPoolData.push({
+        'name': poolNames[i].replace("'", "''"),
+        'link': match[0].link,
+        'regexes': allRegexes,
+        'addresses': allAddresses,
+      })
+    }
+
+    // Manually add the 'unknown pool'
+    finalPoolData.push({
+      'name': 'Unknown',
+      'link': 'https://learnmeabitcoin.com/technical/coinbase-transaction',
+      regexes: [],
+      addresses: [],
+    })
+
+    // Dump everything into the database
+    logger.info(`Insert mining pool info into the database`);
+    let query: string = 'INSERT INTO pools(name, link, regexes, addresses) VALUES ';
+    for (let i = 0; i < finalPoolData.length; ++i) {
+      query += `('${finalPoolData[i].name}', '${finalPoolData[i].link}',
+        '${JSON.stringify(finalPoolData[i].regexes)}', '${JSON.stringify(finalPoolData[i].addresses)}'),`;
+    }
+    query = query.slice(0, -1) + ';';
+
+    try {
+      await connection.query<any>({ sql: 'DELETE FROM pools;', timeout: 120000 }); // We clear the table before insertion
+      await connection.query<any>({ sql: query, timeout: 120000 });
+      connection.release();
+      logger.info('Import completed');
+    } catch (e) {
+      connection.release();
+      logger.info(`Unable to import pools in the database!`);
+      throw e;
+    }
+  }
+
+}
+
+export default new PoolsParser();

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -67,9 +67,9 @@ class PoolsParser {
 
     // Get existing pools from the db
     const connection = await DB.pool.getConnection();
-    let existingPools: any[] = [];
+    let existingPools;
     try {
-      existingPools = await connection.query<any>({ sql: 'SELECT * FROM pools;', timeout: 120000 });
+      [existingPools] = await connection.query<any>({ sql: 'SELECT * FROM pools;', timeout: 120000 });
     } catch (e) {
       logger.err('Unable to get existing pools from the database, skipping pools.json import');
       connection.release();

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -93,7 +93,7 @@ class PoolsParser {
     }
 
     // Manually add the 'unknown pool'
-    if (existingPools.find((pool) => pool.name === 'Unknown') !== undefined) {
+    if (existingPools.find((pool) => pool.name === 'Unknown') === undefined) {
       finalPoolDataAdd.push({
         'name': 'Unknown',
         'link': 'https://learnmeabitcoin.com/technical/coinbase-transaction',

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -79,7 +79,9 @@ const defaults: IConfig = {
     'MEMPOOL_BLOCKS_AMOUNT': 8,
     'PRICE_FEED_UPDATE_INTERVAL': 3600,
     'USE_SECOND_NODE_FOR_MINFEE': false,
-    'EXTERNAL_ASSETS': [],
+    'EXTERNAL_ASSETS': [
+      'https://mempool.space/resources/pools.json'
+    ]
   },
   'ESPLORA': {
     'REST_API_URL': 'http://127.0.0.1:3000',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import loadingIndicators from './api/loading-indicators';
 import mempool from './api/mempool';
 import elementsParser from './api/liquid/elements-parser';
 import databaseMigration from './api/database-migration';
+import poolsParser from './api/pools-parser';
 import syncAssets from './sync-assets';
 import icons from './api/liquid/icons';
 import { Common } from './api/common';
@@ -88,6 +89,7 @@ class Server {
       await checkDbConnection();
       try {
         await databaseMigration.$initializeOrMigrateDatabase();
+        await poolsParser.migratePoolsJson();
       } catch (e) {
         throw new Error(e instanceof Error ? e.message : 'Error');
       }


### PR DESCRIPTION
This PR is a prelude to the new mining dashboard https://github.com/mempool/mempool/pull/1162.

When mempool is started, the database migration will run and increment the db schema version to 3. It will create a new table `pools` and parse + import https://github.com/mempool/mempool/blob/master/frontend/cypress/fixtures/pools.json into the database.

Note: The `PoolsParser` script does not yet support updating. A future PR will allow updating the `pools` table when needed.