### PR TITLE
Index weekly hashrates using last Monday midnight - Fix charts tooltip

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -93,8 +93,11 @@ class Mining {
       const indexedTimestamp = await HashratesRepository.$getWeeklyHashrateTimestamps();
       const hashrates: any[] = [];
       const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-      const lastMidnight = this.getDateMidnight(new Date());
-      let toTimestamp = Math.round((lastMidnight.getTime() - 604800) / 1000);
+
+      const now = new Date();
+      const lastMonday = new Date(now.setDate(now.getDate() - (now.getDay() + 6) % 7));
+      const lastMondayMidnight = this.getDateMidnight(lastMonday);
+      let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800) / 1000);
 
       const totalWeekIndexed = (await BlocksRepository.$blockCount(null, null)) / 1008;
       let indexedThisRun = 0;
@@ -142,7 +145,7 @@ class Mining {
         hashrates.length = 0;
 
         const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-        if (elapsedSeconds > 5) {
+        if (elapsedSeconds > 1) {
           const weeksPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
           const weeksLeft = Math.round(totalWeekIndexed - totalIndexed);
@@ -228,7 +231,7 @@ class Mining {
         }
 
         const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-        if (elapsedSeconds > 5) {
+        if (elapsedSeconds > 1) {
           const daysPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
           const daysLeft = Math.round(totalDayIndexed - totalIndexed);

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -182,8 +182,9 @@ export class HashrateChartComponent implements OnInit {
             difficulty = Math.round(data[1].data[1] / difficultyPowerOfTen.divider);
           }
 
+          const date = new Date(data[0].data[0]).toLocaleDateString(this.locale, { year: 'numeric', month: 'short', day: 'numeric' });
           return `
-            <b style="color: white; margin-left: 18px">${data[0].axisValueLabel}</b><br>
+            <b style="color: white; margin-left: 18px">${date}</b><br>
             <span>${data[0].marker} ${data[0].seriesName}: ${formatNumber(hashrate, this.locale, '1.0-0')} ${hashratePowerOfTen.unit}H/s</span><br>
             <span>${data[1].marker} ${data[1].seriesName}: ${formatNumber(difficulty, this.locale, '1.2-2')} ${difficultyPowerOfTen.unit}</span>
           `;

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -160,7 +160,8 @@ export class HashrateChartPoolsComponent implements OnInit {
         },
         borderColor: '#000',
         formatter: function (data) {
-          let tooltip = `<b style="color: white; margin-left: 18px">${data[0].axisValueLabel}</b><br>`;
+          const date = new Date(data[0].data[0]).toLocaleDateString(this.locale, { year: 'numeric', month: 'short', day: 'numeric' });
+          let tooltip = `<b style="color: white; margin-left: 18px">${date}</b><br>`;
           data.sort((a, b) => b.data[1] - a.data[1]);
           for (const pool of data) {
             if (pool.data[1] > 0) {


### PR DESCRIPTION
Weekly hashrates are currently indexing from last midnight, which means that everytime we restart the server, we may add a new entry even though the most recent one is younger than 7 days.

This PR fixes this issue by doing weekly indexing from last monday midnight.

I also fixed the tooltip labeling formatting for hashrates charts using toLocaleDateString function.
