### PR TITLE
Wait for external assets file writers to complete

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -77,7 +77,7 @@ export class Common {
     };
   }
 
-  static sleep(ms: number): Promise<void> {
+  static sleep$(ms: number): Promise<void> {
     return new Promise((resolve) => {
        setTimeout(() => {
          resolve();

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -1,8 +1,7 @@
 import config from '../config';
 import DB from '../database';
 import logger from '../logger';
-
-const sleep = (ms: number) => new Promise(res => setTimeout(res, ms));
+import { Common } from './common';
 
 class DatabaseMigration {
   private static currentVersion = 17;
@@ -25,7 +24,7 @@ class DatabaseMigration {
         await this.$createMigrationStateTable();
       } catch (e) {
         logger.err('MIGRATIONS: Unable to create `state` table, aborting in 10 seconds. ' + e);
-        await sleep(10000);
+        await Common.sleep$(10000);
         process.exit(-1);
       }
       logger.debug('MIGRATIONS: `state` table initialized.');
@@ -36,7 +35,7 @@ class DatabaseMigration {
       databaseSchemaVersion = await this.$getSchemaVersionFromDatabase();
     } catch (e) {
       logger.err('MIGRATIONS: Unable to get current database migration version, aborting in 10 seconds. ' + e);
-      await sleep(10000);
+      await Common.sleep$(10000);
       process.exit(-1);
     }
 
@@ -52,7 +51,7 @@ class DatabaseMigration {
       await this.$createMissingTablesAndIndexes(databaseSchemaVersion);
     } catch (e) {
       logger.err('MIGRATIONS: Unable to create required tables, aborting in 10 seconds. ' + e);
-      await sleep(10000);
+      await Common.sleep$(10000);
       process.exit(-1);
     }
 

--- a/backend/src/api/liquid/icons.ts
+++ b/backend/src/api/liquid/icons.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import config from '../../config';
 import logger from '../../logger';
 
 class Icons {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -85,16 +85,16 @@ class Server {
 
     this.setUpWebsocketHandling();
 
-    await syncAssets.syncAssets();
+    await syncAssets.syncAssets$();
     diskCache.loadMempoolCache();
 
     if (config.DATABASE.ENABLED) {
       await DB.checkDbConnection();
       try {
-        if (process.env.npm_config_reindex != undefined) { // Re-index requests
+        if (process.env.npm_config_reindex !== undefined) { // Re-index requests
           const tables = process.env.npm_config_reindex.split(',');
           logger.warn(`Indexed data for "${process.env.npm_config_reindex}" tables will be erased in 5 seconds (using '--reindex')`);
-          await Common.sleep(5000);
+          await Common.sleep$(5000);
           await databaseMigration.$truncateIndexedData(tables);
         }
         await databaseMigration.$initializeOrMigrateDatabase();

--- a/frontend/src/app/components/asset/asset.component.html
+++ b/frontend/src/app/components/asset/asset.component.html
@@ -64,7 +64,7 @@
         </div>
         <div class="w-100 d-block d-md-none"></div>
         <div class="col icon-holder">
-          <img *ngIf="!imageError; else defaultIcon" class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + asset.asset_id + '/icon'" (error)="imageError = true">
+          <img *ngIf="!imageError; else defaultIcon" class="assetIcon" [src]="'/api/v1/asset/' + asset.asset_id + '/icon'" (error)="imageError = true">
           <ng-template #defaultIcon>
             <fa-icon class="defaultIcon" [icon]="['fas', 'database']" [fixedWidth]="true" size="8x"></fa-icon>
           </ng-template>

--- a/frontend/src/app/components/assets/asset-group/asset-group.component.html
+++ b/frontend/src/app/components/assets/asset-group/asset-group.component.html
@@ -15,7 +15,7 @@
     <div *ngFor="let asset of group.assets">
       <div class="card">
         <a [routerLink]="['/assets/asset' | relativeUrl, asset.asset_id]">
-          <img class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + asset.asset_id + '/icon'">
+          <img class="assetIcon" [src]="'/api/v1/asset/' + asset.asset_id + '/icon'">
         </a>
         <div class="title">
           <a [routerLink]="['/assets/asset/' | relativeUrl, asset.asset_id]">{{ asset.name }}</a>

--- a/frontend/src/app/components/assets/assets-featured/assets-featured.component.html
+++ b/frontend/src/app/components/assets/assets-featured/assets-featured.component.html
@@ -3,14 +3,14 @@
   <div class="card" *ngFor="let group of featured">
     <ng-template [ngIf]="group.assets" [ngIfElse]="singleAsset">
       <a [routerLink]="['/assets/group' | relativeUrl, group.id]">
-        <img class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + group.assets[0] + '/icon'">
+        <img class="assetIcon" [src]="'/api/v1/asset/' + group.assets[0] + '/icon'">
       </a>
       <div class="title"><a [routerLink]="['/assets/group' | relativeUrl, group.id]">{{ group.name }}</a></div>
       <div class="sub-title" i18n>Group of {{ group.assets.length | number }} assets</div>
     </ng-template>
     <ng-template #singleAsset>
       <a [routerLink]="['/assets/asset/' | relativeUrl, group.asset]">
-        <img class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + group.asset + '/icon'">
+        <img class="assetIcon" [src]="'/api/v1/asset/' + group.asset + '/icon'">
       </a>
       <div class="title">
         <a [routerLink]="['/assets/asset/' | relativeUrl, group.asset]">{{ group.name }}</a>

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -79,7 +79,7 @@
                   <tr *ngFor="let group of featuredAssets">
                     <td class="asset-icon">
                       <a [routerLink]="['/assets/asset/' | relativeUrl, group.asset]">
-                        <img class="assetIcon" [src]="'https://liquid.network/api/v1/asset/' + group.asset + '/icon'">
+                        <img class="assetIcon" [src]="'/api/v1/asset/' + group.asset + '/icon'">
                       </a>
                     </td>
                     <td class="asset-title">


### PR DESCRIPTION
This PR fixes the external asset download which was running asynchronously. Therefore the node backend was sometimes trying to read assets file while it was not fully written on disk yet.

This fixes liquid icons parsing failure issues.

_Also cleanup unrelated things I've noticed on the way 👍🏻._