### PR TITLE
WebSocket uid

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -1,5 +1,6 @@
 import { CpfpInfo, TransactionExtended, TransactionStripped } from '../mempool.interfaces';
 import config from '../config';
+import * as crypto from 'crypto';
 export class Common {
   static nativeAssetId = config.MEMPOOL.NETWORK === 'liquidtestnet' ?
     '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49'
@@ -83,6 +84,10 @@ export class Common {
          resolve();
        }, ms);
     });
+  }
+
+  static randomString(length: number): string {
+    return crypto.randomBytes(length).toString('hex');
   }
 
   static shuffleArray(array: any[]) {

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -34,6 +34,7 @@ class WebsocketHandler {
     }
 
     this.wss.on('connection', (client: WebSocket) => {
+      client['uid'] = Common.randomString(10);
       client.on('error', logger.info);
       client.on('message', async (message: string) => {
         try {
@@ -115,7 +116,10 @@ class WebsocketHandler {
             if (!_blocks) {
               return;
             }
-            client.send(JSON.stringify(this.getInitData(_blocks)));
+            client.send(JSON.stringify({
+              'uid': client['uid'],
+              ...this.getInitData(_blocks)
+            }));
           }
 
           if (parsedMessage.action === 'ping') {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -51,8 +51,9 @@ import { FeesBoxComponent } from './components/fees-box/fees-box.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { DifficultyComponent } from './components/difficulty/difficulty.component';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, faChartArea, faCogs, faCubes, faHammer, faDatabase, faExchangeAlt, faInfoCircle,
-  faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown, faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl } from '@fortawesome/free-solid-svg-icons';
+import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, faChartArea, faCogs, faCubes, faHammer, faDatabase,
+  faExchangeAlt, faInfoCircle, faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown,
+  faSortUp, faAngleDoubleUp, faChevronDown, faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl } from '@fortawesome/free-solid-svg-icons';
 import { ApiDocsComponent } from './components/docs/api-docs.component';
 import { DocsComponent } from './components/docs/docs.component';
 import { ApiDocsNavComponent } from './components/docs/api-docs-nav.component';
@@ -62,6 +63,7 @@ import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-poli
 import { TrademarkPolicyComponent } from './components/trademark-policy/trademark-policy.component';
 import { StorageService } from './services/storage.service';
 import { HttpCacheInterceptor } from './services/http-cache.interceptor';
+import { WebsocketUidInterceptor } from './services/websocket-uid.interceptor';
 import { LanguageService } from './services/language.service';
 import { SponsorComponent } from './components/sponsor/sponsor.component';
 import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
@@ -166,7 +168,8 @@ import { DataCyDirective } from './data-cy.directive';
     StorageService,
     LanguageService,
     ShortenStringPipe,
-    { provide: HTTP_INTERCEPTORS, useClass: HttpCacheInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: HttpCacheInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: WebsocketUidInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -21,6 +21,7 @@ export interface WebsocketResponse {
   loadingIndicators?: ILoadingIndicators;
   backendInfo?: IBackendInfo;
   da?: DifficultyAdjustment;
+  uid?: string;
   'track-tx'?: string;
   'track-address'?: string;
   'track-asset'?: string;

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -72,6 +72,7 @@ export class StateService {
   blockVSize: number;
   env: Env;
   latestBlockHeight = -1;
+  webSocketId = '';
 
   networkChanged$ = new ReplaySubject<string>(1);
   blocks$: ReplaySubject<[BlockExtended, boolean]>;
@@ -216,5 +217,13 @@ export class StateService {
 
   isLiquid() {
     return this.network === 'liquid' || this.network === 'liquidtestnet';
+  }
+
+  setWebSocketUid(uid: string) {
+    this.webSocketId = uid;
+  }
+
+  getWebSocketUid(): string {
+    return this.webSocketId;
   }
 }

--- a/frontend/src/app/services/websocket-uid.interceptor.ts
+++ b/frontend/src/app/services/websocket-uid.interceptor.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpEvent, HttpRequest, HttpHandler } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { StateService } from './state.service';
+
+@Injectable()
+export class WebsocketUidInterceptor implements HttpInterceptor {
+
+  constructor(
+    private stateService: StateService,
+  ) { }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const newRequest = request.clone({
+      headers: request.headers.set('uid', this.stateService.getWebSocketUid())
+    });
+    return next.handle(newRequest);
+  }
+}

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -263,6 +263,10 @@ export class WebsocketService {
       this.stateService.difficultyAdjustment$.next(response.da);
     }
 
+    if (response.uid) {
+      this.stateService.setWebSocketUid(response.uid);
+    }
+
     if (response.backendInfo) {
       this.stateService.backendInfo$.next(response.backendInfo);
 


### PR DESCRIPTION
fixes #1334

The websocket connection will provide the client with the unique user id that will be passed in the header of HTTP requests in order to make per-user loading websocket indicators possible.