### PR TITLE
Created hashrate chart component

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -170,10 +170,7 @@ class Blocks {
    * Index all blocks metadata for the mining dashboard
    */
   public async $generateBlockDatabase() {
-    if (this.blockIndexingStarted === true ||
-      !Common.indexingEnabled() ||
-      memPool.hasPriority()
-    ) {
+    if (this.blockIndexingStarted) {
       return;
     }
 

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -20,6 +20,7 @@ class Blocks {
   private previousDifficultyRetarget = 0;
   private newBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: TransactionExtended[]) => void)[] = [];
   private blockIndexingStarted = false;
+  public blockIndexingCompleted = false;
 
   constructor() { }
 
@@ -240,6 +241,8 @@ class Blocks {
       logger.err('An error occured in $generateBlockDatabase(). Skipping block indexing. ' + e);
       console.log(e);
     }
+
+    this.blockIndexingCompleted = true;
   }
 
   public async $updateBlocks() {

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -261,6 +261,10 @@ class DatabaseMigration {
       }
     }
 
+    if (version < 7) {
+      queries.push(`INSERT INTO state(name, number, string) VALUES ('last_hashrates_indexing', 0, NULL)`);
+    }
+
     return queries;
   }
 

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -111,12 +111,12 @@ class Mining {
       return;
     }
 
-    logger.info(`Indexing hashrates`);
-
     if (this.hashrateIndexingStarted) {
       return;
     }
     this.hashrateIndexingStarted = true;
+
+    logger.info(`Indexing hashrates`);
 
     const totalDayIndexed = (await BlocksRepository.$blockCount(null, null)) / 144;
     const indexedTimestamp = (await HashratesRepository.$get(null)).map(hashrate => hashrate.timestamp);
