### PR TITLE
Added slug into `pools` table

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -6,7 +6,7 @@ import logger from '../logger';
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 class DatabaseMigration {
-  private static currentVersion = 16;
+  private static currentVersion = 17;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
 
@@ -178,6 +178,10 @@ class DatabaseMigration {
       if (databaseSchemaVersion < 16 && isBitcoin === true) {
         logger.warn(`'hashrates' table has been truncated. Re-indexing from scratch.`);
         await this.$executeQuery(connection, 'TRUNCATE hashrates;'); // Need to re-index because we changed timestamps
+      }
+
+      if (databaseSchemaVersion < 17 && isBitcoin === true) {
+        await this.$executeQuery(connection, 'ALTER TABLE `pools` ADD `slug` CHAR(50) NULL');
       }
 
       connection.release();


### PR DESCRIPTION
Related to https://github.com/mempool/mempool/issues/1440

Database schema is upgraded to 17. No data/cache truncation is required.

This PR add slugs for mining pools in the database and the `pools.json` parser. It is not used yet in the user facing application yet.

### Testing

* Before testing https://github.com/mempool/mining-pools/pull/2/ must be merged
* Restart your node backend
* Check:
  * db `state.schema_version` = 17
  * db `pools.slug` field exsits
  * slugs are filled properly for all pools, even for `Unknown`