### PR TITLE
Change blockchain blocks bottom color based on total block fees

### DIFF
--- a/frontend/src/app/app.constants.ts
+++ b/frontend/src/app/app.constants.ts
@@ -31,6 +31,19 @@ export const mempoolFeeColors = [
   'b9254b',
 ];
 
+export const blockFeeBottomColors = [
+  '#105fb0',
+  '#006ebc',
+  '#007cc4',
+  '#008ac8',
+  '#0097c9',
+  '#00a3c7',
+  '#00afc2',
+  '#00babb',
+  '#00c5b3',
+  '#23cfaa',
+];
+
 export const chartColors = [
   "#D81B60",
   "#8E24AA",


### PR DESCRIPTION
An example using 0.195 BTC as the maximum block total fees (in this PR, the maximum is defined as 5 BTC). The higher the block total fees amount, the brighter the blue bottom color becomes.

![image](https://user-images.githubusercontent.com/9780671/155680795-ee6e6796-af1a-4cac-8031-2119af483b67.png)
