### PR TITLE
Feature/simplify indexing condition

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -111,14 +111,20 @@ class Blocks {
     const transactionsTmp = [...transactions];
     transactionsTmp.shift();
     transactionsTmp.sort((a, b) => b.effectiveFeePerVsize - a.effectiveFeePerVsize);
-
     blockExtended.extras.medianFee = transactionsTmp.length > 0 ?
       Common.median(transactionsTmp.map((tx) => tx.effectiveFeePerVsize)) : 0;
-    blockExtended.extras.feeRange = transactionsTmp.length > 0 ?
-      Common.getFeesInRange(transactionsTmp, 8) : [0, 0];
-    blockExtended.extras.totalFees = transactionsTmp.reduce((acc, tx) => {
-      return acc + tx.fee;
-    }, 0)
+
+    const stats = await bitcoinClient.getBlockStats(block.id);
+    blockExtended.extras.feeRange = stats.feerate_percentiles;
+    blockExtended.extras.totalFees = stats.totalfee;
+    blockExtended.extras.avgFee = stats.avgfee;
+    blockExtended.extras.avgFeeRate = stats.avgfeerate;
+    blockExtended.extras.maxFee = stats.maxfee;
+    blockExtended.extras.maxFeeRate = stats.maxfeerate;
+    blockExtended.extras.minFee = stats.minfee;
+    blockExtended.extras.minFeeRate = stats.minfeerate;
+    blockExtended.extras.subsidy = stats.subsidy;
+    blockExtended.extras.medianFeeValue = stats.medianfee;
 
     if (Common.indexingEnabled()) {
       let pool: PoolTag;

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 10;
+  private static currentVersion = 11;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -92,13 +92,13 @@ class DatabaseMigration {
         await this.$executeQuery(connection, this.getCreateBlocksTableQuery(), await this.$checkIfTableExists('blocks'));
       }
       if (databaseSchemaVersion < 5 && isBitcoin === true) {
-        logger.warn(`'blocks' table has been truncated. Re-indexing from scratch.'`);
+        logger.warn(`'blocks' table has been truncated. Re-indexing from scratch.`);
         await this.$executeQuery(connection, 'TRUNCATE blocks;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE blocks ADD `reward` double unsigned NOT NULL DEFAULT "0"');
       }
 
       if (databaseSchemaVersion < 6 && isBitcoin === true) {
-        logger.warn(`'blocks' table has been truncated. Re-indexing from scratch.'`);
+        logger.warn(`'blocks' table has been truncated. Re-indexing from scratch.`);
         await this.$executeQuery(connection, 'TRUNCATE blocks;');  // Need to re-index
         // Cleanup original blocks fields type
         await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `height` integer unsigned NOT NULL DEFAULT "0"');
@@ -125,7 +125,7 @@ class DatabaseMigration {
       }
 
       if (databaseSchemaVersion < 8 && isBitcoin === true) {
-        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.'`);
+        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` DROP INDEX `PRIMARY`');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST');
@@ -134,7 +134,7 @@ class DatabaseMigration {
       }
 
       if (databaseSchemaVersion < 9 && isBitcoin === true) {
-        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.'`);
+        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `state` CHANGE `name` `name` varchar(100)');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` ADD UNIQUE `hashrate_timestamp_pool_id` (`hashrate_timestamp`, `pool_id`)');
@@ -142,6 +142,21 @@ class DatabaseMigration {
 
       if (databaseSchemaVersion < 10 && isBitcoin === true) {
         await this.$executeQuery(connection, 'ALTER TABLE `blocks` ADD INDEX `blockTimestamp` (`blockTimestamp`)');
+      }
+
+      if (databaseSchemaVersion < 11 && isBitcoin === true) {
+        logger.warn(`'blocks' table has been truncated. Re-indexing from scratch.`);
+        await this.$executeQuery(connection, 'TRUNCATE blocks;'); // Need to re-index
+        await this.$executeQuery(connection, `ALTER TABLE blocks
+          ADD avg_fee int unsigned NULL,
+          ADD avg_fee_rate int unsigned NULL,
+          ADD max_fee int unsigned NULL,
+          ADD max_fee_rate int unsigned NULL,
+          ADD min_fee int unsigned NULL,
+          ADD min_fee_rate int unsigned NULL,
+          ADD median_fee_value int unsigned NULL,
+          ADD subsidy float unsigned NULL;
+        `);
       }
 
       connection.release();

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -93,8 +93,11 @@ class Mining {
       const indexedTimestamp = await HashratesRepository.$getWeeklyHashrateTimestamps();
       const hashrates: any[] = [];
       const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-      const lastMidnight = this.getDateMidnight(new Date());
-      let toTimestamp = Math.round((lastMidnight.getTime() - 604800) / 1000);
+
+      const now = new Date();
+      const lastMonday = new Date(now.setDate(now.getDate() - (now.getDay() + 6) % 7));
+      const lastMondayMidnight = this.getDateMidnight(lastMonday);
+      let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800) / 1000);
 
       const totalWeekIndexed = (await BlocksRepository.$blockCount(null, null)) / 1008;
       let indexedThisRun = 0;
@@ -142,7 +145,7 @@ class Mining {
         hashrates.length = 0;
 
         const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-        if (elapsedSeconds > 5) {
+        if (elapsedSeconds > 1) {
           const weeksPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
           const weeksLeft = Math.round(totalWeekIndexed - totalIndexed);
@@ -228,7 +231,7 @@ class Mining {
         }
 
         const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-        if (elapsedSeconds > 5) {
+        if (elapsedSeconds > 1) {
           const daysPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
           const daysLeft = Math.round(totalDayIndexed - totalIndexed);

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -79,7 +79,7 @@ export interface TransactionStripped {
 
 export interface BlockExtension {
   totalFees?: number;
-  medianFee?: number;
+  medianFee?: number; // Actually the median fee rate that we compute ourself
   feeRange?: number[];
   reward?: number;
   coinbaseTx?: TransactionMinerInfo;
@@ -87,7 +87,15 @@ export interface BlockExtension {
   pool?: {
     id: number;
     name: string;
-  }
+  };
+  avgFee?: number;
+  avgFeeRate?: number;
+  maxFee?: number;
+  maxFeeRate?: number;
+  minFee?: number;
+  minFeeRate?: number;
+  subsidy?: number;
+  medianFeeValue?: number; // The actual median fee amount from getblockstats RPC
 }
 
 export interface BlockExtended extends IEsploraApi.Block {

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -187,8 +187,9 @@ export class HashrateChartComponent implements OnInit {
             difficulty = Math.round(data[1].data[1] / difficultyPowerOfTen.divider);
           }
 
+          const date = new Date(data[0].data[0]).toLocaleDateString(this.locale, { year: 'numeric', month: 'short', day: 'numeric' });
           return `
-            <b style="color: white; margin-left: 18px">${data[0].axisValueLabel}</b><br>
+            <b style="color: white; margin-left: 18px">${date}</b><br>
             <span>${data[0].marker} ${data[0].seriesName}: ${formatNumber(hashrate, this.locale, '1.0-0')} ${hashratePowerOfTen.unit}H/s</span><br>
             <span>${data[1].marker} ${data[1].seriesName}: ${formatNumber(difficulty, this.locale, '1.2-2')} ${difficultyPowerOfTen.unit}</span>
           `;

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -92,7 +92,8 @@ export class HashrateChartComponent implements OnInit {
 
                 this.prepareChartOptions({
                   hashrates: data.hashrates.map(val => [val.timestamp * 1000, val.avgHashrate]),
-                  difficulty: diffFixed.map(val => [val.timestamp * 1000, val.difficulty])
+                  difficulty: diffFixed.map(val => [val.timestamp * 1000, val.difficulty]),
+                  timestamp: data.oldestIndexedBlockTimestamp,
                 });
                 this.isLoading = false;
               }),
@@ -125,16 +126,20 @@ export class HashrateChartComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
-    let title = undefined;
+    let title: object;
     if (data.hashrates.length === 0) {
+      const lastBlock = new Date(data.timestamp * 1000);
+      const dd = String(lastBlock.getDate()).padStart(2, '0');
+      const mm = String(lastBlock.getMonth() + 1).padStart(2, '0'); // January is 0!
+      const yyyy = lastBlock.getFullYear();
       title = {
         textStyle: {
-            color: "grey",
+            color: 'grey',
             fontSize: 15
         },
-        text: "Indexing in progress...",
-        left: "center",
-        top: "center"
+        text: `Indexing in progess - ${yyyy}-${mm}-${dd}`,
+        left: 'center',
+        top: 'center'
       };
     }
 
@@ -189,11 +194,11 @@ export class HashrateChartComponent implements OnInit {
           `;
         }.bind(this)
       },
-      xAxis: {
+      xAxis: data.hashrates.length === 0 ? undefined : {
         type: 'time',
         splitNumber: (this.isMobile() || this.widget) ? 5 : 10,
       },
-      legend: {
+      legend: data.hashrates.length === 0 ? undefined : {
         data: [
           {
             name: 'Hashrate',
@@ -219,7 +224,7 @@ export class HashrateChartComponent implements OnInit {
           },
         ],
       },
-      yAxis: [
+      yAxis: data.hashrates.length === 0 ? undefined : [
         {
           min: function (value) {
             return value.min * 0.9;
@@ -258,7 +263,7 @@ export class HashrateChartComponent implements OnInit {
           }
         }
       ],
-      series: [
+      series: data.hashrates.length === 0 ? [] : [
         {
           name: 'Hashrate',
           showSymbol: false,

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -105,7 +105,8 @@ export class HashrateChartPoolsComponent implements OnInit {
 
                 this.prepareChartOptions({
                   legends: legends,
-                  series: series
+                  series: series,
+                  timestamp: data.oldestIndexedBlockTimestamp,
                 });
                 this.isLoading = false;
               }),
@@ -124,16 +125,20 @@ export class HashrateChartPoolsComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
-    let title = undefined;
+    let title: object;
     if (data.series.length === 0) {
+      const lastBlock = new Date(data.timestamp * 1000);
+      const dd = String(lastBlock.getDate()).padStart(2, '0');
+      const mm = String(lastBlock.getMonth() + 1).padStart(2, '0'); // January is 0!
+      const yyyy = lastBlock.getFullYear();
       title = {
         textStyle: {
-            color: "grey",
+            color: 'grey',
             fontSize: 15
         },
-        text: "Indexing in progress...",
-        left: "center",
-        top: this.widget ? 115 : this.isMobile() ? 'center' : 225,
+        text: `Indexing in progess - ${yyyy}-${mm}-${dd}`,
+        left: 'center',
+        top: 'center',
       };
     }
 
@@ -170,14 +175,14 @@ export class HashrateChartPoolsComponent implements OnInit {
           return tooltip;
         }.bind(this)
       },
-      xAxis: {
+      xAxis: data.series.length === 0 ? undefined : {
         type: 'time',
         splitNumber: (this.isMobile() || this.widget) ? 5 : 10,
       },
-      legend: (this.isMobile() || this.widget) ? undefined : {
+      legend: (this.isMobile() || this.widget || data.series.length === 0) ? undefined : {
         data: data.legends
       },
-      yAxis: {
+      yAxis: data.series.length === 0 ? undefined : {
         position: 'right',
         axisLabel: {
           color: 'rgb(110, 112, 121)',

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -165,7 +165,8 @@ export class HashrateChartPoolsComponent implements OnInit {
         },
         borderColor: '#000',
         formatter: function (data) {
-          let tooltip = `<b style="color: white; margin-left: 18px">${data[0].axisValueLabel}</b><br>`;
+          const date = new Date(data[0].data[0]).toLocaleDateString(this.locale, { year: 'numeric', month: 'short', day: 'numeric' });
+          let tooltip = `<b style="color: white; margin-left: 18px">${date}</b><br>`;
           data.sort((a, b) => b.data[1] - a.data[1]);
           for (const pool of data) {
             if (pool.data[1] > 0) {


### PR DESCRIPTION
Weekly hashrates are currently indexing from last midnight, which means that everytime we restart the server, we may add a new entry even though the most recent one is younger than 7 days.

This PR fixes this issue by doing weekly indexing from last monday midnight.

I also fixed the tooltip labeling formatting for hashrates charts using `toLocaleDateString` function. 