### PR TITLE
Fix docs navigation on desktop

### DIFF
--- a/frontend/src/app/components/docs/api-docs-nav.component.html
+++ b/frontend/src/app/components/docs/api-docs-nav.component.html
@@ -1,4 +1,4 @@
 <div *ngFor="let item of restDocs">
   <p *ngIf="( item.type === 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )">{{ item.title }}</p>
-  <a *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )" [routerLink]="['./']" fragment="{{ item.fragment }}" (click)="collapseItem.toggle()">{{ item.title }}</a>
+  <a *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )" [routerLink]="['./']" fragment="{{ item.fragment }}" (click)="navLinkClick($event)">{{ item.title }}</a>
 </div>

--- a/frontend/src/app/components/docs/api-docs-nav.component.ts
+++ b/frontend/src/app/components/docs/api-docs-nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { restApiDocsData } from './api-docs-data';
 
 @Component({
@@ -9,13 +9,17 @@ import { restApiDocsData } from './api-docs-data';
 export class ApiDocsNavComponent implements OnInit {
 
   @Input() network: any;
-  @Input() collapseItem: any = { toggle: () => {} };
+  @Output() navLinkClickEvent: EventEmitter<any> = new EventEmitter();
   restDocs: any[];
 
   constructor() { }
 
   ngOnInit(): void {
     this.restDocs = restApiDocsData;
+  }
+  
+  navLinkClick( event ) {
+    this.navLinkClickEvent.emit( event );
   }
 
 }

--- a/frontend/src/app/components/docs/api-docs.component.html
+++ b/frontend/src/app/components/docs/api-docs.component.html
@@ -4,7 +4,7 @@
     <div id="restAPI" *ngIf="restTabActivated">
 
       <div id="doc-nav-desktop" class="hide-on-mobile" [ngClass]="desktopDocsNavPosition">
-        <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
+        <app-api-docs-nav (navLinkClickEvent)="scrollSameId( $event )" [network]="{ val: network$ | async }"></app-api-docs-nav>
       </div>
 
       <div class="doc-content">
@@ -16,7 +16,7 @@
           <div #collapse="ngbCollapse" [(ngbCollapse)]="mobileMenuOpen">
             <div class="card">
               <div class="card-body">
-                <app-api-docs-nav [collapseItem]="collapse" [network]="{ val: network$ | async }"></app-api-docs-nav>
+                <app-api-docs-nav [network]="{ val: network$ | async }"></app-api-docs-nav>
               </div>
             </div>
           </div>
@@ -26,7 +26,7 @@
 
         <div *ngFor="let item of restDocs">
           <div *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )" class="endpoint-container" id="{{ item.fragment }}">
-            <a class="section-header" [routerLink]="['./']" fragment="{{ item.fragment }}">{{ item.title }} <span>{{ item.category }}</span></a>
+            <a class="section-header" (click)="scrollSameId( $event )" [routerLink]="['./']" fragment="{{ item.fragment }}">{{ item.title }} <span>{{ item.category }}</span></a>
             <div class="endpoint">
               <div class="subtitle" i18n="Api docs endpoint">Endpoint</div>
               <ng-container *ngIf="item.httpRequestMethod === 'GET' && network.val === 'bisq' && item.codeExample.hasOwnProperty('bisq');else liquid_link_example" #bisq_link_example>

--- a/frontend/src/app/components/docs/api-docs.component.ts
+++ b/frontend/src/app/components/docs/api-docs.component.ts
@@ -3,6 +3,7 @@ import { Env, StateService } from 'src/app/services/state.service';
 import { Observable, merge, of } from 'rxjs';
 import { SeoService } from 'src/app/services/seo.service';
 import { tap } from 'rxjs/operators';
+import { ActivatedRoute } from "@angular/router";
 import { restApiDocsData, wsApiDocsData } from './api-docs-data';
 
 @Component({
@@ -28,6 +29,7 @@ export class ApiDocsComponent implements OnInit {
   constructor(
     private stateService: StateService,
     private seoService: SeoService,
+    private route: ActivatedRoute,
   ) { }
 
   ngAfterViewInit() {
@@ -68,6 +70,13 @@ export class ApiDocsComponent implements OnInit {
     this.network$.subscribe((network) => {
       this.active = (network === 'liquid' || network === 'liquidtestnet') ? 2 : 0;
     });
+  }
+
+  scrollSameId( event: any ) {
+    const targetId = event.target.hash.substring(1);
+    if( this.route.snapshot.fragment === targetId ) {
+      document.getElementById( targetId ).scrollIntoView();
+    }
   }
 
   wrapUrl(network: string, code: any, websocket: boolean = false) {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -50,6 +50,7 @@ $dropdown-link-active-bg: #11131f;
 
 html, body {
   height: 100%;
+  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
These changes improve docs navigation for desktop.
- add smooth scrolling to prevent sudden changes when clicking anchor links
- fix anchor scrolling when navigating to the current anchor link
  - to test: 
    1. go to any REST API docs page on desktop (e.g. `/docs/api/rest`)
    2. click on an anchor link in the side nav (e.g. GET Block)...the browser should scroll you to the GET Block documentation
    3. scroll away so GET Block docs are off of your screen
    4. click the GET Block nav link again...you should be scrolled back to GET Block documentation again 

The current site fails at (d).

The next PR will improve docs navigation for mobile (i.e. get rid of the controversial pop-up menu in favor of a custom accordion).

With both parts merged, we'll have solid docs layout + navigation, which can then be used as the basis for FAQs.