### PR TITLE
Create new /mining/blocks page

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -339,7 +339,7 @@ class Blocks {
     return blockExtended;
   }
 
-  public async $getBlocksExtras(fromHeight: number): Promise<BlockExtended[]> {
+  public async $getBlocksExtras(fromHeight: number, limit: number = 15): Promise<BlockExtended[]> {
     try {
       loadingIndicators.setProgress('blocks', 0);
 
@@ -360,7 +360,7 @@ class Blocks {
       }
 
       let nextHash = startFromHash;
-      for (let i = 0; i < 10 && currentHeight >= 0; i++) {
+      for (let i = 0; i < limit && currentHeight >= 0; i++) {
         let block = this.getBlocks().find((b) => b.height === currentHeight);
         if (!block && Common.indexingEnabled()) {
           block = this.prepareBlock(await this.$indexBlock(currentHeight));

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -277,7 +277,10 @@ class BlocksRepository {
     const connection = await DB.pool.getConnection();
     try {
       const [rows]: any[] = await connection.query(`
-        SELECT *, UNIX_TIMESTAMP(blocks.blockTimestamp) as blockTimestamp, pools.id as pool_id, pools.name as pool_name, pools.link as pool_link, pools.addresses as pool_addresses, pools.regexes as pool_regexes
+        SELECT *, UNIX_TIMESTAMP(blocks.blockTimestamp) as blockTimestamp,
+        pools.id as pool_id, pools.name as pool_name, pools.link as pool_link,
+        pools.addresses as pool_addresses, pools.regexes as pool_regexes,
+        previous_block_hash as previousblockhash
         FROM blocks
         JOIN pools ON blocks.pool_id = pools.id
         WHERE height = ${height};

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -658,7 +658,7 @@ class Routes {
 
   public async getBlocksExtras(req: Request, res: Response) {
     try {
-      res.json(await blocks.$getBlocksExtras(parseInt(req.params.height, 10)))
+      res.json(await blocks.$getBlocksExtras(parseInt(req.params.height, 10), 15));
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
     }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -31,6 +31,7 @@ import { MiningDashboardComponent } from './components/mining-dashboard/mining-d
 import { HashrateChartComponent } from './components/hashrate-chart/hashrate-chart.component';
 import { HashrateChartPoolsComponent } from './components/hashrates-chart-pools/hashrate-chart-pools.component';
 import { MiningStartComponent } from './components/mining-start/mining-start.component';
+import { BlocksList } from './components/blocks-list/blocks-list.component';
 
 let routes: Routes = [
   {
@@ -75,6 +76,10 @@ let routes: Routes = [
         path: 'mining',
         component: MiningStartComponent,
         children: [
+          {
+            path: 'blocks',
+            component: BlocksList,
+          },
           {
             path: 'hashrate',
             component: HashrateChartComponent,
@@ -191,6 +196,10 @@ let routes: Routes = [
             component: MiningStartComponent,
             children: [
               {
+                path: 'blocks',
+                component: BlocksList,
+              },
+              {
                 path: 'hashrate',
                 component: HashrateChartComponent,
               },
@@ -299,6 +308,10 @@ let routes: Routes = [
             path: 'mining',
             component: MiningStartComponent,
             children: [
+              {
+                path: 'blocks',
+                component: BlocksList,
+              },
               {
                 path: 'hashrate',
                 component: HashrateChartComponent,
@@ -630,7 +643,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
     initialNavigation: 'enabled',
     scrollPositionRestoration: 'enabled',
     anchorScrolling: 'enabled'
-})],
+  })],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -76,6 +76,7 @@ import { MiningStartComponent } from './components/mining-start/mining-start.com
 import { AmountShortenerPipe } from './shared/pipes/amount-shortener.pipe';
 import { ShortenStringPipe } from './shared/pipes/shorten-string-pipe/shorten-string.pipe';
 import { DifficultyAdjustmentsTable } from './components/difficulty-adjustments-table/difficulty-adjustments-table.components';
+import { BlocksList } from './components/blocks-list/blocks-list.component';
 
 @NgModule({
   declarations: [
@@ -133,6 +134,7 @@ import { DifficultyAdjustmentsTable } from './components/difficulty-adjustments-
     MiningStartComponent,
     AmountShortenerPipe,
     DifficultyAdjustmentsTable,
+    BlocksList,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -7,31 +7,31 @@
   <table class="table table-borderless">
     <thead>
       <th class="height" i18n="latest-blocks.height">Height</th>
+      <th class="pool" i18n="latest-blocks.mined-by">Pool</th>
       <th class="timestamp" i18n="latest-blocks.timestamp">Timestamp</th>
       <th class="mined" i18n="latest-blocks.mined">Mined</th>
-      <th class="pool" i18n="latest-blocks.mined-by">Pool</th>
       <th class="reward text-right" i18n="latest-blocks.reward">Reward</th>
       <th class="fees text-right" i18n="latest-blocks.fees">Fees</th>
       <th class="txs text-right" i18n="latest-blocks.transactions">Txs</th>
       <th class="size" i18n="latest-blocks.size">Size</th>
     </thead>
-    <tbody *ngIf="blocks$ | async as blocks">
+    <tbody *ngIf="blocks$ | async as blocks; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
       <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
         <td>
           <a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height
             }}</a>
-        </td>
-        <td class="timestamp">
-          &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
-        </td>
-        <td class="mined">
-          <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
         </td>
         <td>
           <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
             onError="this.src = './resources/mining-pools/default.svg'">
           <span class="pool-name"><a [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">{{
               block.extras.pool.name }}</a></span>
+        </td>
+        <td class="timestamp">
+          &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
+        </td>
+        <td class="mined">
+          <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
         </td>
         <td class="reward text-right">
           <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-2"></app-amount>
@@ -50,51 +50,41 @@
           </div>
         </td>
       </tr>
-      <ng-template [ngIf]="isLoading">
-        <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10]">
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
-          <td><span class="skeleton-loader"></span></td>
+    </tbody>
+    <ng-template #skeleton>
+      <tbody>
+        <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]">
+          <td>
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="timestamp">
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="mined">
+            <span class="skeleton-loader"></span>
+          </td>
+          <td>
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="reward text-right">
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="fees text-right">
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="txs text-right">
+            <span class="skeleton-loader"></span>
+          </td>
+          <td class="size">
+            <span class="skeleton-loader"></span>
+          </td>
         </tr>
-      </ng-template>
-    </tbody>
-    <tbody *ngIf="isLoading">
-      <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10,11,12]">
-        <td>
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="timestamp">
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="mined">
-          <span class="skeleton-loader"></span>
-        </td>
-        <td>
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="reward text-right">
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="fees text-right">
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="txs text-right">
-          <span class="skeleton-loader"></span>
-        </td>
-        <td class="size">
-          <span class="skeleton-loader"></span>
-        </td>
-      </tr>
-    </tbody>
+      </tbody>
+    </ng-template>
   </table>
 
-  <!-- <ngb-pagination class="pagination-container float-right" [collectionSize]="block.tx_count" [rotate]="true"
-    [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)"
-    [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination> -->
+  <ngb-pagination class="pagination-container float-right mt-3" [class]="isLoading ? 'disabled' : ''" [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5"
+    [pageSize]="15" [(page)]="page" (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
+  </ngb-pagination>
 
 </div>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -1,0 +1,100 @@
+<div class="container-xl">
+  <h1 class="float-left" i18n="latest-blocks.blocks">Blocks</h1>
+  <br>
+
+  <div class="clearfix"></div>
+
+  <table class="table table-borderless">
+    <thead>
+      <th class="height" i18n="latest-blocks.height">Height</th>
+      <th class="timestamp" i18n="latest-blocks.timestamp">Timestamp</th>
+      <th class="mined" i18n="latest-blocks.mined">Mined</th>
+      <th class="pool" i18n="latest-blocks.mined-by">Pool</th>
+      <th class="reward text-right" i18n="latest-blocks.reward">Reward</th>
+      <th class="fees text-right" i18n="latest-blocks.fees">Fees</th>
+      <th class="txs text-right" i18n="latest-blocks.transactions">Txs</th>
+      <th class="size" i18n="latest-blocks.size">Size</th>
+    </thead>
+    <tbody *ngIf="blocks$ | async as blocks">
+      <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
+        <td>
+          <a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height
+            }}</a>
+        </td>
+        <td class="timestamp">
+          &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
+        </td>
+        <td class="mined">
+          <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
+        </td>
+        <td>
+          <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
+            onError="this.src = './resources/mining-pools/default.svg'">
+          <span class="pool-name"><a [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">{{
+              block.extras.pool.name }}</a></span>
+        </td>
+        <td class="reward text-right">
+          <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-2"></app-amount>
+        </td>
+        <td class="fees text-right">
+          <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-2"></app-amount>
+        </td>
+        <td class="txs text-right">
+          {{ block.tx_count | number }}
+        </td>
+        <td class="size">
+          <div class="progress">
+            <div class="progress-bar progress-mempool" role="progressbar"
+              [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }"></div>
+            <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
+          </div>
+        </td>
+      </tr>
+      <ng-template [ngIf]="isLoading">
+        <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10]">
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+          <td><span class="skeleton-loader"></span></td>
+        </tr>
+      </ng-template>
+    </tbody>
+    <tbody *ngIf="isLoading">
+      <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10,11,12]">
+        <td>
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="timestamp">
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="mined">
+          <span class="skeleton-loader"></span>
+        </td>
+        <td>
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="reward text-right">
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="fees text-right">
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="txs text-right">
+          <span class="skeleton-loader"></span>
+        </td>
+        <td class="size">
+          <span class="skeleton-loader"></span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- <ngb-pagination class="pagination-container float-right" [collectionSize]="block.tx_count" [rotate]="true"
+    [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)"
+    [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination> -->
+
+</div>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -1,48 +1,50 @@
-<div class="container-xl">
-  <h1 class="float-left" i18n="latest-blocks.blocks">Blocks</h1>
-  <br>
+<div class="container-xl" [class]="widget ? 'widget' : ''">
+  <h1 *ngIf="!widget" class="float-left" i18n="latest-blocks.blocks">Blocks</h1>
 
   <div class="clearfix"></div>
 
   <table class="table table-borderless">
     <thead>
-      <th class="height" i18n="latest-blocks.height">Height</th>
-      <th class="pool" i18n="latest-blocks.mined-by">Pool</th>
-      <th class="timestamp" i18n="latest-blocks.timestamp">Timestamp</th>
-      <th class="mined" i18n="latest-blocks.mined">Mined</th>
-      <th class="reward text-right" i18n="latest-blocks.reward">Reward</th>
-      <th class="fees text-right" i18n="latest-blocks.fees">Fees</th>
-      <th class="txs text-right" i18n="latest-blocks.transactions">Txs</th>
-      <th class="size" i18n="latest-blocks.size">Size</th>
+      <th class="height" [class]="widget ? 'widget' : ''" i18n="latest-blocks.height">Height</th>
+      <th class="pool text-left" [class]="widget ? 'widget' : ''" i18n="latest-blocks.mined-by">
+        Pool</th>
+      <th class="timestamp" i18n="latest-blocks.timestamp" *ngIf="!widget">Timestamp</th>
+      <th class="mined" i18n="latest-blocks.mined" *ngIf="!widget">Mined</th>
+      <th class="reward text-right" i18n="latest-blocks.reward" [class]="widget ? 'widget' : ''">
+        Reward</th>
+      <th class="fees text-right" i18n="latest-blocks.fees" *ngIf="!widget">Fees</th>
+      <th class="txs text-right" i18n="latest-blocks.transactions" [class]="widget ? 'widget' : ''">Txs</th>
+      <th class="size" i18n="latest-blocks.size" *ngIf="!widget">Size</th>
     </thead>
     <tbody *ngIf="blocks$ | async as blocks; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
       <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
-        <td>
+        <td class="height "[class]="widget ? 'widget' : ''">
           <a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height
             }}</a>
         </td>
-        <td>
+        <td class="pool text-left" [class]="widget ? 'widget' : ''">
           <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
             onError="this.src = './resources/mining-pools/default.svg'">
-          <span class="pool-name"><a [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">{{
+          <span class="pool-name"><a class="clear-link"
+              [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">{{
               block.extras.pool.name }}</a></span>
         </td>
-        <td class="timestamp">
+        <td class="timestamp" *ngIf="!widget">
           &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
         </td>
-        <td class="mined">
+        <td class="mined" *ngIf="!widget">
           <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
         </td>
-        <td class="reward text-right">
+        <td class="reward text-right" [class]="widget ? 'widget' : ''">
           <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-2"></app-amount>
         </td>
-        <td class="fees text-right">
+        <td class="fees text-right" *ngIf="!widget">
           <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-2"></app-amount>
         </td>
-        <td class="txs text-right">
+        <td class="txs text-right" [class]="widget ? 'widget' : ''">
           {{ block.tx_count | number }}
         </td>
-        <td class="size">
+        <td class="size" *ngIf="!widget">
           <div class="progress">
             <div class="progress-bar progress-mempool" role="progressbar"
               [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }"></div>
@@ -53,29 +55,30 @@
     </tbody>
     <ng-template #skeleton>
       <tbody>
-        <tr *ngFor="let item of [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]">
-          <td>
+        <tr *ngFor="let item of skeletonLines">
+          <td class="height" [class]="widget ? 'widget' : ''">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="timestamp">
+          <td class="pool text-left" [class]="widget ? 'widget' : ''">
+            <img width="0" height="25" style="opacity: 0">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="mined">
+          <td class="timestamp" *ngIf="!widget">
             <span class="skeleton-loader"></span>
           </td>
-          <td>
+          <td class="mined" *ngIf="!widget">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="reward text-right">
+          <td class="reward text-right" [class]="widget ? 'widget' : ''">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="fees text-right">
+          <td class="fees text-right" *ngIf="!widget">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="txs text-right">
+          <td class="txs text-right" [class]="widget ? 'widget' : ''">
             <span class="skeleton-loader"></span>
           </td>
-          <td class="size">
+          <td class="size" *ngIf="!widget">
             <span class="skeleton-loader"></span>
           </td>
         </tr>
@@ -83,8 +86,9 @@
     </ng-template>
   </table>
 
-  <ngb-pagination class="pagination-container float-right mt-3" [class]="isLoading ? 'disabled' : ''" [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5"
-    [pageSize]="15" [(page)]="page" (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
+  <ngb-pagination *ngIf="!widget" class="pagination-container float-right mt-3 mb-3 mb-lg-0"
+    [class]="isLoading ? 'disabled' : ''" [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5" [pageSize]="15"
+    [(page)]="page" (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
   </ngb-pagination>
 
 </div>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -3,92 +3,94 @@
 
   <div class="clearfix"></div>
 
-  <table class="table table-borderless">
-    <thead>
-      <th class="height" [class]="widget ? 'widget' : ''" i18n="latest-blocks.height">Height</th>
-      <th class="pool text-left" [class]="widget ? 'widget' : ''" i18n="latest-blocks.mined-by">
-        Pool</th>
-      <th class="timestamp" i18n="latest-blocks.timestamp" *ngIf="!widget">Timestamp</th>
-      <th class="mined" i18n="latest-blocks.mined" *ngIf="!widget">Mined</th>
-      <th class="reward text-right" i18n="latest-blocks.reward" [class]="widget ? 'widget' : ''">
-        Reward</th>
-      <th class="fees text-right" i18n="latest-blocks.fees" *ngIf="!widget">Fees</th>
-      <th class="txs text-right" i18n="latest-blocks.transactions" [class]="widget ? 'widget' : ''">Txs</th>
-      <th class="size" i18n="latest-blocks.size" *ngIf="!widget">Size</th>
-    </thead>
-    <tbody *ngIf="blocks$ | async as blocks; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
-      <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
-        <td class="height "[class]="widget ? 'widget' : ''">
-          <a [routerLink]="['/block' | relativeUrl, block.height]">{{ block.height
-            }}</a>
-        </td>
-        <td class="pool text-left" [class]="widget ? 'widget' : ''">
-          <a class="clear-link"[routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">
-            <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
-            onError="this.src = './resources/mining-pools/default.svg'">
-            <span class="pool-name">{{ block.extras.pool.name }}</span>
-          </a>
-        </td>
-        <td class="timestamp" *ngIf="!widget">
-          &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
-        </td>
-        <td class="mined" *ngIf="!widget">
-          <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
-        </td>
-        <td class="reward text-right" [class]="widget ? 'widget' : ''">
-          <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-2"></app-amount>
-        </td>
-        <td class="fees text-right" *ngIf="!widget">
-          <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-2"></app-amount>
-        </td>
-        <td class="txs text-right" [class]="widget ? 'widget' : ''">
-          {{ block.tx_count | number }}
-        </td>
-        <td class="size" *ngIf="!widget">
-          <div class="progress">
-            <div class="progress-bar progress-mempool" role="progressbar"
-              [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }"></div>
-            <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-    <ng-template #skeleton>
-      <tbody>
-        <tr *ngFor="let item of skeletonLines">
-          <td class="height" [class]="widget ? 'widget' : ''">
-            <span class="skeleton-loader"></span>
+  <div style="min-height: 295px">
+    <table class="table table-borderless">
+      <thead>
+        <th class="height" [class]="widget ? 'widget' : ''" i18n="latest-blocks.height">Height</th>
+        <th class="pool text-left" [class]="widget ? 'widget' : ''" i18n="latest-blocks.mined-by">
+          Pool</th>
+        <th class="timestamp" i18n="latest-blocks.timestamp" *ngIf="!widget">Timestamp</th>
+        <th class="mined" i18n="latest-blocks.mined" *ngIf="!widget">Mined</th>
+        <th class="reward text-right" i18n="latest-blocks.reward" [class]="widget ? 'widget' : ''">
+          Reward</th>
+        <th class="fees text-right" i18n="latest-blocks.fees" *ngIf="!widget">Fees</th>
+        <th class="txs text-right" i18n="latest-blocks.transactions" [class]="widget ? 'widget' : ''">Txs</th>
+        <th class="size" i18n="latest-blocks.size" *ngIf="!widget">Size</th>
+      </thead>
+      <tbody *ngIf="blocks$ | async as blocks; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
+        <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
+          <td class="height " [class]="widget ? 'widget' : ''">
+            <a [routerLink]="['/block' | relativeUrl, block.height]">{{ block.height
+              }}</a>
           </td>
           <td class="pool text-left" [class]="widget ? 'widget' : ''">
-            <img width="0" height="25" style="opacity: 0">
-            <span class="skeleton-loader"></span>
+            <a class="clear-link" [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">
+              <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
+                onError="this.src = './resources/mining-pools/default.svg'">
+              <span class="pool-name">{{ block.extras.pool.name }}</span>
+            </a>
           </td>
           <td class="timestamp" *ngIf="!widget">
-            <span class="skeleton-loader"></span>
+            &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
           </td>
           <td class="mined" *ngIf="!widget">
-            <span class="skeleton-loader"></span>
+            <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
           </td>
           <td class="reward text-right" [class]="widget ? 'widget' : ''">
-            <span class="skeleton-loader"></span>
+            <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-2"></app-amount>
           </td>
           <td class="fees text-right" *ngIf="!widget">
-            <span class="skeleton-loader"></span>
+            <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-2"></app-amount>
           </td>
           <td class="txs text-right" [class]="widget ? 'widget' : ''">
-            <span class="skeleton-loader"></span>
+            {{ block.tx_count | number }}
           </td>
           <td class="size" *ngIf="!widget">
-            <span class="skeleton-loader"></span>
+            <div class="progress">
+              <div class="progress-bar progress-mempool" role="progressbar"
+                [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }"></div>
+              <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
+            </div>
           </td>
         </tr>
       </tbody>
-    </ng-template>
-  </table>
+      <ng-template #skeleton>
+        <tbody>
+          <tr *ngFor="let item of skeletonLines">
+            <td class="height" [class]="widget ? 'widget' : ''">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="pool text-left" [class]="widget ? 'widget' : ''">
+              <img width="0" height="25" style="opacity: 0">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="timestamp" *ngIf="!widget">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="mined" *ngIf="!widget">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="reward text-right" [class]="widget ? 'widget' : ''">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="fees text-right" *ngIf="!widget">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="txs text-right" [class]="widget ? 'widget' : ''">
+              <span class="skeleton-loader"></span>
+            </td>
+            <td class="size" *ngIf="!widget">
+              <span class="skeleton-loader"></span>
+            </td>
+          </tr>
+        </tbody>
+      </ng-template>
+    </table>
 
-  <ngb-pagination *ngIf="!widget" class="pagination-container float-right mt-2"
-    [class]="isLoading ? 'disabled' : ''" [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5" [pageSize]="15"
-    [(page)]="page" (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
-  </ngb-pagination>
-
+    <ngb-pagination *ngIf="!widget" class="pagination-container float-right mt-2" [class]="isLoading ? 'disabled' : ''"
+      [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5" [pageSize]="15" [(page)]="page"
+      (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
+    </ngb-pagination>
+  </div>
+  
 </div>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -19,7 +19,7 @@
     <tbody *ngIf="blocks$ | async as blocks; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
       <tr *ngFor="let block of blocks; let i= index; trackBy: trackByBlock">
         <td class="height "[class]="widget ? 'widget' : ''">
-          <a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height
+          <a [routerLink]="['/block' | relativeUrl, block.height]">{{ block.height
             }}</a>
         </td>
         <td class="pool text-left" [class]="widget ? 'widget' : ''">

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -23,11 +23,11 @@
             }}</a>
         </td>
         <td class="pool text-left" [class]="widget ? 'widget' : ''">
-          <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
+          <a class="clear-link"[routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">
+            <img width="25" height="25" src="{{ block.extras.pool['logo'] }}"
             onError="this.src = './resources/mining-pools/default.svg'">
-          <span class="pool-name"><a class="clear-link"
-              [routerLink]="[('/mining/pool/' + block.extras.pool.id) | relativeUrl]">{{
-              block.extras.pool.name }}</a></span>
+            <span class="pool-name">{{ block.extras.pool.name }}</span>
+          </a>
         </td>
         <td class="timestamp" *ngIf="!widget">
           &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
@@ -86,7 +86,7 @@
     </ng-template>
   </table>
 
-  <ngb-pagination *ngIf="!widget" class="pagination-container float-right mt-3 mb-3 mb-lg-0"
+  <ngb-pagination *ngIf="!widget" class="pagination-container float-right mt-2"
     [class]="isLoading ? 'disabled' : ''" [collectionSize]="blocksCount" [rotate]="true" [maxSize]="5" [pageSize]="15"
     [(page)]="page" (pageChange)="pageChange(page)" [boundaryLinks]="true" [ellipses]="false">
   </ngb-pagination>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -2,14 +2,21 @@
   max-width: 1400px;
   padding-bottom: 0;
 }
+.container-xl.widget {
+  padding-left: 0px;
+}
 
 .container {
   max-width: 100%;
 }
 
-.row {
-  padding-top: 15px;
-  padding-bottom: 15px;
+td {
+  padding-top: 0.7rem !important;
+  padding-bottom: 0.7rem !important;
+}
+
+.clear-link {
+  color: white;
 }
 
 .disabled {
@@ -21,6 +28,16 @@
   background-color: #2d3348;
 }
 
+.pool {
+  width: 17%;
+}
+.pool.widget {
+  width: 40%;
+  @media (max-width: 576px) {
+    padding-left: 30px;
+    width: 60%;
+  }
+}
 .pool-name {
   display: inline-block;
   vertical-align: text-top;
@@ -30,6 +47,12 @@
 .height {
   width: 10%;
   @media (max-width: 1100px) {
+    width: 10%;
+  }
+}
+.height.widget {
+  width: 20%;
+  @media (max-width: 576px) {
     width: 10%;
   }
 }
@@ -52,7 +75,13 @@
   @media (max-width: 1100px) {
     padding-right: 10px;
   }
-  @media (max-width: 800px) {
+  @media (max-width: 875px) {
+    display: none;
+  }
+}
+.txs.widget {
+  padding-right: 0;
+  @media (max-width: 650px) {
     display: none;
   }
 }
@@ -62,15 +91,21 @@
     display: none;
   }
 }
-
-.pool {
-  width: 17%;
+.fees.widget {
+  width: 20%;
 }
 
 .reward {
   @media (max-width: 576px) {
     width: 7%;
     padding-right: 30px;
+  }
+}
+.reward.widget {
+  width: 20%;
+  @media (max-width: 576px) {
+    width: 30%;
+    padding-right: 0;
   }
 }
 

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -1,5 +1,6 @@
 .container-xl {
   max-width: 1400px;
+  padding-bottom: 0;
 }
 
 .container {
@@ -11,6 +12,15 @@
   padding-bottom: 15px;
 }
 
+.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.progress {
+  background-color: #2d3348;
+}
+
 .pool-name {
   display: inline-block;
   vertical-align: text-top;
@@ -18,7 +28,7 @@
 }
 
 .height {
-  width: 12%;
+  width: 10%;
   @media (max-width: 1100px) {
     width: 10%;
   }
@@ -31,6 +41,7 @@
 }
 
 .mined {
+  width: 13%;
   @media (max-width: 576px) {
     display: none;
   }
@@ -53,7 +64,7 @@
 }
 
 .pool {
-  width: 12%;
+  width: 17%;
 }
 
 .reward {

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -1,9 +1,10 @@
 .container-xl {
   max-width: 1400px;
-  padding-bottom: 0;
+  padding-bottom: 100px;
 }
 .container-xl.widget {
   padding-left: 0px;
+  padding-bottom: 0px;
 }
 
 .container {
@@ -117,11 +118,7 @@ td {
   @media (max-width: 650px) {
     width: 20%;
   }
-}
-
-.pagination-container {
-  margin-bottom: 40px;
-  @media (max-width: 992px) {
-    margin-bottom: 80px;
+  @media (max-width: 450px) {
+    display: none;
   }
 }

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -1,0 +1,74 @@
+.container-xl {
+  max-width: 1400px;
+}
+
+.container {
+  max-width: 100%;
+}
+
+.row {
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.pool-name {
+  display: inline-block;
+  vertical-align: text-top;
+  padding-left: 10px;
+}
+
+.height {
+  width: 12%;
+  @media (max-width: 1100px) {
+    width: 10%;
+  }
+}
+
+.timestamp {
+  @media (max-width: 900px) {
+    display: none;
+  }
+}
+
+.mined {
+  @media (max-width: 576px) {
+    display: none;
+  }
+}
+
+.txs {
+  padding-right: 40px;
+  @media (max-width: 1100px) {
+    padding-right: 10px;
+  }
+  @media (max-width: 800px) {
+    display: none;
+  }
+}
+
+.fees {
+  @media (max-width: 650px) {
+    display: none;
+  }
+}
+
+.pool {
+  width: 12%;
+}
+
+.reward {
+  @media (max-width: 576px) {
+    width: 7%;
+    padding-right: 30px;
+  }
+}
+
+.size {
+  width: 12%;
+  @media (max-width: 1000px) {
+    width: 15%;
+  }
+  @media (max-width: 650px) {
+    width: 20%;
+  }
+}

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -118,3 +118,10 @@ td {
     width: 20%;
   }
 }
+
+.pagination-container {
+  margin-bottom: 40px;
+  @media (max-width: 992px) {
+    margin-bottom: 80px;
+  }
+}

--- a/frontend/src/app/components/blocks-list/blocks-list.component.ts
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
 import { BehaviorSubject, Observable, timer } from 'rxjs';
 import { delayWhen, map, retryWhen, switchMap, tap } from 'rxjs/operators';
 import { BlockExtended } from 'src/app/interfaces/node-api.interface';
@@ -12,6 +12,8 @@ import { StateService } from 'src/app/services/state.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BlocksList implements OnInit {
+  @Input() widget: boolean = false;
+
   blocks$: Observable<BlockExtended[]> = undefined
 
   isLoading = true;
@@ -20,17 +22,18 @@ export class BlocksList implements OnInit {
   page = 1;
   blocksCount: number;
   fromHeightSubject: BehaviorSubject<number> = new BehaviorSubject(this.fromBlockHeight);
+  skeletonLines: number[] = [];
 
   constructor(
     private apiService: ApiService,
     public stateService: StateService,
   ) {
-
   }
 
   ngOnInit(): void {
+    this.skeletonLines = this.widget === true ? [...Array(5).keys()] : [...Array(15).keys()]; 
     this.paginationMaxSize = window.matchMedia('(max-width: 670px)').matches ? 3 : 5;
-
+    
     this.blocks$ = this.fromHeightSubject.pipe(
       switchMap(() => {
         this.isLoading = true;
@@ -47,6 +50,9 @@ export class BlocksList implements OnInit {
                 // @ts-ignore: Need to add an extra field for the template
                 block.extras.pool.logo = `./resources/mining-pools/` +
                   block.extras.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg';
+              }
+              if (this.widget) {
+                return blocks.slice(0, 5);
               }
               return blocks;
             }),

--- a/frontend/src/app/components/blocks-list/blocks-list.component.ts
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map, repeat, tap } from 'rxjs/operators';
+import { BlockExtended } from 'src/app/interfaces/node-api.interface';
+import { ApiService } from 'src/app/services/api.service';
+import { StateService } from 'src/app/services/state.service';
+
+@Component({
+  selector: 'app-blocks-list',
+  templateUrl: './blocks-list.component.html',
+  styleUrls: ['./blocks-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BlocksList implements OnInit {
+  blocks$: Observable<BlockExtended[]> = undefined
+  isLoading = true;
+  oldestBlockHeight = undefined;
+
+  constructor(
+    private apiService: ApiService,
+    public stateService: StateService
+  ) {
+
+  }
+
+  ngOnInit(): void {
+    this.blocks$ = this.apiService.getBlocks$(this.oldestBlockHeight)
+      .pipe(
+        tap(blocks => {
+          this.isLoading = false;
+        }),
+        map(blocks => {
+          for (const block of blocks) {
+            // @ts-ignore
+            block.extras.pool.logo = `./resources/mining-pools/` +
+              block.extras.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg';
+            this.oldestBlockHeight = block.height;
+          }
+          return blocks;
+        }),
+        repeat(2),
+      );
+  }
+
+  trackByBlock(index: number, block: BlockExtended) {
+    return block.height;
+  }
+}

--- a/frontend/src/app/components/blocks-list/blocks-list.component.ts
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
-import { BehaviorSubject, Observable, timer } from 'rxjs';
-import { delayWhen, map, retryWhen, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable, timer } from 'rxjs';
+import { delayWhen, map, retryWhen, scan, skip, switchMap, tap } from 'rxjs/operators';
 import { BlockExtended } from 'src/app/interfaces/node-api.interface';
 import { ApiService } from 'src/app/services/api.service';
 import { StateService } from 'src/app/services/state.service';
+import { WebsocketService } from 'src/app/services/websocket.service';
 
 @Component({
   selector: 'app-blocks-list',
@@ -14,57 +15,81 @@ import { StateService } from 'src/app/services/state.service';
 export class BlocksList implements OnInit {
   @Input() widget: boolean = false;
 
-  blocks$: Observable<BlockExtended[]> = undefined
+  blocks$: Observable<any[]> = undefined;
 
   isLoading = true;
   fromBlockHeight = undefined;
   paginationMaxSize: number;
   page = 1;
+  lastPage = 1;
   blocksCount: number;
   fromHeightSubject: BehaviorSubject<number> = new BehaviorSubject(this.fromBlockHeight);
   skeletonLines: number[] = [];
 
   constructor(
     private apiService: ApiService,
+    private websocketService: WebsocketService,
     public stateService: StateService,
   ) {
   }
 
   ngOnInit(): void {
-    this.skeletonLines = this.widget === true ? [...Array(5).keys()] : [...Array(15).keys()]; 
+    this.websocketService.want(['blocks']);
+
+    this.skeletonLines = this.widget === true ? [...Array(5).keys()] : [...Array(15).keys()];
     this.paginationMaxSize = window.matchMedia('(max-width: 670px)').matches ? 3 : 5;
-    
-    this.blocks$ = this.fromHeightSubject.pipe(
-      switchMap(() => {
-        this.isLoading = true;
-        return this.apiService.getBlocks$(this.fromBlockHeight)
-          .pipe(
-            tap(blocks => {
-              if (this.blocksCount === undefined) {
-                this.blocksCount = blocks[0].height;
-              }
-              this.isLoading = false;
-            }),
-            map(blocks => {
-              for (const block of blocks) {
-                // @ts-ignore: Need to add an extra field for the template
-                block.extras.pool.logo = `./resources/mining-pools/` +
-                  block.extras.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg';
-              }
-              if (this.widget) {
-                return blocks.slice(0, 5);
-              }
-              return blocks;
-            }),
-            retryWhen(errors => errors.pipe(delayWhen(() => timer(1000))))
-          )
-      })
-    );
+
+    this.blocks$ = combineLatest([
+      this.fromHeightSubject.pipe(
+        switchMap((fromBlockHeight) => {
+          this.isLoading = true;
+          return this.apiService.getBlocks$(this.page === 1 ? undefined : fromBlockHeight)
+            .pipe(
+              tap(blocks => {
+                if (this.blocksCount === undefined) {
+                  this.blocksCount = blocks[0].height;
+                }
+                this.isLoading = false;
+              }),
+              map(blocks => {
+                for (const block of blocks) {
+                  // @ts-ignore: Need to add an extra field for the template
+                  block.extras.pool.logo = `./resources/mining-pools/` +
+                    block.extras.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg';
+                }
+                if (this.widget) {
+                  return blocks.slice(0, 5);
+                }
+                return blocks;
+              }),
+              retryWhen(errors => errors.pipe(delayWhen(() => timer(1000))))
+            )
+          })
+      ),
+      this.stateService.blocks$
+        .pipe(
+          skip(this.stateService.env.MEMPOOL_BLOCKS_AMOUNT - 1),
+        ),
+    ])
+      .pipe(
+        scan((acc, blocks) => {
+          if (this.page > 1 || acc.length === 0 || (this.page === 1 && this.lastPage !== 1)) {
+            this.lastPage = this.page;
+            return blocks[0];
+          }
+          this.blocksCount = Math.max(this.blocksCount, blocks[1][0].height);
+          // @ts-ignore: Need to add an extra field for the template
+          blocks[1][0].extras.pool.logo = `./resources/mining-pools/` +
+            blocks[1][0].extras.pool.name.toLowerCase().replace(' ', '').replace('.', '') + '.svg';
+          acc.unshift(blocks[1][0]);
+          acc = acc.slice(0, this.widget ? 5 : 15);
+          return acc;
+        }, [])
+      );
   }
 
   pageChange(page: number) {
-    this.fromBlockHeight = this.blocksCount - (page - 1) * 15;
-    this.fromHeightSubject.next(this.fromBlockHeight);
+    this.fromHeightSubject.next(this.blocksCount - (page - 1) * 15);
   }
 
   trackByBlock(index: number, block: BlockExtended) {

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -95,7 +95,7 @@
     </div>
 
     <!-- pool dominance -->
-    <div class="col">
+    <!-- <div class="col">
       <div class="card" style="height: 385px">
         <div class="card-body">
           <h5 class="card-title">
@@ -103,6 +103,20 @@
           </h5>
           <app-hashrate-chart-pools [widget]=true></app-hashrate-chart-pools>
           <div class="mt-1"><a [routerLink]="['/mining/hashrate/pools' | relativeUrl]" i18n="dashboard.view-more">View
+              more &raquo;</a></div>
+        </div>
+      </div>
+    </div> -->
+
+    <!-- Latest blocks -->
+    <div class="col">
+      <div class="card" style="height: 385px">
+        <div class="card-body">
+          <h5 class="card-title">
+            Latest blocks
+          </h5>
+          <app-blocks-list [widget]=true></app-blocks-list>
+          <div><a [routerLink]="['/mining/blocks' | relativeUrl]" i18n="dashboard.view-more">View
               more &raquo;</a></div>
         </div>
       </div>
@@ -115,7 +129,7 @@
             Adjustments
           </h5>
           <app-difficulty-adjustments-table></app-difficulty-adjustments-table>
-          <div class="mt-1"><a [routerLink]="['/mining/hashrate' | relativeUrl]" i18n="dashboard.view-more">View more
+          <div><a [routerLink]="['/mining/hashrate' | relativeUrl]" i18n="dashboard.view-more">View more
               &raquo;</a></div>
         </div>
       </div>

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -151,6 +151,13 @@ export class ApiService {
       );
   }
 
+  getBlocks$(from: number): Observable<BlockExtended[]> {
+    return this.httpClient.get<BlockExtended[]>(
+      this.apiBasePath + this.apiBasePath + `/api/v1/blocks-extras` +
+      (from !== undefined ? `/${from}` : ``)
+    );
+  }
+
   getHistoricalDifficulty$(interval: string | undefined): Observable<any> {
     return this.httpClient.get<any[]>(
         this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/difficulty` +


### PR DESCRIPTION
First implementation of https://github.com/mempool/mempool/issues/1049

Consumes the `/blocks-extra` API endpoint to create a new blocks list page at `/mining/blocks`. There is some work to do on the pagination navigation (you can't "go to page" etc...) and also filters should be added in the future.

![image](https://user-images.githubusercontent.com/9780671/157912760-81f29346-8ae9-4cf0-9cbf-b8f45c4dd3e1.png)

![image](https://user-images.githubusercontent.com/9780671/157914640-1982172d-ccd3-433e-b2d2-7bc3bffc29bd.png)
