### PR TITLE
Asset name overflow fix

### DIFF
--- a/frontend/src/app/components/asset/asset.component.html
+++ b/frontend/src/app/components/asset/asset.component.html
@@ -21,7 +21,7 @@
             <tbody>
               <tr>
                 <td i18n="asset.name|Liquid Asset name">Name</td>
-                <td>{{ assetContract[2] }} ({{ assetContract[1] }})</td>
+                <td class="assetName">{{ assetContract[2] }} ({{ assetContract[1] }})</td>
               </tr>
               <tr>
                 <td i18n="asset.precision|Liquid Asset precision">Precision</td>

--- a/frontend/src/app/components/asset/asset.component.scss
+++ b/frontend/src/app/components/asset/asset.component.scss
@@ -73,3 +73,8 @@ h1 {
 .defaultIcon.skeleton {
   opacity: 0.5;
 }
+
+.assetName {
+  word-break: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
Break long overflowing asset names

<img width="308" alt="Screen Shot 2022-01-21 at 00 14 26" src="https://user-images.githubusercontent.com/8561090/150415281-f392ecd4-a730-4372-82ec-c2a7faee9291.png">
