### PR TITLE
Apply smooth scrolling to docs only

### DIFF
--- a/frontend/src/app/components/docs/docs.component.ts
+++ b/frontend/src/app/components/docs/docs.component.ts
@@ -23,5 +23,10 @@ export class DocsComponent implements OnInit {
     this.activeTab = ( url[2].path === "rest" ) ? 0 : 1;
     this.env = this.stateService.env;
     this.showWebSocketTab = ( ! ( ( this.env.BASE_MODULE === "bisq" ) || ( this.stateService.network === "bisq" ) || ( this.stateService.network === "liquidtestnet" ) ) );
+    document.querySelector<HTMLElement>( "html" ).style.scrollBehavior = "smooth";
+  }
+
+  ngOnDestroy(): void {
+    document.querySelector<HTMLElement>( "html" ).style.scrollBehavior = "auto";
   }
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -50,7 +50,6 @@ $dropdown-link-active-bg: #11131f;
 
 html, body {
   height: 100%;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
Went up the tree and the smooth-scrolling property only seemed to work when applied to the `html` element.