### PR TITLE
Clarify configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Mempool can be self-hosted on a wide variety of your own hardware, ranging from 
 
 The `docker` directory contains the Dockerfiles used to build and release the official images and a `docker-compose.yml` file that is intended for end users to run a Mempool instance with minimal effort.
 
-## bitcoind only configuration
+## bitcoind-only configuration
+
+> If you need the ability to do address lookups, please use the [bitcoind+electrum configuration](#bitcoindelectrum-configuration) instead.
 
 To run an instance with the default settings, use the following command:
 
@@ -51,14 +53,16 @@ You can check if the instance is running by visiting http://localhost - the grap
 
 ## bitcoind+electrum configuration
 
-In order to run with a `electrum` compatible server as the backend, in addition to the settings required for running with `bitcoind` above, you will need to make the following changes to the `docker-compose.yml` file:
+> This configuration gives you the ability to do address lookups.
+
+In order to add on an `electrum` compatible server, in addition to the settings required for running with `bitcoind` above, you will need to make the following changes to the `docker-compose.yml` file:
 
 - Under the `api` service, change the value of the `MEMPOOL_BACKEND` key from `none` to `electrum`:
 
 ```
   api:
     environment:
-      MEMPOOL_BACKEND: "none"
+      MEMPOOL_BACKEND: "electrum"
 ```
 
 - Under the `api` service, set the `ELECTRUM_HOST` and `ELECTRUM_PORT` keys to your Docker host IP address and set `ELECTRUM_TLS_ENABLED` to `false`:
@@ -70,6 +74,8 @@ In order to run with a `electrum` compatible server as the backend, in addition 
       ELECTRUM_PORT: "50002"
       ELECTRUM_TLS_ENABLED: "false"
 ```
+
+## Configuration overrides
 
 You can update any of the backend settings in the `mempool-config.json` file using the following environment variables to override them under the same `api` `environment` section.
 

--- a/contributors/OliverOffing.txt
+++ b/contributors/OliverOffing.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of May 1, 2022.
+
+Signed: OliverOffing


### PR DESCRIPTION
I've recently [misunderstood how the backend configuration works](https://github.com/mempool/mempool/issues/1581#issuecomment-1113466544) and so decided to suggest a few changes in the documentation to help clarify this point.

Overall, I think we should move away from saying things like "`electrum` as the backend", given that you still need to have `bitcoind` alongside.

Similarly, I think the valid options for `MEMPOOL_BACKEND` should change:

- `none` => `bitcoind`
- `electrum` => `bitcoind_electrum`

This might help clarify that `electrum` is an _optional addon_, and not a self-standing backend by itself.