### PR TITLE
Set weekly hashrates timestamp to midnight

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -92,11 +92,11 @@ class Mining {
 
       const indexedTimestamp = await HashratesRepository.$getWeeklyHashrateTimestamps();
       const hashrates: any[] = [];
-      const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+      const genesisTimestamp = 1231006505000; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
 
       const lastMonday = new Date(now.setDate(now.getDate() - (now.getDay() + 6) % 7));
       const lastMondayMidnight = this.getDateMidnight(lastMonday);
-      let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800000));
+      let toTimestamp = lastMondayMidnight.getTime();
 
       const totalWeekIndexed = (await BlocksRepository.$blockCount(null, null)) / 1008;
       let indexedThisRun = 0;
@@ -116,7 +116,7 @@ class Mining {
         // Check if we have blocks for the previous week (which mean that the week
         // we are currently indexing has complete data)
         const blockStatsPreviousWeek: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp - 604800000, toTimestamp - 604800000);
+          null, (fromTimestamp - 604800000) / 1000, (toTimestamp - 604800000) / 1000);
         if (blockStatsPreviousWeek.blockCount === 0) { // We are done indexing
           break;
         }
@@ -191,7 +191,7 @@ class Mining {
       logger.info(`Indexing network daily hashrate`);
 
       const indexedTimestamp = (await HashratesRepository.$getNetworkDailyHashrate(null)).map(hashrate => hashrate.timestamp);
-      const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+      const genesisTimestamp = 1231006505000; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
       const lastMidnight = this.getDateMidnight(new Date());
       let toTimestamp = Math.round(lastMidnight.getTime());
       const hashrates: any[] = [];
@@ -214,7 +214,7 @@ class Mining {
         // Check if we have blocks for the previous day (which mean that the day
         // we are currently indexing has complete data)
         const blockStatsPreviousDay: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp - 86400000, toTimestamp - 86400000);
+          null, (fromTimestamp - 86400000) / 1000, (toTimestamp - 86400000) / 1000);
         if (blockStatsPreviousDay.blockCount === 0) { // We are done indexing
           break;
         }

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -79,9 +79,9 @@ class Mining {
     }
 
     // We only run this once a week
-    const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing');
+    const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing') * 1000;
     const now = new Date();
-    if ((now.getTime() / 1000) - latestTimestamp < 604800) {
+    if (now.getTime() - latestTimestamp < 604800000) {
       return;
     }
 
@@ -96,19 +96,19 @@ class Mining {
 
       const lastMonday = new Date(now.setDate(now.getDate() - (now.getDay() + 6) % 7));
       const lastMondayMidnight = this.getDateMidnight(lastMonday);
-      let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800) / 1000);
+      let toTimestamp = Math.round((lastMondayMidnight.getTime() - 604800000));
 
       const totalWeekIndexed = (await BlocksRepository.$blockCount(null, null)) / 1008;
       let indexedThisRun = 0;
       let totalIndexed = 0;
-      let startedAt = new Date().getTime() / 1000;
+      let startedAt = new Date().getTime();
 
       while (toTimestamp > genesisTimestamp) {
-        const fromTimestamp = toTimestamp - 604800;
+        const fromTimestamp = toTimestamp - 604800000;
 
         // Skip already indexed weeks
-        if (indexedTimestamp.includes(toTimestamp)) {
-          toTimestamp -= 604800;
+        if (indexedTimestamp.includes(toTimestamp / 1000)) {
+          toTimestamp -= 604800000;
           ++totalIndexed;
           continue;
         }
@@ -116,17 +116,17 @@ class Mining {
         // Check if we have blocks for the previous week (which mean that the week
         // we are currently indexing has complete data)
         const blockStatsPreviousWeek: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp - 604800, toTimestamp - 604800);
+          null, fromTimestamp - 604800000, toTimestamp - 604800000);
         if (blockStatsPreviousWeek.blockCount === 0) { // We are done indexing
           break;
         }
 
         const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp, toTimestamp);
+          null, fromTimestamp / 1000, toTimestamp / 1000);
         const lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
           blockStats.lastBlockHeight);
 
