### PR TITLE
Show current network hashrate and difficulty using core RPC

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -630,6 +630,7 @@ class Routes {
       res.json({
         hashrates: hashrates,
         difficulty: difficulty,
+        currentHashrate: await bitcoinClient.getNetworkHashPs()
       });
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -630,7 +630,8 @@ class Routes {
       res.json({
         hashrates: hashrates,
         difficulty: difficulty,
-        currentHashrate: await bitcoinClient.getNetworkHashPs()
+        currentHashrate: await bitcoinClient.getNetworkHashPs(),
+        currentDifficulty: await bitcoinClient.getDifficulty(),
       });
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -5,8 +5,7 @@
       <div class="item">
         <h5 class="card-title" i18n="mining.hashrate">Hashrate</h5>
         <p class="card-text">
-          {{ hashrates.currentHashrate | amountShortener }}
-          <span class="symbol">hashes/sec</span>
+          {{ hashrates.currentHashrate | amountShortener: 1 : 'H/s' }}
         </p>
       </div>
       <div class="item">

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -125,7 +125,7 @@ export class HashrateChartComponent implements OnInit {
                 return {
                   blockCount: parseInt(response.headers.get('x-total-count'), 10),
                   currentDifficulty: Math.round(data.difficulty[data.difficulty.length - 1].difficulty * 100) / 100,
-                  currentHashrate: data.hashrates[data.hashrates.length - 1].avgHashrate,
+                  currentHashrate: data.currentHashrate
                 };
               }),
               retryWhen((errors) => errors.pipe(

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -114,23 +114,15 @@ export class HashrateChartComponent implements OnInit {
                   difficulty: diffFixed.map(val => [val.timestamp * 1000, val.difficulty]),
                 });
                 this.isLoading = false;
-
-                if (data.hashrates.length === 0) {
-                  this.cd.markForCheck();
-                  throw new Error();
-                }
               }),
               map((response) => {
                 const data = response.body;
                 return {
                   blockCount: parseInt(response.headers.get('x-total-count'), 10),
-                  currentDifficulty: Math.round(data.difficulty[data.difficulty.length - 1].difficulty * 100) / 100,
-                  currentHashrate: data.currentHashrate
+                  currentDifficulty: data.currentDifficulty,
+                  currentHashrate: data.currentHashrate,
                 };
               }),
-              retryWhen((errors) => errors.pipe(
-                delay(60000)
-              ))
             );
         }),
         share()


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1566

This PR shows the result of `getnetworkhashps` and `getdifficulty` bitcoin core rpc result in the mining dashboard, instead of using the latest daily network hashrate snapshot value we've indexed. So it's more real time now (based on the last 120 blocks and current tip, by default in core). Also, we don't need to wait for indexing to complete before showing those values anymore.

As a side note, I had to disable the auto refresh (every 60 seconds) of the data. So after this PR a page reload will be required for displaying the chart once indexing is completed. I think this is okay because we will push indexing progress on the websocket (https://github.com/mempool/mempool/pull/1596), so we can use this to refresh the component only when indexing is done in a future PR.

Also updated the hashrate unit as mentioned long time ago.

<img width="556" alt="Screen Shot 2022-05-02 at 5 42 11 PM" src="https://user-images.githubusercontent.com/9780671/166207901-8c801d72-e70c-4401-ba82-4e238f910259.png">

