### PR TITLE
Don't show coinbase tooltip on mining dashboard

### DIFF
--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -30,7 +30,7 @@
                   onError="this.src = './resources/mining-pools/default.svg'">
                 <span class="pool-name">{{ block.extras.pool.name }}</span>
               </a>
-              <span class="tooltiptext badge badge-secondary scriptmessage">{{ block.extras.coinbaseRaw | hex2ascii }}</span>
+              <span *ngIf="!widget" class="tooltiptext badge badge-secondary scriptmessage">{{ block.extras.coinbaseRaw | hex2ascii }}</span>
             </div>
           </td>
           <td class="timestamp" *ngIf="!widget">


### PR DESCRIPTION
@wiz mentioned this last week, unsure where we stand today on this. Feel free to close if you want to keep the tooltip enabled in the mining dashboard, this PR disables it when we're in widget mode.

![image](https://user-images.githubusercontent.com/9780671/159450881-31e40683-fdd5-4666-9727-becb2aadb5e2.png)
