### PR TITLE
Enable nginx warm cache for all /api/v1/mining API endpoints

### DIFF
--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -1,7 +1,7 @@
 location /api/v1/statistics {
 	try_files /dev/null @mempool-api-v1-warmcache;
 }
-location /api/v1/mining/pools {
+location /api/v1/mining {
 	try_files /dev/null @mempool-api-v1-warmcache;
 }
 location /api/v1 {


### PR DESCRIPTION
@nymkappa can you confirm we are ok to warm cache all the API endpoints under `/api/v1/mining` ? i.e.
```
/api/v1/mining/pools/XXX
/api/v1/mining/pool/XXX
/api/v1/mining/hashrate/pools/XXX
/api/v1/mining/reward-stats/XXX
```