### PR TITLE
Tweak new charts design

### DIFF
--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -274,7 +274,7 @@ class BlocksRepository {
     }
 
     query += ` GROUP BY difficulty
-      ORDER BY blockTimestamp DESC`;
+      ORDER BY blockTimestamp`;
 
     const [rows]: any[] = await connection.query(query);
     connection.release();

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -41,7 +41,7 @@ class HashratesRepository {
       query += ` WHERE hashrate_timestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
-    query += ` ORDER by hashrate_timestamp DESC`;
+    query += ` ORDER by hashrate_timestamp`;
 
     const [rows]: any[] = await connection.query(query);
     connection.release();

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.html
@@ -1,10 +1,5 @@
 <div [class]="widget === false ? 'container-xl' : ''">
 
-  <div *ngIf="difficultyObservable$ | async" class="" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
-  <div class="text-center loadingGraphs" *ngIf="isLoading">
-    <div class="spinner-border text-light"></div>
-  </div>
-
   <div class="card-header mb-0 mb-lg-4" [style]="widget ? 'display:none' : ''">
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(difficultyObservable$ | async) as diffChanges">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
@@ -28,6 +23,11 @@
         </label>
       </div>
     </form>
+  </div>
+
+  <div *ngIf="difficultyObservable$ | async" class="mb-5" echarts [initOpts]="chartInitOptions" [options]="chartOptions"></div>
+  <div class="text-center loadingGraphs" *ngIf="isLoading">
+    <div class="spinner-border text-light"></div>
   </div>
 
   <table class="table table-borderless table-sm text-center" *ngIf="!widget">

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.scss
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.scss
@@ -8,3 +8,20 @@
   text-align: center;
   padding-bottom: 3px;
 }
+
+.formRadioGroup {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  @media (min-width: 830px) {
+    flex-direction: row;
+    float: right;
+    margin-top: 0px;
+  }
+  .btn-sm {
+    font-size: 9px;
+    @media (min-width: 830px) {
+      font-size: 14px;
+    }
+  }
+}

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, LOCALE_ID, OnInit } from '@angular/core';
-import { EChartsOption } from 'echarts';
+import { EChartsOption, graphic } from 'echarts';
 import { Observable } from 'rxjs';
 import { map, share, startWith, switchMap, tap } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
