### PR TITLE
Change Citadel link to core

### DIFF
--- a/frontend/src/app/components/about/about.component.html
+++ b/frontend/src/app/components/about/about.component.html
@@ -102,7 +102,7 @@
         <img class="image" src="/resources/profile/ronindojo.png" />
         <span>RoninDojo</span>
       </a>
-      <a href="https://github.com/runcitadel/dashboard" target="_blank" title="Citadel">
+      <a href="https://github.com/runcitadel/core" target="_blank" title="Citadel">
         <img class="image" src="/resources/profile/runcitadel.svg" />
         <span>Citadel</span>
       </a>


### PR DESCRIPTION
The Citadel dashboard repo will soon be replaced, and this is consistend with other projects like Umbrel where the link leads to the main repo.