### PR TITLE
Correcting op_code coloring

### DIFF
--- a/frontend/src/app/shared/pipes/asm-styler/asm-styler.pipe.ts
+++ b/frontend/src/app/shared/pipes/asm-styler/asm-styler.pipe.ts
@@ -264,6 +264,7 @@ export class AsmStylerPipe implements PipeTransform {
       case 'LESSTHAN':
       case 'GREATERTHAN':
       case 'LESSTHANOREQUAL':
+      case 'GREATERTHANOREQUAL':
       case 'MIN':
       case 'MAX':
       case 'WITHIN':
@@ -279,12 +280,12 @@ export class AsmStylerPipe implements PipeTransform {
       case 'CHECKSIG':
       case 'CHECKSIGVERIFY':
       case 'CHECKMULTISIG':
-      case 'CHCEKMULTISIGVERIFY':
+      case 'CHECKMULTISIGVERIFY':
         style = 'crypto';
         break;
 
-      case 'CHECKLOCKTIMEVERIFY':
-      case 'CHECKSEQUENCEVERIFY':
+      case 'CLTV':
+      case 'CSV':
         style = 'locktime';
         break;
 


### PR DESCRIPTION
Fixing a couple of not correctly colored op_code scripts. Using the testnet transaction `88710a9a6751827490f260e307757543f533c0f18bcd6865794713d263d5f5a4` that contain all the op codes I can now verify that all the op codes are correctly colored:

**Before:**
<img width="284" alt="Screen Shot 2022-04-03 at 15 24 55" src="https://user-images.githubusercontent.com/8561090/161425531-735ad5af-3d3e-4c80-9125-0e4e67ebdadc.png">

**After:**
<img width="349" alt="Screen Shot 2022-04-03 at 15 23 50" src="https://user-images.githubusercontent.com/8561090/161425483-1a451f79-7be1-464c-adce-d188cd958fad.png">

