### PR TITLE
Create difficulty chart component

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -69,6 +69,19 @@ class Mining {
       emptyBlocks: emptyBlocks,
     };
   }
+
+  /**
+   * Return the historical difficulty adjustments and oldest indexed block timestamp
+   */
+  public async $getHistoricalDifficulty(interval: string | null): Promise<object> {
+    const difficultyAdjustments = await BlocksRepository.$getBlocksDifficulty(interval);
+    const oldestBlock = new Date(await BlocksRepository.$oldestBlockTimestamp());
+
+    return {
+      adjustments: difficultyAdjustments,
+      oldestIndexedBlockTimestamp: oldestBlock.getTime(),
+    }
+  }
 }
 
 export default new Mining();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -259,10 +259,7 @@ class Server {
         ;
     }
 
-    const indexingAvailable =
-      ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) &&
-      config.DATABASE.ENABLED === true;
-    if (indexingAvailable) {
+    if (Common.indexingEnabled()) {
       this.app
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/24h', routes.$getPools.bind(routes, '24h'))
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/3d', routes.$getPools.bind(routes, '3d'))
@@ -277,7 +274,9 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/blocks', routes.$getPoolBlocks)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/blocks/:height', routes.$getPoolBlocks)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId', routes.$getPool)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool);
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/difficulty', routes.$getHistoricalDifficulty)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/difficulty/:interval', routes.$getHistoricalDifficulty);
     }
 
     if (config.BISQ.ENABLED) {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -223,6 +223,30 @@ class BlocksRepository {
 
     return rows[0];
   }
+
+  /**
+   * Return blocks difficulty
+   */
+   public async $getBlocksDifficulty(interval: string | null): Promise<object[]> {
+    interval = Common.getSqlInterval(interval);
+
+    const connection = await DB.pool.getConnection();
+
+    let query = `SELECT MIN(blockTimestamp) as timestamp, difficulty
+      FROM blocks`;
+
+    if (interval) {
+      query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+    }
+
+    query += ` GROUP BY difficulty
+      ORDER BY blockTimestamp DESC`;
+
+    const [rows]: any[] = await connection.query(query);
+    connection.release();
+
+    return rows;
+  }
 }
 
 export default new BlocksRepository();

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -232,7 +232,7 @@ class BlocksRepository {
 
     const connection = await DB.pool.getConnection();
 
-    let query = `SELECT MIN(blockTimestamp) as timestamp, difficulty, height
+    let query = `SELECT MIN(UNIX_TIMESTAMP(blockTimestamp)) as timestamp, difficulty, height
       FROM blocks`;
 
     if (interval) {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -232,7 +232,7 @@ class BlocksRepository {
 
     const connection = await DB.pool.getConnection();
 
-    let query = `SELECT MIN(blockTimestamp) as timestamp, difficulty
+    let query = `SELECT MIN(blockTimestamp) as timestamp, difficulty, height
       FROM blocks`;
 
     if (interval) {

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -577,7 +577,7 @@ class Routes {
 
   public async $getHistoricalDifficulty(req: Request, res: Response) {
     try {
-      const stats = await BlocksRepository.$getBlocksDifficulty(req.params.interval ?? null);
+      const stats = await mining.$getHistoricalDifficulty(req.params.interval ?? null);
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -575,6 +575,18 @@ class Routes {
     }
   }
 
+  public async $getHistoricalDifficulty(req: Request, res: Response) {
+    try {
+      const stats = await BlocksRepository.$getBlocksDifficulty(req.params.interval ?? null);
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.json(stats);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
+  }
+
   public async getBlock(req: Request, res: Response) {
     try {
       const result = await bitcoinApi.$getBlock(req.params.hash);

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -27,6 +27,7 @@ import { AssetGroupComponent } from './components/assets/asset-group/asset-group
 import { AssetsFeaturedComponent } from './components/assets/assets-featured/assets-featured.component';
 import { AssetsComponent } from './components/assets/assets.component';
 import { PoolComponent } from './components/pool/pool.component';
+import { DifficultyChartComponent } from './components/difficulty-chart/difficulty-chart.component';
 
 let routes: Routes = [
   {
@@ -62,6 +63,10 @@ let routes: Routes = [
       {
         path: 'blocks',
         component: LatestBlocksComponent,
+      },
+      {
+        path: 'mining/difficulty',
+        component: DifficultyChartComponent,
       },
       {
         path: 'mining/pools',
@@ -156,6 +161,10 @@ let routes: Routes = [
             component: LatestBlocksComponent,
           },
           {
+            path: 'mining/difficulty',
+            component: DifficultyChartComponent,
+          },
+          {
             path: 'mining/pools',
             component: PoolRankingComponent,
           },
@@ -240,6 +249,10 @@ let routes: Routes = [
           {
             path: 'blocks',
             component: LatestBlocksComponent,
+          },
+          {
+            path: 'mining/difficulty',
+            component: DifficultyChartComponent,
           },
           {
             path: 'mining/pools',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -68,6 +68,7 @@ import { PushTransactionComponent } from './components/push-transaction/push-tra
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AssetsFeaturedComponent } from './components/assets/assets-featured/assets-featured.component';
 import { AssetGroupComponent } from './components/assets/asset-group/asset-group.component';
+import { DifficultyChartComponent } from './components/difficulty-chart/difficulty-chart.component';
 
 @NgModule({
   declarations: [
@@ -118,6 +119,7 @@ import { AssetGroupComponent } from './components/assets/asset-group/asset-group
     AssetsNavComponent,
     AssetsFeaturedComponent,
     AssetGroupComponent,
+    DifficultyChartComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
@@ -5,4 +5,23 @@
     <div class="spinner-border text-light"></div>
   </div>
 
+  <table class="table table-borderless table-sm text-center">
+    <thead>
+      <tr>
+        <th i18n="mining.rank">Block</th>
+        <th i18n="block.timestamp">Timestamp</th>
+        <th i18n="mining.difficulty">Difficulty</th>
+        <th i18n="mining.change">Change</th>
+      </tr>
+    </thead>
+    <tbody *ngIf="(difficultyObservable$ | async) as diffChange">
+      <tr *ngFor="let change of diffChange">
+        <td><a [routerLink]="['/block' | relativeUrl, change[2]]">{{ change[2] }}</a></td>
+        <td>&lrm;{{ change[0] | date:'yyyy-MM-dd HH:mm' }}</td>
+        <td>{{ formatNumber(change[1], locale, '1.2-2') }}</td>
+        <td [style]="change[3] >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(change[3], locale, '1.2-2') }}%</td>
+      </tr>
+    </tbody>
+  </table>
+
 </div>

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
@@ -1,0 +1,8 @@
+<div class="container-xl">
+
+  <div *ngIf="difficultyObservable$ | async" class="" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
+  <div class="text-center loadingGraphs" *ngIf="isLoading">
+    <div class="spinner-border text-light"></div>
+  </div>
+
+</div>

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
@@ -5,6 +5,31 @@
     <div class="spinner-border text-light"></div>
   </div>
 
+  <div class="card-header mb-0 mb-lg-4">
+    <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(difficultyObservable$ | async) as diffChanges">
+      <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/difficulty' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 90">
+          <input ngbButton type="radio" [value]="'3m'" fragment="3m"> 3M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/difficulty' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 180">
+          <input ngbButton type="radio" [value]="'6m'" fragment="6m"> 6M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/difficulty' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 365">
+          <input ngbButton type="radio" [value]="'1y'" fragment="1y"> 1Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/difficulty' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 730">
+          <input ngbButton type="radio" [value]="'2y'" fragment="2y"> 2Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/difficulty' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 1095">
+          <input ngbButton type="radio" [value]="'3y'" fragment="3y"> 3Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm">
+          <input ngbButton type="radio" [value]="'all'" [routerLink]="['/mining/difficulty' | relativeUrl]" fragment="all"> ALL
+        </label>
+      </div>
+    </form>
+  </div>
+
   <table class="table table-borderless table-sm text-center">
     <thead>
       <tr>
@@ -14,12 +39,12 @@
         <th i18n="mining.change">Change</th>
       </tr>
     </thead>
-    <tbody *ngIf="(difficultyObservable$ | async) as diffChange">
-      <tr *ngFor="let change of diffChange">
-        <td><a [routerLink]="['/block' | relativeUrl, change[2]]">{{ change[2] }}</a></td>
-        <td>&lrm;{{ change[0] | date:'yyyy-MM-dd HH:mm' }}</td>
-        <td>{{ formatNumber(change[1], locale, '1.2-2') }}</td>
-        <td [style]="change[3] >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(change[3], locale, '1.2-2') }}%</td>
+    <tbody *ngIf="(difficultyObservable$ | async) as diffChanges">
+      <tr *ngFor="let diffChange of diffChanges.data">
+        <td><a [routerLink]="['/block' | relativeUrl, diffChange.height]">{{ diffChange.height }}</a></td>
+        <td>&lrm;{{ diffChange.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
+        <td>{{ formatNumber(diffChange.difficulty, locale, '1.2-2') }}</td>
+        <td [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(diffChange.change, locale, '1.2-2') }}%</td>
       </tr>
     </tbody>
   </table>

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
@@ -43,7 +43,8 @@
       <tr *ngFor="let diffChange of diffChanges.data">
         <td><a [routerLink]="['/block' | relativeUrl, diffChange.height]">{{ diffChange.height }}</a></td>
         <td>&lrm;{{ diffChange.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
-        <td>{{ formatNumber(diffChange.difficulty, locale, '1.2-2') }}</td>
+        <td class="d-none d-md-block">{{ formatNumber(diffChange.difficulty, locale, '1.2-2') }}</td>
+        <td class="d-block d-md-none">{{ diffChange.difficultyShorten }}</td>
         <td [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(diffChange.change, locale, '1.2-2') }}%</td>
       </tr>
     </tbody>

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -44,6 +44,13 @@ export class DifficultyChartComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const powerOfTen = {
+      terra: Math.pow(10, 12),
+      giga: Math.pow(10, 9),
+      mega: Math.pow(10, 6),
+      kilo: Math.pow(10, 3),
+    }
+
     this.difficultyObservable$ = this.radioGroupForm.get('dateSpan').valueChanges
       .pipe(
         startWith('1y'),
@@ -62,8 +69,20 @@ export class DifficultyChartComponent implements OnInit {
                 const tableData = [];
                 for (let i = 0; i < data.adjustments.length - 1; ++i) {
                   const change = (data.adjustments[i].difficulty / data.adjustments[i + 1].difficulty - 1) * 100;
+                  let selectedPowerOfTen = { divider: powerOfTen.terra, unit: 'T' };
+                  if (data.adjustments[i].difficulty < powerOfTen.mega) {
+                    selectedPowerOfTen = { divider: 1, unit: '' }; // no scaling
+                  } else if (data.adjustments[i].difficulty < powerOfTen.giga) {
+                    selectedPowerOfTen = { divider: powerOfTen.mega, unit: 'M' };
+                  } else if (data.adjustments[i].difficulty < powerOfTen.terra) {
+                    selectedPowerOfTen = { divider: powerOfTen.giga, unit: 'G' };
+                  }
+
                   tableData.push(Object.assign(data.adjustments[i], {
-                    change: change
+                    change: change,
+                    difficultyShorten: formatNumber(
+                      data.adjustments[i].difficulty / selectedPowerOfTen.divider,
+                      this.locale, '1.2-2') + selectedPowerOfTen.unit
                   }));
                 }
                 return {

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit } from '@angular/core';
+import { EChartsOption } from 'echarts';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { ApiService } from 'src/app/services/api.service';
+import { SeoService } from 'src/app/services/seo.service';
+
+@Component({
+  selector: 'app-difficulty-chart',
+  templateUrl: './difficulty-chart.component.html',
+  styleUrls: ['./difficulty-chart.component.scss'],
+  styles: [`
+    .loadingGraphs {
+      position: absolute;
+      top: 38%;
+      left: calc(50% - 15px);
+      z-index: 100;
+    }
+  `],
+})
+export class DifficultyChartComponent implements OnInit {
+  chartOptions: EChartsOption = {};
+  chartInitOptions = {
+    renderer: 'svg'
+  };
+
+  difficultyObservable$: Observable<any>;
+  isLoading = true;
+
+  constructor(
+    private seoService: SeoService,
+    private apiService: ApiService,
+  ) {
+    this.seoService.setTitle($localize`:@@mining.difficulty:Difficulty`);
+  }
+
+  ngOnInit(): void {
+    this.difficultyObservable$ = this.apiService.getHistoricalDifficulty$(undefined)
+      .pipe(
+        map(data => {
+          return data.map(val => [val.timestamp, val.difficulty])
+        }),
+        tap(data => {
+          this.prepareChartOptions(data);
+          this.isLoading = false;
+        })
+      )
+  }
+
+  prepareChartOptions(data) {
+    this.chartOptions = {
+      title: {
+        text: $localize`:@@mining.difficulty:Difficulty`,
+        left: 'center',
+        textStyle: {
+          color: '#FFF',
+        },
+      },
+      tooltip: {
+        show: true,
+        trigger: 'axis',
+      },
+      axisPointer: {
+        type: 'line',
+      },
+      xAxis: [
+        {
+          type: 'time',
+        }
+      ],
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          fontSize: 11,
+          formatter: function(val) {
+            const diff = val / Math.pow(10, 12); // terra
+            return diff.toString() + 'T';
+          }
+        },
+        splitLine: {
+          lineStyle: {
+            type: 'dotted',
+            color: '#ffffff66',
+            opacity: 0.25,
+          }
+        }
+      },
+      series: [
+        {
+          data: data,
+          type: 'line',
+          smooth: false,
+          lineStyle: {
+            width: 3,
+          },
+          areaStyle: {}
+        },
+      ],
+    };
+  }
+
+}

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -43,7 +43,7 @@
     </form>
   </div>
 
-  <table class="table table-borderless text-center pools-table" [alwaysCallback]="true" infiniteScroll [infiniteScrollDistance]="1.5" [infiniteScrollUpDistance]="1.5" [infiniteScrollThrottle]="50">
+  <table class="table table-borderless text-center pools-table">
     <thead>
       <tr>
         <th class="d-none d-md-block" i18n="mining.rank">Rank</th>

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -107,7 +107,7 @@ export class PoolRankingComponent implements OnInit {
       if (parseFloat(pool.share) < poolShareThreshold) {
         return;
       }
-      data.push(<PieSeriesOption>{
+      data.push({
         value: pool.share,
         name: pool.name + (this.isMobile() ? `` : ` (${pool.share}%)`),
         label: {
@@ -115,9 +115,9 @@ export class PoolRankingComponent implements OnInit {
           overflow: 'break',
         },
         tooltip: {
-          backgroundColor: "#282d47",
+          backgroundColor: '#282d47',
           textStyle: {
-            color: "#FFFFFF",
+            color: '#FFFFFF',
           },
           formatter: () => {
             if (this.poolsWindowPreference === '24h') {
@@ -131,7 +131,7 @@ export class PoolRankingComponent implements OnInit {
           }
         },
         data: pool.poolId,
-      });
+      } as PieSeriesOption);
     });
     return data;
   }
@@ -205,10 +205,10 @@ export class PoolRankingComponent implements OnInit {
 
     this.chartInstance = ec;
     this.chartInstance.on('click', (e) => {
-      this.router.navigate(['/mining/pool/', e.data.data]); 
-    })
+      this.router.navigate(['/mining/pool/', e.data.data]);
+    });
   }
-  
+
   /**
    * Default mining stats if something goes wrong
    */

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { EChartsOption, PieSeriesOption } from 'echarts';
@@ -23,7 +23,7 @@ import { StateService } from '../../services/state.service';
     }
   `],
 })
-export class PoolRankingComponent implements OnInit, OnDestroy {
+export class PoolRankingComponent implements OnInit {
   poolsWindowPreference: string;
   radioGroupForm: FormGroup;
 
@@ -88,9 +88,6 @@ export class PoolRankingComponent implements OnInit, OnDestroy {
         }),
         share()
       );
-  }
-
-  ngOnDestroy(): void {
   }
 
   formatPoolUI(pool: SinglePoolStats) {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -129,18 +129,31 @@ export class ApiService {
     return this.httpClient.post<any>(this.apiBaseUrl + this.apiBasePath + '/api/tx', hexPayload, { responseType: 'text' as 'json'});
   }
 
-  listPools$(interval: string | null) : Observable<PoolsStats> {
-    return this.httpClient.get<PoolsStats>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pools/${interval}`);
+  listPools$(interval: string | undefined) : Observable<PoolsStats> {
+    return this.httpClient.get<PoolsStats>(
+      this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pools` +
+      (interval !== undefined ? `/${interval}` : '')
+    );
   }
 
-  getPoolStats$(poolId: number, interval: string | null): Observable<PoolStat> {
-    return this.httpClient.get<PoolStat>(this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool/${poolId}/${interval}`);
+  getPoolStats$(poolId: number, interval: string | undefined): Observable<PoolStat> {
+    return this.httpClient.get<PoolStat>(
+      this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool/${poolId}` +
+      (interval !== undefined ? `/${interval}` : '')
+    );
   }
 
   getPoolBlocks$(poolId: number, fromHeight: number): Observable<BlockExtended[]> {
     return this.httpClient.get<BlockExtended[]>(
         this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pool/${poolId}/blocks` +
         (fromHeight !== undefined ? `/${fromHeight}` : '')
+      );
+  }
+
+  getHistoricalDifficulty$(interval: string | undefined): Observable<any[]> {
+    return this.httpClient.get<any[]>(
+        this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/difficulty` +
+        (interval !== undefined ? `/${interval}` : '')
       );
   }
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -150,7 +150,7 @@ export class ApiService {
       );
   }
 
-  getHistoricalDifficulty$(interval: string | undefined): Observable<any[]> {
+  getHistoricalDifficulty$(interval: string | undefined): Observable<any> {
     return this.httpClient.get<any[]>(
         this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/difficulty` +
         (interval !== undefined ? `/${interval}` : '')


### PR DESCRIPTION
This PR adds a new mining components, showing the historical difficulty adjustments.

![image](https://user-images.githubusercontent.com/9780671/154382000-b6c0aa44-cee4-4cc8-a606-5409eb89eeb7.png)
![image](https://user-images.githubusercontent.com/9780671/154387137-fb977913-3a4b-4549-a8fd-d52719058ad3.png)

A new API endpoint has been added at: `/api/v1/mining/difficulty/:interval`
The page can be accessed at: `/mining/difficulty/` (it will be accessible through UI once added to the mining dashboard page).

Min timespan is 3 months, it does not make much sense to show smaller ones.
The table of difficulty adjustments is not paginated. We should test the rendering performance on potato hardware. The current maximum number of rows is 343 if you index all blocks from genesis, which I think should not be an issue for rendering.