@@ -47,13 +47,6 @@ export class DifficultyChartComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    const powerOfTen = {
-      terra: Math.pow(10, 12),
-      giga: Math.pow(10, 9),
-      mega: Math.pow(10, 6),
-      kilo: Math.pow(10, 3),
-    }
-
     this.difficultyObservable$ = this.radioGroupForm.get('dateSpan').valueChanges
       .pipe(
         startWith('1y'),
@@ -94,6 +87,13 @@ export class DifficultyChartComponent implements OnInit {
 
   prepareChartOptions(data) {
     this.chartOptions = {
+      color: new graphic.LinearGradient(0, 0, 0, 0.65, [
+        { offset: 0, color: '#D81B60' },
+        { offset: 0.25, color: '#8E24AA' },
+        { offset: 0.5, color: '#5E35B1' },
+        { offset: 0.75, color: '#3949AB' },
+        { offset: 1, color: '#1E88E5' }
+      ]),
       title: {
         text: this.widget? '' : $localize`:@@mining.difficulty:Difficulty`,
         left: 'center',
@@ -104,6 +104,17 @@ export class DifficultyChartComponent implements OnInit {
       tooltip: {
         show: true,
         trigger: 'axis',
+        backgroundColor: 'rgba(17, 19, 31, 1)',
+        borderRadius: 4,
+        shadowColor: 'rgba(0, 0, 0, 0.5)',
+        textStyle: {
+          color: '#b1b1b1',
+        },
+        borderColor: '#000',
+        formatter: params => {
+          return `<b style="color: white">${params[0].axisValueLabel}</b><br>
+            ${params[0].marker} ${formatNumber(params[0].value[1], this.locale, '1.0-0')}`
+        }
       },
       axisPointer: {
         type: 'line',
@@ -136,9 +147,6 @@ export class DifficultyChartComponent implements OnInit {
         smooth: false,
         lineStyle: {
           width: 2,
-        },
-        areaStyle: {
-          opacity: 0.25
         },
       },
     };

--- a/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
+++ b/frontend/src/app/components/difficulty-chart/difficulty-chart.component.ts
@@ -63,9 +63,9 @@ export class DifficultyChartComponent implements OnInit {
                 ) / 3600 / 24;
 
                 const tableData = [];
-                for (let i = 0; i < data.adjustments.length - 1; ++i) {
+                for (let i = data.adjustments.length - 1; i > 0; --i) {
                   const selectedPowerOfTen: any = selectPowerOfTen(data.adjustments[i].difficulty);
-                  const change = (data.adjustments[i].difficulty / data.adjustments[i + 1].difficulty - 1) * 100;
+                  const change = (data.adjustments[i].difficulty / data.adjustments[i - 1].difficulty - 1) * 100;
 
                   tableData.push(Object.assign(data.adjustments[i], {
                     change: change,
@@ -149,6 +149,31 @@ export class DifficultyChartComponent implements OnInit {
           width: 2,
         },
       },
+      dataZoom: this.widget ? null : [{
+        type: 'inside',
+        realtime: true,
+        zoomLock: true,
+        zoomOnMouseWheel: true,
+        moveOnMouseMove: true,
+        maxSpan: 100,
+        minSpan: 10,
+      }, {
+        showDetail: false,
+        show: true,
+        type: 'slider',
+        brushSelect: false,
+        realtime: true,
+        bottom: 0,
+        selectedDataBackground: {
+          lineStyle: {
+            color: '#fff',
+            opacity: 0.45,
+          },
+          areaStyle: {
+            opacity: 0,
+          }
+        },
+      }],
     };
   }
 

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, LOCALE_ID, OnInit } from '@angular/core';
-import { EChartsOption } from 'echarts';
+import { EChartsOption, graphic } from 'echarts';
 import { Observable } from 'rxjs';
 import { map, share, startWith, switchMap, tap } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
@@ -78,6 +78,13 @@ export class HashrateChartComponent implements OnInit {
 
   prepareChartOptions(data) {
     this.chartOptions = {
+      color: new graphic.LinearGradient(0, 0, 0, 0.65, [
+        { offset: 0, color: '#F4511E' },
+        { offset: 0.25, color: '#FB8C00' },
+        { offset: 0.5, color: '#FFB300' },
+        { offset: 0.75, color: '#FDD835' },
+        { offset: 1, color: '#7CB342' }
+      ]),
       grid: {
         right: this.right,
         left: this.left,
@@ -92,6 +99,17 @@ export class HashrateChartComponent implements OnInit {
       tooltip: {
         show: true,
         trigger: 'axis',
+        backgroundColor: 'rgba(17, 19, 31, 1)',
+        borderRadius: 4,
+        shadowColor: 'rgba(0, 0, 0, 0.5)',
+        textStyle: {
+          color: '#b1b1b1',
+        },
+        borderColor: '#000',
+        formatter: params => {
+          return `<b style="color: white">${params[0].axisValueLabel}</b><br>
+            ${params[0].marker} ${formatNumber(params[0].value[1], this.locale, '1.0-0')} H/s`
+        }
       },
       axisPointer: {
         type: 'line',
@@ -124,9 +142,6 @@ export class HashrateChartComponent implements OnInit {
         smooth: false,
         lineStyle: {
           width: 2,
-        },
-        areaStyle: {
-          opacity: 0.25
         },
       },
       dataZoom: this.widget ? null : [{

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -4,9 +4,9 @@
 
     <!-- pool distribution -->
     <div class="col">
-      <div class="main-title" i18n="mining.pool-share">Mining Pools Share (1w)</div>
       <div class="card">
         <div class="card-body">
+          <h5 class="card-title" i18n="mining.pool-share">Mining Pools Share (1w)</h5>
           <app-pool-ranking [widget]=true></app-pool-ranking>
           <div class="text-center"><a href="" [routerLink]="['/mining/pools' | relativeUrl]" i18n="dashboard.view-more">View more
               &raquo;</a></div>
@@ -16,9 +16,9 @@
 
     <!-- hashrate -->
     <div class="col">
-      <div class="main-title" i18n="mining.hashrate">Hashrate (1y)</div>
       <div class="card">
         <div class="card-body">
+          <h5 class="card-title" i18n="mining.hashrate">Hashrate (1y)</h5>
           <app-hashrate-chart [widget]=true></app-hashrate-chart>
           <div class="text-center"><a href="" [routerLink]="['/mining/hashrate' | relativeUrl]" i18n="dashboard.view-more">View more
               &raquo;</a></div>
@@ -28,9 +28,9 @@
 
     <!-- difficulty -->
     <div class="col">
-      <div class="main-title" i18n="mining.difficulty">Difficulty (1y)</div>
       <div class="card">
         <div class="card-body">
+          <h5 class="card-title" i18n="ning.difficulty">Difficulty (1y)</h5>
           <app-difficulty-chart [widget]=true></app-difficulty-chart>
           <div class="text-center"><a href="" [routerLink]="['/mining/difficulty' | relativeUrl]" i18n="dashboard.view-more">View more
               &raquo;</a></div>

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
@@ -15,6 +15,11 @@
   height: 100%;
 }
 
+.card-title {
+  color: #4a68b9;
+  font-size: 1rem;
+}
+
 .card-wrapper {
   .card {
     height: auto !important;

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -121,21 +121,24 @@ export class PoolRankingComponent implements OnInit {
         value: pool.share,
         name: pool.name + (this.isMobile() ? `` : ` (${pool.share}%)`),
         label: {
-          color: '#FFFFFF',
+          color: '#b1b1b1',
           overflow: 'break',
         },
         tooltip: {
-          backgroundColor: '#282d47',
+          backgroundColor: 'rgba(17, 19, 31, 1)',
+          borderRadius: 4,
+          shadowColor: 'rgba(0, 0, 0, 0.5)',
           textStyle: {
-            color: '#FFFFFF',
+            color: '#b1b1b1',
           },
+          borderColor: '#000',
           formatter: () => {
             if (this.poolsWindowPreference === '24h') {
-              return `<u><b>${pool.name} (${pool.share}%)</b></u><br>` +
+              return `<b style="color: white">${pool.name} (${pool.share}%)</b><br>` +
                 pool.lastEstimatedHashrate.toString() + ' PH/s' +
                 `<br>` + pool.blockCount.toString() + ` blocks`;
             } else {
-              return `<u><b>${pool.name} (${pool.share}%)</b></u><br>` +
+              return `<b style="color: white">${pool.name} (${pool.share}%)</b><br>` +
                 pool.blockCount.toString() + ` blocks`;
             }
           }


### PR DESCRIPTION
- I applied the existing tooltip color and style to all the new mining charts
- Added fancy coloring to the hashrate and difficulty chart (kinda experimental, we can play around with color palettes here)
- Added data zoom component to the difficulty chart for consistency

## Hashrate
### Widget
![image](https://user-images.githubusercontent.com/9780671/154980157-de69d82d-3d9c-4e04-8fe2-8431fb5f4182.png)
### Full page
![image](https://user-images.githubusercontent.com/9780671/154980343-43fdf7ea-40d9-4136-9390-5e0be89a7127.png)

## Difficulty
### Widget
![image](https://user-images.githubusercontent.com/9780671/154980204-d55bd171-aab9-49ad-aab8-941eb65c8be1.png)
### Full page
![image](https://user-images.githubusercontent.com/9780671/154983576-7d446c93-2749-409c-bc4d-2fd8db414939.png)