### PR TITLE
Capitalize js package labels in docs

### DIFF
--- a/frontend/src/app/components/docs/code-template.component.html
+++ b/frontend/src/app/components/docs/code-template.component.html
@@ -12,7 +12,7 @@
       <ng-template ngbNavContent>
         <div class="subtitle"><ng-container i18n="API Docs code example">Code Example</ng-container> <app-clipboard [text]="wrapCommonJS(code)"></app-clipboard></div>
         <div class="links">
-          <a [href]="npmGithubLink()" target="_blank">github repository</a>
+          <a [href]="npmGithubLink()" target="_blank">GitHub Repo</a>
         </div>
         <pre><code [innerText]="wrapCommonJS(code)"></code></pre>
       </ng-template>
@@ -22,8 +22,8 @@
       <ng-template ngbNavContent>
         <div class="subtitle"><ng-container i18n="API Docs install lib">Install Package</ng-container> <app-clipboard [text]="wrapImportTemplate()"></app-clipboard></div>
         <div class="links">
-          <a [href]="npmGithubLink()" target="_blank">github repository</a>
-          <a [href]="npmModuleLink()" target="_blank">npm package</a>
+          <a [href]="npmGithubLink()" target="_blank">GitHub Repo</a>
+          <a [href]="npmModuleLink()" target="_blank">NPM Package</a>
         </div>
         <pre><code [innerText]="wrapImportTemplate()"></code></pre>
         <div class="subtitle"><ng-container i18n="API Docs code example">Code Example</ng-container> <app-clipboard [text]="wrapEsModule(code)"></app-clipboard></div>


### PR DESCRIPTION
This change is very minor but bugs me.

## Current labels

All-lowercase looks sloppy and unprofessional.

![Screenshot from 2022-03-14 13-08-57](https://user-images.githubusercontent.com/93150691/158224583-1475868e-0ca9-44eb-ac57-a780566e5cf4.png)

## Proposed Labels (this PR)

Better.

![Screenshot from 2022-03-14 13-09-10](https://user-images.githubusercontent.com/93150691/158224597-57f6721f-c38b-4122-ae87-4c1bce866783.png)

## Alternative (not implemented, but could be if desired)

Icons courtesy of [Simple Icons](https://simpleicons.org/).

![Screenshot from 2022-03-14 13-09-17](https://user-images.githubusercontent.com/93150691/158224625-80a12fba-75b8-4dfa-a296-854097e747a4.png)

![Screenshot from 2022-03-14 13-09-36](https://user-images.githubusercontent.com/93150691/158224633-5ed1a026-2d39-44c8-a3c6-5c30792f5f67.png)