### PR TITLE
Index blocks.blockTimestamp for faster hashrates indexing

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -140,6 +140,10 @@ class DatabaseMigration {
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD UNIQUE `hashrate_timestamp_pool_id` (`hashrate_timestamp`, `pool_id`)');
       }
 
+      if (databaseSchemaVersion < 10 && isBitcoin === true) {
+        await this.$executeQuery(connection, 'ALTER TABLE `blocks` ADD INDEX `blockTimestamp` (`blockTimestamp`)');
+      }
+
       connection.release();
     } catch (e) {
       connection.release();


### PR DESCRIPTION
The performance gain are so insane, I'm still dubious if this is actually a real improvement or some cache magic on mysql server.  It also make the pools stats (pie chart + table) generation much faster because we filter `blocks` by timestamp.

What I did before testing:
* Restart mysql server `service mysql restart`
* `SET GLOBAL query_cache_size = 0;`
* `FLUSH QUERY CACHE;`
* `FLUSH TABLES;`

To test:
* rollback your db `state.schema_version.number` to `6`
* Delete `state.last_hashrates_indexing` and `state.last_weekly_hashrates_indexing`
* Delete `hashrates` table. 
* Run the node back and observe the log

### Before

```
Mar  8 17:01:44 [154776] DEBUG: Getting weekly pool hashrate for Mon, 21 Feb 2022 23:49:55 GMT | ~0.09 weeks/sec | ~720 weeks left to index
Mar  8 17:01:45 [154776] DEBUG: Getting network daily hashrate for Mon, 14 Feb 2022 00:00:00 GMT | ~1.67 days/sec | ~5024 days left to index
```

### After (lol)

```
Mar  8 17:03:04 [154846] DEBUG: Getting network daily hashrate for Sat, 13 Mar 2010 00:00:00 GMT | ~729.50 days/sec | ~668 days left to index
Mar  8 17:03:04 [154846] DEBUG: Getting weekly pool hashrate for Mon, 20 Nov 2017 23:49:55 GMT | ~37.17 weeks/sec | ~498 weeks left to index
```