### PR TITLE
Update nginx-mempool.conf: do not exit on startup if cannot reach mempool.space

### DIFF
--- a/contributors/omfgd00d.txt
+++ b/contributors/omfgd00d.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of March 25, 2022.
+
+Signed: omfgd00d

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -46,22 +46,28 @@
 
 	# mainnet API
 	location /api/v1/donations {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/donations/images {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/contributors {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/contributors/images {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/translators {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/translators/images {
-		proxy_pass https://mempool.space;
+		set $upstream mempool.space;
+		proxy_pass https://$upstream;
 	}
 	location /api/v1/ws {
 		proxy_pass http://127.0.0.1:8999/;

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -45,29 +45,24 @@
 	}
 
 	# mainnet API
+	set $mempoolSpaceServices "https://mempool.space";
 	location /api/v1/donations {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/donations/images {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/contributors {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/contributors/images {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/translators {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/translators/images {
-		set $upstream mempool.space;
-		proxy_pass https://$upstream;
+		proxy_pass https://$mempoolSpaceServices;
 	}
 	location /api/v1/ws {
 		proxy_pass http://127.0.0.1:8999/;


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1452

From [this page](https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/):

>If you use proxy_pass or fastcgi_pass definitions in your nginx server config, then nginx checks the hostname during the startup phase. If one of these servers is not available, nginx will not start.

The workaround to this problem is to use an nginx variable for the upstream host. This will prevent the nginx server from exiting if it cannot reach the host on startup.