@@ -149,7 +149,7 @@ class Mining {
         blockStats.lastBlockHeight);
 
       const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-      if (elapsedSeconds > 1) {
+      if (elapsedSeconds > 10) {
         const daysPerSeconds = Math.max(1, Math.round(indexedThisRun / elapsedSeconds));
         const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
         const daysLeft = Math.round(totalDayIndexed - totalIndexed);

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -118,18 +118,21 @@ class Mining {
     }
     this.hashrateIndexingStarted = true;
 
-    const oldestIndexedBlockHeight = await BlocksRepository.$getOldestIndexedBlockHeight();
+    const totalDayIndexed = (await BlocksRepository.$blockCount(null, null)) / 144;
     const indexedTimestamp = (await HashratesRepository.$get(null)).map(hashrate => hashrate.timestamp);
-
+    let startedAt = new Date().getTime() / 1000;
     const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
     const lastMidnight = new Date();
     lastMidnight.setUTCHours(0); lastMidnight.setUTCMinutes(0); lastMidnight.setUTCSeconds(0); lastMidnight.setUTCMilliseconds(0);
     let toTimestamp = Math.round(lastMidnight.getTime() / 1000);
+    let indexedThisRun = 0;
+    let totalIndexed = 0;
 
     while (toTimestamp > genesisTimestamp) {
       const fromTimestamp = toTimestamp - 86400;
       if (indexedTimestamp.includes(fromTimestamp)) {
         toTimestamp -= 86400;
+        ++totalIndexed;
         continue;
       }
 
@@ -145,10 +148,14 @@ class Mining {
       lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
         blockStats.lastBlockHeight);
 
-      if (toTimestamp % 864000 === 0) { // Log every 10 days during initial indexing
+      const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
+      if (elapsedSeconds > 1) {
+        const daysPerSeconds = Math.max(1, Math.round(indexedThisRun / elapsedSeconds));
         const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
-        const blocksLeft = blockStats.lastBlockHeight - oldestIndexedBlockHeight;
-        logger.debug(`Counting blocks and hashrate for ${formattedDate}. ${blocksLeft} blocks left`);
+        const daysLeft = Math.round(totalDayIndexed - totalIndexed);
+        logger.debug(`Getting hashrate for ${formattedDate} | ~${daysPerSeconds} days/sec | ~${daysLeft} days left to index`);
+        startedAt = new Date().getTime() / 1000;
+        indexedThisRun = 0;
       }
 
       await HashratesRepository.$saveDailyStat({
@@ -158,6 +165,8 @@ class Mining {
       });
 
       toTimestamp -= 86400;
+      ++indexedThisRun;
+      ++totalIndexed;
     }
 
     await HashratesRepository.$setLatestRunTimestamp();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -164,12 +164,17 @@ class Server {
     }
   }
 
-  runIndexingWhenReady() {
+  async runIndexingWhenReady() {
     if (!Common.indexingEnabled() || mempool.hasPriority()) {
       return;
     }
-    blocks.$generateBlockDatabase();
-    mining.$generateNetworkHashrateHistory();
+
+    try {
+      await blocks.$generateBlockDatabase();
+      await mining.$generateNetworkHashrateHistory();
+    } catch (e) {
+      logger.info(`Unable to run indexing right now, trying again later. ` + e);
+    }
   }
 
   setUpWebsocketHandling() {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -173,7 +173,7 @@ class Server {
       await blocks.$generateBlockDatabase();
       await mining.$generateNetworkHashrateHistory();
     } catch (e) {
-      logger.info(`Unable to run indexing right now, trying again later. ` + e);
+      logger.err(`Unable to run indexing right now, trying again later. ` + e);
     }
   }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -285,7 +285,9 @@ class Server {
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId', routes.$getPool)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:poolId/:interval', routes.$getPool)
         .get(config.MEMPOOL.API_URL_PREFIX + 'mining/difficulty', routes.$getHistoricalDifficulty)
-        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/difficulty/:interval', routes.$getHistoricalDifficulty);
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/difficulty/:interval', routes.$getHistoricalDifficulty)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/hashrate', routes.$getHistoricalHashrate)
+        .get(config.MEMPOOL.API_URL_PREFIX + 'mining/hashrate/:interval', routes.$getHistoricalHashrate);
     }
 
     if (config.BISQ.ENABLED) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -164,12 +164,12 @@ class Server {
     }
   }
 
-  async runIndexingWhenReady() {
+  runIndexingWhenReady() {
     if (!Common.indexingEnabled() || mempool.hasPriority()) {
       return;
     }
-    await blocks.$generateBlockDatabase();
-    await mining.$generateNetworkHashrateHistory();
+    blocks.$generateBlockDatabase();
+    mining.$generateNetworkHashrateHistory();
   }
 
   setUpWebsocketHandling() {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -89,6 +89,12 @@ class Server {
     if (config.DATABASE.ENABLED) {
       await checkDbConnection();
       try {
+        if (process.env.npm_config_reindex != undefined) { // Re-index requests
+          const tables = process.env.npm_config_reindex.split(',');
+          logger.warn(`Indexed data for "${process.env.npm_config_reindex}" tables will be erased in 5 seconds from now (using '--reindex') ...`);
+          await Common.sleep(5000);
+          await databaseMigration.$truncateIndexedData(tables);
+        }
         await databaseMigration.$initializeOrMigrateDatabase();
         await poolsParser.migratePoolsJson();
       } catch (e) {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -281,6 +281,13 @@ class BlocksRepository {
 
     return rows;
   }
+
+  public async $getOldestIndexedBlockHeight(): Promise<number> {
+    const connection = await DB.pool.getConnection();
+    const [rows]: any[] = await connection.query(`SELECT MIN(height) as minHeight FROM blocks`);
+    connection.release();
+    return rows[0].minHeight;
+  }
 }
 
 export default new BlocksRepository();

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -150,6 +150,40 @@ class BlocksRepository {
   }
 
   /**
+   * Get blocks count between two dates
+   * @param poolId 
+   * @param from - The oldest timestamp
+   * @param to - The newest timestamp
+   * @returns 
+   */
+  public async $blockCountBetweenTimestamp(poolId: number | null, from: number, to: number): Promise<number> {
+    const params: any[] = [];
+    let query = `SELECT
+      count(height) as blockCount,
+      max(height) as lastBlockHeight
+      FROM blocks`;
+
+    if (poolId) {
+      query += ` WHERE pool_id = ?`;
+      params.push(poolId);
+    }
+
+    if (poolId) {
+      query += ` AND`;
+    } else {
+      query += ` WHERE`;
+    }
+    query += ` UNIX_TIMESTAMP(blockTimestamp) BETWEEN '${from}' AND '${to}'`;
+
+    // logger.debug(query);
+    const connection = await DB.pool.getConnection();
+    const [rows] = await connection.query(query, params);
+    connection.release();
+
+    return <number>rows[0];
+  }
+
+  /**
    * Get the oldest indexed block
    */
   public async $oldestBlockTimestamp(): Promise<number> {

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -43,10 +43,27 @@ class HashratesRepository {
       query += ` WHERE hashrate_timestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
+    query += ` ORDER by hashrate_timestamp DESC`;
+
     const [rows]: any[] = await connection.query(query);
     connection.release();
 
     return rows;
+  }
+
+  public async $setLatestRunTimestamp() {
+    const connection = await DB.pool.getConnection();
+    const query = `UPDATE state SET number = ? WHERE name = 'last_hashrates_indexing'`;
+    await connection.query<any>(query, [Math.round(new Date().getTime() / 1000)]);
+    connection.release();
+  }
+
+  public async $getLatestRunTimestamp(): Promise<number> {
+    const connection = await DB.pool.getConnection();
+    const query = `SELECT number FROM state WHERE name = 'last_hashrates_indexing'`;
+    const [rows] = await connection.query<any>(query);
+    connection.release();
+    return rows[0]['number'];
   }
 }
 

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -1,0 +1,42 @@
+import { DB } from '../database';
+import logger from '../logger';
+
+class HashratesRepository {
+  /**
+   * Save indexed block data in the database
+   */
+  public async $saveDailyStat(dailyStat: any) {
+    const connection = await DB.pool.getConnection();
+
+    try {
+      const query = `INSERT INTO
+      hashrates(hashrate_timestamp, avg_hashrate, pool_id)
+      VALUE (FROM_UNIXTIME(?), ?, ?)`;
+
+      const params: any[] = [
+        dailyStat.hashrateTimestamp, dailyStat.avgHashrate,
+        dailyStat.poolId
+      ];
+
+      // logger.debug(query);
+      await connection.query(query, params);
+    } catch (e: any) {
+      logger.err('$saveHashrateInDatabase() error' + (e instanceof Error ? e.message : e));
+    }
+
+    connection.release();
+  }
+
+  /**
+   * Returns an array of all timestamp we've already indexed
+   */
+  public async $getAllTimestamp(): Promise<number[]> {
+    const connection = await DB.pool.getConnection();
+    const [rows]: any[] = await connection.query(`SELECT UNIX_TIMESTAMP(hashrate_timestamp) as timestamp from hashrates`);
+    connection.release();
+    
+    return rows.map(val => val.timestamp);
+  }
+}
+
+export default new HashratesRepository();

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -6,21 +6,19 @@ class HashratesRepository {
   /**
    * Save indexed block data in the database
    */
-  public async $saveDailyStat(dailyStat: any) {
+  public async $saveHashrates(hashrates: any) {
+    let query = `INSERT INTO
+      hashrates(hashrate_timestamp, avg_hashrate, pool_id) VALUES`;
+
+    for (const hashrate of hashrates) {
+      query += ` (FROM_UNIXTIME(${hashrate.hashrateTimestamp}), ${hashrate.avgHashrate}, ${hashrate.poolId}),`;
+    }
+    query = query.slice(0, -1);
+
     const connection = await DB.pool.getConnection();
-
     try {
-      const query = `INSERT INTO
-      hashrates(hashrate_timestamp, avg_hashrate, pool_id)
-      VALUE (FROM_UNIXTIME(?), ?, ?)`;
-
-      const params: any[] = [
-        dailyStat.hashrateTimestamp, dailyStat.avgHashrate,
-        dailyStat.poolId
-      ];
-
       // logger.debug(query);
-      await connection.query(query, params);
+      await connection.query(query);
     } catch (e: any) {
       logger.err('$saveHashrateInDatabase() error' + (e instanceof Error ? e.message : e));
     }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -22,7 +22,6 @@ import elementsParser from './api/liquid/elements-parser';
 import icons from './api/liquid/icons';
 import miningStats from './api/mining';
 import axios from 'axios';
-import PoolsRepository from './repositories/PoolsRepository';
 import mining from './api/mining';
 import BlocksRepository from './repositories/BlocksRepository';
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -586,6 +586,18 @@ class Routes {
     }
   }
 
+  public async $getHistoricalHashrate(req: Request, res: Response) {
+    try {
+      const stats = await mining.$getHistoricalHashrates(req.params.interval ?? null);
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.json(stats);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
+  }
+
   public async getBlock(req: Request, res: Response) {
     try {
       const result = await bitcoinApi.$getBlock(req.params.hash);

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -29,6 +29,8 @@ import { AssetsComponent } from './components/assets/assets.component';
 import { PoolComponent } from './components/pool/pool.component';
 import { MiningDashboardComponent } from './components/mining-dashboard/mining-dashboard.component';
 import { DifficultyChartComponent } from './components/difficulty-chart/difficulty-chart.component';
+import { HashrateChartComponent } from './components/hashrate-chart/hashrate-chart.component';
+import { MiningStartComponent } from './components/mining-start/mining-start.component';
 
 let routes: Routes = [
   {
@@ -70,16 +72,35 @@ let routes: Routes = [
         component: LatestBlocksComponent,
       },
       {
-        path: 'mining/difficulty',
-        component: DifficultyChartComponent,
-      },
-      {
-        path: 'mining/pools',
-        component: PoolRankingComponent,
-      },
-      {
-        path: 'mining/pool/:poolId',
-        component: PoolComponent,
+        path: 'mining',
+        component: MiningStartComponent,
+        children: [
+          {
+            path: 'difficulty',
+            component: DifficultyChartComponent,
+          },
+          {
+            path: 'hashrate',
+            component: HashrateChartComponent,
+          },
+          {
+            path: 'pools',
+            component: PoolRankingComponent,
+          },
+          {
+            path: 'pool',
+            children: [
+              {
+                path: ':poolId',
+                component: PoolComponent,
+              },
+              {
+                path: ':poolId/hashrate',
+                component: HashrateChartComponent,
+              },
+            ]
+          },
+        ]
       },
       {
         path: 'graphs',
@@ -170,16 +191,35 @@ let routes: Routes = [
             component: LatestBlocksComponent,
           },
           {
-            path: 'mining/difficulty',
-            component: DifficultyChartComponent,
-          },
-          {
-            path: 'mining/pools',
-            component: PoolRankingComponent,
-          },
-          {
-            path: 'mining/pool/:poolId',
-            component: PoolComponent,
+            path: 'mining',
+            component: MiningStartComponent,
+            children: [
+              {
+                path: 'difficulty',
+                component: DifficultyChartComponent,
+              },
+              {
+                path: 'hashrate',
+                component: HashrateChartComponent,
+              },
+              {
+                path: 'pools',
+                component: PoolRankingComponent,
+              },
+              {
+                path: 'pool',
+                children: [
+                  {
+                    path: ':poolId',
+                    component: PoolComponent,
+                  },
+                  {
+                    path: ':poolId/hashrate',
+                    component: HashrateChartComponent,
+                  },
+                ]
+              },
+            ]
           },
           {
             path: 'graphs',
@@ -264,16 +304,35 @@ let routes: Routes = [
             component: LatestBlocksComponent,
           },
           {
-            path: 'mining/difficulty',
-            component: DifficultyChartComponent,
-          },
-          {
-            path: 'mining/pools',
-            component: PoolRankingComponent,
-          },
-          {
-            path: 'mining/pool/:poolId',
-            component: PoolComponent,
+            path: 'mining',
+            component: MiningStartComponent,
+            children: [
+              {
+                path: 'difficulty',
+                component: DifficultyChartComponent,
+              },
+              {
+                path: 'hashrate',
+                component: HashrateChartComponent,
+              },
+              {
+                path: 'pools',
+                component: PoolRankingComponent,
+              },
+              {
+                path: 'pool',
+                children: [
+                  {
+                    path: ':poolId',
+                    component: PoolComponent,
+                  },
+                  {
+                    path: ':poolId/hashrate',
+                    component: HashrateChartComponent,
+                  },
+                ]
+              },
+            ]
           },
           {
             path: 'graphs',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -71,6 +71,8 @@ import { AssetGroupComponent } from './components/assets/asset-group/asset-group
 import { AssetCirculationComponent } from './components/asset-circulation/asset-circulation.component';
 import { MiningDashboardComponent } from './components/mining-dashboard/mining-dashboard.component';
 import { DifficultyChartComponent } from './components/difficulty-chart/difficulty-chart.component';
+import { HashrateChartComponent } from './components/hashrate-chart/hashrate-chart.component';
+import { MiningStartComponent } from './components/mining-start/mining-start.component';
 
 @NgModule({
   declarations: [
@@ -124,6 +126,8 @@ import { DifficultyChartComponent } from './components/difficulty-chart/difficul
     AssetCirculationComponent,
     MiningDashboardComponent,
     DifficultyChartComponent,
+    HashrateChartComponent,
+    MiningStartComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),

--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -130,3 +130,32 @@ export const formatNumber = (s, precision = null) => {
 // Utilities for segwitFeeGains
 const witnessSize = (vin: Vin) => vin.witness.reduce((S, w) => S + (w.length / 2), 0);
 const scriptSigSize = (vin: Vin) => vin.scriptsig ? vin.scriptsig.length / 2 : 0;
+
+// Power of ten wrapper
+export function selectPowerOfTen(val: number) {
+  const powerOfTen = {
+    exa: Math.pow(10, 18),
+    peta: Math.pow(10, 15),
+    terra: Math.pow(10, 12),
+    giga: Math.pow(10, 9),
+    mega: Math.pow(10, 6),
+    kilo: Math.pow(10, 3),
+  };
+
+  let selectedPowerOfTen;
+  if (val < powerOfTen.mega) {
+    selectedPowerOfTen = { divider: 1, unit: '' }; // no scaling
+  } else if (val < powerOfTen.giga) {
+    selectedPowerOfTen = { divider: powerOfTen.mega, unit: 'M' };
+  } else if (val < powerOfTen.terra) {
+    selectedPowerOfTen = { divider: powerOfTen.giga, unit: 'G' };
+  } else if (val < powerOfTen.peta) {
+    selectedPowerOfTen = { divider: powerOfTen.terra, unit: 'T' };
+  } else if (val < powerOfTen.exa) {
+    selectedPowerOfTen = { divider: powerOfTen.peta, unit: 'P' };
+  } else {
+    selectedPowerOfTen = { divider: powerOfTen.exa, unit: 'E' };
+  }
+
+  return selectedPowerOfTen;
+}

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -134,17 +134,18 @@ export class DifficultyChartComponent implements OnInit {
           }
         }
       },
-      series: [
-        {
-          data: data,
-          type: 'line',
-          smooth: false,
-          lineStyle: {
-            width: 3,
-          },
-          areaStyle: {}
+      series: {
+        showSymbol: false,
+        data: data,
+        type: 'line',
+        smooth: false,
+        lineStyle: {
+          width: 2,
         },
-      ],
+        areaStyle: {
+          opacity: 0.25
+        },
+      },
     };
   }
 

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -116,8 +116,9 @@ export class DifficultyChartComponent implements OnInit {
         type: 'value',
         axisLabel: {
           formatter: (val) => {
-            const diff = val / Math.pow(10, 12); // terra
-            return diff.toString() + 'T';
+            const selectedPowerOfTen: any = selectPowerOfTen(val);
+            const diff = val / selectedPowerOfTen.divider;
+            return `${diff} ${selectedPowerOfTen.unit}`;
           }
         },
         splitLine: {

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from 'src/app/services/api.service';
 import { SeoService } from 'src/app/services/seo.service';
 import { formatNumber } from '@angular/common';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { selectPowerOfTen } from 'src/app/bitcoin.utils';
 
 @Component({
   selector: 'app-difficulty-chart',
@@ -70,15 +71,8 @@ export class DifficultyChartComponent implements OnInit {
 
                 const tableData = [];
                 for (let i = 0; i < data.adjustments.length - 1; ++i) {
+                  const selectedPowerOfTen: any = selectPowerOfTen(data.adjustments[i].difficulty);
                   const change = (data.adjustments[i].difficulty / data.adjustments[i + 1].difficulty - 1) * 100;
-                  let selectedPowerOfTen = { divider: powerOfTen.terra, unit: 'T' };
-                  if (data.adjustments[i].difficulty < powerOfTen.mega) {
-                    selectedPowerOfTen = { divider: 1, unit: '' }; // no scaling
-                  } else if (data.adjustments[i].difficulty < powerOfTen.giga) {
-                    selectedPowerOfTen = { divider: powerOfTen.mega, unit: 'M' };
-                  } else if (data.adjustments[i].difficulty < powerOfTen.terra) {
-                    selectedPowerOfTen = { divider: powerOfTen.giga, unit: 'G' };
-                  }
 
                   tableData.push(Object.assign(data.adjustments[i], {
                     change: change,

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -1,1 +1,53 @@
-<p>hashrate-chart works!</p>
+<div [class]="widget === false ? 'container-xl' : ''">
+
+  <div *ngIf="hashrateObservable$ | async" class="" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
+  <div class="text-center loadingGraphs" *ngIf="isLoading">
+    <div class="spinner-border text-light"></div>
+  </div>
+
+  <div class="card-header mb-0 mb-lg-4" [style]="widget ? 'display:none' : ''">
+    <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as diffChanges">
+      <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 90">
+          <input ngbButton type="radio" [value]="'3m'" fragment="3m"> 3M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 180">
+          <input ngbButton type="radio" [value]="'6m'" fragment="6m"> 6M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 365">
+          <input ngbButton type="radio" [value]="'1y'" fragment="1y"> 1Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 730">
+          <input ngbButton type="radio" [value]="'2y'" fragment="2y"> 2Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 1095">
+          <input ngbButton type="radio" [value]="'3y'" fragment="3y"> 3Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm">
+          <input ngbButton type="radio" [value]="'all'" [routerLink]="['/mining/hashrate' | relativeUrl]" fragment="all"> ALL
+        </label>
+      </div>
+    </form>
+  </div>
+
+  <!-- <table class="table table-borderless table-sm text-center" *ngIf="!widget">
+    <thead>
+      <tr>
+        <th i18n="mining.rank">Block</th>
+        <th i18n="block.timestamp">Timestamp</th>
+        <th i18n="mining.hashrate">Difficulty</th>
+        <th i18n="mining.change">Change</th>
+      </tr>
+    </thead>
+    <tbody *ngIf="(hashrateObservable$ | async) as diffChanges">
+      <tr *ngFor="let diffChange of diffChanges.data">
+        <td><a [routerLink]="['/block' | relativeUrl, diffChange.height]">{{ diffChange.height }}</a></td>
+        <td>&lrm;{{ diffChange.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
+        <td class="d-none d-md-block">{{ formatNumber(diffChange.hashrate, locale, '1.2-2') }}</td>
+        <td class="d-block d-md-none">{{ diffChange.difficultyShorten }}</td>
+        <td [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(diffChange.change, locale, '1.2-2') }}%</td>
+      </tr>
+    </tbody>
+  </table> -->
+
+</div>

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -4,50 +4,29 @@
   <div class="text-center loadingGraphs" *ngIf="isLoading">
     <div class="spinner-border text-light"></div>
   </div>
-
-  <div class="card-header mb-0 mb-lg-4" [style]="widget ? 'display:none' : ''">
-    <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as diffChanges">
+  
+  <div class="card-header mb-0 mb-lg-4 mt-3" [style]="widget ? 'display:none' : ''">
+    <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as hashrates">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
-        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 90">
-          <input ngbButton type="radio" [value]="'3m'" fragment="3m"> 3M
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 90">
+          <input ngbButton type="radio" [value]="'3m'"> 3M
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 180">
-          <input ngbButton type="radio" [value]="'6m'" fragment="6m"> 6M
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 180">
+          <input ngbButton type="radio" [value]="'6m'"> 6M
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 365">
-          <input ngbButton type="radio" [value]="'1y'" fragment="1y"> 1Y
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 365">
+          <input ngbButton type="radio" [value]="'1y'"> 1Y
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 730">
-          <input ngbButton type="radio" [value]="'2y'" fragment="2y"> 2Y
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 730">
+          <input ngbButton type="radio" [value]="'2y'"> 2Y
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" [routerLink]="['/mining/hashrate' | relativeUrl]" *ngIf="diffChanges.availableTimespanDay >= 1095">
-          <input ngbButton type="radio" [value]="'3y'" fragment="3y"> 3Y
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 1095">
+          <input ngbButton type="radio" [value]="'3y'"> 3Y
         </label>
         <label ngbButtonLabel class="btn-primary btn-sm">
-          <input ngbButton type="radio" [value]="'all'" [routerLink]="['/mining/hashrate' | relativeUrl]" fragment="all"> ALL
+          <input ngbButton type="radio" [value]="'all'"> ALL
         </label>
       </div>
     </form>
   </div>
-
-  <!-- <table class="table table-borderless table-sm text-center" *ngIf="!widget">
-    <thead>
-      <tr>
-        <th i18n="mining.rank">Block</th>
-        <th i18n="block.timestamp">Timestamp</th>
-        <th i18n="mining.hashrate">Difficulty</th>
-        <th i18n="mining.change">Change</th>
-      </tr>
-    </thead>
-    <tbody *ngIf="(hashrateObservable$ | async) as diffChanges">
-      <tr *ngFor="let diffChange of diffChanges.data">
-        <td><a [routerLink]="['/block' | relativeUrl, diffChange.height]">{{ diffChange.height }}</a></td>
-        <td>&lrm;{{ diffChange.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}</td>
-        <td class="d-none d-md-block">{{ formatNumber(diffChange.hashrate, locale, '1.2-2') }}</td>
-        <td class="d-block d-md-none">{{ diffChange.difficultyShorten }}</td>
-        <td [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">{{ formatNumber(diffChange.change, locale, '1.2-2') }}%</td>
-      </tr>
-    </tbody>
-  </table> -->
-
 </div>

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -1,0 +1,1 @@
+<p>hashrate-chart works!</p>

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -1,11 +1,6 @@
-<div [class]="widget === false ? 'container-xl' : ''">
+<div [class]="widget === false ? 'full-container' : ''">
 
-  <div *ngIf="hashrateObservable$ | async" class="" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
-  <div class="text-center loadingGraphs" *ngIf="isLoading">
-    <div class="spinner-border text-light"></div>
-  </div>
-  
-  <div class="card-header mb-0 mb-lg-4 mt-3" [style]="widget ? 'display:none' : ''">
+  <div class="card-header mb-0 mb-lg-4" [style]="widget ? 'display:none' : ''">
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as hashrates">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="hashrates.availableTimespanDay >= 90">
@@ -29,4 +24,10 @@
       </div>
     </form>
   </div>
+
+  <div *ngIf="hashrateObservable$ | async" [class]="widget === false ? 'chart' : ''" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
+  <div class="text-center loadingGraphs" *ngIf="isLoading">
+    <div class="spinner-border text-light"></div>
+  </div>
+  
 </div>

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
@@ -8,3 +8,37 @@
   text-align: center;
   padding-bottom: 3px;
 }
+
+.full-container {
+  width: 100%;
+  height: calc(100% - 100px);
+  @media (max-width: 992px) {
+    height: calc(100% - 140px);
+  };
+  @media (max-width: 576px) {
+    height: calc(100% - 180px);
+  };
+}
+
+.chart {
+  width: 100%;
+  height: 100%;
+  padding: 1.25rem;
+}
+
+.formRadioGroup {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  @media (min-width: 830px) {
+    flex-direction: row;
+    float: right;
+    margin-top: 0px;
+  }
+  .btn-sm {
+    font-size: 9px;
+    @media (min-width: 830px) {
+      font-size: 14px;
+    }
+  }
+}

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
@@ -23,7 +23,8 @@
 .chart {
   width: 100%;
   height: 100%;
-  padding: 1.25rem;
+  padding-bottom: 20px;
+  padding-right: 20px;
 }
 
 .formRadioGroup {

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
@@ -1,0 +1,10 @@
+.main-title {
+  position: relative;
+  color: #ffffff91;
+  margin-top: -13px;
+  font-size: 10px;
+  text-transform: uppercase;
+  font-weight: 500;
+  text-align: center;
+  padding-bottom: 3px;
+}

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from 'src/app/services/api.service';
 import { SeoService } from 'src/app/services/seo.service';
 import { formatNumber } from '@angular/common';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { selectPowerOfTen } from 'src/app/bitcoin.utils';
 
 @Component({
   selector: 'app-hashrate-chart',
@@ -103,28 +104,7 @@ export class HashrateChartComponent implements OnInit {
         type: 'value',
         axisLabel: {
           formatter: (val) => {
-            const powerOfTen = {
-              exa: Math.pow(10, 18),
-              peta: Math.pow(10, 15),
-              terra: Math.pow(10, 12),
-              giga: Math.pow(10, 9),
-              mega: Math.pow(10, 6),
-              kilo: Math.pow(10, 3),
-            };
-
-            let selectedPowerOfTen = { divider: powerOfTen.exa, unit: 'E' };
-            if (val < powerOfTen.mega) {
-              selectedPowerOfTen = { divider: 1, unit: '' }; // no scaling
-            } else if (val < powerOfTen.giga) {
-              selectedPowerOfTen = { divider: powerOfTen.mega, unit: 'M' };
-            } else if (val < powerOfTen.terra) {
-              selectedPowerOfTen = { divider: powerOfTen.giga, unit: 'G' };
-            } else if (val < powerOfTen.peta) {
-              selectedPowerOfTen = { divider: powerOfTen.terra, unit: 'T' };
-            } else if (val < powerOfTen.exa) {
-              selectedPowerOfTen = { divider: powerOfTen.peta, unit: 'P' };
-            }
-
+            const selectedPowerOfTen: any = selectPowerOfTen(val);
             const newVal = val / selectedPowerOfTen.divider;
             return `${newVal} ${selectedPowerOfTen.unit}`
           }

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-hashrate-chart',
+  templateUrl: './hashrate-chart.component.html',
+  styleUrls: ['./hashrate-chart.component.scss']
+})
+export class HashrateChartComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -66,15 +66,15 @@ export class HashrateChartComponent implements OnInit {
                 };
               }),
             );
-          }),
-          share()
-        );
+        }),
+        share()
+      );
   }
 
   prepareChartOptions(data) {
     this.chartOptions = {
       title: {
-        text: this.widget? '' : $localize`:@@mining.hashrate:Hashrate`,
+        text: this.widget ? '' : $localize`:@@mining.hashrate:Hashrate`,
         left: 'center',
         textStyle: {
           color: '#FFF',
@@ -102,7 +102,7 @@ export class HashrateChartComponent implements OnInit {
               giga: Math.pow(10, 9),
               mega: Math.pow(10, 6),
               kilo: Math.pow(10, 3),
-            }
+            };
 
             let selectedPowerOfTen = { divider: powerOfTen.exa, unit: 'E' };
             if (val < powerOfTen.mega) {
@@ -135,9 +135,11 @@ export class HashrateChartComponent implements OnInit {
         type: 'line',
         smooth: false,
         lineStyle: {
-          width: 3,
+          width: 2,
         },
-        areaStyle: {},
+        areaStyle: {
+          opacity: 0.25
+        },
       },
       dataZoom: this.widget ? null : [{
         type: 'inside',

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -22,12 +22,16 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 })
 export class HashrateChartComponent implements OnInit {
   @Input() widget: boolean = false;
+  @Input() right: number | string = 10;
+  @Input() left: number | string = 75;
 
   radioGroupForm: FormGroup;
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg'
+    renderer: 'svg',
+    width: 'auto',
+    height: 'auto',
   };
 
   hashrateObservable$: Observable<any>;
@@ -73,6 +77,10 @@ export class HashrateChartComponent implements OnInit {
 
   prepareChartOptions(data) {
     this.chartOptions = {
+      grid: {
+        right: this.right,
+        left: this.left,
+      },
       title: {
         text: this.widget ? '' : $localize`:@@mining.hashrate:Hashrate`,
         left: 'center',

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -106,7 +106,7 @@ export class HashrateChartComponent implements OnInit {
           formatter: (val) => {
             const selectedPowerOfTen: any = selectPowerOfTen(val);
             const newVal = val / selectedPowerOfTen.divider;
-            return `${newVal} ${selectedPowerOfTen.unit}`
+            return `${newVal} ${selectedPowerOfTen.unit}H/s`
           }
         },
         splitLine: {

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -1,15 +1,173 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, Input, LOCALE_ID, OnInit } from '@angular/core';
+import { EChartsOption } from 'echarts';
+import { Observable } from 'rxjs';
+import { map, share, startWith, switchMap, tap } from 'rxjs/operators';
+import { ApiService } from 'src/app/services/api.service';
+import { SeoService } from 'src/app/services/seo.service';
+import { formatNumber } from '@angular/common';
+import { FormBuilder, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-hashrate-chart',
   templateUrl: './hashrate-chart.component.html',
-  styleUrls: ['./hashrate-chart.component.scss']
+  styleUrls: ['./hashrate-chart.component.scss'],
+  styles: [`
+    .loadingGraphs {
+      position: absolute;
+      top: 38%;
+      left: calc(50% - 15px);
+      z-index: 100;
+    }
+  `],
 })
 export class HashrateChartComponent implements OnInit {
+  @Input() widget: boolean = false;
 
-  constructor() { }
+  radioGroupForm: FormGroup;
 
-  ngOnInit(): void {
+  chartOptions: EChartsOption = {};
+  chartInitOptions = {
+    renderer: 'svg'
+  };
+
+  hashrateObservable$: Observable<any>;
+  isLoading = true;
+  formatNumber = formatNumber;
+
+  constructor(
+    @Inject(LOCALE_ID) public locale: string,
+    private seoService: SeoService,
+    private apiService: ApiService,
+    private formBuilder: FormBuilder,
+  ) {
+    this.seoService.setTitle($localize`:@@mining.hashrate:hashrate`);
+    this.radioGroupForm = this.formBuilder.group({ dateSpan: '1y' });
+    this.radioGroupForm.controls.dateSpan.setValue('1y');
   }
 
+  ngOnInit(): void {
+    this.hashrateObservable$ = this.radioGroupForm.get('dateSpan').valueChanges
+      .pipe(
+        startWith('1y'),
+        switchMap((timespan) => {
+          return this.apiService.getHistoricalHashrate$(timespan)
+            .pipe(
+              tap(data => {
+                this.prepareChartOptions(data.hashrates.map(val => [val.timestamp * 1000, val.avgHashrate]));
+                this.isLoading = false;
+              }),
+              map(data => {
+                const availableTimespanDay = (
+                  (new Date().getTime() / 1000) - (data.oldestIndexedBlockTimestamp / 1000)
+                ) / 3600 / 24;
+                return {
+                  availableTimespanDay: availableTimespanDay,
+                  data: data.hashrates
+                };
+              }),
+            );
+          }),
+          share()
+        );
+  }
+
+  prepareChartOptions(data) {
+    this.chartOptions = {
+      title: {
+        text: this.widget? '' : $localize`:@@mining.hashrate:Hashrate`,
+        left: 'center',
+        textStyle: {
+          color: '#FFF',
+        },
+      },
+      tooltip: {
+        show: true,
+        trigger: 'axis',
+      },
+      axisPointer: {
+        type: 'line',
+      },
+      xAxis: {
+        type: 'time',
+        splitNumber: this.isMobile() ? 5 : 10,
+      },
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          formatter: (val) => {
+            const powerOfTen = {
+              exa: Math.pow(10, 18),
+              peta: Math.pow(10, 15),
+              terra: Math.pow(10, 12),
+              giga: Math.pow(10, 9),
+              mega: Math.pow(10, 6),
+              kilo: Math.pow(10, 3),
+            }
+
+            let selectedPowerOfTen = { divider: powerOfTen.exa, unit: 'E' };
+            if (val < powerOfTen.mega) {
+              selectedPowerOfTen = { divider: 1, unit: '' }; // no scaling
+            } else if (val < powerOfTen.giga) {
+              selectedPowerOfTen = { divider: powerOfTen.mega, unit: 'M' };
+            } else if (val < powerOfTen.terra) {
+              selectedPowerOfTen = { divider: powerOfTen.giga, unit: 'G' };
+            } else if (val < powerOfTen.peta) {
+              selectedPowerOfTen = { divider: powerOfTen.terra, unit: 'T' };
+            } else if (val < powerOfTen.exa) {
+              selectedPowerOfTen = { divider: powerOfTen.peta, unit: 'P' };
+            }
+
+            const newVal = val / selectedPowerOfTen.divider;
+            return `${newVal} ${selectedPowerOfTen.unit}`
+          }
+        },
+        splitLine: {
+          lineStyle: {
+            type: 'dotted',
+            color: '#ffffff66',
+            opacity: 0.25,
+          }
+        },
+      },
+      series: {
+        showSymbol: false,
+        data: data,
+        type: 'line',
+        smooth: false,
+        lineStyle: {
+          width: 3,
+        },
+        areaStyle: {},
+      },
+      dataZoom: this.widget ? null : [{
+        type: 'inside',
+        realtime: true,
+        zoomLock: true,
+        zoomOnMouseWheel: true,
+        moveOnMouseMove: true,
+        maxSpan: 100,
+        minSpan: 10,
+      }, {
+        showDetail: false,
+        show: true,
+        type: 'slider',
+        brushSelect: false,
+        realtime: true,
+        bottom: 0,
+        selectedDataBackground: {
+          lineStyle: {
+            color: '#fff',
+            opacity: 0.45,
+          },
+          areaStyle: {
+            opacity: 0,
+          }
+        },
+      }],
+    };
+  }
+
+  isMobile() {
+    return (window.innerWidth <= 767.98);
+  }
 }

--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -31,7 +31,7 @@
       <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" id="btn-home">
         <a class="nav-link" [routerLink]="['/' | relativeUrl]" (click)="collapse()"><fa-icon [icon]="['fas', 'tachometer-alt']" [fixedWidth]="true" i18n-title="master-page.dashboard" title="Dashboard"></fa-icon></a>
       </li>
-      <li class="nav-item" routerLinkActive="active" id="btn-pools" *ngIf="stateService.env.MINING_DASHBOARD">
+      <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" id="btn-pools" *ngIf="stateService.env.MINING_DASHBOARD">
         <a class="nav-link" [routerLink]="['/mining' | relativeUrl]" (click)="collapse()"><fa-icon [icon]="['fas', 'hammer']" [fixedWidth]="true" i18n-title="master-page.mining-dashboard" title="Mining Dashboard"></fa-icon></a>
       </li>
       <li class="nav-item" routerLinkActive="active" id="btn-blocks" *ngIf="!stateService.env.MINING_DASHBOARD">

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -14,6 +14,18 @@
       </div>
     </div>
 
+    <!-- hashrate -->
+    <div class="col">
+      <div class="main-title" i18n="mining.hashrate">Hashrate (1y)</div>
+      <div class="card">
+        <div class="card-body">
+          <app-hashrate-chart [widget]=true></app-hashrate-chart>
+          <div class="text-center"><a href="" [routerLink]="['/mining/hashrate' | relativeUrl]" i18n="dashboard.view-more">View more
+              &raquo;</a></div>
+        </div>
+      </div>
+    </div>
+
     <!-- difficulty -->
     <div class="col">
       <div class="main-title" i18n="mining.difficulty">Difficulty (1y)</div>

--- a/frontend/src/app/components/mining-start/mining-start.component.html
+++ b/frontend/src/app/components/mining-start/mining-start.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/frontend/src/app/components/mining-start/mining-start.component.ts
+++ b/frontend/src/app/components/mining-start/mining-start.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-mining-start',
+  templateUrl: './mining-start.component.html',
+})
+export class MiningStartComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -156,4 +156,11 @@ export class ApiService {
         (interval !== undefined ? `/${interval}` : '')
       );
   }
+
+  getHistoricalHashrate$(interval: string | undefined): Observable<any> {
+    return this.httpClient.get<any[]>(
+        this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/hashrate` +
+        (interval !== undefined ? `/${interval}` : '')
+      );
+  }
 }

--- a/production/nginx-cache-warmer
+++ b/production/nginx-cache-warmer
@@ -21,6 +21,12 @@ do for url in / \
 	'/api/v1/mining/pools/2y' \
 	'/api/v1/mining/pools/3y' \
 	'/api/v1/mining/pools/all' \
+	'/api/v1/mining/hashrate/3m' \
+	'/api/v1/mining/hashrate/6m' \
+	'/api/v1/mining/hashrate/1y' \
+	'/api/v1/mining/hashrate/2y' \
+	'/api/v1/mining/hashrate/3y' \
+	'/api/v1/mining/hashrate/all' \
 
 	do
 		curl -s "https://${hostname}${url}" >/dev/null


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9780671/154884058-0c9d454e-1ad9-4640-9b22-7eebf3e88286.png)

This PR adds a new indexing loop as well as a new hashrate chart component. We generate one data point per day (as it does not make much sense to have lower resolution due to the luck factor in mining). The indexing starts after the block indexing is completed. It will go back in time as far as we have blocks in our database. It cannot be disabled right now but does not require much resources nor time to run. A pi should be able to generate the data points in a few hours.

Also, it will generate one new data point every 24 hours as soon as the node backend is running. This should be discussed in more details in the future (we could use a cronjob instead for example).

**Note**

Once the hashrate indexing is complete, we set the current timestamp into `state.last_hashrates_indexing` table. This is used to only run the loop once every 24 hours. If you need to re-index:
* `npm run start --reindex` will erase all blocks and hashrate indexed data

**Performances**

On my laptop, I'm generating the daily hashrate data (for the whole network) at ~3 days/sec. It will be slower once we index hashrate for individual mining pools as well.