### PR TITLE
Fix duplicate hashrate data points in "difficulty vs hashrate" chart

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -70,7 +70,7 @@ class BitcoinApi implements AbstractBitcoinApi {
     }
 
     return this.bitcoindClient.getBlock(hash)
-      .then((block: IBitcoinApi.Block) => this.convertBlock(block));
+      .then((block: IBitcoinApi.Block) => BitcoinApi.convertBlock(block));
   }
 
   $getAddress(address: string): Promise<IEsploraApi.Address> {
@@ -186,7 +186,7 @@ class BitcoinApi implements AbstractBitcoinApi {
     return esploraTransaction;
   }
 
-  private convertBlock(block: IBitcoinApi.Block): IEsploraApi.Block {
+  static convertBlock(block: IBitcoinApi.Block): IEsploraApi.Block {
     return {
       id: block.hash,
       height: block.height,

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 14;
+  private static currentVersion = 15;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -173,6 +173,12 @@ class DatabaseMigration {
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` DROP FOREIGN KEY `hashrates_ibfk_1`');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` MODIFY `pool_id` SMALLINT UNSIGNED NOT NULL DEFAULT "0"');
+      }
+
+      if (databaseSchemaVersion < 15 && isBitcoin === true) {
+        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
+        await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
+        await this.$executeQuery(connection, 'ALTER TABLE `hashrates` MODIFY `avg_hashrate` DOUBLE UNSIGNED NOT NULL DEFAULT "0"');
       }
 
       connection.release();

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 15;
+  private static currentVersion = 14;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -173,12 +173,6 @@ class DatabaseMigration {
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` DROP FOREIGN KEY `hashrates_ibfk_1`');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` MODIFY `pool_id` SMALLINT UNSIGNED NOT NULL DEFAULT "0"');
-      }
-
-      if (databaseSchemaVersion < 15 && isBitcoin === true) {
-        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
-        await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
-        await this.$executeQuery(connection, 'ALTER TABLE `hashrates` MODIFY `avg_hashrate` DOUBLE UNSIGNED NOT NULL DEFAULT "0"');
       }
 
       connection.release();

--- a/backend/src/api/liquid/elements-parser.ts
+++ b/backend/src/api/liquid/elements-parser.ts
@@ -33,7 +33,7 @@ class ElementsParser {
   }
 
   public async $getPegDataByMonth(): Promise<any> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const query = `SELECT SUM(amount) AS amount, DATE_FORMAT(FROM_UNIXTIME(datetime), '%Y-%m-01') AS date FROM elements_pegs GROUP BY DATE_FORMAT(FROM_UNIXTIME(datetime), '%Y%m')`;
     const [rows] = await connection.query<any>(query);
     connection.release();
@@ -79,7 +79,7 @@ class ElementsParser {
 
   protected async $savePegToDatabase(height: number, blockTime: number, amount: number, txid: string,
     txindex: number, bitcoinaddress: string, bitcointxid: string, bitcoinindex: number, final_tx: number): Promise<void> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const query = `INSERT INTO elements_pegs(
         block, datetime, amount, txid, txindex, bitcoinaddress, bitcointxid, bitcoinindex, final_tx
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
@@ -93,7 +93,7 @@ class ElementsParser {
   }
 
   protected async $getLatestBlockHeightFromDatabase(): Promise<number> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const query = `SELECT number FROM state WHERE name = 'last_elements_block'`;
     const [rows] = await connection.query<any>(query);
     connection.release();
@@ -101,7 +101,7 @@ class ElementsParser {
   }
 
   protected async $saveLatestBlockToDatabase(blockHeight: number) {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const query = `UPDATE state SET number = ? WHERE name = 'last_elements_block'`;
     await connection.query<any>(query, [blockHeight]);
     connection.release();

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -80,8 +80,8 @@ class Mining {
 
     // We only run this once a week
     const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing');
-    const now = new Date().getTime() / 1000;
-    if (now - latestTimestamp < 604800) {
+    const now = new Date();
+    if ((now.getTime() / 1000) - latestTimestamp < 604800) {
       return;
     }
 
@@ -94,7 +94,6 @@ class Mining {
       const hashrates: any[] = [];
       const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
 
-      const now = new Date();
       const lastMonday = new Date(now.setDate(now.getDate() - (now.getDay() + 6) % 7));
       const lastMondayMidnight = this.getDateMidnight(lastMonday);
       let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800) / 1000);
@@ -108,7 +107,7 @@ class Mining {
         const fromTimestamp = toTimestamp - 604800;
 
         // Skip already indexed weeks
-        if (indexedTimestamp.includes(toTimestamp + 1)) {
+        if (indexedTimestamp.includes(toTimestamp)) {
           toTimestamp -= 604800;
           ++totalIndexed;
           continue;
@@ -133,7 +132,7 @@ class Mining {
 
         for (const pool of pools) {
           hashrates.push({
-            hashrateTimestamp: toTimestamp + 1,
+            hashrateTimestamp: toTimestamp,
             avgHashrate: pool['hashrate'],
             poolId: pool.poolId,
             share: pool['share'],
@@ -202,7 +201,7 @@ class Mining {
         const fromTimestamp = toTimestamp - 86400;
 
         // Skip already indexed weeks
-        if (indexedTimestamp.includes(fromTimestamp)) {
+        if (indexedTimestamp.includes(toTimestamp)) {
           toTimestamp -= 86400;
           ++totalIndexed;
           continue;
@@ -220,7 +219,7 @@ class Mining {
         hashrates.push({
           hashrateTimestamp: toTimestamp,
           avgHashrate: lastBlockHashrate,
-          poolId: null,
+          poolId: 0,
           share: 1,
           type: 'daily',
         });

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -66,7 +66,7 @@ class PoolsParser {
     logger.debug(`Found ${poolNames.length} unique mining pools`);
 
     // Get existing pools from the db
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     let existingPools;
     try {
       [existingPools] = await connection.query<any>({ sql: 'SELECT * FROM pools;', timeout: 120000 });
@@ -152,7 +152,7 @@ class PoolsParser {
    * Manually add the 'unknown pool'
    */
   private async insertUnknownPool() {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows]: any[] = await connection.query({ sql: 'SELECT name from pools where name="Unknown"', timeout: 120000 });
       if (rows.length === 0) {

--- a/backend/src/api/statistics.ts
+++ b/backend/src/api/statistics.ts
@@ -155,7 +155,7 @@ class Statistics {
   }
 
   private async $createZeroedStatistic(): Promise<number | undefined> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const query = `INSERT INTO statistics(
               added,
@@ -216,7 +216,7 @@ class Statistics {
   }
 
   private async $create(statistics: Statistic): Promise<number | undefined> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const query = `INSERT INTO statistics(
               added,
@@ -421,7 +421,7 @@ class Statistics {
 
   private async $get(id: number): Promise<OptimizedStatistic | undefined> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics WHERE id = ?`;
       const [rows] = await connection.query<any>(query, [id]);
       connection.release();
@@ -435,7 +435,7 @@ class Statistics {
 
   public async $list2H(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 120`;
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -448,7 +448,7 @@ class Statistics {
 
   public async $list24H(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 1440`;
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -461,7 +461,7 @@ class Statistics {
 
   public async $list1W(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDaysAvg(300, '1 WEEK'); // 5m interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -474,7 +474,7 @@ class Statistics {
 
   public async $list1M(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDaysAvg(1800, '1 MONTH'); // 30m interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -487,7 +487,7 @@ class Statistics {
 
   public async $list3M(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDaysAvg(7200, '3 MONTH'); // 2h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -500,7 +500,7 @@ class Statistics {
 
   public async $list6M(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDaysAvg(10800, '6 MONTH'); // 3h interval 
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -513,7 +513,7 @@ class Statistics {
 
   public async $list1Y(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDays(28800, '1 YEAR'); // 8h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -526,7 +526,7 @@ class Statistics {
 
   public async $list2Y(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDays(28800, "2 YEAR"); // 8h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();
@@ -539,7 +539,7 @@ class Statistics {
 
   public async $list3Y(): Promise<OptimizedStatistic[]> {
     try {
-      const connection = await DB.pool.getConnection();
+      const connection = await DB.getConnection();
       const query = this.getQueryForDays(43200, "3 YEAR"); // 12h interval
       const [rows] = await connection.query<any>({ sql: query, timeout: this.queryTimeout });
       connection.release();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import * as WebSocket from 'ws';
 import * as cluster from 'cluster';
 import axios from 'axios';
 
-import { checkDbConnection } from './database';
+import { checkDbConnection, DB } from './database';
 import config from './config';
 import routes from './routes';
 import blocks from './api/blocks';
@@ -180,8 +180,8 @@ class Server {
 
     try {
       blocks.$generateBlockDatabase();
-      mining.$generateNetworkHashrateHistory();
-      mining.$generatePoolHashrateHistory();
+      await mining.$generateNetworkHashrateHistory();
+      await mining.$generatePoolHashrateHistory();
     } catch (e) {
       logger.err(`Unable to run indexing right now, trying again later. ` + e);
     }

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -8,7 +8,7 @@ class BlocksRepository {
    * Save indexed block data in the database
    */
   public async $saveBlockInDatabase(block: BlockExtended) {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
 
     try {
       const query = `INSERT INTO blocks(
@@ -70,7 +70,7 @@ class BlocksRepository {
       return [];
     }
 
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows]: any[] = await connection.query(`
         SELECT height
@@ -116,7 +116,7 @@ class BlocksRepository {
 
     query += ` GROUP by pools.id`;
 
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, params);
       connection.release();
@@ -154,7 +154,7 @@ class BlocksRepository {
     }
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, params);
       connection.release();
@@ -194,7 +194,7 @@ class BlocksRepository {
     query += ` blockTimestamp BETWEEN FROM_UNIXTIME('${from}') AND FROM_UNIXTIME('${to}')`;
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, params);
       connection.release();
@@ -217,7 +217,7 @@ class BlocksRepository {
       LIMIT 1;`;
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows]: any[] = await connection.query(query);
       connection.release();
@@ -253,7 +253,7 @@ class BlocksRepository {
       LIMIT 10`;
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, params);
       connection.release();
@@ -274,7 +274,7 @@ class BlocksRepository {
    * Get one block by height
    */
   public async $getBlockByHeight(height: number): Promise<object | null> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows]: any[] = await connection.query(`
         SELECT *, UNIX_TIMESTAMP(blocks.blockTimestamp) as blockTimestamp,
@@ -305,7 +305,7 @@ class BlocksRepository {
   public async $getBlocksDifficulty(interval: string | null): Promise<object[]> {
     interval = Common.getSqlInterval(interval);
 
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
 
     // :D ... Yeah don't ask me about this one https://stackoverflow.com/a/40303162
     // Basically, using temporary user defined fields, we are able to extract all
@@ -356,7 +356,7 @@ class BlocksRepository {
   }
 
   public async $getOldestIndexedBlockHeight(): Promise<number> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows]: any[] = await connection.query(`SELECT MIN(height) as minHeight FROM blocks`);
       connection.release();

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -8,7 +8,7 @@ class PoolsRepository {
    * Get all pools tagging info
    */
   public async $getPools(): Promise<PoolTag[]> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const [rows] = await connection.query('SELECT id, name, addresses, regexes FROM pools;');
     connection.release();
     return <PoolTag[]>rows;
@@ -18,7 +18,7 @@ class PoolsRepository {
    * Get unknown pool tagging info
    */
   public async $getUnknownPool(): Promise<PoolTag> {
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     const [rows] = await connection.query('SELECT id, name FROM pools where name = "Unknown"');
     connection.release();
     return <PoolTag>rows[0];
@@ -42,7 +42,7 @@ class PoolsRepository {
       ORDER BY COUNT(height) DESC`;
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query);
       connection.release();
@@ -64,7 +64,7 @@ class PoolsRepository {
       LEFT JOIN blocks on pools.id = blocks.pool_id AND blocks.blockTimestamp BETWEEN FROM_UNIXTIME(?) AND FROM_UNIXTIME(?)
       GROUP BY pools.id`;
 
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, [from, to]);
       connection.release();
@@ -87,7 +87,7 @@ class PoolsRepository {
       WHERE pools.id = ?`;
 
     // logger.debug(query);
-    const connection = await DB.pool.getConnection();
+    const connection = await DB.getConnection();
     try {
       const [rows] = await connection.query(query, [poolId]);
       connection.release();

--- a/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.component.html
+++ b/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.component.html
@@ -17,7 +17,7 @@
         </td>
         <td class="text-right">{{ diffChange.difficultyShorten }}</td>
         <td class="text-right" [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">
-          {{ diffChange.change >= 0 ? '+' : '' }}{{ formatNumber(diffChange.change, locale, '1.2-2') }}%
+          {{ diffChange.change >= 0 ? '+' : '' }}{{ diffChange.change | amountShortener }}%
         </td>
       </tr>
     </tbody>

--- a/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.components.ts
+++ b/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.components.ts
@@ -43,7 +43,7 @@ export class DifficultyAdjustmentsTable implements OnInit {
             const change = (data.difficulty[i].difficulty / data.difficulty[i - 1].difficulty - 1) * 100;
 
             tableData.push(Object.assign(data.difficulty[i], {
-              change: change,
+              change: Math.round(change * 100) / 100,
               difficultyShorten: formatNumber(
                 data.difficulty[i].difficulty / selectedPowerOfTen.divider,
                 this.locale, '1.2-2') + selectedPowerOfTen.unit

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -5,30 +5,32 @@
     <!-- Temporary stuff here - Will be moved to a component once we have more useful data to show -->
     <div class="col">
       <div class="main-title">Reward stats</div>
-      <div class="card" style="height: 123px">
-        <div class="card-body more-padding">
-          <div class="fee-estimation-container" *ngIf="$rewardStats | async as rewardStats; else loadingReward">
-            <div class="item">
-              <h5 class="card-title mb-1" i18n="mining.rewards">Miners Reward</h5>
-              <div class="card-text">
-                <app-amount [satoshis]="rewardStats.totalReward" digitsInfo="1.2-2" [noFiat]="true"></app-amount>
-                <div class="symbol">in the last 8 blocks</div>
+      <div class="card-wrapper">
+        <div class="card" style="height: 123px">
+          <div class="card-body more-padding">
+            <div class="reward-container" *ngIf="$rewardStats | async as rewardStats; else loadingReward">
+              <div class="item">
+                <h5 class="card-title" i18n="mining.rewards">Miners Reward</h5>
+                <div class="card-text">
+                  <app-amount [satoshis]="rewardStats.totalReward" digitsInfo="1.2-2" [noFiat]="true"></app-amount>
+                  <div class="symbol">in the last 8 blocks</div>
+                </div>
               </div>
-            </div>
-            <div class="item">
-              <h5 class="card-title mb-1" i18n="mining.rewards-per-tx">Reward Per Tx</h5>
-              <div class="card-text">
-                {{ rewardStats.rewardPerTx | amountShortener }}
-                <span class="symbol">sats/tx</span>
-                <div class="symbol">in the last 8 blocks</div>
+              <div class="item">
+                <h5 class="card-title" i18n="mining.rewards-per-tx">Reward Per Tx</h5>
+                <div class="card-text">
+                  {{ rewardStats.rewardPerTx | amountShortener }}
+                  <span class="symbol">sats/tx</span>
+                  <div class="symbol">in the last 8 blocks</div>
+                </div>
               </div>
-            </div>
-            <div class="item">
-              <h5 class="card-title mb-1" i18n="mining.average-fee">Average Fee</h5>
-              <div class="card-text">
-                {{ rewardStats.feePerTx | amountShortener}}
-                <span class="symbol">sats/tx</span>
-                <div class="symbol">in the last 8 blocks</div>
+              <div class="item">
+                <h5 class="card-title" i18n="mining.average-fee">Average Fee</h5>
+                <div class="card-text">
+                  {{ rewardStats.feePerTx | amountShortener}}
+                  <span class="symbol">sats/tx</span>
+                  <div class="symbol">in the last 8 blocks</div>
+                </div>
               </div>
             </div>
           </div>
@@ -36,24 +38,24 @@
       </div>
     </div>
     <ng-template #loadingReward>
-      <div class="fee-estimation-container">
+      <div class="reward-container">
         <div class="item">
-          <h5 class="card-title" i18n="">Miners Reward</h5>
-          <div class="card-text">
+          <h5 class="card-title" i18n="mining.rewards">Miners Reward</h5>
+          <div class="card-text skeleton">
             <div class="skeleton-loader"></div>
             <div class="skeleton-loader"></div>
           </div>
         </div>
         <div class="item">
-          <h5 class="card-title" i18n="">Reward Per Tx</h5>
-          <div class="card-text">
+          <h5 class="card-title" i18n="mining.rewards-per-tx">Reward Per Tx</h5>
+          <div class="card-text skeleton">
             <div class="skeleton-loader"></div>
             <div class="skeleton-loader"></div>
           </div>
         </div>
         <div class="item">
-          <h5 class="card-title" i18n="">Average Fee</h5>
-          <div class="card-text">
+          <h5 class="card-title" i18n="mining.average-fee">Average Fee</h5>
+          <div class="card-text skeleton">
             <div class="skeleton-loader"></div>
             <div class="skeleton-loader"></div>
           </div>

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
@@ -59,50 +59,57 @@
   padding-bottom: 3px;
 }
 
-.fee-estimation-container {
+.reward-container {
   display: flex;
-  justify-content: space-between;
-  @media (min-width: 376px) {
-    flex-direction: row;
+  flex-direction: row;
+  justify-content: space-around;
+  height: 76px;
+  .shared-block {
+    color: #ffffff66;
+    font-size: 12px;
   }
   .item {
-    max-width: 150px;
-    margin: 0;
-    width: -webkit-fill-available;
-    @media (min-width: 376px) {
-      margin: 0 auto 0px;
-    }
-    &:first-child{
+    display: table-cell;
+    padding: 0 5px;
+    width: 100%;
+    &:nth-child(1) {
       display: none;
       @media (min-width: 485px) {
-        display: block;
+        display: table-cell;
       }
       @media (min-width: 768px) {
         display: none;
       }
       @media (min-width: 992px) {
-        display: block;
+        display: table-cell;
       }
     }
-    &:last-child {
-      margin-bottom: 0;
-    }
-    .card-text span {
-      color: #ffffff66;
-      font-size: 12px;
-      top: 0px;
-    }
-    .fee-text{
-      border-bottom: 1px solid #ffffff1c;
-      width: fit-content;
-      margin: auto;
-      line-height: 1.45;
-      padding: 0px 2px;
-    }
-    .fiat {
-      display: block;
-      font-size: 14px !important;
-    }
+  }
+  .card-text {
+    font-size: 22px;
+    margin-top: -9px;
+    position: relative;
+  }
+  .card-text.skeleton {
+    margin-top: 0px;
+  }
+}
+
+.more-padding {
+  padding: 18px;
+}
+
+.card-wrapper {
+  .card {
+    height: auto !important;
+  }
+  .card-body {
+    display: flex;
+    flex: inherit;
+    text-align: center;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 22px 20px;
   }
 }
 

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.ts
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.ts
@@ -36,8 +36,8 @@ export class MiningDashboardComponent implements OnInit {
 
         return {
           'totalReward': totalReward,
-          'rewardPerTx': totalReward / totalTx,
-          'feePerTx': totalFee / totalTx,
+          'rewardPerTx': Math.round(totalReward / totalTx),
+          'feePerTx': Math.round(totalFee / totalTx),
         }
       })
     );

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -153,7 +153,7 @@ export class ApiService {
 
   getBlocks$(from: number): Observable<BlockExtended[]> {
     return this.httpClient.get<BlockExtended[]>(
-      this.apiBasePath + this.apiBasePath + `/api/v1/blocks-extras` +
+      this.apiBaseUrl + this.apiBasePath + `/api/v1/blocks-extras` +
       (from !== undefined ? `/${from}` : ``)
     );
   }

--- a/frontend/src/app/shared/pipes/amount-shortener.pipe.ts
+++ b/frontend/src/app/shared/pipes/amount-shortener.pipe.ts
@@ -1,22 +1,39 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+// https://medium.com/@thunderroid/angular-short-number-suffix-pipe-1k-2m-3b-dded4af82fb4
+
 @Pipe({
   name: 'amountShortener'
 })
 export class AmountShortenerPipe implements PipeTransform {
-  transform(num: number, ...args: number[]): unknown {
-    const digits = args[0] || 1;
-    const lookup = [
-      { value: 1, symbol: '' },
-      { value: 1e3, symbol: 'k' },
-      { value: 1e6, symbol: 'M' },
-      { value: 1e9, symbol: 'G' },
-      { value: 1e12, symbol: 'T' },
-      { value: 1e15, symbol: 'P' },
-      { value: 1e18, symbol: 'E' }
+  transform(number: number, args?: any): any {
+    if (isNaN(number)) return null; // will only work value is a number
+    if (number === null) return null;
+    if (number === 0) return null;
+    let abs = Math.abs(number);
+    const rounder = Math.pow(10, 1);
+    const isNegative = number < 0; // will also work for Negetive numbers
+    let key = '';
+
+    const powers = [
+      { key: 'E', value: 10e18 },
+      { key: 'P', value: 10e15 },
+      { key: 'T', value: 10e12 },
+      { key: 'B', value: 10e9 },
+      { key: 'M', value: 10e6 },
+      { key: 'K', value: 1000 }
     ];
-    const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
-    var item = lookup.slice().reverse().find((item) => num >= item.value);
-    return item ? (num / item.value).toFixed(digits).replace(rx, '$1') + item.symbol : '0';
+
+    for (let i = 0; i < powers.length; i++) {
+      let reduced = abs / powers[i].value;
+      reduced = Math.round(reduced * rounder) / rounder;
+      if (reduced >= 1) {
+        abs = reduced;
+        key = powers[i].key;
+        break;
+      }
+    }
+
+    return (isNegative ? '-' : '') + abs + key;
   }
 }


### PR DESCRIPTION
* Increments DB schema version to 14 to fix unique constraint by making pool_id = 0 instead of NULL
* Use wrapper around getBlock() to call Bitcoin Core RPC instead of esplora backend, due to https://github.com/Blockstream/esplora/issues/370
* Use wrapper around DB.getConnection() so we can always set session time zone to UTC upon connecting