### PR TITLE
Append missing addresses to bisq transactions

### DIFF
--- a/frontend/src/app/bisq/bisq-transaction/bisq-transaction.component.html
+++ b/frontend/src/app/bisq/bisq-transaction/bisq-transaction.component.html
@@ -67,14 +67,11 @@
                 </tr>
                 <tr>
                   <td i18n="transaction.fee-per-vbyte|Transaction fee">Fee per vByte</td>
-                  <td *ngIf="!isLoadingTx; else loadingTxFee">
+                  <td>
                     {{ tx.fee / (tx.weight / 4) | feeRounding }} <span class="symbol">sat/vB</span>
                     &nbsp;
                     <app-tx-fee-rating [tx]="tx"></app-tx-fee-rating>
                   </td>
-                  <ng-template #loadingTxFee>
-                    <td><span class="skeleton-loader"></span></td>
-                  </ng-template>
                 </tr>
               </tbody>
             </table>

--- a/frontend/src/app/bisq/bisq-transaction/bisq-transaction.component.ts
+++ b/frontend/src/app/bisq/bisq-transaction/bisq-transaction.component.ts
@@ -23,7 +23,6 @@ export class BisqTransactionComponent implements OnInit, OnDestroy {
   txId: string;
   price: number;
   isLoading = true;
-  isLoadingTx = true;
   error = null;
   subscription: Subscription;
 
@@ -43,7 +42,6 @@ export class BisqTransactionComponent implements OnInit, OnDestroy {
     this.subscription = this.route.paramMap.pipe(
       switchMap((params: ParamMap) => {
         this.isLoading = true;
-        this.isLoadingTx = true;
         this.error = null;
         document.body.scrollTo(0, 0);
         this.txId = params.get('id') || '';
@@ -94,19 +92,29 @@ export class BisqTransactionComponent implements OnInit, OnDestroy {
         }
 
         this.bisqTx = tx;
-        this.isLoading = false;
 
         return this.electrsApiService.getTransaction$(this.txId);
       }),
     )
-    .subscribe((tx) => {
-      this.isLoadingTx = false;
+    .subscribe((tx: Transaction) => {
+      this.isLoading = false;
 
       if (!tx) {
         return;
       }
 
       this.tx = tx;
+
+      try {
+        for (let i = 0; i < this.bisqTx.outputs.length; i++) {
+          this.bisqTx.outputs[i].address = tx.vout[i].scriptpubkey_address;
+        }
+        for (let i = 0; i < this.bisqTx.inputs.length; i++) {
+          this.bisqTx.inputs[i].address = tx.vin[i].prevout.scriptpubkey_address;
+        }
+      } catch (e) {
+        console.log(e);
+      }
     },
     (error) => {
       this.error = error;


### PR DESCRIPTION
The new Bisq JSON data format is missing the addresses so we just use the address data from the actual Bitcoin transaction.

Before
<img width="767" alt="Screen Shot 2022-03-24 at 01 19 40" src="https://user-images.githubusercontent.com/8561090/159797546-400bdb1e-42da-4f21-bdfc-4e92e105a9fd.png">

After
<img width="926" alt="Screen Shot 2022-03-24 at 01 19 45" src="https://user-images.githubusercontent.com/8561090/159797557-6fd0b3d0-54dd-4321-ae02-5b05999d6c46.png">

