### PR TITLE
fix lightning force close label with CSV delay <= 16

### DIFF
--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -42,7 +42,7 @@ export class AddressLabelsComponent implements OnInit {
       }
 
       const topElement = this.vin.witness[this.vin.witness.length - 2];
-      if (/^OP_IF OP_PUSHBYTES_33 \w{66} OP_ELSE OP_PUSHBYTES_(1 \w{2}|2 \w{4}) OP_CSV OP_DROP OP_PUSHBYTES_33 \w{66} OP_ENDIF OP_CHECKSIG$/.test(this.vin.inner_witnessscript_asm)) {
+      if (/^OP_IF OP_PUSHBYTES_33 \w{66} OP_ELSE OP_PUSH(NUM_\d+|BYTES_(1 \w{2}|2 \w{4})) OP_CSV OP_DROP OP_PUSHBYTES_33 \w{66} OP_ENDIF OP_CHECKSIG$/.test(this.vin.inner_witnessscript_asm)) {
         // https://github.com/lightning/bolts/blob/master/03-transactions.md#commitment-transaction-outputs
         if (topElement === '01') {
           // top element is '01' to get in the revocation path


### PR DESCRIPTION
when force closing a lightning channel with CSV delay <= 16, `OP_PUSHNUM` will be used in the script

example: https://mempool.space/testnet/tx/e693f75ab2ca50a3048a1b8b63a72042516f6cdb2786c1a5b215f963c54137fd