### PR TITLE
Fix database migration/typing issues

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -293,6 +293,7 @@ class DatabaseMigration {
    */
   private getMigrationQueriesFromVersion(version: number): string[] {
     const queries: string[] = [];
+    const isBitcoin = ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK);
 
     if (version < 1) {
       if (config.MEMPOOL.NETWORK !== 'liquid' && config.MEMPOOL.NETWORK !== 'liquidtestnet') {
@@ -300,11 +301,11 @@ class DatabaseMigration {
       }
     }
 
-    if (version < 7) {
+    if (version < 7 && isBitcoin === true) {
       queries.push(`INSERT INTO state(name, number, string) VALUES ('last_hashrates_indexing', 0, NULL)`);
     }
 
-    if (version < 9) {
+    if (version < 9  && isBitcoin === true) {
       queries.push(`INSERT INTO state(name, number, string) VALUES ('last_weekly_hashrates_indexing', 0, NULL)`);
     }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 12;
+  private static currentVersion = 13;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -159,6 +159,13 @@ class DatabaseMigration {
       if (databaseSchemaVersion < 12 && isBitcoin === true) {
         // No need to re-index because the new data type can contain larger values
         await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `fees` BIGINT UNSIGNED NOT NULL DEFAULT "0"');
+      }
+
+      if (databaseSchemaVersion < 13 && isBitcoin === true) {
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `difficulty` DOUBLE UNSIGNED NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `median_fee` BIGINT UNSIGNED NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `avg_fee` BIGINT UNSIGNED NOT NULL DEFAULT "0"');
+        await this.$executeQuery(connection, 'ALTER TABLE blocks MODIFY `avg_fee_rate` BIGINT UNSIGNED NOT NULL DEFAULT "0"');
       }
 
       connection.release();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -97,8 +97,10 @@ class Server {
           await databaseMigration.$truncateIndexedData(tables);
         }
         await databaseMigration.$initializeOrMigrateDatabase();
-        await this.$resetHashratesIndexingState();
-        await poolsParser.migratePoolsJson();
+        if (Common.indexingEnabled()) {
+          await this.$resetHashratesIndexingState();
+          await poolsParser.migratePoolsJson();
+        }
       } catch (e) {
         throw new Error(e instanceof Error ? e.message : 'Error');
       }


### PR DESCRIPTION
Increments db version to 13

Fixes

> Mar 11 19:52:09 node206  mempool[56081]: ERR <liquid> MIGRATIONS: Unable to migrate database, aborting. Error: Data too long for column 'name' at row 1