### PR TITLE
Don't navigate to root when sub network url is wrong.

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -294,7 +294,7 @@ let routes: Routes = [
       },
       {
         path: '**',
-        redirectTo: ''
+        redirectTo: '/testnet'
       },
     ]
   },
@@ -430,7 +430,7 @@ let routes: Routes = [
       },
       {
         path: '**',
-        redirectTo: ''
+        redirectTo: '/signet'
       },
     ]
   },
@@ -738,7 +738,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
   },
   {
     path: '**',
-    redirectTo: ''
+    redirectTo: '/testnet'
   }];
 }
 


### PR DESCRIPTION
When going to for example [mempool.ninja/testnet/foo](url) it should redirect to `/testnet` not `/`

fixes #1399