### PR TITLE
Adding a "mixed" dev proxy

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -218,6 +218,10 @@
               "proxyConfig": "proxy.conf.local.js",
               "verbose": true
             },
+            "mixed": {
+              "proxyConfig": "proxy.conf.mixed.js",
+              "verbose": true
+            },
             "staging": {
               "proxyConfig": "proxy.conf.js",
               "disableHostCheck": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "start": "npm run generate-config && npm run sync-assets-dev && ng serve -c local",
     "start:stg": "npm run generate-config && npm run sync-assets-dev && ng serve -c staging",
     "start:local-prod": "npm run generate-config && npm run sync-assets-dev && ng serve -c local-prod",
+    "start:mixed": "npm run generate-config && npm run sync-assets-dev && ng serve -c mixed",
     "build": "npm run generate-config && ng build --configuration production --localize && npm run sync-assets && npm run build-mempool.js",
     "sync-assets": "node sync-assets.js && rsync -av ./dist/mempool/browser/en-US/resources ./dist/mempool/browser/resources",
     "sync-assets-dev": "node sync-assets.js dev",

--- a/frontend/proxy.conf.mixed.js
+++ b/frontend/proxy.conf.mixed.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+
+const FRONTEND_CONFIG_FILE_NAME = 'mempool-frontend-config.json';
+
+let configContent;
+
+// Read frontend config 
+try {
+    const rawConfig = fs.readFileSync(FRONTEND_CONFIG_FILE_NAME);
+    configContent = JSON.parse(rawConfig);
+    console.log(`${FRONTEND_CONFIG_FILE_NAME} file found, using provided config`);
+} catch (e) {
+    console.log(e);
+    if (e.code !== 'ENOENT') {
+      throw new Error(e);
+  } else {
+      console.log(`${FRONTEND_CONFIG_FILE_NAME} file not found, using default config`);
+  }
+}
+
+let PROXY_CONFIG = [];
+
+if (configContent && configContent.BASE_MODULE === 'liquid') {
+  PROXY_CONFIG.push(...[
+    {
+      context: ['/liquid/api/v1/**'],
+      target: `http://localhost:8999`,
+      secure: false,
+      ws: true,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+      pathRewrite: {
+          "^/liquid": ""
+      },
+    },
+    {
+      context: ['/liquid/api/**'],
+      target: `https://liquid.network`,
+      secure: false,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+    },
+  ]);
+}
+
+if (configContent && configContent.BASE_MODULE === 'bisq') {
+  PROXY_CONFIG.push(...[
+    {
+      context: ['/bisq/api/v1/ws'],
+      target: `http://localhost:8999`,
+      secure: false,
+      ws: true,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+      pathRewrite: {
+          "^/bisq": ""
+      },
+    },
+    {
+      context: ['/bisq/api/v1/**'],
+      target: `http://localhost:8999`,
+      secure: false,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+    },
+    {
+      context: ['/bisq/api/**'],
+      target: `http://localhost:8999`,
+      secure: false,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+      pathRewrite: {
+          "^/bisq/api/": "/api/v1/bisq/"
+      },
+    },
+  ]);
+}
+
+PROXY_CONFIG.push(...[
+  {
+    context: ['/api/v1/**'],
+    target: `http://localhost:8999`,
+    secure: false,
+    ws: true,
+    changeOrigin: true,
+    proxyTimeout: 30000,
+  },
+  {
+    context: ['/api/**'],
+    target: `https://mempool.space`,
+    secure: false,
+    changeOrigin: true,
+    proxyTimeout: 30000,
+  }
+]);
+
+console.log(PROXY_CONFIG);
+
+module.exports = PROXY_CONFIG;


### PR DESCRIPTION
This is a middle ground between `npm run start:local-prod` and `npm run start`

The new `npm run start:mixed` proxy will generally redirect all
`/api/` endpoints to Mempool.space or Liquid.network depending on Base Module
`/api/v1/` will redirect to the local NodeJS.

This is very helpful during development when there is a lack of a proper Esplora backend setup.
It makes it easier to browse around and develop on pages like Liquid Assets.

mempool, liquid and bisq as Frontend Base Module is supported.