### PR TITLE
Add coinbase.hex and pool info in blocks data stream

### DIFF
--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -17,7 +17,8 @@ class TransactionUtils {
           scriptpubkey_address: vout.scriptpubkey_address,
           value: vout.value
         }))
-        .filter((vout) => vout.value)
+        .filter((vout) => vout.value),
+      hex: tx.hex
     };
   }
 

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -1,7 +1,7 @@
 import logger from '../logger';
 import * as WebSocket from 'ws';
 import { BlockExtended, TransactionExtended, WebsocketResponse, MempoolBlock,
-  OptimizedStatistic, ILoadingIndicators, IConversionRates } from '../mempool.interfaces';
+  OptimizedStatistic, ILoadingIndicators, IConversionRates, PoolTag } from '../mempool.interfaces';
 import blocks from './blocks';
 import memPool from './mempool';
 import backendInfo from './backend-info';

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -82,11 +82,13 @@ export interface BlockExtended extends IEsploraApi.Block {
   reward?: number;
   coinbaseTx?: TransactionMinerInfo;
   matchRate?: number;
+  miner: PoolTag | undefined;
 }
 
 export interface TransactionMinerInfo {
   vin: VinStrippedToScriptsig[];
   vout: VoutStrippedToScriptPubkey[];
+  hex: string | undefined;
 }
 
 export interface MempoolStats {


### PR DESCRIPTION
This PR simply adds two new information in the websocket blocks data stream:
* Added `hex` in `BlockExtended` interface
* Added `miner` (type `PoolTag`)

![image](https://user-images.githubusercontent.com/9780671/152151587-4b28a407-f68f-431d-9a73-26bef18f14d1.png)
