### PR TITLE
Replaced /mining/pools?interval=X by /mining/pools/X

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -256,7 +256,16 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/1y', routes.$getStatisticsByTime.bind(routes, '1y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/2y', routes.$getStatisticsByTime.bind(routes, '2y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/3y', routes.$getStatisticsByTime.bind(routes, '3y'))
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools', routes.$getPools)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/24h', routes.$getPools.bind(routes, '24h'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3d', routes.$getPools.bind(routes, '3d'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/1w', routes.$getPools.bind(routes, '1w'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/1m', routes.$getPools.bind(routes, '1m'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3m', routes.$getPools.bind(routes, '3m'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/6m', routes.$getPools.bind(routes, '6m'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/1y', routes.$getPools.bind(routes, '1y'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/2y', routes.$getPools.bind(routes, '2y'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3y', routes.$getPools.bind(routes, '3y'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/all', routes.$getPools.bind(routes, 'all'))
         ;
     }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -532,9 +532,9 @@ class Routes {
     }
   }
 
-  public async $getPools(req: Request, res: Response) {
+  public async $getPools(interval: string, req: Request, res: Response) {
     try {
-      let stats = await miningStats.$getPoolsStats(req.query.interval as string);
+      let stats = await miningStats.$getPoolsStats(interval);
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -122,10 +122,6 @@ export class ApiService {
   }
 
   listPools$(interval: string | null) : Observable<PoolsStats> {
-    let params = {};
-    if (interval) {
-      params = new HttpParams().set('interval', interval);
-    }
-    return this.httpClient.get<PoolsStats>(this.apiBaseUrl + this.apiBasePath + '/api/v1/mining/pools', {params});
+    return this.httpClient.get<PoolsStats>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pools/${interval}`);
   }
 }

--- a/production/nginx-cache-warmer
+++ b/production/nginx-cache-warmer
@@ -11,15 +11,16 @@ do for url in / \
 	'/api/v1/statistics/1y' \
 	'/api/v1/statistics/2y' \
 	'/api/v1/statistics/3y' \
-	'/api/v1/mining/pools?interval=24h' \
-	'/api/v1/mining/pools?interval=3d' \
-	'/api/v1/mining/pools?interval=1w' \
-	'/api/v1/mining/pools?interval=1m' \
-	'/api/v1/mining/pools?interval=3m' \
-	'/api/v1/mining/pools?interval=6m' \
-	'/api/v1/mining/pools?interval=1y' \
-	'/api/v1/mining/pools?interval=2y' \
-	'/api/v1/mining/pools?interval=3y' \
+	'/api/v1/mining/pools/24h' \
+	'/api/v1/mining/pools/3d' \
+	'/api/v1/mining/pools/1w' \
+	'/api/v1/mining/pools/1m' \
+	'/api/v1/mining/pools/3m' \
+	'/api/v1/mining/pools/6m' \
+	'/api/v1/mining/pools/1y' \
+	'/api/v1/mining/pools/2y' \
+	'/api/v1/mining/pools/3y' \
+	'/api/v1/mining/pools/all' \
 
 	do
 		curl -s "https://${hostname}${url}" >/dev/null


### PR DESCRIPTION
Fixes `API endpoints should not use ?interval=1d but simply /1d` from https://github.com/mempool/mempool/pull/1162#pullrequestreview-865932360

Cache warmer has been updated accordingly.