### PR TITLE
Fix typo in hashrate widget

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -6,7 +6,7 @@
         <h5 class="card-title" i18n="mining.hashrate">Hashrate</h5>
         <p class="card-text">
           {{ hashrates.currentHashrate | amountShortener }}
-          <span class="symbol">hashes/tx</span>
+          <span class="symbol">hashes/sec</span>
         </p>
       </div>
       <div class="item">


### PR DESCRIPTION
Fix typo introduced in https://github.com/mempool/mempool/pull/1362