### PR TITLE
Consider we're synced with the mempool if we cached 99% of pending txs

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -168,7 +168,8 @@ class Mempool {
     const newTransactionsStripped = newTransactions.map((tx) => Common.stripTransaction(tx));
     this.latestTransactions = newTransactionsStripped.concat(this.latestTransactions).slice(0, 6);
 
-    if (!this.inSync && transactions.length === Object.keys(this.mempoolCache).length) {
+    const syncedThreshold = 0.99; // If we synced 99% of the mempool tx count, consider we're synced
+    if (!this.inSync && Object.keys(this.mempoolCache).length >= transactions.length * syncedThreshold) {
       this.inSync = true;
       logger.notice('The mempool is now in sync!');
       loadingIndicators.setProgress('mempool', 100);


### PR DESCRIPTION
When the node backend is starting, it first sync with the mempool by indexing/caching all pending transactions. Right now, we are waiting for a 100% match between the number of transactions cached, and the number of transactions in the mempool.

This leads to unpredictable node backend start time, since the node backend is always trying to catch up with the mempool, every 2 seconds. In case there is a lot of incoming transactions, it may take quite a while before catching up, because within 2 seconds the node will most likely receive new txs while the node backend is indexing the one found during the previous loop iteration.

This one line PR therefore considers that if we indexed/cached 99% of the mempool transactions, the node backend is synced, and we can start the blocks indexing and other things.

Note that the chosen 99% threshold is arbitrary, but will probably make the node backend start time much more predictable.