### PR TITLE
Return empty pool addresses on testnet and signet

### DIFF
--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -1,4 +1,5 @@
 import { Common } from '../api/common';
+import config from '../config';
 import { DB } from '../database';
 import logger from '../logger';
 import { PoolInfo, PoolTag } from '../mempool.interfaces';
@@ -94,7 +95,11 @@ class PoolsRepository {
       connection.release();
 
       rows[0].regexes = JSON.parse(rows[0].regexes);
-      rows[0].addresses = JSON.parse(rows[0].addresses);
+      if (['testnet', 'signet'].includes(config.MEMPOOL.NETWORK)) {
+        rows[0].addresses = []; // pools.json only contains mainnet addresses
+      } else {
+        rows[0].addresses = JSON.parse(rows[0].addresses);
+      }
 
       return rows[0];
     } catch (e) {


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1478

### Testing

* In `backend/mempool-config.json`, change `MEMPOOL.NETWORK` to `testnet`
* Restart node backend
* Open `/mining/pool/antpool`
* Confirm that addresses are empty (showing `~`, don't forget to clear your browser cache)
* Repeat for `signet`
* Reset `MEMPOOL.NETWORK` to `mainnet` and make sure addresses are still showing proplery