### PR TITLE
Fix hashrate indexing backend logic (split daily/weekly indexing logic, timezone issue, unclosed db connection)

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -171,7 +171,7 @@ class Blocks {
   }
 
   /**
-   * Index all blocks metadata for the mining dashboard
+   * [INDEXING] Index all blocks metadata for the mining dashboard
    */
   public async $generateBlockDatabase() {
     if (this.blockIndexingStarted) {

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 8;
+  private static currentVersion = 9;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -131,6 +131,10 @@ class DatabaseMigration {
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD `share` float NOT NULL DEFAULT "0"');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD `type` enum("daily", "weekly") DEFAULT "daily"');
+      }
+
+      if (databaseSchemaVersion < 9) {
+        await this.$executeQuery(connection, 'ALTER TABLE `state` CHANGE `name` `name` varchar(100)')
       }
 
       connection.release();
@@ -274,6 +278,10 @@ class DatabaseMigration {
 
     if (version < 7) {
       queries.push(`INSERT INTO state(name, number, string) VALUES ('last_hashrates_indexing', 0, NULL)`);
+    }
+
+    if (version < 9) {
+      queries.push(`INSERT INTO state(name, number, string) VALUES ('last_weekly_hashrates_indexing', 0, NULL)`);
     }
 
     return queries;

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -134,7 +134,8 @@ class DatabaseMigration {
       }
 
       if (databaseSchemaVersion < 9) {
-        await this.$executeQuery(connection, 'ALTER TABLE `state` CHANGE `name` `name` varchar(100)')
+        await this.$executeQuery(connection, 'ALTER TABLE `state` CHANGE `name` `name` varchar(100)');
+        await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD UNIQUE `hashrate_timestamp_pool_id` (`hashrate_timestamp`, `pool_id`)');
       }
 
       connection.release();

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -134,6 +134,8 @@ class DatabaseMigration {
       }
 
       if (databaseSchemaVersion < 9) {
+        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.'`);
+        await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `state` CHANGE `name` `name` varchar(100)');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD UNIQUE `hashrate_timestamp_pool_id` (`hashrate_timestamp`, `pool_id`)');
       }

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -219,7 +219,7 @@ class Mining {
           blockStats.lastBlockHeight);
 
         hashrates.push({
-          hashrateTimestamp: fromTimestamp,
+          hashrateTimestamp: toTimestamp,
           avgHashrate: lastBlockHashrate,
           poolId: null,
           share: 1,

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -75,28 +75,7 @@ class Mining {
   }
 
   /**
-   * Return the historical difficulty adjustments and oldest indexed block timestamp
-   */
-  public async $getHistoricalDifficulty(interval: string | null): Promise<object> {
-    return await BlocksRepository.$getBlocksDifficulty(interval);
-  }
-
-  /**
-   * Return the historical hashrates and oldest indexed block timestamp
-   */
-  public async $getNetworkHistoricalHashrates(interval: string | null): Promise<object> {
-    return await HashratesRepository.$getNetworkDailyHashrate(interval);
-  }
-
-  /**
-   * Return the historical hashrates and oldest indexed block timestamp for one or all pools
-   */
-  public async $getPoolsHistoricalHashrates(interval: string | null, poolId: number): Promise<object> {
-    return await HashratesRepository.$getPoolsWeeklyHashrate(interval);
-  }
-
-  /**
-   * Generate weekly mining pool hashrate history
+   * [INDEXING] Generate weekly mining pool hashrate history
    */
   public async $generatePoolHashrateHistory(): Promise<void> {
     if (!blocks.blockIndexingCompleted || this.weeklyHashrateIndexingStarted) {
@@ -192,7 +171,7 @@ class Mining {
   }
 
   /**
-   * Generate daily hashrate data
+   * [INDEXING] Generate daily hashrate data
    */
   public async $generateNetworkHashrateHistory(): Promise<void> {
     if (!blocks.blockIndexingCompleted || this.hashrateIndexingStarted) {

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -97,9 +97,8 @@ class Mining {
       const indexedTimestamp = await HashratesRepository.$getWeeklyHashrateTimestamps();
       const hashrates: any[] = [];
       const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-      const lastWeekMidnight = this.getDateMidnight(new Date());
-      lastWeekMidnight.setDate(lastWeekMidnight.getDate() - 7);
-      let toTimestamp = Math.round(lastWeekMidnight.getTime() / 1000);
+      const lastMidnight = this.getDateMidnight(new Date());
+      let toTimestamp = Math.round((lastMidnight.getTime() - 604800) / 1000);
 
       const totalWeekIndexed = (await BlocksRepository.$blockCount(null, null)) / 1008;
       let indexedThisRun = 0;
@@ -167,7 +166,6 @@ class Mining {
       this.weeklyHashrateIndexingStarted = false;
       throw e;
     }
-
   }
 
   /**

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -11,6 +11,7 @@ export class DB {
     password: config.DATABASE.PASSWORD,
     connectionLimit: 10,
     supportBigNumbers: true,
+    timezone: '+00:00',
   });
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -177,9 +177,9 @@ class Server {
     }
 
     try {
-      await blocks.$generateBlockDatabase();
-      await mining.$generateNetworkHashrateHistory();
-      await mining.$generatePoolHashrateHistory();
+      blocks.$generateBlockDatabase();
+      mining.$generateNetworkHashrateHistory();
+      mining.$generatePoolHashrateHistory();
     } catch (e) {
       logger.err(`Unable to run indexing right now, trying again later. ` + e);
     }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -167,7 +167,8 @@ class Server {
   }
 
   async $resetHashratesIndexingState() {
-    return await HashratesRepository.$setLatestRunTimestamp(0);
+    await HashratesRepository.$setLatestRunTimestamp('last_hashrates_indexing', 0);
+    await HashratesRepository.$setLatestRunTimestamp('last_week_hashrates_indexing', 0);
   }
 
   async $runIndexingWhenReady() {
@@ -178,6 +179,7 @@ class Server {
     try {
       await blocks.$generateBlockDatabase();
       await mining.$generateNetworkHashrateHistory();
+      await mining.$generatePoolHashrateHistory();
     } catch (e) {
       logger.err(`Unable to run indexing right now, trying again later. ` + e);
     }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -168,7 +168,7 @@ class Server {
 
   async $resetHashratesIndexingState() {
     await HashratesRepository.$setLatestRunTimestamp('last_hashrates_indexing', 0);
-    await HashratesRepository.$setLatestRunTimestamp('last_week_hashrates_indexing', 0);
+    await HashratesRepository.$setLatestRunTimestamp('last_weekly_hashrates_indexing', 0);
   }
 
   async $runIndexingWhenReady() {

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -43,26 +43,38 @@ class PoolsRepository {
 
     // logger.debug(query);
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query);
-    connection.release();
+    try {
+      const [rows] = await connection.query(query);
+      connection.release();
 
-    return <PoolInfo[]>rows;
+      return <PoolInfo[]>rows;
+    } catch (e) {
+      connection.release();
+      logger.err('$getPoolsInfo() error' + (e instanceof Error ? e.message : e));
+      throw e;
+    }
   }
 
   /**
    * Get basic pool info and block count between two timestamp
    */
    public async $getPoolsInfoBetween(from: number, to: number): Promise<PoolInfo[]> {
-    let query = `SELECT COUNT(height) as blockCount, pools.id as poolId, pools.name as poolName
+    const query = `SELECT COUNT(height) as blockCount, pools.id as poolId, pools.name as poolName
       FROM pools
       LEFT JOIN blocks on pools.id = blocks.pool_id AND blocks.blockTimestamp BETWEEN FROM_UNIXTIME(?) AND FROM_UNIXTIME(?)
       GROUP BY pools.id`;
 
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query, [from, to]);
-    connection.release();
+    try {
+      const [rows] = await connection.query(query, [from, to]);
+      connection.release();
 
-    return <PoolInfo[]>rows;
+      return <PoolInfo[]>rows;
+    } catch (e) {
+      connection.release();
+      logger.err('$getPoolsInfoBetween() error' + (e instanceof Error ? e.message : e));
+      throw e;
+    }
   }
 
   /**
@@ -76,13 +88,19 @@ class PoolsRepository {
 
     // logger.debug(query);
     const connection = await DB.pool.getConnection();
-    const [rows] = await connection.query(query, [poolId]);
-    connection.release();
+    try {
+      const [rows] = await connection.query(query, [poolId]);
+      connection.release();
 
-    rows[0].regexes = JSON.parse(rows[0].regexes);
-    rows[0].addresses = JSON.parse(rows[0].addresses);
+      rows[0].regexes = JSON.parse(rows[0].regexes);
+      rows[0].addresses = JSON.parse(rows[0].addresses);
 
-    return rows[0];
+      return rows[0];
+    } catch (e) {
+      connection.release();
+      logger.err('$getPool() error' + (e instanceof Error ? e.message : e));
+      throw e;
+    }
   }
 }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -24,6 +24,7 @@ import miningStats from './api/mining';
 import axios from 'axios';
 import mining from './api/mining';
 import BlocksRepository from './repositories/BlocksRepository';
+import HashratesRepository from './repositories/HashratesRepository';
 
 class Routes {
   constructor() {}
@@ -576,7 +577,7 @@ class Routes {
 
   public async $getHistoricalDifficulty(req: Request, res: Response) {
     try {
-      const stats = await mining.$getHistoricalDifficulty(req.params.interval ?? null);
+      const stats = await BlocksRepository.$getBlocksDifficulty(req.params.interval ?? null);
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
@@ -588,7 +589,7 @@ class Routes {
 
   public async $getPoolsHistoricalHashrate(req: Request, res: Response) {
     try {
-      const hashrates = await mining.$getPoolsHistoricalHashrates(req.params.interval ?? null, parseInt(req.params.poolId, 10));
+      const hashrates = await HashratesRepository.$getPoolsWeeklyHashrate(req.params.interval ?? null);
       const oldestIndexedBlockTimestamp = await BlocksRepository.$oldestBlockTimestamp();
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
@@ -604,8 +605,8 @@ class Routes {
 
   public async $getHistoricalHashrate(req: Request, res: Response) {
     try {
-      const hashrates = await mining.$getNetworkHistoricalHashrates(req.params.interval ?? null);
-      const difficulty = await mining.$getHistoricalDifficulty(req.params.interval ?? null);
+      const hashrates = await HashratesRepository.$getNetworkDailyHashrate(req.params.interval ?? null);
+      const difficulty = await BlocksRepository.$getBlocksDifficulty(req.params.interval ?? null);
       const oldestIndexedBlockTimestamp = await BlocksRepository.$oldestBlockTimestamp();
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');


### PR DESCRIPTION
Sorry for this a bit messy PR. I did not manage to keep it clean and ended up fixing couple of things on the way.

There was a bug which prevented weekly mining pool hashrate to be indexed every 7 days. This PR aims to fix this by splitting the daily network hashrate indexing and the weekly mining pool hashrate indexing for better code clarity.

`hashrates` table will be re-indexed.

Other changes have been included in this PR:
* **Set mysql pool connections to UTC** (https://github.com/mempool/mempool/pull/1302/files#diff-dde14f2dcfa45fbb45ec72e88993c487ac9445d8104f6484c9bc7cf6491ddb34R14)
* Make sure to close all db connection related to indexing
* Using the "end timestamp" to store the hashrate instead of the "start timestamp" (https://github.com/mempool/mempool/pull/1302/files#diff-6e52d1ac88aaf914de6bddf422ee7501d8650e9915d8ceb65a7b3c923525a41cR222)
* Removes useless wrappers (see https://github.com/mempool/mempool/pull/1302/files#diff-6d412117f054f60bc5481f2c7096c4b114f5632090d43c9c6cbe01c9b9e5211d)