### PR TITLE
Only reset hashrate state flag after database migration - Fix weekly …

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -142,8 +142,8 @@ class Mining {
       lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
         blockStats.lastBlockHeight);
 
-      if (totalIndexed % 7 === 0 && !indexedTimestamp.includes(fromTimestamp + 1)) { // Save weekly pools hashrate
-        logger.debug("Indexing weekly hashrates for mining pools");
+      if (totalIndexed > 7 && totalIndexed % 7 === 0 && !indexedTimestamp.includes(fromTimestamp + 1)) { // Save weekly pools hashrate
+        logger.debug(`Indexing weekly hashrates for mining pools (timestamp: ${fromTimestamp})`);
         let pools = await PoolsRepository.$getPoolsInfoBetween(fromTimestamp - 604800, fromTimestamp);
         const totalBlocks = pools.reduce((acc, pool) => acc + pool.blockCount, 0);
         pools = pools.map((pool: any) => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,8 +96,8 @@ class Server {
           await Common.sleep(5000);
           await databaseMigration.$truncateIndexedData(tables);
         }
-        await this.$resetHashratesIndexingState();
         await databaseMigration.$initializeOrMigrateDatabase();
+        await this.$resetHashratesIndexingState();
         await poolsParser.migratePoolsJson();
       } catch (e) {
         throw new Error(e instanceof Error ? e.message : 'Error');


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1296

Also fixes a hashrate indexing issue which was not showing the network hashrate + difficulty using default 1100 blocks indexing config.

![image](https://user-images.githubusercontent.com/9780671/156884036-eced15e2-c9b7-4266-b546-975c09d8d544.png)
