### PR TITLE
Created mining pool stats page

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -154,4 +154,19 @@ export class Common {
     });
     return parents;
   }
+
+  static getSqlInterval(interval: string | null): string | null {
+    switch (interval) {
+      case '24h': return '1 DAY';
+      case '3d': return '3 DAY';
+      case '1w': return '1 WEEK';
+      case '1m': return '1 MONTH';
+      case '3m': return '3 MONTH';
+      case '6m': return '6 MONTH';
+      case '1y': return '1 YEAR';
+      case '2y': return '2 YEAR';
+      case '3y': return '3 YEAR';
+      default: return null;
+    }
+  }
 }

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -7,23 +7,26 @@ class Mining {
   constructor() {
   }
 
+  private getSqlInterval(interval: string | null): string | null {
+    switch (interval) {
+      case '24h': return '1 DAY';
+      case '3d': return '3 DAY';
+      case '1w': return '1 WEEK';
+      case '1m': return '1 MONTH';
+      case '3m': return '3 MONTH';
+      case '6m': return '6 MONTH';
+      case '1y': return '1 YEAR';
+      case '2y': return '2 YEAR';
+      case '3y': return '3 YEAR';
+      default: return null;
+    }
+  }
+
   /**
    * Generate high level overview of the pool ranks and general stats
    */
   public async $getPoolsStats(interval: string | null) : Promise<object> {
-    let sqlInterval: string | null = null;
-    switch (interval) {
-      case '24h': sqlInterval = '1 DAY'; break;
-      case '3d': sqlInterval = '3 DAY'; break;
-      case '1w': sqlInterval = '1 WEEK'; break;
-      case '1m': sqlInterval = '1 MONTH'; break;
-      case '3m': sqlInterval = '3 MONTH'; break;
-      case '6m': sqlInterval = '6 MONTH'; break;
-      case '1y': sqlInterval = '1 YEAR'; break;
-      case '2y': sqlInterval = '2 YEAR'; break;
-      case '3y': sqlInterval = '3 YEAR'; break;
-      default: sqlInterval = null; break;
-    }
+    const sqlInterval = this.getSqlInterval(interval);
 
     const poolsStatistics = {};
 
@@ -63,6 +66,24 @@ class Mining {
     poolsStatistics['lastEstimatedHashrate'] = lastBlockHashrate;
 
     return poolsStatistics;
+  }
+
+  /**
+   * Get all mining pool stats for a pool
+   */
+  public async $getPoolStat(interval: string | null, poolId: number): Promise<object> {
+    const pool = await PoolsRepository.$getPool(poolId);
+    if (!pool) {
+      throw new Error("This mining pool does not exist");
+    }
+
+    const sqlInterval = this.getSqlInterval(interval);
+    const blocks = await BlocksRepository.$getBlocksByPool(sqlInterval, poolId);
+
+    return {
+      pool: pool,
+      blocks: blocks,
+    };
   }
 }
 

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -2,7 +2,6 @@ import { PoolInfo, PoolStats } from '../mempool.interfaces';
 import BlocksRepository, { EmptyBlocks } from '../repositories/BlocksRepository';
 import PoolsRepository from '../repositories/PoolsRepository';
 import bitcoinClient from './bitcoin/bitcoin-client';
-import { Common } from './common';
 
 class Mining {
   constructor() {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -275,7 +275,9 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3y', routes.$getPools.bind(routes, '3y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/all', routes.$getPools.bind(routes, 'all'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId', routes.$getPool)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool);
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool-blocks/:poolId', routes.$getPoolBlocks)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool-blocks/:poolId/:height', routes.$getPoolBlocks);
     }
 
     if (config.BISQ.ENABLED) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -256,6 +256,14 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/1y', routes.$getStatisticsByTime.bind(routes, '1y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/2y', routes.$getStatisticsByTime.bind(routes, '2y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/3y', routes.$getStatisticsByTime.bind(routes, '3y'))
