### PR TITLE
Truncate hashrates after #1435 - Fix hashrate indexing logs

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 15;
+  private static currentVersion = 16;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -173,6 +173,11 @@ class DatabaseMigration {
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` DROP FOREIGN KEY `hashrates_ibfk_1`');
         await this.$executeQuery(connection, 'ALTER TABLE `hashrates` MODIFY `pool_id` SMALLINT UNSIGNED NOT NULL DEFAULT "0"');
+      }
+
+      if (databaseSchemaVersion < 16 && isBitcoin === true) {
+        logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
+        await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index because we changed timestamps
       }
 
       connection.release();

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -154,7 +154,7 @@ class Mining {
         await HashratesRepository.$saveHashrates(hashrates);
         hashrates.length = 0;
 
-        const elapsedSeconds = Math.max(1, Math.round((new Date().getTime()) - startedAt));
+        const elapsedSeconds = Math.max(1, Math.round((new Date().getTime()) - startedAt)) / 1000;
         if (elapsedSeconds > 1) {
           const weeksPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp).toUTCString();
@@ -244,7 +244,7 @@ class Mining {
           hashrates.length = 0;
         }
 
-        const elapsedSeconds = Math.max(1, Math.round(new Date().getTime() - startedAt));
+        const elapsedSeconds = Math.max(1, Math.round(new Date().getTime() - startedAt)) / 1000;
         if (elapsedSeconds > 1) {
           const daysPerSeconds = (indexedThisRun / elapsedSeconds).toFixed(2);
           const formattedDate = new Date(fromTimestamp).toUTCString();


### PR DESCRIPTION
Add a missing `TRUNCATE` after merging #1435.
Fix logging spam (missing `/ 1000`).