### PR TITLE
Liquid asset loading fixes

### DIFF
--- a/frontend/src/app/assets/assets.component.html
+++ b/frontend/src/app/assets/assets.component.html
@@ -43,7 +43,7 @@
       <thead>
         <th i18n="Asset name header">Name</th>
         <th i18n="Asset ticker header">Ticker</th>
-        <th i18n="Asset Issuer Domain header">Issuer domain</th>
+        <th class="d-none d-md-block" i18n="Asset Issuer Domain header">Issuer domain</th>
         <th i18n="Asset ID header">Asset ID</th>
       </thead>
       <tbody>

--- a/frontend/src/app/components/asset/asset.component.html
+++ b/frontend/src/app/components/asset/asset.component.html
@@ -66,7 +66,7 @@
         <div class="col icon-holder">
           <img *ngIf="!imageError; else defaultIcon" class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + asset.asset_id + '/icon'" (error)="imageError = true">
           <ng-template #defaultIcon>
-            <fa-icon [icon]="['fas', 'database']" [fixedWidth]="true" size="10x"></fa-icon>
+            <fa-icon class="defaultIcon" [icon]="['fas', 'database']" [fixedWidth]="true" size="8x"></fa-icon>
           </ng-template>
         </div>
       </div>
@@ -109,28 +109,39 @@
 
   <ng-template [ngIf]="isLoadingAsset && !error">
 
-    <ng-template #loadingTmpl>
-      <div class="col">
-        <table class="table table-borderless table-striped">
-          <tbody>
-            <tr>
-              <td colspan="2"><span class="skeleton-loader"></span></td>
-            </tr>
-            <tr>
-              <td colspan="2"><span class="skeleton-loader"></span></td>
-            </tr>
-            <tr>
-              <td colspan="2"><span class="skeleton-loader"></span></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </ng-template>
-
     <div class="box">
       <div class="row">
-        <ng-container *ngTemplateOutlet="loadingTmpl"></ng-container>
-        <ng-container *ngTemplateOutlet="loadingTmpl"></ng-container>
+        <div class="col">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+              <tr>
+                <td colspan="2"><span class="skeleton-loader"></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="w-100 d-block d-md-none"></div>
+        <div class="col icon-holder">
+          <fa-icon class="defaultIcon skeleton" [icon]="['fas', 'database']" [fixedWidth]="true" size="8x"></fa-icon>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/app/components/asset/asset.component.scss
+++ b/frontend/src/app/components/asset/asset.component.scss
@@ -51,10 +51,10 @@ h1 {
 }
 
 .assetIcon {
-  max-height: 150px;
+  height: 150px;
   margin: 25px;
   @media (min-width: 768px) {
-    max-height: 300px;
+    height: 250px;
     margin: 0;
   }
 }
@@ -63,4 +63,13 @@ h1 {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.defaultIcon {
+  margin: 25px;
+  height: 150px;
+}
+
+.defaultIcon.skeleton {
+  opacity: 0.5;
 }


### PR DESCRIPTION
Assets on mobile and asset pages did not show the skeleton loading properly.

Assets (Mobile)

<img width="485" alt="Screen Shot 2022-01-20 at 22 55 32" src="https://user-images.githubusercontent.com/8561090/150404015-86466334-8ebf-4344-8cf5-7bcda2dffc8f.png">
Asset (desktop)


<img width="845" alt="Screen Shot 2022-01-20 at 23 01 06" src="https://user-images.githubusercontent.com/8561090/150404665-2b00e950-4e73-49b1-8e94-316c08a7cc56.png">

