### PR TITLE
[Indexing] - Support 10 blocks depth reorgs

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -23,6 +23,7 @@ class Blocks {
   private newBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: TransactionExtended[]) => void)[] = [];
   private blockIndexingStarted = false;
   public blockIndexingCompleted = false;
+  public reindexFlag = true; // Always re-index the latest indexed data in case the node went offline with an invalid block tip (reorg)
 
   constructor() { }
 
@@ -189,9 +190,11 @@ class Blocks {
    * [INDEXING] Index all blocks metadata for the mining dashboard
    */
   public async $generateBlockDatabase() {
-    if (this.blockIndexingStarted) {
+    if (this.blockIndexingStarted && !this.reindexFlag) {
       return;
     }
+
+    this.reindexFlag = false;
 
     const blockchainInfo = await bitcoinClient.getBlockchainInfo();
     if (blockchainInfo.blocks !== blockchainInfo.headers) { // Wait for node to sync
@@ -199,6 +202,7 @@ class Blocks {
     }
 
     this.blockIndexingStarted = true;
+    this.blockIndexingCompleted = false;
 
     try {
       let currentBlockHeight = blockchainInfo.blocks;
@@ -316,6 +320,12 @@ class Blocks {
 
       if (Common.indexingEnabled()) {
         await blocksRepository.$saveBlockInDatabase(blockExtended);
+
+        // If the last 10 blocks chain is not valid, re-index them (reorg)
+        const chainValid = await blocksRepository.$validateRecentBlocks();
+        if (!chainValid) {
+          this.reindexFlag = true;
+        }
       }
 
       if (block.height % 2016 === 0) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import icons from './api/liquid/icons';
 import { Common } from './api/common';
 import mining from './api/mining';
 import HashratesRepository from './repositories/HashratesRepository';
+import BlocksRepository from './repositories/BlocksRepository';
 import poolsUpdater from './tasks/pools-updater';
 
 class Server {
@@ -179,6 +180,10 @@ class Server {
 
     try {
       await poolsUpdater.updatePoolsJson();
+      if (blocks.reindexFlag) {
+        await BlocksRepository.$deleteBlocks(10);
+        await HashratesRepository.$deleteLastEntries();
+      }
       blocks.$generateBlockDatabase();
       await mining.$generateNetworkHashrateHistory();
       await mining.$generatePoolHashrateHistory();

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -169,6 +169,9 @@ class HashratesRepository {
     }
   }
 
+  /**
+   * Set latest run timestamp
+   */
   public async $setLatestRunTimestamp(key: string, val: any = null) {
     const connection = await DB.getConnection();
     const query = `UPDATE state SET number = ? WHERE name = ?`;
@@ -181,6 +184,9 @@ class HashratesRepository {
     }
   }
 
+  /**
+   * Get latest run timestamp
+   */
   public async $getLatestRunTimestamp(key: string): Promise<number> {
     const connection = await DB.getConnection();
     const query = `SELECT number FROM state WHERE name = ?`;
@@ -198,6 +204,29 @@ class HashratesRepository {
       logger.err('$setLatestRunTimestamp() error' + (e instanceof Error ? e.message : e));
       throw e;
     }
+  }
+
+  /**
+   * Delete most recent data points for re-indexing
+   */
+  public async $deleteLastEntries() {
+    logger.debug(`Delete latest hashrates data points from the database`);
+
+    let connection;
+    try {
+      connection = await DB.getConnection();
+      const [rows] = await connection.query(`SELECT MAX(hashrate_timestamp) as timestamp FROM hashrates GROUP BY type`);
+      for (const row of rows) {
+        await connection.query(`DELETE FROM hashrates WHERE hashrate_timestamp = ?`, [row.timestamp]);
+      }
+      // Re-run the hashrate indexing to fill up missing data
+      await this.$setLatestRunTimestamp('last_hashrates_indexing', 0);
+      await this.$setLatestRunTimestamp('last_weekly_hashrates_indexing', 0);
+    } catch (e) {
+      logger.err('$deleteLastEntries() error' + (e instanceof Error ? e.message : e));
+    }
+
+    connection.release();
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1221

This is very basic implementation of reorg support for indexing.

* When we're done indexing a newly received block, we validate the chain of the past 10 indexed blocks
  * If the chain is broken, then we delete the past 10 indexed blocks, the last network hashrate daily entry and the last pools weekly  hashrate entries
  * We then re-index this data as usual
* When the node backend starts, we always re-index the previously mentioned data, in case the node went offline with a now invalid chain 

### How to test

1. Save latest indexed block hash
```mysql
MariaDB [mempool]> select height, hash from blocks order by height desc limit 1;
+--------+------------------------------------------------------------------+
| height | hash                                                             |
+--------+------------------------------------------------------------------+
| 727443 | 0000000000000000000702e1aab00e57c8727df44fe98f923429990dd273799f |
+--------+------------------------------------------------------------------+
```
2. Manually change the most recent block `blocks.hash` in the database to simulate a network fork
```mysql
MariaDB [mempool]> UPDATE `blocks` SET `hash` = '8aeaa61e5110ab6df6378cad7e9000000000004a8160b3d19230000000015314' WHERE `height` = '727443';
Query OK, 1 row affected (0.009 sec)
Rows matched: 1  Changed: 1  Warnings: 0

MariaDB [mempool]> select height, hash from blocks order by height desc limit 1;
+--------+------------------------------------------------------------------+
| height | hash                                                             |
+--------+------------------------------------------------------------------+
| 727443 | 8aeaa61e5110ab6df6378cad7e9000000000004a8160b3d19230000000015314 |
+--------+------------------------------------------------------------------+

```
3. Wait for a new block to be mined. In the log, you should see the following
  ```sh
Mar 15 13:43:29 [16547] NOTICE: Chain divergence detected at block 727444, re-indexing most recent data
Mar 15 13:43:29 [16547] DEBUG: Delete 10 most recent indexed blocks from the database
Mar 15 13:43:29 [16547] DEBUG: Delete latest hashrates data points from the database
Mar 15 13:43:29 [16547] INFO: Indexing blocks from #727444 to #0
Mar 15 13:43:30 [16547] DEBUG: Indexing 10 blocks from #727444 to #717443
Mar 15 13:43:36 [16547] INFO: Block indexing completed
Mar 15 13:43:36 [16547] INFO: Indexing network daily hashrate
Mar 15 13:43:36 [16547] INFO: Indexing mining pools weekly hashrates
Mar 15 13:43:36 [16547] INFO: Daily network hashrate indexing completed
Mar 15 13:43:36 [16547] INFO: Weekly pools hashrate indexing complete
  ```
4. Verify that the invalid block modified in step 1 has properly been re-indexed:
```mysql
MariaDB [mempool]> select height, hash from blocks where height = 727443;
+--------+------------------------------------------------------------------+
| height | hash                                                             |
+--------+------------------------------------------------------------------+
| 727443 | 0000000000000000000702e1aab00e57c8727df44fe98f923429990dd273799f |
+--------+------------------------------------------------------------------+
```