### PR TITLE
Format Transaction vBytes per second (vB/s) tooltip value

### DIFF
--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -3,6 +3,7 @@ import { EChartsOption } from 'echarts';
 import { OnChanges } from '@angular/core';
 import { StorageService } from 'src/app/services/storage.service';
 import { formatterXAxis, formatterXAxisLabel } from 'src/app/shared/graphs.utils';
+import { formatNumber } from '@angular/common';
 
 @Component({
   selector: 'app-incoming-transactions-graph',
@@ -116,7 +117,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
               itemFormatted += `<div class="item">
                 <div class="indicator-container">${colorSpan(item.color)}</div>
                 <div class="grow"></div>
-                <div class="value">${item.value[1]} <span class="symbol">vB/s</span></div>
+                <div class="value">${formatNumber(item.value[1], this.locale, '1.0-0')}<span class="symbol">vB/s</span></div>
               </div>`;
             }
           });


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1276

It seems that production database is storing `statistics.vbytes_per_second` into a `double` instead of an `unsigned integer`. In the database migration, it shows that it's supposed to be an `unsigned integer` (see https://github.com/mempool/mempool/blob/master/backend/src/api/database-migration.ts#L379). I guess this is just a legacy table.

To fix the decimal point issue you can either:
* Merge this PR (format in the front end), which also format the number using the user's locale
* Manually change production db `statistics.vbytes_per_second` db field type to `unsigned integer`, which should truncate all values to the nearest integer (loss of precision, non reversible)

### Before

![image](https://user-images.githubusercontent.com/9780671/159426449-797b50c1-4989-4320-b94f-fff665328bf6.png)

### After

![image](https://user-images.githubusercontent.com/9780671/159426526-879e0800-0c50-4e4b-8723-b1b32d38709a.png)
