### PR TITLE
Don't wait for 100% mempool sync before starting block indexing

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -168,8 +168,7 @@ class Mempool {
     const newTransactionsStripped = newTransactions.map((tx) => Common.stripTransaction(tx));
     this.latestTransactions = newTransactionsStripped.concat(this.latestTransactions).slice(0, 6);
 
-    const syncedThreshold = 0.99; // If we synced 99% of the mempool tx count, consider we're synced
-    if (!this.inSync && Object.keys(this.mempoolCache).length >= transactions.length * syncedThreshold) {
+    if (!this.inSync && transactions.length === Object.keys(this.mempoolCache).length) {
       this.inSync = true;
       logger.notice('The mempool is now in sync!');
       loadingIndicators.setProgress('mempool', 100);

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -13,6 +13,7 @@ class Mempool {
   private static WEBSOCKET_REFRESH_RATE_MS = 10000;
   private static LAZY_DELETE_AFTER_SECONDS = 30;
   private inSync: boolean = false;
+  private mempoolCacheDelta: number = -1;
   private mempoolCache: { [txId: string]: TransactionExtended } = {};
   private mempoolInfo: IBitcoinApi.MempoolInfo = { loaded: false, size: 0, bytes: 0, usage: 0, total_fee: 0,
                                                     maxmempool: 300000000, mempoolminfee: 0.00001000, minrelaytxfee: 0.00001000 };
@@ -30,6 +31,17 @@ class Mempool {
   constructor() {
     setInterval(this.updateTxPerSecond.bind(this), 1000);
     setInterval(this.deleteExpiredTransactions.bind(this), 20000);
+  }
+
+  /**
+   * Return true if we should leave resources available for mempool tx caching
+   */
+  public hasPriority(): boolean {
+    if (this.inSync) {
+      return false;
+    } else {
+      return this.mempoolCacheDelta == -1 || this.mempoolCacheDelta > 25;
+    }
   }
 
   public isInSync(): boolean {
@@ -99,6 +111,8 @@ class Mempool {
     const transactions = await bitcoinApi.$getRawMempool();
     const diff = transactions.length - currentMempoolSize;
     const newTransactions: TransactionExtended[] = [];
+
+    this.mempoolCacheDelta = Math.abs(diff);
 
     if (!this.inSync) {
       loadingIndicators.setProgress('mempool', Object.keys(this.mempoolCache).length / transactions.length * 100);
@@ -173,6 +187,8 @@ class Mempool {
       logger.notice('The mempool is now in sync!');
       loadingIndicators.setProgress('mempool', 100);
     }
+
+    this.mempoolCacheDelta = Math.abs(transactions.length - Object.keys(this.mempoolCache).length);
 
     if (this.mempoolChangedCallback && (hasChange || deletedTransactions.length)) {
       this.mempoolChangedCallback(this.mempoolCache, newTransactions, deletedTransactions);


### PR DESCRIPTION
This PR reverts https://github.com/mempool/mempool/commit/2f921f4cc73994cc9ea9c317c8897de0d1881340 (https://github.com/mempool/mempool/pull/1240) because it may have unintended side effects as @wiz rightly noted.
* getRecommendedFees API: At start and for a couple of seconds, the recommended fee may be slightly off
* runStatistics: The first statistics data point may be a bit off
* bitcoin-api.ts::appendMempoolFeeData: Unsure about this one, so better not change anything about it

A new method has been provided instead of modifying the current behavior.

The original goal was to provide a method for running node backend operations without having to wait for 100% match between our mempool cache and core mempool. For example, this lead to situation like this. Note that `DELTA` here is the difference between our cached mempool tx count and core mempool tx count:

```
Feb 11 20:51:47 [1328826] NOTICE: Mempool Server is running on port 8999
Feb 11 20:51:47 [1328826] WARN: DELTA: 8527
Feb 11 20:51:57 [1328826] WARN: DELTA: 2186
Feb 11 20:51:59 [1328826] WARN: DELTA: 1723
Feb 11 20:52:01 [1328826] WARN: DELTA: 1
Feb 11 20:52:03 [1328826] WARN: DELTA: 7
Feb 11 20:52:03 [1328826] WARN: DELTA: 1
Feb 11 20:52:05 [1328826] WARN: DELTA: 8
Feb 11 20:52:05 [1328826] WARN: DELTA: 1
Feb 11 20:52:07 [1328826] WARN: DELTA: 2
Feb 11 20:52:07 [1328826] WARN: DELTA: 1
Feb 11 20:52:09 [1328826] WARN: DELTA: 6
Feb 11 20:52:09 [1328826] WARN: DELTA: 1
Feb 11 20:52:11 [1328826] WARN: DELTA: 9
Feb 11 20:52:11 [1328826] WARN: DELTA: 1
Feb 11 20:52:13 [1328826] WARN: DELTA: 2
Feb 11 20:52:13 [1328826] WARN: DELTA: 1
Feb 11 20:52:15 [1328826] WARN: DELTA: 5
Feb 11 20:52:15 [1328826] WARN: DELTA: 1
Feb 11 20:52:18 [1328826] WARN: DELTA: 5
Feb 11 20:52:18 [1328826] WARN: DELTA: 1
Feb 11 20:52:20 [1328826] WARN: DELTA: 10
Feb 11 20:52:20 [1328826] WARN: DELTA: 1
Feb 11 20:52:22 [1328826] WARN: DELTA: 3
Feb 11 20:52:22 [1328826] WARN: DELTA: 1
Feb 11 20:52:24 [1328826] WARN: DELTA: 1
Feb 11 20:52:24 [1328826] WARN: DELTA: 1
Feb 11 20:52:26 [1328826] WARN: DELTA: 9
Feb 11 20:52:26 [1328826] WARN: DELTA: 1
Feb 11 20:52:28 [1328826] WARN: DELTA: 6
Feb 11 20:52:28 [1328826] WARN: DELTA: 1
Feb 11 20:52:30 [1328826] WARN: DELTA: 6
Feb 11 20:52:30 [1328826] WARN: DELTA: 1
Feb 11 20:52:32 [1328826] WARN: DELTA: 3
Feb 11 20:52:32 [1328826] WARN: DELTA: 1
Feb 11 20:52:34 [1328826] WARN: DELTA: 13
Feb 11 20:52:34 [1328826] WARN: DELTA: 1
Feb 11 20:52:37 [1328826] WARN: DELTA: 4
Feb 11 20:52:37 [1328826] WARN: DELTA: 1
Feb 11 20:52:39 [1328826] WARN: DELTA: 7
Feb 11 20:52:39 [1328826] WARN: DELTA: 1
Feb 11 20:52:41 [1328826] WARN: DELTA: 10
Feb 11 20:52:41 [1328826] WARN: DELTA: 1
Feb 11 20:52:43 [1328826] WARN: DELTA: 5
Feb 11 20:52:43 [1328826] WARN: DELTA: 2
Feb 11 20:52:45 [1328826] WARN: DELTA: 6
Feb 11 20:52:45 [1328826] WARN: DELTA: 1
Feb 11 20:52:47 [1328826] WARN: DELTA: 7
Feb 11 20:52:47 [1328826] WARN: DELTA: 1
Feb 11 20:52:49 [1328826] WARN: DELTA: 4
Feb 11 20:52:49 [1328826] NOTICE: The mempool is now in sync!
```

It took around 1 minute to get a 100% match in this case. When there is many incoming transactions, it can take even longer. This blocks the node backend resources unnecessarily, and could provide bad first UX in the future.

This PR aims to fix that.
