### PR TITLE
fix and improve block time estimations

### DIFF
--- a/frontend/src/app/components/difficulty/difficulty.component.ts
+++ b/frontend/src/app/components/difficulty/difficulty.component.ts
@@ -66,14 +66,7 @@ export class DifficultyComponent implements OnInit {
             }
           }
 
-          const timeAvgDiff = change * 0.1;
-
-          let timeAvgMins = 10;
-          if (timeAvgDiff > 0) {
-            timeAvgMins -= Math.abs(timeAvgDiff);
-          } else {
-            timeAvgMins += Math.abs(timeAvgDiff);
-          }
+          const timeAvgMins = blocksInEpoch ? diff / blocksInEpoch / 60 : 10;
 
           const timeAvg = timeAvgMins.toFixed(0);
           const remainingTime = (remainingBlocks * timeAvgMins * 60 * 1000) + (now * 1000);

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -26,7 +26,7 @@
                 <app-time-until [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time-until>
               </ng-template>
               <ng-template #timeDiffMainnet>
-                <app-time-until [time]="(timeAvg * i) + now + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
+                <app-time-until [time]="(timeAvg * i) + lastBlockTime + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
               </ng-template>
             </div>
             <ng-template #mergedBlock>

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -26,7 +26,7 @@
                 <app-time-until [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time-until>
               </ng-template>
               <ng-template #timeDiffMainnet>
-                <app-time-until [time]="(timeAvg * i) + lastBlockTime + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
+                <app-time-until [time]="(timeAvg * i) + now + timeAvg + timeOffset" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time-until>
               </ng-template>
             </div>
             <ng-template #mergedBlock>

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -33,7 +33,7 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
   networkSubscription: Subscription;
   network = '';
   now = new Date().getTime();
-  lastBlockTime: number;
+  timeOffset = 0;
   showMiningInfo = false;
 
   blockWidth = 125;
@@ -130,8 +130,6 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
           this.stateService.lastDifficultyAdjustment$
         ])),
         map(([block, DATime]) => {
-          this.lastBlockTime = block.timestamp * 1000;
-
           this.now = new Date().getTime();
           const now = new Date().getTime() / 1000;
           const diff = now - DATime;
@@ -142,7 +140,10 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
           // testnet difficulty is set to 1 after 20 minutes of no blockSize
           // therefore the time between blocks will always be below 20 minutes (1200s)
           if (this.stateService.network === 'testnet' && now - block.timestamp + timeAvg > 1200) {
+            this.timeOffset = -Math.min(now - block.timestamp, 1200) * 1000;
             timeAvg = 1200;
+          } else {
+            this.timeOffset = 0;
           }
 
           return timeAvg * 1000;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49868160/157340638-604f37c3-7251-47fa-b4f3-8f816b99d7a2.png)

testnet has been going like this for at least 3000 blocks (around 1 per minute) but the difficulty adjustment panel says 1694 blocks will be mined in 1 minute

fixes this ^
fixes #1051

and set the mempool block time estimations relative to the chaintip instead of `now`, because it is statistically more likely for a block to be mined when the tip is mined 10 minutes ago than just now

Questions and comments are welcome!