### PR TITLE
Fix TV View layout

### DIFF
--- a/frontend/cypress/integration/mainnet/mainnet.spec.ts
+++ b/frontend/cypress/integration/mainnet/mainnet.spec.ts
@@ -178,7 +178,7 @@ describe('Mainnet', () => {
           cy.viewport('macbook-16');
           cy.visit('/');
           cy.waitForSkeletonGone();
-          cy.get('.blockchain-blocks-0 > a').click().then(() => {
+          cy.get('.blockchain-blocks-0 > a').click({force: true}).then(() => {
             cy.get('[ngbtooltip="Next Block"] > .ng-fa-icon > .svg-inline--fa').should('not.exist');
             cy.get('[ngbtooltip="Previous Block"] > .ng-fa-icon > .svg-inline--fa').should('be.visible');
             cy.waitForPageIdle();
@@ -192,7 +192,7 @@ describe('Mainnet', () => {
           cy.viewport('macbook-16');
           cy.visit('/');
           cy.waitForSkeletonGone();
-          cy.get('.blockchain-blocks-0 > a').click().then(() => {
+          cy.get('.blockchain-blocks-0 > a').click({force: true}).then(() => {
             cy.waitForPageIdle();
             cy.get('[ngbtooltip="Next Block"] > .ng-fa-icon > .svg-inline--fa').should('not.exist');
             cy.get('[ngbtooltip="Previous Block"] > .ng-fa-icon > .svg-inline--fa').should('be.visible');
@@ -205,7 +205,7 @@ describe('Mainnet', () => {
           cy.viewport('macbook-16');
           cy.visit('/');
           cy.waitForSkeletonGone();
-          cy.get('.blockchain-blocks-4 > a').click().then(() => {
+          cy.get('.blockchain-blocks-4 > a').click({force: true}).then(() => {
             cy.waitForPageIdle();
 
             // block 6
@@ -264,7 +264,7 @@ describe('Mainnet', () => {
           cy.viewport('macbook-16');
           cy.visit('/');
           cy.waitForSkeletonGone();
-          cy.get('.blockchain-blocks-0 > a').click().then(() => {
+          cy.get('.blockchain-blocks-0 > a').click({force: true}).then(() => {
             cy.waitForPageIdle();
             cy.get('[ngbtooltip="Next Block"] > .ng-fa-icon > .svg-inline--fa').should('not.exist');
             cy.get('[ngbtooltip="Previous Block"] > .ng-fa-icon > .svg-inline--fa').should('be.visible');
@@ -324,6 +324,44 @@ describe('Mainnet', () => {
       });
     });
 
+    describe('tv view page', () => {
+      it('loads the tv screen - desktop > 700px height', () => {
+        cy.viewport(1280, 720);
+        cy.visit('/');
+        cy.waitForSkeletonGone();
+        cy.get('#btn-tv').click().then(() => {
+          cy.viewport(1280, 720);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
+          cy.get('#mempool-block-0').should('be.visible');
+        });
+      });
+
+      it('loads the tv screen - desktop > 500px height', () => {
+        cy.viewport(800, 600);
+        cy.visit('/');
+        cy.waitForSkeletonGone();
+        cy.visit('/tv').then(() => {
+          cy.viewport(800, 600);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
+          cy.get('#mempool-block-0').should('be.visible');
+        });
+      });
+
+      it('loads the tv screen - desktop < 500px height', () => {
+        cy.viewport(320, 480);
+        cy.visit('/');
+        cy.waitForSkeletonGone();
+        cy.visit('/tv').then(() => {
+          cy.viewport(320, 480);
+          cy.get('.chart');
+          cy.get('.blocks').should('not.visible');
+          cy.get('#mempool-block-0').should('not.visible');
+        });
+      });
+    });
+
     describe('graphs page', () => {
       it('check buttons - mobile', () => {
         cy.viewport('iphone-6');
@@ -349,26 +387,6 @@ describe('Mainnet', () => {
         cy.get('#dropdownFees').should('be.visible');
         cy.get('.btn-group').should('be.visible');
       });
-    });
-
-    it('loads the tv screen - desktop', () => {
-      cy.viewport('macbook-16');
-      cy.visit('/');
-      cy.waitForSkeletonGone();
-      cy.get('#btn-tv').click().then(() => {
-        cy.viewport('macbook-16');
-        cy.get('.chart-holder');
-        cy.get('.blockchain-wrapper').should('be.visible');
-        cy.get('#mempool-block-0').should('be.visible');
-      });
-    });
-
-    it('loads the tv screen - mobile', () => {
-      cy.viewport('iphone-6');
-      cy.visit('/tv');
-      cy.waitForSkeletonGone();
-      cy.get('.chart-holder');
-      cy.get('.blockchain-wrapper').should('not.visible');
     });
 
     it('loads genesis block and click on the arrow left', () => {
@@ -455,26 +473,6 @@ describe('Mainnet', () => {
         cy.get('#dropdownFees').should('be.visible');
         cy.get('.btn-group').should('be.visible');
       });
-    });
-
-    it('loads the tv screen - desktop', () => {
-      cy.viewport('macbook-16');
-      cy.visit('/');
-      cy.waitForSkeletonGone();
-      cy.get('#btn-tv').click().then(() => {
-        cy.viewport('macbook-16');
-        cy.get('.chart-holder');
-        cy.get('.blockchain-wrapper').should('be.visible');
-        cy.get('#mempool-block-0').should('be.visible');
-      });
-    });
-
-    it('loads the tv screen - mobile', () => {
-      cy.viewport('iphone-6');
-      cy.visit('/tv');
-      cy.waitForSkeletonGone();
-      cy.get('.chart-holder');
-      cy.get('.blockchain-wrapper').should('not.visible');
     });
 
     it('loads the api screen', () => {

--- a/frontend/cypress/integration/signet/signet.spec.ts
+++ b/frontend/cypress/integration/signet/signet.spec.ts
@@ -60,31 +60,43 @@ describe('Signet', () => {
       });
     });
 
-    describe('tv mode', () => {
-      it('loads the tv screen - desktop', () => {
-        cy.viewport('macbook-16');
-        cy.visit('/signet');
+    describe('tv view page', () => {
+      it('loads the tv screen - desktop > 700px height', () => {
+        cy.viewport(1280, 720);
+        cy.visit('/');
         cy.waitForSkeletonGone();
         cy.get('#btn-tv').click().then(() => {
-          cy.get('.chart-holder').should('be.visible');
+          cy.viewport(1280, 720);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
           cy.get('#mempool-block-0').should('be.visible');
-          cy.get('.tv-only').should('not.exist');
         });
       });
 
-      it('loads the tv screen - mobile', () => {
-        cy.visit('/signet');
+      it('loads the tv screen - desktop > 500px height', () => {
+        cy.viewport(800, 600);
+        cy.visit('/');
         cy.waitForSkeletonGone();
-        cy.get('#btn-tv').click().then(() => {
-          cy.viewport('iphone-8');
-          cy.get('.chart-holder').should('be.visible');
-          cy.get('.tv-only').should('not.exist');
-          //TODO: Remove comment when the bug is fixed
-          //cy.get('#mempool-block-0').should('be.visible');
+        cy.visit('/tv').then(() => {
+          cy.viewport(800, 600);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
+          cy.get('#mempool-block-0').should('be.visible');
+        });
+      });
+
+      it('loads the tv screen - desktop < 500px height', () => {
+        cy.viewport(320, 480);
+        cy.visit('/');
+        cy.waitForSkeletonGone();
+        cy.visit('/tv').then(() => {
+          cy.viewport(320, 480);
+          cy.get('.chart');
+          cy.get('.blocks').should('not.visible');
+          cy.get('#mempool-block-0').should('not.visible');
         });
       });
     });
-
 
     it('loads the api screen', () => {
       cy.visit('/signet');

--- a/frontend/cypress/integration/testnet/testnet.spec.ts
+++ b/frontend/cypress/integration/testnet/testnet.spec.ts
@@ -60,30 +60,43 @@ describe('Testnet', () => {
       });
     });
 
-    describe('tv mode', () => {
-      it('loads the tv screen - desktop', () => {
-        cy.viewport('macbook-16');
-        cy.visit('/testnet');
+    describe('tv view page', () => {
+      it('loads the tv screen - desktop > 700px height', () => {
+        cy.viewport(1280, 720);
+        cy.visit('/');
         cy.waitForSkeletonGone();
         cy.get('#btn-tv').click().then(() => {
-          cy.wait(1000);
-          cy.get('.tv-only').should('not.exist');
-          //TODO: Remove comment when the bug is fixed
-          //cy.get('#mempool-block-0').should('be.visible');
+          cy.viewport(1280, 720);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
+          cy.get('#mempool-block-0').should('be.visible');
         });
       });
 
-      it('loads the tv screen - mobile', () => {
-        cy.visit('/testnet');
+      it('loads the tv screen - desktop > 500px height', () => {
+        cy.viewport(800, 600);
+        cy.visit('/');
         cy.waitForSkeletonGone();
-        cy.get('#btn-tv').click().then(() => {
-          cy.viewport('iphone-6');
-          cy.wait(1000);
-          cy.get('.tv-only').should('not.exist');
+        cy.visit('/tv').then(() => {
+          cy.viewport(800, 600);
+          cy.get('.chart');
+          cy.get('.blocks').should('be.visible');
+          cy.get('#mempool-block-0').should('be.visible');
+        });
+      });
+
+      it('loads the tv screen - desktop < 500px height', () => {
+        cy.viewport(320, 480);
+        cy.visit('/');
+        cy.waitForSkeletonGone();
+        cy.visit('/tv').then(() => {
+          cy.viewport(320, 480);
+          cy.get('.chart');
+          cy.get('.blocks').should('not.visible');
+          cy.get('#mempool-block-0').should('not.visible');
         });
       });
     });
-
 
     it('loads the api screen', () => {
       cy.visit('/testnet');

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -1,25 +1,28 @@
-<div class="blocks-container blockchain-blocks-container" *ngIf="(loadingBlocks$ | async) === false; else loadingBlocksTemplate">
-  <div *ngFor="let block of blocks; let i = index; trackBy: trackByBlocksFn" >
-    <div class="text-center bitcoin-block mined-block blockchain-blocks-{{ i }}" id="bitcoin-block-{{ block.height }}" [ngStyle]="blockStyles[i]" [class.blink-bg]="(specialBlocks[block.height] !== undefined)">
-      <a draggable="false" [routerLink]="['/block/' | relativeUrl, block.id]" [state]="{ data: { block: block } }" 
-        class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">&nbsp;</a>
+<div class="d-flex flex-column blocks-container" *ngIf="(loadingBlocks$ | async) === false; else loadingBlocksTemplate">
+  <div class="d-flex flex-row block-container">
+    <div *ngFor="let block of blocks; let i = index; trackBy: trackByBlocksFn" class="block-margin" [ngStyle]="{left: blockStyles[i].left}">
       <div class="block-height">
         <a [routerLink]="['/block/' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a>
       </div>
-      <div class="block-body">
-        <div class="fees">
-          ~{{ block.medianFee | number:feeRounding }} <ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container>
-        </div>
-        <div class="fee-span">
-          {{ block.feeRange[1] | number:feeRounding }} - {{ block.feeRange[block.feeRange.length - 1] | number:feeRounding }} <ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container>
-        </div>
-        <div class="block-size" [innerHTML]="'&lrm;' + (block.size | bytes: 2)"></div>
-        <div class="transaction-count">
-          <ng-container *ngTemplateOutlet="block.tx_count === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: block.tx_count | number}"></ng-container>
-          <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
-          <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
-        </div>
-        <div class="time-difference"><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></div>
+      <div class="text-center bitcoin-block mined-block blockchain-blocks-{{ i }}" id="bitcoin-block-{{ block.height }}" [class.blink-bg]="(specialBlocks[block.height] !== undefined)">
+        <a draggable="false" [routerLink]="['/block/' | relativeUrl, block.id]" [state]="{ data: { block: block } }" 
+          class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">
+          <div class="block-body" [ngStyle]="{background: blockStyles[i].background}">
+            <div class="fees">
+              ~{{ block.medianFee | number:feeRounding }} <ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container>
+            </div>
+            <div class="fee-span">
+              {{ block.feeRange[1] | number:feeRounding }} - {{ block.feeRange[block.feeRange.length - 1] | number:feeRounding }} <ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container>
+            </div>
+            <div class="block-size" [innerHTML]="'&lrm;' + (block.size | bytes: 2)"></div>
+            <div class="transaction-count">
+              <ng-container *ngTemplateOutlet="block.tx_count === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: block.tx_count | number}"></ng-container>
+              <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
+              <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
+            </div>
+            <div class="time-difference"><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></div>
+          </div>
+        </a>
       </div>
     </div>
   </div>
@@ -27,11 +30,15 @@
 </div>
 
 <ng-template #loadingBlocksTemplate>
-  <div class="blocks-container">
-    <div class="flashing">
-      <div *ngFor="let block of emptyBlocks; let i = index; trackBy: trackByBlocksFn" >
-        <div class="text-center bitcoin-block mined-block" id="bitcoin-block-{{ block.height }}" [ngStyle]="emptyBlockStyles[i]"></div>
-      </div>
+  <div class="d-flex flex-column blocks-container empty-blocks-container">
+    <div class="d-flex flex-row block-container flashing">
+        <div *ngFor="let block of emptyBlocks; let i = index; trackBy: trackByBlocksFn" >
+          <div class="block-margin">
+            <div class="text-center bitcoin-block mined-block" id="bitcoin-block-{{ block.height }}" [ngStyle]="{left: emptyBlockStyles[i].left}">
+              <div class="block-body" [ngStyle]="{background: emptyBlockStyles[i].background}"></div>
+          </div>
+        </div>
+      </div>  
     </div>
   </div>
 </ng-template>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -1,14 +1,62 @@
+.block-container {
+  position: relative;
+}
+
+.block-margin {
+  position: absolute;
+  margin-right: 25px;
+  transition: 2s;
+}
+
 .bitcoin-block {
+  width: 125px;
+  height: 125px;
+  min-width: 125px;
+  min-height: 125px;
+  position: relative;
+  margin-left: 30px;
+  left: 13px;
+}
+
+.bitcoin-block::after {
+  content: '';
+  width: 125px;
+  height: 24px;
+  position:absolute;
+  top: 2px;
+  left: -20px;
+  background-color: #232838;
+  transform:skew(40deg);
+  transform-origin:top;
+}
+
+.bitcoin-block::before {
+  content: '';
+  width: 20px;
+  height: 125px;
+  position: absolute;
+  top: 14px;
+  left: -20px;
+  background-color: #191c27;
+  transform: skewY(50deg);
+  transform-origin: top;
+}
+
+.block-size {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.block-body {
+  position: absolute;
+  margin-top: 6px;
   width: 125px;
   height: 125px;
 }
 
 .blockLink {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  left: 0;
   z-index: 10;
+  color: white;
 }
 
 .blockLink:hover {
@@ -20,24 +68,20 @@
 }
 
 .mined-block {
-  position: absolute;
-  top: 0px;
-  transition: 2s;
-}
-
-.block-size {
-  font-size: 16px;
-  font-weight: bold;
+  margin-top: 10px;
+  margin-left: 1px;
+  margin-right: 4px;
+  padding-top: 20px;
 }
 
 .blocks-container {
-  position: absolute;
-  top: 0px;
-  left: 40px;
+  position: relative;
+  margin-left: 23px;
 }
 
-.block-body {
-  text-align: center;
+.empty-blocks-container {
+  margin-top: 24px;
+  margin-left: 36px;
 }
 
 .time-difference {
@@ -46,7 +90,7 @@
 
 .fees {
   font-size: 12px;
-  margin-top: 10px;
+  padding-top: 10px;
   margin-bottom: 2px;
 }
 
@@ -63,37 +107,10 @@
 }
 
 .block-height {
-  position: absolute;
+  text-align: center;
   font-size: 16px;
-  bottom: 160px;
   width: 100%;
-  left: -12px;
   z-index: 1;
-}
-
-.bitcoin-block::after {
-  content: '';
-  width: 125px;
-  height: 24px;
-  position:absolute;
-  top: -24px;
-  left: -20px;
-  background-color: #232838;
-  transform:skew(40deg);
-  transform-origin:top;
-}
-
-.bitcoin-block::before {
-  content: '';
-  width: 20px;
-  height: 125px;
-  position: absolute;
-  top: -12px;
-  left: -20px;
-  background-color: #191c27;
-
-  transform: skewY(50deg);
-  transform-origin: top;
 }
 
 .black-background {
@@ -103,9 +120,8 @@
 }
 
 #arrow-up {
-  position: relative;
-  left: 30px;
-  top: 140px;
+  position: absolute;
+  top: 200px;
   width: 0;
   height: 0;
   border-left: 35px solid transparent;

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -125,14 +125,14 @@ export class BlockchainBlocksComponent implements OnInit, OnDestroy {
       }
       this.arrowVisible = true;
       if (newBlockFromLeft) {
-        this.arrowLeftPx = blockindex * 155 + 30 - 205;
+        this.arrowLeftPx = blockindex * 155 + 45 - 205;
         setTimeout(() => {
           this.transition = '2s';
-          this.arrowLeftPx = blockindex * 155 + 30;
+          this.arrowLeftPx = blockindex * 155 + 45;
           this.cd.markForCheck();
         }, 50);
       } else {
-        this.arrowLeftPx = blockindex * 155 + 30;
+        this.arrowLeftPx = blockindex * 155 + 45;
         if (!animate) {
           setTimeout(() => {
             this.transition = '2s';
@@ -180,7 +180,7 @@ export class BlockchainBlocksComponent implements OnInit, OnDestroy {
       background: "#2d3348",
     };
   }
-
+  
   mountEmptyBlocks() {
     const emptyBlocks = [];
     for (let i = 0; i < this.stateService.env.KEEP_BLOCKS_AMOUNT; i++) {

--- a/frontend/src/app/components/blockchain/blockchain.component.html
+++ b/frontend/src/app/components/blockchain/blockchain.component.html
@@ -1,9 +1,7 @@
 <div class="text-center" class="blockchain-wrapper">
-  <div class="position-container {{ network }}">
-    <span>
-      <app-mempool-blocks></app-mempool-blocks>
-      <app-blockchain-blocks></app-blockchain-blocks>
-      <div id="divider"></div>
-    </span>
+  <div class="d-flex flex-row position-container">
+    <app-mempool-blocks></app-mempool-blocks>
+    <div id="divider"></div>
+    <app-blockchain-blocks></app-blockchain-blocks>
   </div>
 </div>

--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -1,23 +1,15 @@
 #divider {
-  width: 3px;
+  width: 2.5px;
+  min-width: 2.5px;
+  margin-top: 10px;
+  margin-left: 3px;
   height: 200px;
-  left: 0;
-  top: -50px;
   background-image: url('/resources/divider-new.png');
   background-repeat: repeat-y;
-  position: absolute;
-  margin-bottom: 120px;
-}
-
-#divider > img {
-  position: absolute;
-  left: -100px;
-  top: -28px;
 }
 
 .blockchain-wrapper {
-  overflow: hidden;
-  height: 250px;
+  height: 235px;
 
   -webkit-user-select: none; /* Safari */        
   -moz-user-select: none; /* Firefox */
@@ -26,25 +18,7 @@
 }
 
 .position-container {
-  position: absolute;
-  left: 50%;
-  top: 75px;
-}
-
-.position-container.liquid, .position-container.liquidtestnet {
-  left: 420px;
-}
-
-@media (max-width: 767.98px) {
-  .position-container {
-    left: 95%;
-  }
-  .position-container.liquid, .position-container.liquidtestnet {
-    left: 50%;
-  }
-  .position-container.loading {
-    left: 50%;
-  }
+  margin-top: 15px;
 }
 
 .black-background {
@@ -54,10 +28,6 @@
 }
 
 .loading-block {
-  position: absolute;
   text-align: center;
   margin: auto;
-  width: 300px;
-  left: -150px;
-  top: 0px;
 }

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -1,51 +1,56 @@
 <ng-container *ngIf="(loadingBlocks$ | async) === false; else loadingBlocks">
-  <div class="mempool-blocks-container" *ngIf="(timeAvg$ | async) as timeAvg;">
-    <div class="flashing">
+  <div class="d-flex flex-column mempool-blocks-container {{ network }}">
+    <div class="d-flex flex-row flex-row-reverse flashing" *ngIf="(timeAvg$ | async) as timeAvg;">
       <ng-template ngFor let-projectedBlock [ngForOf]="mempoolBlocks$ | async" let-i="index" [ngForTrackBy]="trackByFn">
-        <div class="bitcoin-block text-center mempool-block" id="mempool-block-{{ i }}" [ngStyle]="mempoolBlockStyles[i]" [class.blink-bg]="projectedBlock.blink">
+        <div class="bitcoin-block text-center mempool-block" id="mempool-block-{{ i }}" [class.blink-bg]="projectedBlock.blink">
           <a draggable="false" [routerLink]="['/mempool-block/' | relativeUrl, i]"
-            class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">&nbsp;</a>
-          <div class="block-body">
-            <div class="fees">
-              ~{{ projectedBlock.medianFee | number:feeRounding }} <span i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
-            </div>
-            <div class="fee-span">
-              {{ projectedBlock.feeRange[0] | number:feeRounding }} - {{ projectedBlock.feeRange[projectedBlock.feeRange.length - 1] | number:feeRounding }} <span i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
-            </div>
-            <div class="block-size" [innerHTML]="'&lrm;' + (projectedBlock.blockSize | bytes: 2)"></div>
-            <div class="transaction-count">
-              <ng-container *ngTemplateOutlet="projectedBlock.nTx === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: projectedBlock.nTx | number}"></ng-container>
-              <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
-              <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
-            </div>
-            <div class="time-difference" *ngIf="projectedBlock.blockVSize <= stateService.blockVSize; else mergedBlock">
-              <ng-template [ngIf]="network === 'liquid' || network === 'liquidtestnet'" [ngIfElse]="timeDiffMainnet">
-                <app-time-until [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time-until>
-              </ng-template>
-              <ng-template #timeDiffMainnet>
-                <app-time-until [time]="(timeAvg * i) + now + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
-              </ng-template>
-            </div>
-            <ng-template #mergedBlock>
-              <div class="time-difference">
-                <b>(<ng-container *ngTemplateOutlet="blocksPlural; context: {$implicit: projectedBlock.blockVSize / stateService.blockVSize | ceil }"></ng-container>)</b>
-                <ng-template #blocksPlural let-i i18n="shared.blocks">{{ i }} <span class="shared-block">blocks</span></ng-template>
+            class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">
+            <div class="block-body" [ngStyle]="mempoolBlockStyles[i]">
+              <div class="fees">
+                ~{{ projectedBlock.medianFee | number:feeRounding }} <span i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
               </div>
-            </ng-template>
-          </div>
+              <div class="fee-span">
+                {{ projectedBlock.feeRange[0] | number:feeRounding }} - {{ projectedBlock.feeRange[projectedBlock.feeRange.length - 1] | number:feeRounding }} <span i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
+              </div>
+              <div class="block-size" [innerHTML]="'&lrm;' + (projectedBlock.blockSize | bytes: 2)"></div>
+              <div class="transaction-count">
+                <ng-container *ngTemplateOutlet="projectedBlock.nTx === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: projectedBlock.nTx | number}"></ng-container>
+                <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
+                <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
+              </div>
+              <div class="time-difference" *ngIf="projectedBlock.blockVSize <= stateService.blockVSize; else mergedBlock">
+                <ng-template [ngIf]="network === 'liquid' || network === 'liquidtestnet'" [ngIfElse]="timeDiffMainnet">
+                  <app-time-until [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time-until>
+                </ng-template>
+                <ng-template #timeDiffMainnet>
+                  <app-time-until [time]="(timeAvg * i) + now + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
+                </ng-template>
+              </div>
+              <ng-template #mergedBlock>
+                <div class="time-difference">
+                  <b>(<ng-container *ngTemplateOutlet="blocksPlural; context: {$implicit: projectedBlock.blockVSize / stateService.blockVSize | ceil }"></ng-container>)</b>
+                  <ng-template #blocksPlural let-i i18n="shared.blocks">{{ i }} <span class="shared-block">blocks</span></ng-template>
+                </div>
+              </ng-template>
+            </div>
+          </a>
           <span class="animated-border"></span>
         </div>
       </ng-template>
     </div>
-    <div *ngIf="arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + 75 + 'px', transition: transition }"></div>
+    <div class="d-flex justify-content-end">
+      <div [hidden]="!arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + 2 + 'px', transition: transition }"></div>
+    </div>
   </div>
 </ng-container>
 
 <ng-template #loadingBlocks>
-  <div class="mempool-blocks-container">
-    <div class="flashing">
+  <div class="d-flex flex-column mempool-blocks-container {{ network }}">
+    <div class="d-flex flex-row flex-row-reverse flashing">
       <ng-template ngFor let-projectedBlock [ngForOf]="mempoolEmptyBlocks" let-i="index" [ngForTrackBy]="trackByFn">
-        <div class="bitcoin-block text-center mempool-block" id="mempool-block-{{ i }}" [ngStyle]="mempoolEmptyBlockStyles[i]"></div>
+        <div class="bitcoin-block text-center mempool-block" id="mempool-block-{{ i }}" [ngStyle]="{left: mempoolEmptyBlockStyles[i].left}">
+          <div class="block-body" [ngStyle]="{background: mempoolEmptyBlockStyles[i].background}"></div>
+        </div>
       </ng-template>
     </div>
   </div>

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -1,7 +1,33 @@
 .bitcoin-block {
   width: 125px;
   height: 125px;
-  transition: 2s;
+  min-width: 125px;
+  min-height: 125px;
+  position: relative;
+  margin-left: 30px;
+}
+
+.bitcoin-block::after {
+  content: '';
+  width: 125px;
+  height: 24px;
+  position:absolute;
+  right: 57px;
+  background-color: #232838;
+  transform:skew(40deg);
+  transform-origin:top;
+}
+
+.bitcoin-block::before {
+  content: '';
+  width: 20px;
+  height: 125px;
+  position: absolute;
+  top: 12px;
+  right: 162px;
+  background-color: #191c27;
+  transform: skewY(50deg);
+  transform-origin: top;
 }
 
 .block-size {
@@ -9,26 +35,33 @@
   font-weight: bold;
 }
 
-.mempool-blocks-container {
+.block-body {
+  right: 37px;
   position: absolute;
-  top: 0px;
-  right: 0px;
-  left: 0px;
+  margin-top: 24px;
+  width: 125px;
+  height: 125px;
+  padding-top: 10px;
+}
+
+.blockLink {
+  z-index: 10;
+  color: white;
+}
+
+.mempool-blocks-container {
+  margin-top: 36px;
+  width: calc(50vw - 10px);
+}
+
+.mempool-blocks-container.liquid, .mempool-blocks-container.liquidtestnet {
+  width: calc(25vw - 10px);
 }
 
 .flashing {
   animation: opacityPulse 2s ease-out;
   animation-iteration-count: infinite;
   opacity: 1;
-}
-
-.mempool-block {
-  position: absolute;
-  top: 0;
-}
-
-.block-body {
-  text-align: center;
 }
 
 @keyframes opacityPulse {
@@ -43,7 +76,7 @@
 
 .fees {
   font-size: 12px;
-  margin-top: 10px;
+  // margin-top: 10px;
   margin-bottom: 2px;
 }
 
@@ -57,31 +90,6 @@
   font-size: 10px;
   margin-top: 3px;
   margin-bottom: 4px;
-}
-
-.bitcoin-block::after {
-  content: '';
-  width: 125px;
-  height: 24px;
-  position:absolute;
-  top: -24px;
-  left: -20px;
-  background-color: #232838;
-  transform:skew(40deg);
-  transform-origin:top;
-}
-
-.bitcoin-block::before {
-  content: '';
-  width: 20px;
-  height: 125px;
-  position: absolute;
-  top: -12px;
-  left: -20px;
-  background-color: #191c27;
-
-  transform: skewY(50deg);
-  transform-origin: top;
 }
 
 .mempool-block.bitcoin-block::after {
@@ -100,21 +108,12 @@
 
 #arrow-up {
   position: relative;
-  right: 75px;
-  top: 140px;
+  top: 40px;
   width: 0;
   height: 0;
   border-left: 35px solid transparent;
   border-right: 35px solid transparent;
   border-bottom: 35px solid #FFF;
-}
-
-.blockLink {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  z-index: 10;
 }
 
 .blockLink.disabled {

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -252,7 +252,6 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
     });
 
     return {
-      'right': 40 + index * 155 + 'px',
       'background': backgroundGradients.join(',') + ')'
     };
   }
@@ -263,7 +262,7 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
       'background': '#554b45',
     };
   }
-
+  
   calculateTransactionPosition() {
     if ((!this.txFeePerVSize && (this.markIndex === undefined || this.markIndex === -1)) || !this.mempoolBlocks) {
       this.arrowVisible = false;

--- a/frontend/src/app/components/television/television.component.html
+++ b/frontend/src/app/components/television/television.component.html
@@ -1,22 +1,15 @@
-<div id="tv-wrapper">
-  <div class="tv-container">
-    <div class="chart-holder">
-      <app-mempool-graph
-        [template]="'advanced'"
-        [limitFee]="500"
-        [height]="600"
-        [left]="60"
-        [right]="10"
-        [data]="mempoolStats && mempoolStats.length ? mempoolStats : null"
-        [showZoom]="false"
-      ></app-mempool-graph>
-    </div>
-    <div class="blockchain-wrapper">
-      <div class="position-container">
-        <app-mempool-blocks></app-mempool-blocks>
-        <app-blockchain-blocks></app-blockchain-blocks>
-        <div id="divider"></div>
-      </div>
-    </div>
+<div id="tv-wrapper" class="d-flex flex-column tv-wrapper">
+  <div class="chart flex-grow-1">
+    <app-mempool-graph
+      [template]="'advanced'"
+      [limitFee]="500"
+      [height]="'85%'"
+      [top]='10'
+      [data]="mempoolStats && mempoolStats.length ? mempoolStats : null"
+      [showZoom]="false"
+    ></app-mempool-graph>
+  </div>
+  <div class="blocks">
+    <app-blockchain></app-blockchain>
   </div>
 </div>

--- a/frontend/src/app/components/television/television.component.scss
+++ b/frontend/src/app/components/television/television.component.scss
@@ -9,49 +9,29 @@
   align-items: center;
 }
 
-#tv-wrapper {
+.tv-wrapper {
   height: 100vh;
+  padding: 0;
+  justify-content: space-evenly !important;
+  padding: 15px 0px 15px 0px;
+}
+
+.chart {
+  min-height: 70%;
+  @media only screen and (max-height: 700px) {
+    zoom: 0.7;
+  }
+  @media only screen and (max-height: 500px) {
+    min-height: 100%;
+  }
+}
+
+.blocks {
+  @media only screen and (max-height: 700px) {
+    zoom: 0.7;
+  };
+  @media only screen and (max-height: 500px) {
+    display: none;
+  };
   overflow: hidden;
-  position: relative;
-}
-
-.chart-holder {
-  position: relative;
-  height: 655px;
-  width: 100%;
-  margin: 30px auto 0;
-}
-
-.blockchain-wrapper {
-  display: block;
-  height: 100%;
-  min-height: 240px;
-  position: relative;
-  top: 30px;
-
-  .position-container {
-    position: absolute;
-    left: 50%;
-    bottom: 170px;
-  }
-
-  #divider {
-    width: 3px;
-    height: 175px;
-    left: 0;
-    top: -40px;
-    background-image: url('/resources/divider-new.png');
-    background-repeat: repeat-y;
-    position: absolute;
-    img {
-      position: absolute;
-      left: -100px;
-      top: -28px;
-    }
-  }
-}
-.tv-container {
-  display: flex;
-  margin-top: 0px;
-  flex-direction: column;
 }

--- a/frontend/src/app/components/television/television.component.ts
+++ b/frontend/src/app/components/television/television.component.ts
@@ -4,7 +4,6 @@ import { OptimizedMempoolStats } from '../../interfaces/node-api.interface';
 import { StateService } from 'src/app/services/state.service';
 import { ApiService } from 'src/app/services/api.service';
 import { SeoService } from 'src/app/services/seo.service';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-television',
@@ -37,6 +36,14 @@ export class TelevisionComponent implements OnInit {
         this.mempoolStats.unshift(mempoolStats);
         this.mempoolStats = this.mempoolStats.slice(0, this.mempoolStats.length - 1);
       });
-  }
 
+    // Hide the scrollbar manually
+    var style = document.createElement("style");
+    style.innerHTML = `
+      body::-webkit-scrollbar {display: none;}
+      body {-ms-overflow-style: none}
+      html {scrollbar-width: none;}
+    `;
+    document.head.appendChild(style);
+  }
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -55,7 +55,6 @@ html, body {
 body {
   background-color: #11131f;
   min-width: 375px;
-  padding-bottom: 60px;
 }
 
 .container {
@@ -282,7 +281,7 @@ html:lang(ru) .card-title {
 
 .echarts {
   height: 100%;
-  min-height: 180px;
+  min-height: 100%;
 }
 
 .tx-wrapper-tooltip-chart,


### PR DESCRIPTION
I rewrote the html/css for the mempool/blockchain blocks so that it does not use absolute positioning anymore.
This was required to fix the TV view layout.

I'm terrible a css so please let me know if it's fully broken and what need to be changes.

This PR should not create regression in the dashbaord:
* Blocks position and width
* Arrow positioning must still be correct (transactions and blocks arrow)
* Must not break other network specific rendering

I tired to use Cypress for checking the rendering on different device, but the rendering seems incorrect. Please try on your different devices (including mobile) and please leave a screenshot if the rendering looks broken.

The basic things to check are the following, settings can be tweaked.
* If the viewport is less than 500px, blocks are not shown at the bottom and the chart takes all the space
* If the viewport is between 500px and 700px, we show everything, but we set the zoom factor to 0.7
* If the viewport is more than 700px tall, we show everything with a zoom factor of 1