### PR TITLE
If we have incomplete data for the day/week, don't index hashrate

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -113,12 +113,16 @@ class Mining {
           continue;
         }
 
-        const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp, toTimestamp);
-        if (blockStats.blockCount === 0) { // We are done indexing, no blocks left
+        // Check if we have blocks for the previous week (which mean that the week
+        // we are currently indexing has complete data)
+        const blockStatsPreviousWeek: any = await BlocksRepository.$blockCountBetweenTimestamp(
+          null, fromTimestamp - 604800, toTimestamp - 604800);
+        if (blockStatsPreviousWeek.blockCount === 0) { // We are done indexing
           break;
         }
 
+        const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
+          null, fromTimestamp, toTimestamp);
         const lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
           blockStats.lastBlockHeight);
 
@@ -207,12 +211,16 @@ class Mining {
           continue;
         }
 
-        const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp, toTimestamp);
-        if (blockStats.blockCount === 0) { // We are done indexing, no blocks left
+        // Check if we have blocks for the previous day (which mean that the day
+        // we are currently indexing has complete data)
+        const blockStatsPreviousDay: any = await BlocksRepository.$blockCountBetweenTimestamp(
+          null, fromTimestamp - 86400, toTimestamp - 86400);
+        if (blockStatsPreviousDay.blockCount === 0) { // We are done indexing
           break;
         }
 
+        const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
+          null, fromTimestamp, toTimestamp);
         const lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
           blockStats.lastBlockHeight);
 


### PR DESCRIPTION
Until now, hashrates indexing was using all available data set even if it was incomplete, leading to discrepancy in the results between setups.

Basic example of what was done wrong:
* We have 145 indexed blocks
* We generate 2 daily hashrates entries
  * One for yesterday's 144 blocks
  * One for the day before yesterday's (145 - 144) blocks => Here the data set is incomplete, there was probably more than 1 block during that day. When we call `getnetworkhashps 1 {blockHeight}` we will get a near random value (super volatile hashrate)

This PR adds one additional check during the hashrate indexing, which stop indexing hashrates at the last full day/week data set. Older incomplete day/week will not be indexed unless additional older blocks are indexed in the future.

### How to test

* `TRUNCATE blocks; TRUNCATE hashrates;`
* Set `INDEXING_BLOCKS_AMOUNT` to `2000`
* Run the node backend and wait for blocks and hashrates indexing to complete

* Note the oldest `blockTimestamp` you've indexed
```mysql
MariaDB [mempool]> SELECT MIN(blockTimestamp), DAYOFWEEK(MIN(blockTimestamp)) from blocks;
+---------------------+--------------------------------+
| MIN(blockTimestamp) | DAYOFWEEK(MIN(blockTimestamp)) |
+---------------------+--------------------------------+
| 2022-03-08 02:15:42 |                              3 |
+---------------------+--------------------------------+
```
* Here we can se see that the day from `2022-03-08 00:00:00` to `2022-03-09 00:00:00` is not complete (we are missing 02:15:42 worth of data). Therefore our last full indexed day is between `2022-03-09 00:00:00` and `2022-03-10 00:00:00`. You can confirmed with the following command.

```mysql
MariaDB [mempool]> SELECT MIN(hashrate_timestamp) from hashrates where type='daily';
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-10 00:00:00     |
+-------------------------+
```
* March 8th is on Tuesday, therefore, the week from `2022-03-07 00:00:00` to `2022-03-14 00:00:00` is incomplete (we are missing Monday and a bit of data for Tuesday as well. Therefore our last full indexed week is between `2022-03-14 00:00:00` and `2022-03-21 00:00:00`. You can confirmed with the following command.
```mysql
MariaDB [mempool]> SELECT MIN(hashrate_timestamp) from hashrates where type='weekly';
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-20 23:49:55     | // Ignore the 10 minutes 5 seconds gap, that's another weird thing I need to figure out :P ...
+-------------------------+
```

### Before the fix
```mysql
MariaDB [mempool]> SELECT MIN(hashrate_timestamp) from hashrates where type='daily';
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-09 00:00:00     |
+-------------------------+
```
```mysql
MariaDB [mempool]> SELECT MIN(hashrate_timestamp) from hashrates where type='weekly';
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-13 23:49:55     |
+-------------------------+
```