### PR TITLE
Run hashrate indexing after midnight

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -174,8 +174,8 @@ class Server {
 
   async $resetHashratesIndexingState() {
     try {
-      await HashratesRepository.$setLatestRunTimestamp('last_hashrates_indexing', 0);
-      await HashratesRepository.$setLatestRunTimestamp('last_weekly_hashrates_indexing', 0);
+      await HashratesRepository.$setLatestRun('last_hashrates_indexing', 0);
+      await HashratesRepository.$setLatestRun('last_weekly_hashrates_indexing', 0);
     } catch (e) {
       logger.err(`Cannot reset hashrate indexing timestamps. Reason: ` + (e instanceof Error ? e.message : e));
     }

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -147,13 +147,13 @@ class HashratesRepository {
   /**
    * Set latest run timestamp
    */
-  public async $setLatestRunTimestamp(key: string, val: any = null) {
+  public async $setLatestRun(key: string, val: number) {
     const query = `UPDATE state SET number = ? WHERE name = ?`;
 
     try {
-      await DB.query(query, (val === null) ? [Math.round(new Date().getTime() / 1000), key] : [val, key]);
+      await DB.query(query, [val, key]);
     } catch (e) {
-      logger.err(`Cannot set last indexing timestamp for ${key}. Reason: ` + (e instanceof Error ? e.message : e));
+      logger.err(`Cannot set last indexing run for ${key}. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }
@@ -161,7 +161,7 @@ class HashratesRepository {
   /**
    * Get latest run timestamp
    */
-  public async $getLatestRunTimestamp(key: string): Promise<number> {
+  public async $getLatestRun(key: string): Promise<number> {
     const query = `SELECT number FROM state WHERE name = ?`;
 
     try {
@@ -172,7 +172,7 @@ class HashratesRepository {
       }
       return rows[0]['number'];
     } catch (e) {
-      logger.err(`Cannot retreive last indexing timestamp for ${key}. Reason: ` + (e instanceof Error ? e.message : e));
+      logger.err(`Cannot retrieve last indexing run for ${key}. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }
@@ -189,8 +189,8 @@ class HashratesRepository {
         await DB.query(`DELETE FROM hashrates WHERE hashrate_timestamp = ?`, [row.timestamp]);
       }
       // Re-run the hashrate indexing to fill up missing data
-      await this.$setLatestRunTimestamp('last_hashrates_indexing', 0);
-      await this.$setLatestRunTimestamp('last_weekly_hashrates_indexing', 0);
+      await this.$setLatestRun('last_hashrates_indexing', 0);
+      await this.$setLatestRun('last_weekly_hashrates_indexing', 0);
     } catch (e) {
       logger.err('Cannot delete latest hashrates data points. Reason: ' + (e instanceof Error ? e.message : e));
     }
@@ -205,8 +205,8 @@ class HashratesRepository {
     try {
       await DB.query(`DELETE FROM hashrates WHERE hashrate_timestamp >= FROM_UNIXTIME(?)`, [timestamp]);
       // Re-run the hashrate indexing to fill up missing data
-      await this.$setLatestRunTimestamp('last_hashrates_indexing', 0);
-      await this.$setLatestRunTimestamp('last_weekly_hashrates_indexing', 0);
+      await this.$setLatestRun('last_hashrates_indexing', 0);
+      await this.$setLatestRun('last_weekly_hashrates_indexing', 0);
     } catch (e) {
       logger.err('Cannot delete latest hashrates data points. Reason: ' + (e instanceof Error ? e.message : e));
     }


### PR DESCRIPTION
Related to https://github.com/mempool/mempool/issues/1566

This PR makes hashrate indexing more consistent between instances, by running indexing around midnight UTC for everyone.

Note that if a block is found at midnight, then the network hashrate may still be slightly different between instances due to block propagation delays. This is fine as it won't impact much the estimated hashrate, values between instances will be very close anyway.

### Testing

After deploying the PR you must wait for the current UTC day to end
* After midnight UTC, check if `/graphs/mining/hashrate-difficulty` has a new entry after midnight (daily network hashrate indexing), not that the new value may take some time to show due to caching, you can clear your cache in your network tab if needed
* At the beginning of the next week (Monday, a bit after midnight UTC), check if `/graphs/mining/pools-dominance` has new entry. The previous remarks about caching also applies