-        let pools = await PoolsRepository.$getPoolsInfoBetween(fromTimestamp, toTimestamp);
+        let pools = await PoolsRepository.$getPoolsInfoBetween(fromTimestamp / 1000, toTimestamp / 1000);
         const totalBlocks = pools.reduce((acc, pool) => acc + pool.blockCount, 0);
         pools = pools.map((pool: any) => {
           pool.hashrate = (pool.blockCount / totalBlocks) * lastBlockHashrate;
@@ -136,7 +136,7 @@ class Mining {
 
         for (const pool of pools) {
           hashrates.push({
-            hashrateTimestamp: toTimestamp,
+            hashrateTimestamp: toTimestamp / 1000,
             avgHashrate: pool['hashrate'],
             poolId: pool.poolId,
             share: pool['share'],
@@ -147,17 +147,17 @@ class Mining {
         await HashratesRepository.$saveHashrates(hashrates);
         hashrates.length = 0;
 
-        const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
+        const elapsedSeconds = Math.max(1, Math.round((new Date().getTime()) - startedAt));
         if (elapsedSeconds > 1) {
           const weeksPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
-          const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
+          const formattedDate = new Date(fromTimestamp).toUTCString();
           const weeksLeft = Math.round(totalWeekIndexed - totalIndexed);
           logger.debug(`Getting weekly pool hashrate for ${formattedDate} | ~${weeksPerSeconds} weeks/sec | ~${weeksLeft} weeks left to index`);
-          startedAt = new Date().getTime() / 1000;
+          startedAt = new Date().getTime();
           indexedThisRun = 0;
         }
 
-        toTimestamp -= 604800;
+        toTimestamp -= 604800000;
         ++indexedThisRun;
         ++totalIndexed;
       }
@@ -180,8 +180,8 @@ class Mining {
 
     // We only run this once a day
     const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_hashrates_indexing');
-    const now = new Date().getTime() / 1000;
-    if (now - latestTimestamp < 86400) {
+    const now = new Date().getTime();
+    if (now - latestTimestamp < 86400000) {
       return;
     }
 
@@ -193,20 +193,20 @@ class Mining {
       const indexedTimestamp = (await HashratesRepository.$getNetworkDailyHashrate(null)).map(hashrate => hashrate.timestamp);
       const genesisTimestamp = 1231006505; // bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
       const lastMidnight = this.getDateMidnight(new Date());
-      let toTimestamp = Math.round(lastMidnight.getTime() / 1000);
+      let toTimestamp = Math.round(lastMidnight.getTime());
       const hashrates: any[] = [];
 
       const totalDayIndexed = (await BlocksRepository.$blockCount(null, null)) / 144;
       let indexedThisRun = 0;
       let totalIndexed = 0;
-      let startedAt = new Date().getTime() / 1000;
+      let startedAt = new Date().getTime();
 
       while (toTimestamp > genesisTimestamp) {
-        const fromTimestamp = toTimestamp - 86400;
+        const fromTimestamp = toTimestamp - 86400000;
 
         // Skip already indexed weeks
-        if (indexedTimestamp.includes(toTimestamp)) {
-          toTimestamp -= 86400;
+        if (indexedTimestamp.includes(toTimestamp / 1000)) {
+          toTimestamp -= 86400000;
           ++totalIndexed;
           continue;
         }
@@ -214,18 +214,18 @@ class Mining {
         // Check if we have blocks for the previous day (which mean that the day
         // we are currently indexing has complete data)
         const blockStatsPreviousDay: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp - 86400, toTimestamp - 86400);
+          null, fromTimestamp - 86400000, toTimestamp - 86400000);
         if (blockStatsPreviousDay.blockCount === 0) { // We are done indexing
           break;
         }
 
         const blockStats: any = await BlocksRepository.$blockCountBetweenTimestamp(
-          null, fromTimestamp, toTimestamp);
+          null, fromTimestamp / 1000, toTimestamp / 1000);
         const lastBlockHashrate = await bitcoinClient.getNetworkHashPs(blockStats.blockCount,
           blockStats.lastBlockHeight);
 
         hashrates.push({
-          hashrateTimestamp: toTimestamp,
+          hashrateTimestamp: toTimestamp / 1000,
           avgHashrate: lastBlockHashrate,
           poolId: 0,
           share: 1,
@@ -237,17 +237,17 @@ class Mining {
           hashrates.length = 0;
         }
 
-        const elapsedSeconds = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
+        const elapsedSeconds = Math.max(1, Math.round(new Date().getTime() - startedAt));
         if (elapsedSeconds > 1) {
           const daysPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
-          const formattedDate = new Date(fromTimestamp * 1000).toUTCString();
+          const formattedDate = new Date(fromTimestamp).toUTCString();
           const daysLeft = Math.round(totalDayIndexed - totalIndexed);
           logger.debug(`Getting network daily hashrate for ${formattedDate} | ~${daysPerSeconds} days/sec | ~${daysLeft} days left to index`);
-          startedAt = new Date().getTime() / 1000;
+          startedAt = new Date().getTime();
           indexedThisRun = 0;
         }
 
-        toTimestamp -= 86400;
+        toTimestamp -= 86400000;
         ++indexedThisRun;
         ++totalIndexed;
       }


### PR DESCRIPTION
Because of early timestamp truncating I was doing in the weekly hashrates indexing loop, all timestamp were off by a bit, instead of being set to exactly midnight (for timestamps, javascript uses milliseconds, mariadb uses seconds).

We now divide javascript timestamps by `/ 1000` only when we need to make a db query, so we avoid rounding error during the indexing loop.

### How to test

* Note the shifted timestamp on weekly hashrates
```mysql
MariaDB [mempool]> select hashrate_timestamp from hashrates where type='weekly' limit 1;
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-13 23:49:55     |
+-------------------------+
```
* `TRUNCATE hashrates;`
* Restart node backend and wait for hashrates to re-index
* Verify if weekly hashrates are now on midnight 
```mysql
MariaDB [mempool]> select hashrate_timestamp from hashrates where type='weekly' limit 1;
+-------------------------+
| MIN(hashrate_timestamp) |
+-------------------------+
| 2022-03-14 00:00:00     |
+-------------------------+
```