### PR TITLE
Display unknown for non standard output types

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -216,7 +216,7 @@ class BitcoinApi implements AbstractBitcoinApi {
     if (map[outputType]) {
       return map[outputType];
     } else {
-      return '';
+      return 'unknown';
     }
   }
 


### PR DESCRIPTION
fixes #126

Follow same behavior as Esplora and display UNKNOWN for non standard output types instead of blank.

<img width="358" alt="Screen Shot 2022-03-09 at 10 44 02" src="https://user-images.githubusercontent.com/8561090/157415775-fc6e2c86-e5ef-4ea3-a2b1-4b2a6c1eaade.png">
