### PR TITLE
Use 10 minutes avg block time for halving calculation

### DIFF
--- a/frontend/src/app/components/difficulty/difficulty.component.ts
+++ b/frontend/src/app/components/difficulty/difficulty.component.ts
@@ -63,10 +63,8 @@ export class DifficultyComponent implements OnInit {
           colorPreviousAdjustments = '#ffffff66';
         }
 
-        const timeAvgMins = da.timeAvg;
-        const now = new Date().getTime() / 1000;
         const blocksUntilHalving = 210000 - (block.height % 210000);
-        const timeUntilHalving = (blocksUntilHalving * timeAvgMins * 60 * 1000) + (now * 1000);
+        const timeUntilHalving = new Date().getTime() + (blocksUntilHalving * 600000);
 
         const data = {
           base: `${da.progressPercent.toFixed(2)}%`,


### PR DESCRIPTION
Use hard coded 10 minutes average block time for calculating the next halving time, since over long period of time the average should be around 10 minutes.

Fixes https://github.com/mempool/mempool/issues/1405