### PR TITLE
Use slugs in cache warmer

### DIFF
--- a/production/install
+++ b/production/install
@@ -321,7 +321,7 @@ LIQUIDTESTNET_ASSET_REGISTRY_DB_NAME=asset_registry_testnet_db
 # packages needed for mempool ecosystem
 DEBIAN_PKG=()
 DEBIAN_PKG+=(zsh vim curl screen openssl python3)
-DEBIAN_PKG+=(build-essential git git-lfs clang cmake)
+DEBIAN_PKG+=(build-essential git git-lfs clang cmake jq)
 DEBIAN_PKG+=(autotools-dev autoconf automake pkg-config bsdmainutils)
 DEBIAN_PKG+=(libevent-dev libdb-dev libssl-dev libtool-dev autotools-dev)
 DEBIAN_PKG+=(libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev)
@@ -330,7 +330,7 @@ DEBIAN_PKG+=(nodejs npm mariadb-server nginx-core python-certbot-nginx rsync ufw
 # packages needed for mempool ecosystem
 FREEBSD_PKG=()
 FREEBSD_PKG+=(zsh sudo git screen curl wget calc neovim)
-FREEBSD_PKG+=(openssh-portable py38-pip rust llvm90)
+FREEBSD_PKG+=(openssh-portable py38-pip rust llvm90 jq)
 FREEBSD_PKG+=(boost-libs autoconf automake gmake gcc libevent libtool pkgconf)
 FREEBSD_PKG+=(nginx rsync py38-certbot-nginx mariadb105-server keybase)
 

--- a/production/nginx-cache-warmer
+++ b/production/nginx-cache-warmer
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 hostname=$(hostname)
+slugs=(`curl -sSL https://raw.githubusercontent.com/mempool/mining-pools/master/pools.json | jq -r '.slugs[]'`)
+
 while true
 do for url in / \
 	'/api/v1/statistics/2h' \
@@ -39,7 +41,6 @@ do for url in / \
 		curl -s "https://${hostname}${url}" >/dev/null
 	done
 
-	slugs=$(cat pools.json | jq -r .slugs[])
 	for slug in $slugs
 	do
 		curl -s "https://${hostname}/api/v1/mining/pool/${slug}/hashrate" >/dev/null

--- a/production/nginx-cache-warmer
+++ b/production/nginx-cache-warmer
@@ -39,12 +39,11 @@ do for url in / \
 		curl -s "https://${hostname}${url}" >/dev/null
 	done
 
-	counter=1
-	while [ $counter -le 134 ]
+	slugs=$(cat pools.json | jq -r .slugs[])
+	for slug in $slugs
 	do
-		curl -s "https://${hostname}/api/v1/mining/pool/${counter}/hashrate" >/dev/null
-		curl -s "https://${hostname}/api/v1/mining/pool/${counter}" >/dev/null
-		((counter++))
+		curl -s "https://${hostname}/api/v1/mining/pool/${slug}/hashrate" >/dev/null
+		curl -s "https://${hostname}/api/v1/mining/pool/${slug}" >/dev/null
 	done
 
 	sleep 10


### PR DESCRIPTION
Execution directory must be in the `pools.json` folder, or we need to set the full path