### PR TITLE
Mining stats does not depends on the websocket blocks number anymore

### DIFF
--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -386,10 +386,14 @@ class BlocksRepository {
       connection = await DB.getConnection();
 
       // We need to use a subquery
-      const query = `SELECT SUM(reward) as totalReward, SUM(fees) as totalFee, SUM(tx_count) as totalTx
-        FROM (SELECT reward, fees, tx_count FROM blocks ORDER by height DESC LIMIT ${blockCount}) as sub`;
+      const query = `
+        SELECT MIN(height) as startBlock, MAX(height) as endBlock, SUM(reward) as totalReward, SUM(fees) as totalFee, SUM(tx_count) as totalTx
+        FROM
+          (SELECT height, reward, fees, tx_count FROM blocks
+          ORDER by height DESC
+          LIMIT ?) as sub`;
 
-      const [rows]: any = await connection.query(query);
+      const [rows]: any = await connection.query(query, [blockCount]);
       connection.release();
  
       return rows[0];

--- a/frontend/src/app/components/reward-stats/reward-stats.component.ts
+++ b/frontend/src/app/components/reward-stats/reward-stats.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map, skip, switchMap } from 'rxjs/operators';
+import { concat, Observable } from 'rxjs';
+import { map, switchMap, tap } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
 import { StateService } from 'src/app/services/state.service';
 
@@ -12,25 +12,39 @@ import { StateService } from 'src/app/services/state.service';
 })
 export class RewardStatsComponent implements OnInit {
   public $rewardStats: Observable<any>;
+  private lastBlockHeight: number;
 
   constructor(private apiService: ApiService, private stateService: StateService) { }
 
   ngOnInit(): void {
-    this.$rewardStats = this.stateService.blocks$
+    this.$rewardStats = concat(
+      // We fetch the latest reward stats when the page load and
+      // wait for the API response before listening to websocket blocks
+      this.apiService.getRewardStats$()
+        .pipe(
+          tap((stats) => {
+            this.lastBlockHeight = stats.endBlock;
+          })
+        ),
+      // Or when we receive a newer block, newer than the latest reward stats api call
+      this.stateService.blocks$
+        .pipe(
+          switchMap((block) => {
+            if (block[0].height <= this.lastBlockHeight) {
+              return []; // Return an empty stream so the last pipe is not executed
+            }
+            this.lastBlockHeight = block[0].height;
+            return this.apiService.getRewardStats$();
+          })
+        )
+      )
       .pipe(
-        // (we always receives some blocks at start so only trigger for the last one)
-        skip(this.stateService.env.MEMPOOL_BLOCKS_AMOUNT - 1),
-        switchMap(() => {
-          return this.apiService.getRewardStats$()
-            .pipe(
-              map((stats) => {
-                return {
-                  totalReward: stats.totalReward,
-                  rewardPerTx: stats.totalReward / stats.totalTx,
-                  feePerTx: stats.totalFee / stats.totalTx,
-                };
-              })
-            );
+        map((stats) => {
+          return {
+            totalReward: stats.totalReward,
+            rewardPerTx: stats.totalReward / stats.totalTx,
+            feePerTx: stats.totalFee / stats.totalTx,
+          };
         })
       );
   }

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -119,6 +119,8 @@ export interface BlockExtended extends Block {
 }
 
 export interface RewardStats {
+  startBlock: number;
+  endBlock: number;
   totalReward: number;
   totalFee: number;
   totalTx: number;


### PR DESCRIPTION
The mining stats component assumes the websocket will send `this.stateService.env.MEMPOOL_BLOCKS_AMOUNT` when we load the mining dashboard page.

`MEMPOOL_BLOCKS_AMOUNT` has nothing to do with how many past blocks are sent through the websocket, but it was still working fine because it is usually set to `8`, which matches the backend setting `config.MEMPOOL.INITIAL_BLOCKS_AMOUNT`.

Also, as a side note, it seems to me that the frontend actually has no idea how many blocks to expect from the websocket when loading the page. Therefore I got rid of any assumption about this.

The same issue exists in other places in the mining dashboard code, and I will make separate PR to fix them.