### PR TITLE
Let backend set its own HTTP cache time headers for APIs

### DIFF
--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -29,7 +29,6 @@ location @mempool-api-v1-warmcache {
 	proxy_cache api;
 	proxy_cache_valid 200 10s;
 	proxy_redirect off;
-	expires 10s;
 }
 
 location @mempool-api-v1-coldcache {


### PR DESCRIPTION
```
curl -si https://mempool.ninja/api/v1/statistics/24h
```
gotta check expires headers for all api endpoints