+        ;
+    }
+
+    const indexingAvailable =
+      ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) &&
+      config.DATABASE.ENABLED === true;
+    if (indexingAvailable) {
+      this.app
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/24h', routes.$getPools.bind(routes, '24h'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3d', routes.$getPools.bind(routes, '3d'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/1w', routes.$getPools.bind(routes, '1w'))
@@ -266,7 +274,8 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/2y', routes.$getPools.bind(routes, '2y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3y', routes.$getPools.bind(routes, '3y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/all', routes.$getPools.bind(routes, 'all'))
-        ;
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId', routes.$getPool)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool);
     }
 
     if (config.BISQ.ENABLED) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -274,10 +274,10 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/2y', routes.$getPools.bind(routes, '2y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3y', routes.$getPools.bind(routes, '3y'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/all', routes.$getPools.bind(routes, 'all'))
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/blocks', routes.$getPoolBlocks)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/blocks/:height', routes.$getPoolBlocks)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId', routes.$getPool)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool-blocks/:poolId', routes.$getPoolBlocks)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool-blocks/:poolId/:height', routes.$getPoolBlocks);
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool);
     }
 
     if (config.BISQ.ENABLED) {

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -1,23 +1,23 @@
 import { IEsploraApi } from './api/bitcoin/esplora-api.interface';
 
 export interface PoolTag {
-  id: number, // mysql row id
-  name: string,
-  link: string,
-  regexes: string, // JSON array
-  addresses: string, // JSON array
+  id: number; // mysql row id
+  name: string;
+  link: string;
+  regexes: string; // JSON array
+  addresses: string; // JSON array
 }
 
 export interface PoolInfo {
-  poolId: number, // mysql row id
-  name: string,
-  link: string,
-  blockCount: number,
+  poolId: number; // mysql row id
+  name: string;
+  link: string;
+  blockCount: number;
 }
 
 export interface PoolStats extends PoolInfo {
-  rank: number,
-  emptyBlocks: number,
+  rank: number;
+  emptyBlocks: number;
 }
 
 export interface MempoolBlock {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -172,7 +172,7 @@ class BlocksRepository {
     startHeight: number | null = null
   ): Promise<object[]> {
     const params: any[] = [];
-    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, reward
+    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, 0 as reward
       FROM blocks
       WHERE pool_id = ?`;
     params.push(poolId);

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -172,7 +172,7 @@ class BlocksRepository {
     startHeight: number | null = null
   ): Promise<object[]> {
     const params: any[] = [];
-    let query = `SELECT height, hash as id, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, 0 as reward
+    let query = `SELECT height, hash as id, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, reward
       FROM blocks
       WHERE pool_id = ?`;
     params.push(poolId);

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -44,7 +44,7 @@ class BlocksRepository {
         block.extras?.reward ?? 0,
       ];
 
-      logger.debug(query);
+      // logger.debug(query);
       await connection.query(query, params);
     } catch (e: any) {
       if (e.errno === 1062) { // ER_DUP_ENTRY
@@ -102,7 +102,7 @@ class BlocksRepository {
       query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows] = await connection.query(query, params);
     connection.release();
@@ -134,7 +134,7 @@ class BlocksRepository {
       query += ` blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows] = await connection.query(query, params);
     connection.release();
@@ -152,7 +152,7 @@ class BlocksRepository {
       LIMIT 1;`;
 
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows]: any[] = await connection.query(query);
     connection.release();
@@ -185,7 +185,7 @@ class BlocksRepository {
     query += ` ORDER BY height DESC
       LIMIT 10`;
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows] = await connection.query(query, params);
     connection.release();

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -172,7 +172,7 @@ class BlocksRepository {
     startHeight: number | null = null
   ): Promise<object[]> {
     const params: any[] = [];
-    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, 0 as reward
+    let query = `SELECT height, hash as id, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, 0 as reward
       FROM blocks
       WHERE pool_id = ?`;
     params.push(poolId);

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1,6 +1,7 @@
 import { BlockExtended, PoolTag } from '../mempool.interfaces';
 import { DB } from '../database';
 import logger from '../logger';
+import { Common } from '../api/common';
 
 export interface EmptyBlocks {
   emptyBlocks: number;
@@ -43,6 +44,7 @@ class BlocksRepository {
         block.extras?.reward ?? 0,
       ];
 
+      logger.debug(query);
       await connection.query(query, params);
     } catch (e: any) {
       if (e.errno === 1062) { // ER_DUP_ENTRY
@@ -64,35 +66,45 @@ class BlocksRepository {
     }
 
     const connection = await DB.pool.getConnection();
-    const [rows] : any[] = await connection.query(`
+    const [rows]: any[] = await connection.query(`
       SELECT height
       FROM blocks
-      WHERE height <= ${startHeight} AND height >= ${endHeight}
+      WHERE height <= ? AND height >= ?
       ORDER BY height DESC;
-    `);
+    `, [startHeight, endHeight]);
     connection.release();
 
     const indexedBlockHeights: number[] = [];
     rows.forEach((row: any) => { indexedBlockHeights.push(row.height); });
     const seekedBlocks: number[] = Array.from(Array(startHeight - endHeight + 1).keys(), n => n + endHeight).reverse();
-    const missingBlocksHeights =  seekedBlocks.filter(x => indexedBlockHeights.indexOf(x) === -1);
+    const missingBlocksHeights = seekedBlocks.filter(x => indexedBlockHeights.indexOf(x) === -1);
 
     return missingBlocksHeights;
   }
 
   /**
-   * Count empty blocks for all pools
+   * Get empty blocks for one or all pools
    */
-  public async $countEmptyBlocks(interval: string | null): Promise<EmptyBlocks[]> {
-    const query = `
-      SELECT pool_id as poolId
-      FROM blocks
-      WHERE tx_count = 1` +
-      (interval != null ? ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()` : ``)
-    ;
+  public async $getEmptyBlocks(poolId: number | null, interval: string | null = null): Promise<EmptyBlocks[]> {
+    interval = Common.getSqlInterval(interval);
 
+    const params: any[] = [];
+    let query = `SELECT height, hash, tx_count, size, pool_id, weight, UNIX_TIMESTAMP(blockTimestamp) as timestamp
+      FROM blocks
+      WHERE tx_count = 1`;
+
+    if (poolId) {
+      query += ` AND pool_id = ?`;
+      params.push(poolId);
+    }
+
+    if (interval) {
+      query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+    }
+
+    logger.debug(query);
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query);
+    const [rows] = await connection.query(query, params);
     connection.release();
 
     return <EmptyBlocks[]>rows;
@@ -101,15 +113,30 @@ class BlocksRepository {
   /**
    * Get blocks count for a period
    */
-   public async $blockCount(interval: string | null): Promise<number> {
-    const query = `
-      SELECT count(height) as blockCount
-      FROM blocks` +
-      (interval != null ? ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()` : ``)
-    ;
+  public async $blockCount(poolId: number | null, interval: string | null): Promise<number> {
+    interval = Common.getSqlInterval(interval);
 
+    const params: any[] = [];
+    let query = `SELECT count(height) as blockCount
+      FROM blocks`;
+
+    if (poolId) {
+      query += ` WHERE pool_id = ?`;
+      params.push(poolId);
+    }
+
+    if (interval) {
+      if (poolId) {
+        query += ` AND`;
+      } else {
+        query += ` WHERE`;
+      }
+      query += ` blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+    }
+
+    logger.debug(query);
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query);
+    const [rows] = await connection.query(query, params);
     connection.release();
 
     return <number>rows[0].blockCount;
@@ -119,13 +146,15 @@ class BlocksRepository {
    * Get the oldest indexed block
    */
   public async $oldestBlockTimestamp(): Promise<number> {
-    const connection = await DB.pool.getConnection();
-    const [rows]: any[] = await connection.query(`
-      SELECT blockTimestamp
+    const query = `SELECT blockTimestamp
       FROM blocks
       ORDER BY height
-      LIMIT 1;
-    `);
+      LIMIT 1;`;
+
+
+    logger.debug(query);
+    const connection = await DB.pool.getConnection();
+    const [rows]: any[] = await connection.query(query);
     connection.release();
 
     if (rows.length <= 0) {
@@ -138,18 +167,34 @@ class BlocksRepository {
   /**
    * Get blocks mined by a specific mining pool
    */
-  public async $getBlocksByPool(interval: string | null, poolId: number): Promise<object> {
-    const query = `
-      SELECT *
+  public async $getBlocksByPool(
+    poolId: number,
+    startHeight: number | null = null
+  ): Promise<object[]> {
+    const params: any[] = [];
+    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp
       FROM blocks
-      WHERE pool_id = ${poolId}`
-      + (interval != null ? ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()` : ``);
+      WHERE pool_id = ?`;
+    params.push(poolId);
 
+    if (startHeight) {
+      query += ` AND height < ?`;
+      params.push(startHeight);
+    }
+
+    query += ` ORDER BY height DESC
+      LIMIT 10`;
+
+    logger.debug(query);
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query);
+    const [rows] = await connection.query(query, params);
     connection.release();
 
-    return rows;
+    for (const block of <object[]>rows) {
+      delete block['blockTimestamp'];
+    }
+
+    return <object[]>rows;
   }
 
   /**

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -136,6 +136,23 @@ class BlocksRepository {
   }
 
   /**
+   * Get blocks mined by a specific mining pool
+   */
+  public async $getBlocksByPool(interval: string | null, poolId: number): Promise<object> {
+    const query = `
+      SELECT *
+      FROM blocks
+      WHERE pool_id = ${poolId}`
+      + (interval != null ? ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()` : ``);
+
+    const connection = await DB.pool.getConnection();
+    const [rows] = await connection.query(query);
+    connection.release();
+
+    return rows;
+  }
+
+  /**
    * Get one block by height
    */
    public async $getBlockByHeight(height: number): Promise<object | null> {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -172,7 +172,7 @@ class BlocksRepository {
     startHeight: number | null = null
   ): Promise<object[]> {
     const params: any[] = [];
-    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp
+    let query = `SELECT height, hash, tx_count, size, weight, pool_id, UNIX_TIMESTAMP(blockTimestamp) as timestamp, reward
       FROM blocks
       WHERE pool_id = ?`;
     params.push(poolId);

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -41,7 +41,7 @@ class PoolsRepository {
     query += ` GROUP BY pool_id
       ORDER BY COUNT(height) DESC`;
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows] = await connection.query(query);
     connection.release();
@@ -58,7 +58,7 @@ class PoolsRepository {
       FROM pools
       WHERE pools.id = ?`;
 
-    logger.debug(query);
+    // logger.debug(query);
     const connection = await DB.pool.getConnection();
     const [rows] = await connection.query(query, [poolId]);
     connection.release();

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -63,6 +63,9 @@ class PoolsRepository {
     const [rows] = await connection.query(query, [poolId]);
     connection.release();
 
+    rows[0].regexes = JSON.parse(rows[0].regexes);
+    rows[0].addresses = JSON.parse(rows[0].addresses);
+
     return rows[0];
   }
 }

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -41,6 +41,23 @@ class PoolsRepository {
 
     return <PoolInfo[]>rows;
   }
+
+  /**
+   * Get mining pool statistics for one pool
+   */
+   public async $getPool(poolId: number) : Promise<object> {
+    const query = `
+      SELECT *
+      FROM pools
+      WHERE pools.id = ${poolId}
+    `;
+
+    const connection = await DB.pool.getConnection();
+    const [rows] = await connection.query(query);
+    connection.release();
+
+    return rows[0];
+  }
 }
 
 export default new PoolsRepository();

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -22,6 +22,8 @@ import elementsParser from './api/liquid/elements-parser';
 import icons from './api/liquid/icons';
 import miningStats from './api/mining';
 import axios from 'axios';
+import PoolsRepository from './repositories/PoolsRepository';
+import mining from './api/mining';
 
 class Routes {
   constructor() {}
@@ -530,6 +532,19 @@ class Routes {
         statusCode = 404;
       }
       res.status(statusCode).send(e instanceof Error ? e.message : e);
+    }
+  }
+
+  public async $getPool(req: Request, res: Response) {
+    try {
+      const poolId = parseInt(req.params.poolId);
+      const stats = await mining.$getPoolStat(req.params.interval ?? null, poolId);
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
+      res.json(stats);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
     }
   }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -24,6 +24,7 @@ import miningStats from './api/mining';
 import axios from 'axios';
 import PoolsRepository from './repositories/PoolsRepository';
 import mining from './api/mining';
+import BlocksRepository from './repositories/BlocksRepository';
 
 class Routes {
   constructor() {}
@@ -537,8 +538,7 @@ class Routes {
 
   public async $getPool(req: Request, res: Response) {
     try {
-      const poolId = parseInt(req.params.poolId);
-      const stats = await mining.$getPoolStat(req.params.interval ?? null, poolId);
+      const stats = await mining.$getPoolStat(req.params.interval ?? null, parseInt(req.params.poolId, 10));
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
@@ -548,9 +548,24 @@ class Routes {
     }
   }
 
+  public async $getPoolBlocks(req: Request, res: Response) {
+    try {
+      const poolBlocks = await BlocksRepository.$getBlocksByPool(
+        parseInt(req.params.poolId, 10),
+        parseInt(req.params.height, 10) ?? null,
+      );
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
+      res.json(poolBlocks);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
+  }
+
   public async $getPools(interval: string, req: Request, res: Response) {
     try {
-      let stats = await miningStats.$getPoolsStats(interval);
+      const stats = await miningStats.$getPoolsStats(interval);
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -66,6 +66,7 @@ export function app(locale: string): express.Express {
   server.get('/address/*', getLocalizedSSR(indexHtml));
   server.get('/blocks', getLocalizedSSR(indexHtml));
   server.get('/mining/pools', getLocalizedSSR(indexHtml));
+  server.get('/mining/pool/*', getLocalizedSSR(indexHtml));
   server.get('/graphs', getLocalizedSSR(indexHtml));
   server.get('/liquid', getLocalizedSSR(indexHtml));
   server.get('/liquid/tx/*', getLocalizedSSR(indexHtml));

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -72,6 +72,10 @@ let routes: Routes = [
         component: PoolComponent,
       },
       {
+        path: 'mining/pool/:poolId/:interval',
+        component: PoolComponent,
+      },
+      {
         path: 'graphs',
         component: StatisticsComponent,
       },
@@ -164,6 +168,10 @@ let routes: Routes = [
             component: PoolComponent,
           },
           {
+            path: 'mining/pool/:poolId/:interval',
+            component: PoolComponent,
+          },
+          {
             path: 'graphs',
             component: StatisticsComponent,
           },
@@ -247,6 +255,10 @@ let routes: Routes = [
           },
           {
             path: 'mining/pool/:poolId',
+            component: PoolComponent,
+          },
+          {
+            path: 'mining/pool/:poolId/:interval',
             component: PoolComponent,
           },
           {

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -72,10 +72,6 @@ let routes: Routes = [
         component: PoolComponent,
       },
       {
-        path: 'mining/pool/:poolId/:interval',
-        component: PoolComponent,
-      },
-      {
         path: 'graphs',
         component: StatisticsComponent,
       },
@@ -168,10 +164,6 @@ let routes: Routes = [
             component: PoolComponent,
           },
           {
-            path: 'mining/pool/:poolId/:interval',
-            component: PoolComponent,
-          },
-          {
             path: 'graphs',
             component: StatisticsComponent,
           },
@@ -255,10 +247,6 @@ let routes: Routes = [
           },
           {
             path: 'mining/pool/:poolId',
-            component: PoolComponent,
-          },
-          {
-            path: 'mining/pool/:poolId/:interval',
             component: PoolComponent,
           },
           {

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -26,6 +26,7 @@ import { PoolRankingComponent } from './components/pool-ranking/pool-ranking.com
 import { AssetGroupComponent } from './components/assets/asset-group/asset-group.component';
 import { AssetsFeaturedComponent } from './components/assets/assets-featured/assets-featured.component';
 import { AssetsComponent } from './components/assets/assets.component';
+import { PoolComponent } from './components/pool/pool.component';
 
 let routes: Routes = [
   {
@@ -65,6 +66,10 @@ let routes: Routes = [
       {
         path: 'mining/pools',
         component: PoolRankingComponent,
+      },
+      {
+        path: 'mining/pool/:poolId',
+        component: PoolComponent,
       },
       {
         path: 'graphs',
@@ -155,6 +160,10 @@ let routes: Routes = [
             component: PoolRankingComponent,
           },
           {
+            path: 'mining/pool/:poolId',
+            component: PoolComponent,
+          },
+          {
             path: 'graphs',
             component: StatisticsComponent,
           },
@@ -235,6 +244,10 @@ let routes: Routes = [
           {
             path: 'mining/pools',
             component: PoolRankingComponent,
+          },
+          {
+            path: 'mining/pool/:poolId',
+            component: PoolComponent,
           },
           {
             path: 'graphs',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { TimeSpanComponent } from './components/time-span/time-span.component';
 import { SeoService } from './services/seo.service';
 import { MempoolGraphComponent } from './components/mempool-graph/mempool-graph.component';
 import { PoolRankingComponent } from './components/pool-ranking/pool-ranking.component';
+import { PoolComponent } from './components/pool/pool.component';
 import { LbtcPegsGraphComponent } from './components/lbtc-pegs-graph/lbtc-pegs-graph.component';
 import { AssetComponent } from './components/asset/asset.component';
 import { AssetsComponent } from './components/assets/assets.component';
@@ -96,6 +97,7 @@ import { AssetGroupComponent } from './components/assets/asset-group/asset-group
     IncomingTransactionsGraphComponent,
     MempoolGraphComponent,
     PoolRankingComponent,
+    PoolComponent,
     LbtcPegsGraphComponent,
     AssetComponent,
     AssetsComponent,

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -1,7 +1,7 @@
 <div class="container-xl">
   <!-- <app-difficulty [showProgress]=false [showHalving]=true></app-difficulty>  -->
 
-  <div class="hashrate-pie" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
+  <div class="hashrate-pie" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"></div>
   <div class="text-center loadingGraphs" *ngIf="isLoading">
     <div class="spinner-border text-light"></div>
   </div>

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -58,7 +58,7 @@
       <tr *ngFor="let pool of miningStats.pools">
         <td class="d-none d-md-block">{{ pool.rank }}</td>
         <td class="text-right"><img width="25" height="25" src="{{ pool.logo }}" onError="this.src = './resources/mining-pools/default.svg'"></td>
-        <td class="">{{ pool.name }}</td>
+        <td class=""><a [routerLink]="[('/mining/pool/' + pool.poolId) | relativeUrl]">{{ pool.name }}</a></td>
         <td class="" *ngIf="this.poolsWindowPreference === '24h'">{{ pool.lastEstimatedHashrate }} {{ miningStats.miningUnits.hashrateUnit }}</td>
         <td class="">{{ pool['blockText'] }}</td>
         <td class="d-none d-md-block">{{ pool.emptyBlocks }} ({{ pool.emptyBlockRatio }}%)</td>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -8,6 +8,46 @@
     <div class="box">
       <div class="row">
         <div class="col-sm">
+          <div class="card-header mb-0 mb-lg-4 pr-0">
+            <form [formGroup]="radioGroupForm" class="formRadioGroup float-right">
+              <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'24h'"> 24h
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'3d'"> 3D
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'1w'"> 1W
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'1m'"> 1M
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'3m'"> 3M
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'6m'"> 6M
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'1y'"> 1Y
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'2y'"> 2Y
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'3y'"> 3Y
+                </label>
+                <label ngbButtonLabel class="btn-primary btn-sm">
+                  <input ngbButton type="radio" [value]="'all'"> ALL
+                </label>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm">
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
@@ -47,9 +87,9 @@
       <th class="d-none d-lg-block" style="width: 15%;" i18n="latest-blocks.transactions">Transactions</th>
       <th style="width: 20%;" i18n="latest-blocks.size">Size</th>
     </thead>
-    <tbody>
+    <tbody *ngIf="blocks$ | async as blocks">
       <tr *ngFor="let block of blocks">
-        <td><a [routerLink]="['/block' | relativeUrl, block.hash]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
+        <td><a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
         <td class="d-none d-md-block">&lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
         <td><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></td>
         <td class="d-none d-lg-block">{{ block.tx_count | number }}</td>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -95,7 +95,7 @@
     </thead>
     <tbody *ngIf="blocks$ | async as blocks">
       <tr *ngFor="let block of blocks">
-        <td><a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
+        <td><a [routerLink]="['/block' | relativeUrl, block.id]">{{ block.height }}</a></td>
         <td class="d-none d-md-block">&lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
         <td><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></td>
         <td class=""><app-amount [satoshis]="block['reward']" digitsInfo="1.2-2" [noFiat]="true"></app-amount></td>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -47,11 +47,11 @@
 
     <div class="box">
       <div class="row">
-        <div class="col-md-8">
+        <div class="col-lg-9">
           <table class="table table-borderless table-striped" style="table-layout: fixed;">
             <tbody>
               <tr>
-                <td class="col-4 col-lg-3">Addresses</td>
+                <td class="col-3 col-lg-3">Addresses</td>
                 <td class="text-truncate" *ngIf="poolStats.pool.addresses.length else noaddress">
                   <div class="scrollable">
                     <a *ngFor="let address of poolStats.pool.addresses" [routerLink]="['/address' | relativeUrl, address]">{{ address }}<br></a>
@@ -60,22 +60,22 @@
                 <ng-template #noaddress><td>~</td></ng-template>
               </tr>
               <tr>
-                <td class="col-4 col-lg-3">Coinbase Tags</td>
+                <td class="col-3 col-lg-3">Coinbase Tags</td>
                 <td class="text-truncate">{{ poolStats.pool.regexes }}</td>
               </tr>
             </tbody>
           </table>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-3">
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
-                <td>Mined Blocks</td>
-                <td>{{ poolStats.blockCount }}</td>
+                <td class="col-3 col-lg-8">Mined Blocks</td>
+                <td class="text-left">{{ poolStats.blockCount }}</td>
               </tr>
               <tr>
-                <td>Empty Blocks</td>
-                <td>{{ poolStats.emptyBlocks.length }}</td>
+                <td class="col-3 col-lg-8">Empty Blocks</td>
+                <td class="text-left">{{ poolStats.emptyBlocks.length }}</td>
               </tr>
             </tbody>
           </table>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,5 +1,66 @@
 <div class="container-xl">
 
-  Pool
+  <div *ngIf="poolStats$ | async as poolStats">
+    <h1>
+      {{ poolStats.pool.name }}
+    </h1>
+
+    <div class="box">
+      <div class="row">
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td>Address</td>
+                <td>{{ poolStats.pool.addresses }}</td>
+              </tr>
+              <tr>
+                <td>Coinbase Tag</td>
+                <td>{{ poolStats.pool.regexes }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td>Mined Blocks</td>
+                <td>{{ poolStats.blockCount }}</td>
+              </tr>
+              <tr>
+                <td>Empty Blocks</td>
+                <td>{{ poolStats.emptyBlocks.length }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <table class="table table-borderless" [alwaysCallback]="true" infiniteScroll [infiniteScrollDistance]="1.5" [infiniteScrollUpDistance]="1.5" [infiniteScrollThrottle]="50" (scrolled)="loadMore()">
+    <thead>
+      <th style="width: 15%;" i18n="latest-blocks.height">Height</th>
+      <th class="d-none d-md-block" style="width: 20%;" i18n="latest-blocks.timestamp">Timestamp</th>
+      <th style="width: 20%;" i18n="latest-blocks.mined">Mined</th>
+      <th class="d-none d-lg-block" style="width: 15%;" i18n="latest-blocks.transactions">Transactions</th>
+      <th style="width: 20%;" i18n="latest-blocks.size">Size</th>
+    </thead>
+    <tbody>
+      <tr *ngFor="let block of blocks">
+        <td><a [routerLink]="['/block' | relativeUrl, block.hash]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
+        <td class="d-none d-md-block">&lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
+        <td><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></td>
+        <td class="d-none d-lg-block">{{ block.tx_count | number }}</td>
+        <td>
+          <div class="progress">
+            <div class="progress-bar progress-mempool" role="progressbar" [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }"></div>
+            <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
 </div>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -51,7 +51,7 @@
           <table class="table table-borderless table-striped" style="table-layout: fixed;">
             <tbody>
               <tr>
-                <td class="col-3 col-lg-3">Addresses</td>
+                <td class="col-4 col-lg-3">Addresses</td>
                 <td class="text-truncate" *ngIf="poolStats.pool.addresses.length else noaddress">
                   <div class="scrollable">
                     <a *ngFor="let address of poolStats.pool.addresses" [routerLink]="['/address' | relativeUrl, address]">{{ address }}<br></a>
@@ -60,7 +60,7 @@
                 <ng-template #noaddress><td>~</td></ng-template>
               </tr>
               <tr>
-                <td class="col-3 col-lg-3">Coinbase Tags</td>
+                <td class="col-4 col-lg-3">Coinbase Tags</td>
                 <td class="text-truncate">{{ poolStats.pool.regexes }}</td>
               </tr>
             </tbody>
@@ -70,11 +70,11 @@
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
-                <td class="col-3 col-lg-8">Mined Blocks</td>
+                <td class="col-4 col-lg-8">Mined Blocks</td>
                 <td class="text-left">{{ poolStats.blockCount }}</td>
               </tr>
               <tr>
-                <td class="col-3 col-lg-8">Empty Blocks</td>
+                <td class="col-4 col-lg-8">Empty Blocks</td>
                 <td class="text-left">{{ poolStats.emptyBlocks.length }}</td>
               </tr>
             </tbody>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,62 +1,61 @@
-<div class="container-xl">
+<div class="container">
 
   <div *ngIf="poolStats$ | async as poolStats">
     <h1>
       {{ poolStats.pool.name }}
     </h1>
 
+    <div class="box pl-0 bg-transparent">
+      <div class="card-header mb-0 mb-lg-4 pr-0 pl-0">
+        <form [formGroup]="radioGroupForm" class="formRadioGroup ml-0">
+          <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'24h'"> 24h
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'3d'"> 3D
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'1w'"> 1W
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'1m'"> 1M
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'3m'"> 3M
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'6m'"> 6M
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'1y'"> 1Y
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'2y'"> 2Y
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'3y'"> 3Y
+            </label>
+            <label ngbButtonLabel class="btn-primary btn-sm">
+              <input ngbButton type="radio" [value]="'all'"> ALL
+            </label>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <div class="box">
       <div class="row">
         <div class="col-sm">
-          <div class="card-header mb-0 mb-lg-4 pr-0">
-            <form [formGroup]="radioGroupForm" class="formRadioGroup float-right">
-              <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'24h'"> 24h
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'3d'"> 3D
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'1w'"> 1W
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'1m'"> 1M
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'3m'"> 3M
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'6m'"> 6M
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'1y'"> 1Y
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'2y'"> 2Y
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'3y'"> 3Y
-                </label>
-                <label ngbButtonLabel class="btn-primary btn-sm">
-                  <input ngbButton type="radio" [value]="'all'"> ALL
-                </label>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm">
-          <table class="table table-borderless table-striped">
+          <table class="table table-borderless table-striped" style="table-layout: fixed;">
             <tbody>
               <tr>
                 <td>Address</td>
-                <td>{{ poolStats.pool.addresses }}</td>
+                <td class="text-truncate">{{ poolStats.pool.addresses }}</td>
               </tr>
               <tr>
                 <td>Coinbase Tag</td>
-                <td>{{ poolStats.pool.regexes }}</td>
+                <td class="text-truncate">{{ poolStats.pool.regexes }}</td>
               </tr>
             </tbody>
           </table>
@@ -84,6 +83,7 @@
       <th style="width: 15%;" i18n="latest-blocks.height">Height</th>
       <th class="d-none d-md-block" style="width: 20%;" i18n="latest-blocks.timestamp">Timestamp</th>
       <th style="width: 20%;" i18n="latest-blocks.mined">Mined</th>
+      <th style="width: 10%;" i18n="latest-blocks.reward">Reward</th>
       <th class="d-none d-lg-block" style="width: 15%;" i18n="latest-blocks.transactions">Transactions</th>
       <th style="width: 20%;" i18n="latest-blocks.size">Size</th>
     </thead>
@@ -92,6 +92,7 @@
         <td><a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
         <td class="d-none d-md-block">&lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
         <td><app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since></td>
+        <td class=""><app-amount [satoshis]="block['reward']" digitsInfo="1.2-2" [noFiat]="true"></app-amount></td>
         <td class="d-none d-lg-block">{{ block.tx_count | number }}</td>
         <td>
           <div class="progress">

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,0 +1,5 @@
+<div class="container-xl">
+
+  Pool
+
+</div>

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,7 +1,8 @@
 <div class="container">
 
   <div *ngIf="poolStats$ | async as poolStats">
-    <h1>
+    <h1 class="m-0">
+      <img width="50" src="{{ poolStats['logo'] }}" onError="this.src = './resources/mining-pools/default.svg'" class="mr-3">
       {{ poolStats.pool.name }}
     </h1>
 

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -47,21 +47,26 @@
 
     <div class="box">
       <div class="row">
-        <div class="col-sm">
+        <div class="col-md-8">
           <table class="table table-borderless table-striped" style="table-layout: fixed;">
             <tbody>
               <tr>
-                <td>Address</td>
-                <td class="text-truncate">{{ poolStats.pool.addresses }}</td>
+                <td class="col-4 col-lg-3">Addresses</td>
+                <td class="text-truncate" *ngIf="poolStats.pool.addresses.length else noaddress">
+                  <div class="scrollable">
+                    <a *ngFor="let address of poolStats.pool.addresses" [routerLink]="['/address' | relativeUrl, address]">{{ address }}<br></a>
+                  </div>
+                </td>
+                <ng-template #noaddress><td>~</td></ng-template>
               </tr>
               <tr>
-                <td>Coinbase Tag</td>
+                <td class="col-4 col-lg-3">Coinbase Tags</td>
                 <td class="text-truncate">{{ poolStats.pool.regexes }}</td>
               </tr>
             </tbody>
           </table>
         </div>
-        <div class="col-sm">
+        <div class="col-md-4">
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>

--- a/frontend/src/app/components/pool/pool.component.scss
+++ b/frontend/src/app/components/pool/pool.component.scss
@@ -30,3 +30,12 @@
     }
   }
 }
+
+div.scrollable {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  max-height: 100px;
+}

--- a/frontend/src/app/components/pool/pool.component.scss
+++ b/frontend/src/app/components/pool/pool.component.scss
@@ -1,0 +1,32 @@
+.progress {
+  background-color: #2d3348;
+}
+
+@media (min-width: 768px) {
+  .d-md-block {
+      display: table-cell !important;
+  }
+}
+@media (min-width: 992px) {
+  .d-lg-block {
+      display: table-cell !important;
+  }
+}
+
+.formRadioGroup {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  @media (min-width: 830px) {
+    margin-left: 2%;
+    flex-direction: row;
+    float: left;
+    margin-top: 0px;
+  }
+  .btn-sm {
+    font-size: 9px;
+    @media (min-width: 830px) {
+      font-size: 14px;
+    }
+  }
+}

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -49,11 +49,11 @@ export class PoolComponent implements OnInit {
         }),
         map((poolStats) => {
           let regexes = '"';
-          for (const regex of JSON.parse(poolStats.pool.regexes)) {
+          for (const regex of poolStats.pool.regexes) {
             regexes += regex + '", "';
           }
           poolStats.pool.regexes = regexes.slice(0, -3);
-          poolStats.pool.addresses = JSON.parse(poolStats.pool.addresses);
+          poolStats.pool.addresses = poolStats.pool.addresses;
 
           return Object.assign({
             logo: `./resources/mining-pools/` + poolStats.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg'

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -49,6 +49,13 @@ export class PoolComponent implements OnInit {
           return this.apiService.getPoolStats$(this.poolId, params[1] ?? '1w');
         }),
         map((poolStats) => {
+          let regexes = '"';
+          for (const regex of JSON.parse(poolStats.pool.regexes)) {
+            regexes += regex + '", "';
+          }
+          poolStats.pool.regexes = regexes.slice(0, -3);
+          poolStats.pool.addresses = JSON.parse(poolStats.pool.addresses);
+
           return Object.assign({
             logo: `./resources/mining-pools/` + poolStats.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg'
           }, poolStats);

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -1,9 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { once } from 'process';
-import { BehaviorSubject, combineLatest, from, merge, Observable } from 'rxjs';
-import { delay, distinctUntilChanged, map, scan, startWith, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { BlockExtended, PoolStat } from 'src/app/interfaces/node-api.interface';
 import { ApiService } from 'src/app/services/api.service';
 import { StateService } from 'src/app/services/state.service';
@@ -11,7 +10,8 @@ import { StateService } from 'src/app/services/state.service';
 @Component({
   selector: 'app-pool',
   templateUrl: './pool.component.html',
-  styleUrls: ['./pool.component.scss']
+  styleUrls: ['./pool.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PoolComponent implements OnInit {
   poolStats$: Observable<PoolStat>;
@@ -22,7 +22,6 @@ export class PoolComponent implements OnInit {
 
   blocks: BlockExtended[] = [];
   poolId: number = undefined;
-  isLoading = false;
   radioGroupForm: FormGroup;
 
   constructor(

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -1,4 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { map, switchMap, tap } from 'rxjs/operators';
+import { BlockExtended, PoolStat } from 'src/app/interfaces/node-api.interface';
+import { ApiService } from 'src/app/services/api.service';
+import { StateService } from 'src/app/services/state.service';
 
 @Component({
   selector: 'app-pool',
@@ -6,9 +12,55 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./pool.component.scss']
 })
 export class PoolComponent implements OnInit {
+  poolStats$: Observable<PoolStat>;
+  isLoading = false;
+
+  poolId: number;
+  interval: string;
+
+  blocks: any[] = [];
+
   constructor(
+    private apiService: ApiService,
+    private route: ActivatedRoute,
+    public stateService: StateService,
   ) { }
 
   ngOnInit(): void {
+    this.poolStats$ = this.route.params
+      .pipe(
+        switchMap((params) => {
+          this.poolId = params.poolId;
+          this.interval = params.interval;
+          this.loadMore(2);
+          return this.apiService.getPoolStats$(params.poolId, params.interval ?? 'all');
+        }),
+      );
+  }
+
+  loadMore(chunks = 0) {
+    let fromHeight: number | undefined;
+    if (this.blocks.length > 0) {
+      fromHeight = this.blocks[this.blocks.length - 1].height - 1;
+    }
+
+    this.apiService.getPoolBlocks$(this.poolId, fromHeight)
+      .subscribe((blocks) => {
+        this.blocks = this.blocks.concat(blocks);
+
+        const chunksLeft = chunks - 1;
+        if (chunksLeft > 0) {
+          this.loadMore(chunksLeft);
+        }
+        // this.cd.markForCheck();
+      },
+      (error) => {
+        console.log(error);
+        // this.cd.markForCheck();
+      });
+  }
+
+  trackByBlock(index: number, block: BlockExtended) {
+    return block.height;
   }
 }

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -48,6 +48,11 @@ export class PoolComponent implements OnInit {
           }
           return this.apiService.getPoolStats$(this.poolId, params[1] ?? '1w');
         }),
+        map((poolStats) => {
+          return Object.assign({
+            logo: `./resources/mining-pools/` + poolStats.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg'
+          }, poolStats);
+        })
       );
 
     this.blocks$ = this.fromHeightSubject

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-pool',
+  templateUrl: './pool.component.html',
+  styleUrls: ['./pool.component.scss']
+})
+export class PoolComponent implements OnInit {
+  constructor(
+  ) { }
+
+  ngOnInit(): void {
+  }
+}

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -55,7 +55,7 @@ export interface LiquidPegs {
 export interface ITranslators { [language: string]: string; }
 
 export interface SinglePoolStats {
-  pooldId: number;
+  poolId: number;
   name: string;
   link: string;
   blockCount: number;

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -106,6 +106,10 @@ export interface BlockExtension {
   reward?: number;
   coinbaseTx?: Transaction;
   matchRate?: number;
+  pool?: {
+    id: number;
+    name: string;
+  }
 
   stage?: number; // Frontend only
 }

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -54,6 +54,9 @@ export interface LiquidPegs {
 
 export interface ITranslators { [language: string]: string; }
 
+/**
+ * PoolRanking component
+ */
 export interface SinglePoolStats {
   poolId: number;
   name: string;
@@ -66,20 +69,35 @@ export interface SinglePoolStats {
   emptyBlockRatio: string;
   logo: string;
 }
-
 export interface PoolsStats {
   blockCount: number;
   lastEstimatedHashrate: number;
   oldestIndexedBlockTimestamp: number;
   pools: SinglePoolStats[];
 }
-
 export interface MiningStats {
-  lastEstimatedHashrate: string,
-  blockCount: number,
-  totalEmptyBlock: number,
-  totalEmptyBlockRatio: string,
-  pools: SinglePoolStats[],
+  lastEstimatedHashrate: string;
+  blockCount: number;
+  totalEmptyBlock: number;
+  totalEmptyBlockRatio: string;
+  pools: SinglePoolStats[];
+}
+
+/**
+ * Pool component
+ */
+export interface PoolInfo {
+  id: number | null; // mysql row id
+  name: string;
+  link: string;
+  regexes: string; // JSON array
+  addresses: string; // JSON array
+  emptyBlocks: number;
+}
+export interface PoolStat {
+  pool: PoolInfo;
+  blockCount: number;
+  emptyBlocks: BlockExtended[];
 }
 
 export interface BlockExtension {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { CpfpInfo, OptimizedMempoolStats, DifficultyAdjustment, AddressInformation, LiquidPegs, ITranslators, PoolsStats } from '../interfaces/node-api.interface';
+import { CpfpInfo, OptimizedMempoolStats, DifficultyAdjustment, AddressInformation, LiquidPegs, ITranslators, PoolsStats, PoolStat, BlockExtended, BlockExtension } from '../interfaces/node-api.interface';
 import { Observable } from 'rxjs';
 import { StateService } from './state.service';
 import { WebsocketResponse } from '../interfaces/websocket.interface';
@@ -131,5 +131,13 @@ export class ApiService {
 
   listPools$(interval: string | null) : Observable<PoolsStats> {
     return this.httpClient.get<PoolsStats>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pools/${interval}`);
+  }
+
+  getPoolStats$(poolId: number, interval: string | null): Observable<PoolStat> {
+    return this.httpClient.get<PoolStat>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool/${poolId}/${interval}`);
+  }
+
+  getPoolBlocks$(poolId: number, fromHeight: number): Observable<BlockExtended[]> {
+    return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool-blocks/${poolId}/${fromHeight}`);
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -138,6 +138,10 @@ export class ApiService {
   }
 
   getPoolBlocks$(poolId: number, fromHeight: number): Observable<BlockExtended[]> {
-    return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool-blocks/${poolId}/${fromHeight}`);
+    if (fromHeight !== undefined) {
+      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +`/api/v1/mining/pool-blocks/${poolId}/${fromHeight}`);
+    } else {
+      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +`/api/v1/mining/pool-blocks/${poolId}`);
+    }
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -139,9 +139,11 @@ export class ApiService {
 
   getPoolBlocks$(poolId: number, fromHeight: number): Observable<BlockExtended[]> {
     if (fromHeight !== undefined) {
-      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +`/api/v1/mining/pool-blocks/${poolId}/${fromHeight}`);
+      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +
+        `/api/v1/mining/pool/${poolId}/blocks/${fromHeight}`);
     } else {
-      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +`/api/v1/mining/pool-blocks/${poolId}`);
+      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +
+        `/api/v1/mining/pool/${poolId}/blocks`);
     }
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -138,12 +138,9 @@ export class ApiService {
   }
 
   getPoolBlocks$(poolId: number, fromHeight: number): Observable<BlockExtended[]> {
-    if (fromHeight !== undefined) {
-      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +
-        `/api/v1/mining/pool/${poolId}/blocks/${fromHeight}`);
-    } else {
-      return this.httpClient.get<BlockExtended[]>(this.apiBaseUrl + this.apiBasePath +
-        `/api/v1/mining/pool/${poolId}/blocks`);
-    }
+    return this.httpClient.get<BlockExtended[]>(
+        this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool/${poolId}/blocks` +
+        (fromHeight !== undefined ? `/${fromHeight}` : '')
+      );
   }
 }


### PR DESCRIPTION
# Description

This PR adds a new page at `/mining/pool/:poolId` and is used to show the data noted below. Note that this is just a PoC/building block and that much more thinking has to be put into what we want to show, how we want to show it, as well as the html/css... (see screenshot for reference)

* Known addresses
* Known coinbase tag
* Mined block count based on the user selected time span
* Empty block count based on the user selected time span
* Mined block list with infinite scroll support

Also, 4 new API endpoints were added:
* `/api/v1/mining/pool/:poolId'` - Get pool stats for all indexed block
* `/api/v1/mining/pool/:poolId/:interval'` - Get pool stats for a specific interval
* `/api/v1/mining/pool-blocks/:poolId'` - Get the last 10 blocks mined by a pool
* `/api/v1/mining/pool-blocks/:poolId/:height'` - Get 10 blocks mined by a pool older than specified block height

![image](https://user-images.githubusercontent.com/9780671/153802925-b7c105da-8f18-4a8e-85ec-619b4914828c.png)
![image](https://user-images.githubusercontent.com/9780671/153803307-0a0b47cb-945b-4e79-9381-7e10dd0ea0c9.png)

I also did a bit of refactoring in my queries to make sure we don't use unfiltered user input.
Mining related API endpoints are now only available for Bitcoin networks and if the database is enabled.

# Testing

To access the new page, open the mining overview page from the menu, then you can click on individual pools in the list.

This PR does not change the data structure for blocks, nor modify any backend interfaces, so no special action should be required.
Note that the `reward` is currently showing 0 always, as this new field was created in another PR (#1235) and is currently under review.