### PR TITLE
Add data zoom on pool hashrate chart

### DIFF
--- a/frontend/src/app/components/pool/pool.component.scss
+++ b/frontend/src/app/components/pool/pool.component.scss
@@ -31,6 +31,13 @@
   }
 }
 
+.chart {
+  margin-bottom: 20px;
+  @media (max-width: 768px) {
+    margin-bottom: 10px;
+  }
+}
+
 div.scrollable {
   width: 100%;
   height: 100%;

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -172,6 +172,34 @@ export class PoolComponent implements OnInit {
           },
         },
       ],
+      dataZoom: [{
+        type: 'inside',
+        realtime: true,
+        zoomLock: true,
+        maxSpan: 100,
+        minSpan: 10,
+        moveOnMouseMove: false,
+      }, {
+        fillerColor: '#aaaaff15',
+        borderColor: '#ffffff88',
+        showDetail: false,
+        show: true,
+        type: 'slider',
+        brushSelect: false,
+        realtime: true,
+        bottom: 0,
+        left: 20,
+        right: 15,
+        selectedDataBackground: {          
+          lineStyle: {
+            color: '#fff',
+            opacity: 0.45,
+          },
+          areaStyle: {
+            opacity: 0,
+          },          
+        },
+      }],
     };
   }
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1442

The original issue was to add timespan switcher in the chart, but it only makes sense for mining pools which are still active today. Therefore I re-added the datazoom element below the chart so users can select their own timespan, whether the pool is still active.

I also slightly changed the colors so it is slightly less visible than other charts which don't have data below them.

### Desktop

![image](https://user-images.githubusercontent.com/9780671/160580059-ec67ccb2-59a4-4403-adc6-fdbc1f0e338a.png)

### Mobile

![image](https://user-images.githubusercontent.com/9780671/160580786-a5536076-8afa-4605-a9c6-11c6f79b2291.png)
