### PR TITLE
Index more block data

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 5;
+  private static currentVersion = 6;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -76,6 +76,7 @@ class DatabaseMigration {
   private async $createMissingTablesAndIndexes(databaseSchemaVersion: number) {
     await this.$setStatisticsAddedIndexedFlag(databaseSchemaVersion);
 
+    const isBitcoin = ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK);
     const connection = await DB.pool.getConnection();
     try {
       await this.$executeQuery(connection, this.getCreateElementsTableQuery(), await this.$checkIfTableExists('elements_pegs'));
@@ -89,6 +90,29 @@ class DatabaseMigration {
       if (databaseSchemaVersion < 4) {
         await this.$executeQuery(connection, 'DROP table IF EXISTS blocks;');
         await this.$executeQuery(connection, this.getCreateBlocksTableQuery(), await this.$checkIfTableExists('blocks'));
+      }
+      if (databaseSchemaVersion < 5 && isBitcoin === true) {
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `reward` double unsigned NOT NULL DEFAULT "0"');
+      }
+
+      if (databaseSchemaVersion < 6 && isBitcoin === true) {
+        // Cleanup original blocks fields type
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `height` integer unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `tx_count` smallint unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `size` integer unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `weight` integer unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `difficulty` double NOT NULL DEFAULT "0"');
+        // We also fix the pools.id type so we need to drop/re-create the foreign key
+        await this.$executeQuery(connection, 'ALTER TABLE blocks DROP FOREIGN KEY IF EXISTS `blocks_ibfk_1`');
+        await this.$executeQuery(connection, 'ALTER TABLE pools MODIFY `id` smallint unsigned AUTO_INCREMENT');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `pool_id` smallint unsigned NULL');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD FOREIGN KEY (`pool_id`) REFERENCES `pools` (`id`)');
+        // Add new block indexing fields
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `version` integer unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `bits` integer unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `nonce` bigint unsigned NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `merkle_root` varchar(65) NOT NULL DEFAULT ""');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `previous_block_hash` varchar(65) NULL');
       }
       connection.release();
     } catch (e) {
@@ -227,10 +251,6 @@ class DatabaseMigration {
       if (config.MEMPOOL.NETWORK !== 'liquid' && config.MEMPOOL.NETWORK !== 'liquidtestnet') {
         queries.push(this.getShiftStatisticsQuery());
       }
-    }
-
-    if (version < 5 && (['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) === true)) {
-      queries.push('ALTER TABLE blocks ADD `reward` double unsigned NOT NULL DEFAULT "0"');
     }
 
     return queries;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -20,12 +20,14 @@ class BlocksRepository {
         height,  hash,     blockTimestamp, size,
         weight,  tx_count, coinbase_raw,   difficulty,
         pool_id, fees,     fee_span,       median_fee,
-        reward
+        reward,  version,  bits,           nonce,
+        merkle_root,       previous_block_hash
       ) VALUE (
         ?, ?, FROM_UNIXTIME(?), ?,
         ?, ?, ?, ?,
         ?, ?, ?, ?,
-        ?
+        ?, ?, ?, ?,
+        ?,    ?
       )`;
 
       const params: any[] = [
@@ -37,11 +39,16 @@ class BlocksRepository {
         block.tx_count,
         '',
         block.difficulty,
-        block.extras?.pool?.id, // Should always be set to something
+        block.extras.pool?.id, // Should always be set to something
         0,
         '[]',
         block.extras.medianFee ?? 0,
-        block.extras?.reward ?? 0,
+        block.extras.reward ?? 0,
+        block.version,
+        block.bits,
+        block.nonce,
+        block.merkle_root,
+        block.previousblockhash
       ];
 
       // logger.debug(query);


### PR DESCRIPTION
This PR adds the following fields to the `blocks` table. Also, block indexing save this new data in the database.
* `version`: `integer unsigned`
* `bits`: `integer unsigned`
* `nonce`: `bigint unsigned`
* `merkle_root`: `varchar(65)`
* `previous_block_hash`: `varchar(65)`

It also set proper data type for existing fiels:
* `height`: `int(11)` => `integer unsigned`
* `tx_count`: `int(11)` => `smallint unsigned`
* `size`: `int(11)` => `integer unsigned`
* `weight`: `int(11)` => `integer unsigned`
* `difficulty`: `bigint(20)` => `double`

Database schema is incremented to version `6`. If you have trouble running the migration, let me know, or if you don't mind loosing currently indexed data:
* Drop `blocks` table
* Drop `pools` table
* Set `state.schema_version = 2`
* Re-start node backend