### PR TITLE
Fix query to insert unknown mining pool

### DIFF
--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -135,10 +135,11 @@ class PoolsParser {
     logger.debug(`Update pools table now`);
 
     // Add new mining pools into the database
-    let queryAdd: string = 'INSERT INTO pools(name, link, regexes, addresses) VALUES ';
+    let queryAdd: string = 'INSERT INTO pools(name, link, regexes, addresses, slug) VALUES ';
     for (let i = 0; i < finalPoolDataAdd.length; ++i) {
       queryAdd += `('${finalPoolDataAdd[i].name}', '${finalPoolDataAdd[i].link}',
-      '${JSON.stringify(finalPoolDataAdd[i].regexes)}', '${JSON.stringify(finalPoolDataAdd[i].addresses)}'),`;
+      '${JSON.stringify(finalPoolDataAdd[i].regexes)}', '${JSON.stringify(finalPoolDataAdd[i].addresses)}',
+      ${JSON.stringify(finalPoolDataAdd[i].slug)}),`;
     }
     queryAdd = queryAdd.slice(0, -1) + ';';
 

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -108,7 +108,7 @@ class PoolsParser {
 
       if (slug === undefined) {
         // Only keep alphanumerical
-        slug = poolNames[i].replace(/[^a-z0-9]/gi,'').toLowerCase();
+        slug = poolNames[i].replace(/[^a-z0-9]/gi, '').toLowerCase();
         logger.debug(`No slug found for '${poolNames[i]}', generating it => '${slug}'`);
       }
 
@@ -180,7 +180,7 @@ class PoolsParser {
       const [rows]: any[] = await connection.query({ sql: 'SELECT name from pools where name="Unknown"', timeout: 120000 });
       if (rows.length === 0) {
         await connection.query({
-          sql: `INSERT INTO pools(name, link, regexes, addresses)
+          sql: `INSERT INTO pools(name, link, regexes, addresses, slug)
           VALUES("Unknown", "https://learnmeabitcoin.com/technical/coinbase-transaction", "[]", "[]", "unknown");
         `});
       } else {
@@ -189,7 +189,7 @@ class PoolsParser {
           regexes='[]', addresses='[]',
           slug='unknown'
           WHERE name='Unknown'
-        `)        
+        `);
       }
     } catch (e) {
       logger.err('Unable to insert "Unknown" mining pool');


### PR DESCRIPTION
Fix regression introduced in [bb0fd78f2857e0568cfafa7fe3f9d292f4b05e68](https://github.com/mempool/mempool/commit/bb0fd78f2857e0568cfafa7fe3f9d292f4b05e68#diff-e5f65c2e3cf3c60bab8efba5ca79e7be5b42ebcc586a6332b2f0456e5821a793R167).

The query which is supposed to insert the `Unknown` mining pool in the database was wrong and therefore block indexing was stuck at the most recent block mined by an `Unknown` entity, since the pool was not in the database.

Poor testing was the cause of this bug. My bad.