### PR TITLE
Avoid parralel hashrate indexing when initial query is too slow

### DIFF
--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -86,16 +86,17 @@ class Mining {
       return;
     }
 
+    this.weeklyHashrateIndexingStarted = true;
+
     // We only run this once a week
     const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing') * 1000;
     const now = new Date();
     if (now.getTime() - latestTimestamp < 604800000) {
+      this.weeklyHashrateIndexingStarted = false;
       return;
     }
 
     try {
-      this.weeklyHashrateIndexingStarted = true;
-
       logger.info(`Indexing mining pools weekly hashrates`);
 
       const indexedTimestamp = await HashratesRepository.$getWeeklyHashrateTimestamps();
@@ -186,16 +187,17 @@ class Mining {
       return;
     }
 
+    this.hashrateIndexingStarted = true;
+
     // We only run this once a day
     const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_hashrates_indexing') * 1000;
     const now = new Date().getTime();
     if (now - latestTimestamp < 86400000) {
+      this.hashrateIndexingStarted = false;
       return;
     }
 
     try {
-      this.hashrateIndexingStarted = true;
-
       logger.info(`Indexing network daily hashrate`);
 
       const indexedTimestamp = (await HashratesRepository.$getNetworkDailyHashrate(null)).map(hashrate => hashrate.timestamp);

--- a/backend/src/api/mining.ts
+++ b/backend/src/api/mining.ts
@@ -86,14 +86,20 @@ class Mining {
       return;
     }
 
-    this.weeklyHashrateIndexingStarted = true;
-
-    // We only run this once a week
-    const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing') * 1000;
     const now = new Date();
-    if (now.getTime() - latestTimestamp < 604800000) {
+
+    try {
+      this.weeklyHashrateIndexingStarted = true;
+
+      // We only run this once a week
+      const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_weekly_hashrates_indexing') * 1000;
+      if (now.getTime() - latestTimestamp < 604800000) {
+        this.weeklyHashrateIndexingStarted = false;
+        return;
+      }
+    } catch (e) {
       this.weeklyHashrateIndexingStarted = false;
-      return;
+      throw e;
     }
 
     try {
@@ -187,14 +193,20 @@ class Mining {
       return;
     }
 
-    this.hashrateIndexingStarted = true;
-
-    // We only run this once a day
-    const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_hashrates_indexing') * 1000;
     const now = new Date().getTime();
-    if (now - latestTimestamp < 86400000) {
+
+    try {
+      this.hashrateIndexingStarted = true;
+
+      // We only run this once a day
+      const latestTimestamp = await HashratesRepository.$getLatestRunTimestamp('last_hashrates_indexing') * 1000;
+      if (now - latestTimestamp < 86400000) {
+        this.hashrateIndexingStarted = false;
+        return;
+      }
+    } catch (e) {
       this.hashrateIndexingStarted = false;
-      return;
+      throw e;
     }
 
     try {


### PR DESCRIPTION
This PR fixes a recent error we got on one of our server:
```
Apr  2 13:55:46 node202  mempool[38957]: INFO Indexing network daily hashrate
Apr  2 13:55:46 node202 syslogd: last message repeated 2 times
```

Hashrate indexing are not supposed to run concurrently. The problem was that I was setting the  `hashrateIndexingStarted` flag after the first mysql query. During daily backup, this initial query may take a couple of seconds to execute, since mysql server is busy dumping the database.
Since the flag was not set before the query completes, every 2 seconds the indexing was being run again and again.

Once mysql server is available again, all queries completes at the same time. All indexing attempts think they have to index something. They all race to insert the new entry but only one prevails:
```
Apr  2 13:55:47 node202  mempool[38957]: INFO Daily network hashrate indexing completed
```

And all other fails with the following:
```
Apr  2 13:55:47 node202  mempool[38957]: ERR $saveHashrateInDatabase() errorDuplicate entry '2022-04-02 00:00:00-0' for key 'hashrate_timestamp_pool_id'
Apr  2 13:55:47 node202  mempool[38957]: ERR Unable to run indexing right now, trying again later. Error: Duplicate entry '2022-04-02 00:00:00-0' for key 'hashrate_timestamp_pool_id'
Apr  2 13:55:47 node202  mempool[38957]: ERR $saveHashrateInDatabase() errorDuplicate entry '2022-04-02 00:00:00-0' for key 'hashrate_timestamp_pool_id'
Apr  2 13:55:47 node202  mempool[38957]: ERR Unable to run indexing right now, trying again later. Error: Duplicate entry '2022-04-02 00:00:00-0' for key 'hashrate_timestamp_pool_id'
```