### PR TITLE
Send 404 when accessing non existing mining pool

### DIFF
--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -80,7 +80,7 @@ class PoolsRepository {
   /**
    * Get mining pool statistics for one pool
    */
-   public async $getPool(slug: string): Promise<PoolTag> {
+   public async $getPool(slug: string): Promise<PoolTag | null> {
     const query = `
       SELECT *
       FROM pools
@@ -92,6 +92,11 @@ class PoolsRepository {
 
       const [rows] = await connection.query(query, [slug]);
       connection.release();
+
+      if (rows.length < 1) {
+        logger.debug(`$getPool(): slug ${slug} does not match any known pool`);
+        return null;
+      }
 
       rows[0].regexes = JSON.parse(rows[0].regexes);
       rows[0].addresses = JSON.parse(rows[0].addresses);

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -94,7 +94,7 @@ class PoolsRepository {
       connection.release();
 
       if (rows.length < 1) {
-        logger.debug(`$getPool(): slug ${slug} does not match any known pool`);
+        logger.debug(`$getPool(): slug does not match any known pool`);
         return null;
       }
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -545,7 +545,11 @@ class Routes {
       res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(stats);
     } catch (e) {
-      res.status(500).send(e instanceof Error ? e.message : e);
+      if (e instanceof Error && e.message.indexOf('This mining pool does not exist') > -1) {
+        res.status(404).send(e.message);
+      } else {
+        res.status(500).send(e instanceof Error ? e.message : e);
+      }
     }
   }
 
@@ -560,7 +564,11 @@ class Routes {
       res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(poolBlocks);
     } catch (e) {
-      res.status(500).send(e instanceof Error ? e.message : e);
+      if (e instanceof Error && e.message.indexOf('This mining pool does not exist') > -1) {
+        res.status(404).send(e.message);
+      } else {
+        res.status(500).send(e instanceof Error ? e.message : e);
+      }
     }
   }
 
@@ -616,7 +624,11 @@ class Routes {
         hashrates: hashrates,
       });
     } catch (e) {
-      res.status(500).send(e instanceof Error ? e.message : e);
+      if (e instanceof Error && e.message.indexOf('This mining pool does not exist') > -1) {
+        res.status(404).send(e.message);
+      } else {
+        res.status(500).send(e instanceof Error ? e.message : e);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1480

### Testing

```bash
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/foundryusa/hashrate ; echo
{"oldestIndexedBlockTimestamp":1231006505,"hashrates":[{"timestamp":.............
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/foundryusa/blocks ; echo
[{"id":"000000000000000000067737546a7b7d61f0cf6017605979766ed64b90db.............
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/foundryusa/blocks/725000 ; echo
[{"id":"00000000000000000005a2953fde8345c97bcf245569c8cc348ad3b1e3bb.............
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/foundryusa ; echo
{"pool":{"id":111,"name":"Foundry USA","link":"https://foundrydigita.............
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/foundryusa/all ; echo
{"pool":{"id":111,"name":"Foundry USA","link":"https://foundrydigita.............

$ curl -s 192.168.0.103:4200/api/v1/mining/pool/needmoresats/hashrate ; echo
This mining pool does not exist
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/needmoresats/blocks ; echo
This mining pool does not exist
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/needmoresats/blocks/725000 ; echo
This mining pool does not exist
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/needmoresats ; echo
This mining pool does not exist
$ curl -s 192.168.0.103:4200/api/v1/mining/pool/needmoresats/all ; echo
This mining pool does not exist
```