### PR TITLE
If mining dashboard is enabled, set block miner to "Unknown" by default

### DIFF
--- a/frontend/src/app/components/miner/miner.component.ts
+++ b/frontend/src/app/components/miner/miner.component.ts
@@ -27,6 +27,11 @@ export class MinerComponent implements OnChanges {
 
   ngOnChanges() {
     this.miner = '';
+    if (this.stateService.env.MINING_DASHBOARD) {
+      this.miner = 'Unknown';
+      this.url = this.relativeUrlPipe.transform(`/mining/pool/unknown`);
+      this.target = '';
+    }
     this.loading = true;
     this.findMinerFromCoinbase();
   }


### PR DESCRIPTION
Currently `Unknown` miner tag is not clickable even if the mining dashboard is enabled. This PR fixes that.

### Testing

* Set `MINING_DASHBOARD: false` in `mempool-frontend-config.json` file (or hardcode `this.env.MINING_DASHBOARD = false;` in `state.service.ts` constructor
* Open `block/00000000000000000004aa43bb3f52af890f23a564a85b77a849c991f5a9702a`
* Check that the miner tag shows `Unknown` and is not clickable, with grey color
* Check that other non `Unknown` blocks tags are still linking to pools website in a new window
* Set `MINING_DASHBOARD: true` in `mempool-frontend-config.json` file (or hardcode `this.env.MINING_DASHBOARD = true;` in `state.service.ts` constructor
* Open `block/00000000000000000004aa43bb3f52af890f23a564a85b77a849c991f5a9702a`
* Check that the miner tag shows `Unknown` and is clickable, with blue color. Clicking on it opens `/mining/pool/unknown`
* Check that other non `Unknown` blocks tags are also linking to their respective mining dashboard pool page
