### PR TITLE
Revise main readme and docker install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Mempool can be conveniently installed on the following full-node distros:
 
 The following instructions are for a manual installation on Linux or FreeBSD. You may need to change file and directory paths to match your OS.
 
-You will need [Bitcoin](https://github.com/bitcoin/bitcoin), [Electrum](https://github.com/romanz/electrs), [Node.js](https://github.com/nodejs/node), [MariaDB](https://github.com/mariadb/server), and [Nginx](https://github.com/nginx/nginx). Below, we walk through how to configure each of these.
+You will need [Bitcoin Core](https://github.com/bitcoin/bitcoin), [Electrum Server](https://github.com/romanz/electrs), [Node.js](https://github.com/nodejs/node), [MariaDB](https://github.com/mariadb/server), and [Nginx](https://github.com/nginx/nginx). Below, we walk through how to configure each of these.
 
 ### 1. Get Latest Mempool Release
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Mempool can be self-hosted on a wide variety of your own hardware, ranging from 
 We support the following installation methods, ranked in order from simple to advanced:
 
 1) [One-click installation on full-node distros](#one-click-installation)
-2) [Docker installation on Linux using docker-compose](#docker-installation)
+2) [Docker installation on Linux using docker-compose](./docker/README.md)
 3) [Manual installation on Linux or FreeBSD](#manual-installation)
-4) [Production installation on a powerful FreeBSD server](https://github.com/mempool/mempool/tree/master/production)
+4) [Production installation on a powerful FreeBSD server](./production/README.md)
+
+This doc offers install notes on the one-click method and manual install method. Follow the links above for install notes on Docker and production installations.
 
 <a id="one-click-installation"></a>
-### One-click installation on full-node distros
+### One-Click Installation
 
 Mempool can be conveniently installed on the following full-node distros: 
 - [Umbrel](https://github.com/getumbrel/umbrel)
@@ -27,278 +29,12 @@ Mempool can be conveniently installed on the following full-node distros:
 - [myNode](https://github.com/mynodebtc/mynode)
 - [Start9](https://github.com/Start9Labs/embassy-os)
 
-# Docker Installation
+<a id="manual-installation"></a>
+### Manual Installation
 
-The `docker` directory contains the Dockerfiles used to build and release the official images and a `docker-compose.yml` file that is intended for end users to run a Mempool instance with minimal effort.
+The following instructions are for a manual installation on Linux or FreeBSD. You may need to change file and directory paths to match your OS.
 
-## bitcoind only configuration
-
-To run an instance with the default settings, use the following command:
-
-```bash
-$ docker-compose up
-```
-
-The default configuration will allow you to run Mempool using `bitcoind` as the backend, so address lookups will be disabled. It assumes you have added RPC credentials for the `mempool` user with a `mempool` password in your `bitcoin.conf` file:
-
-```
-rpcuser=mempool
-rpcpassword=mempool
-```
-
-If you want to use your current credentials, update them in the `docker-compose.yml` file:
-
-```
-  api:
-    environment:
-      MEMPOOL_BACKEND: "none"
-      RPC_HOST: "172.27.0.1"
-      RPC_PORT: "8332"
-      RPC_USER: "mempool"
-      RPC_PASS: "mempool"
-```
-
-Note: the IP in the example above refers to Docker's default gateway IP address so the container can hit the `bitcoind` instance running on the host machine. If your setup is different, update it accordingly.
-
-You can check if the instance is running by visiting http://localhost - the graphs will be populated as new transactions are detected.
-
-## bitcoind+electrum configuration
-
-In order to run with a `electrum` compatible server as the backend, in addition to the settings required for running with `bitcoind` above, you will need to make the following changes to the `docker-compose.yml` file:
-
-- Under the `api` service, change the value of the `MEMPOOL_BACKEND` key from `none` to `electrum`:
-
-```
-  api:
-    environment:
-      MEMPOOL_BACKEND: "none"
-```
-
-- Under the `api` service, set the `ELECTRUM_HOST` and `ELECTRUM_PORT` keys to your Docker host IP address and set `ELECTRUM_TLS_ENABLED` to `false`:
-
-```
-  api:
-    environment:
-      ELECTRUM_HOST: "172.27.0.1"
-      ELECTRUM_PORT: "50002"
-      ELECTRUM_TLS_ENABLED: "false"
-```
-
-You can update any of the backend settings in the `mempool-config.json` file using the following environment variables to override them under the same `api` `environment` section.
-
-JSON:
-```
-  "MEMPOOL": {
-    "NETWORK": "mainnet",
-    "BACKEND": "electrum",
-    "HTTP_PORT": 8999,
-    "SPAWN_CLUSTER_PROCS": 0,
-    "API_URL_PREFIX": "/api/v1/",
-    "POLL_RATE_MS": 2000,
-    "CACHE_DIR": "./cache",
-    "CLEAR_PROTECTION_MINUTES": 20,
-    "RECOMMENDED_FEE_PERCENTILE": 50,
-    "BLOCK_WEIGHT_UNITS": 4000000,
-    "INITIAL_BLOCKS_AMOUNT": 8,
-    "MEMPOOL_BLOCKS_AMOUNT": 8,
-    "PRICE_FEED_UPDATE_INTERVAL": 600,
-    "USE_SECOND_NODE_FOR_MINFEE": false,
-    "EXTERNAL_ASSETS": ["https://raw.githubusercontent.com/mempool/mining-pools/master/pools.json"],
-    "STDOUT_LOG_MIN_PRIORITY": "info"
-  },
-```
-
-docker-compose overrides:
-```
-      MEMPOOL_NETWORK: ""
-      MEMPOOL_BACKEND: ""
-      MEMPOOL_HTTP_PORT: ""
-      MEMPOOL_SPAWN_CLUSTER_PROCS: ""
-      MEMPOOL_API_URL_PREFIX: ""
-      MEMPOOL_POLL_RATE_MS: ""
-      MEMPOOL_CACHE_DIR: ""
-      MEMPOOL_CLEAR_PROTECTION_MINUTES: ""
-      MEMPOOL_RECOMMENDED_FEE_PERCENTILE: ""
-      MEMPOOL_BLOCK_WEIGHT_UNITS: ""
-      MEMPOOL_INITIAL_BLOCKS_AMOUNT: ""
-      MEMPOOL_MEMPOOL_BLOCKS_AMOUNT: ""
-      MEMPOOL_PRICE_FEED_UPDATE_INTERVAL: ""
-      MEMPOOL_USE_SECOND_NODE_FOR_MINFEE: ""
-      MEMPOOL_EXTERNAL_ASSETS: ""
-      MEMPOOL_STDOUT_LOG_MIN_PRIORITY: ""
-```
-
-JSON:
-```
-"CORE_RPC": {
-    "HOST": "127.0.0.1",
-    "PORT": 8332,
-    "USERNAME": "mempool",
-    "PASSWORD": "mempool"
-  },
-```
-docker-compose overrides:
-```
-      CORE_RPC_HOST: ""
-      CORE_RPC_PORT: ""
-      CORE_RPC_USERNAME: ""
-      CORE_RPC_PASSWORD: ""
-```
-
-JSON:
-```
-  "ELECTRUM": {
-    "HOST": "127.0.0.1",
-    "PORT": 50002,
-    "TLS_ENABLED": true
-  },
-```
-
-docker-compose overrides:
-```
-      ELECTRUM_HOST: ""
-      ELECTRUM_PORT: ""
-      ELECTRUM_TLS: ""
-```
-
-JSON:
-```
-  "ESPLORA": {
-    "REST_API_URL": "http://127.0.0.1:3000"
-  },
-```
-docker-compose overrides:
-```
-      ESPLORA_REST_API_URL: ""
-```
-
-JSON:
-```
-  "SECOND_CORE_RPC": {
-    "HOST": "127.0.0.1",
-    "PORT": 8332,
-    "USERNAME": "mempool",
-    "PASSWORD": "mempool"
-  },
-```
-
-docker-compose overrides:
-```
-      SECOND_CORE_RPC_HOST: ""
-      SECOND_CORE_RPC_PORT: ""
-      SECOND_CORE_RPC_USERNAME: ""
-      SECOND_CORE_RPC_PASSWORD: ""
-```
-
-JSON:
-```
-  "DATABASE": {
-    "ENABLED": true,
-    "HOST": "127.0.0.1",
-    "PORT": 3306,
-    "DATABASE": "mempool",
-    "USERNAME": "mempool",
-    "PASSWORD": "mempool"
-  },
-```
-
-docker-compose overrides:
-```
-      DATABASE_ENABLED: ""
-      DATABASE_HOST: ""
-      DATABASE_PORT: ""
-      DATABASE_DATABASE: ""
-      DATABASE_USERAME: ""
-      DATABASE_PASSWORD: ""
-```
-
-JSON:
-```
-  "SYSLOG": {
-    "ENABLED": true,
-    "HOST": "127.0.0.1",
-    "PORT": 514,
-    "MIN_PRIORITY": "info",
-    "FACILITY": "local7"
-  },
-```
-
-docker-compose overrides:
-```
-      SYSLOG_ENABLED: ""
-      SYSLOG_HOST: ""
-      SYSLOG_PORT: ""
-      SYSLOG_MIN_PRIORITY: ""
-      SYSLOG_FACILITY: ""
-```
-
-JSON:
-```
-  "STATISTICS": {
-    "ENABLED": true,
-    "TX_PER_SECOND_SAMPLE_PERIOD": 150
-  },
-```
-
-docker-compose overrides:
-```
-      STATISTICS_ENABLED: ""
-      STATISTICS_TX_PER_SECOND_SAMPLE_PERIOD: ""
-```
-
-JSON:
-```
-  "BISQ": {
-    "ENABLED": false,
-    "DATA_PATH": "/bisq/statsnode-data/btc_mainnet/db"
-  }
-```
-
-docker-compose overrides:
-```
-      BISQ_ENABLED: ""
-      BISQ_DATA_PATH: ""
-```
-
-JSON:
-```
-  "SOCKS5PROXY": {
-    "ENABLED": false,
-    "HOST": "127.0.0.1",
-    "PORT": "9050",
-    "USERNAME": "",
-    "PASSWORD": ""
-  }
-```
-
-docker-compose overrides:
-```
-      SOCKS5PROXY_ENABLED: ""
-      SOCKS5PROXY_HOST: ""
-      SOCKS5PROXY_PORT: ""
-      SOCKS5PROXY_USERNAME: ""
-      SOCKS5PROXY_PASSWORD: ""
-```
-
-JSON:
-```
-  "PRICE_DATA_SERVER": {
-    "TOR_URL": "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/getAllMarketPrices",
-    "CLEARNET_URL": "https://price.bisq.wiz.biz/getAllMarketPrices"
-  }
-```
-
-docker-compose overrides:
-```
-      PRICE_DATA_SERVER_TOR_URL: ""
-      PRICE_DATA_SERVER_CLEARNET_URL: ""
-```
-
-# Manual Installation
-
-The following instructions are for a manual installation on Linux or FreeBSD. The file and directory paths may need to be changed to match your OS.
-
-## Dependencies
+Dependencies:
 
 * [Bitcoin](https://github.com/bitcoin/bitcoin)
 * [Electrum](https://github.com/romanz/electrs)
@@ -306,9 +42,10 @@ The following instructions are for a manual installation on Linux or FreeBSD. Th
 * [MariaDB](https://github.com/mariadb/server)
 * [Nginx](https://github.com/nginx/nginx)
 
-## Mempool
+#### Get Latest Mempool Release
 
 Clone the mempool repo, and checkout the latest release tag:
+
 ```bash
   git clone https://github.com/mempool/mempool
   cd mempool
@@ -316,20 +53,22 @@ Clone the mempool repo, and checkout the latest release tag:
   git checkout $latestrelease
 ```
 
-## Bitcoin Core (bitcoind)
+#### Configure Bitcoin Core
 
 Enable RPC and txindex in `bitcoin.conf`:
+
 ```bash
   rpcuser=mempool
   rpcpassword=mempool
   txindex=1
 ```
 
-## MySQL
+#### Get & Configure MySQL
 
-Install MariaDB from OS package manager:
+Install MariaDB from your OS package manager:
+
 ```bash
-  # Linux
+  # Debian, Ubuntu, etc.
   apt-get install mariadb-server mariadb-client
 
   # macOS
@@ -338,6 +77,7 @@ Install MariaDB from OS package manager:
 ```
 
 Create database and grant privileges:
+
 ```bash
   MariaDB [(none)]> drop database mempool;
   Query OK, 0 rows affected (0.00 sec)
@@ -349,7 +89,8 @@ Create database and grant privileges:
   Query OK, 0 rows affected (0.00 sec)
 ```
 
-## Mempool Backend
+#### Build Mempool Backend
+
 Install mempool dependencies from npm and build the backend:
 
 ```bash
@@ -365,7 +106,8 @@ In the `backend` folder, make a copy of the sample config and modify it to fit y
   cp mempool-config.sample.json mempool-config.json
 ```
 
-Edit `mempool-config.json` to add your Bitcoin Core node RPC credentials:
+Edit `mempool-config.json` with your Bitcoin Core node RPC credentials:
+
 ```bash
 {
   "MEMPOOL": {
@@ -401,7 +143,7 @@ Start the backend:
   npm run start
 ```
 
-When it's running you should see output like this:
+When it's running, you should see output like this:
 
 ```bash
   Mempool updated in 0.189 seconds
@@ -424,9 +166,9 @@ When it's running you should see output like this:
   Updating mempool
 ```
 
-## Mempool Frontend
+#### Build Mempool Frontend
 
-Install mempool dependencies from npm and build the frontend static HTML/CSS/JS:
+Install the Mempool dependencies with npm and build the frontend:
 
 ```bash
   # frontend
@@ -435,15 +177,15 @@ Install mempool dependencies from npm and build the frontend static HTML/CSS/JS:
   npm run build
 ```
 
-Install the output into nginx webroot folder:
+Install the output into the nginx webroot folder:
 
 ```bash
   sudo rsync -av --delete dist/ /var/www/
 ```
 
-## nginx + certbot
+#### `nginx` + `certbot`
 
-Install the supplied nginx.conf and nginx-mempool.conf in /etc/nginx
+Install the supplied `nginx.conf` and `nginx-mempool.conf` in `/etc/nginx`:
 
 ```bash
   # install nginx and certbot
@@ -457,7 +199,6 @@ Install the supplied nginx.conf and nginx-mempool.conf in /etc/nginx
 
 ```
 
-If everything went okay you should see the beautiful mempool :grin:
+If everything went well, you should see the beautiful mempool :grin:
 
-If you get stuck on "loading blocks", this means the websocket can't connect.
-Check your nginx proxy setup, firewalls, etc. and open an issue if you need help.
+If you get stuck on "loading blocks", this means the websocket can't connect. Check your nginx proxy setup, firewalls, etc. and open an issue if you need help.

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ It is an open-source project developed and operated for the benefit of the Bitco
 
 ![mempool](https://mempool.space/resources/screenshots/v2.3.0-dashboard.png)
 
-## Installation Methods
+# Installation Methods
 
 Mempool can be self-hosted on a wide variety of your own hardware, ranging from a simple one-click installation on a Raspberry Pi full-node distro all the way to a robust production instance on a powerful FreeBSD server. 
 
 We support the following installation methods, ranked in order from simple to advanced:
 
 1) [One-click installation on full-node distros](#one-click-installation)
-2) [Docker installation on Linux using docker-compose](./docker/README.md)
+2) [Docker installation on Linux using docker-compose](./docker)
 3) [Manual installation on Linux or FreeBSD](#manual-installation)
-4) [Production installation on a powerful FreeBSD server](./production/README.md)
+4) [Production installation on a powerful FreeBSD server](./production)
 
 This doc offers install notes on the one-click method and manual install method. Follow the links above for install notes on Docker and production installations.
 
 <a id="one-click-installation"></a>
-### One-Click Installation
+## One-Click Installation
 
 Mempool can be conveniently installed on the following full-node distros: 
 - [Umbrel](https://github.com/getumbrel/umbrel)
@@ -30,74 +30,73 @@ Mempool can be conveniently installed on the following full-node distros:
 - [Start9](https://github.com/Start9Labs/embassy-os)
 
 <a id="manual-installation"></a>
-### Manual Installation
+## Manual Installation
 
 The following instructions are for a manual installation on Linux or FreeBSD. You may need to change file and directory paths to match your OS.
 
 You will need [Bitcoin](https://github.com/bitcoin/bitcoin), [Electrum](https://github.com/romanz/electrs), [Node.js](https://github.com/nodejs/node), [MariaDB](https://github.com/mariadb/server), and [Nginx](https://github.com/nginx/nginx). Below, we walk through how to configure each of these.
 
-#### 1. Get Latest Mempool Release
+### 1. Get Latest Mempool Release
 
 Clone the Mempool repo, and checkout the latest release tag:
 
 ```bash
-  git clone https://github.com/mempool/mempool
-  cd mempool
-  latestrelease=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
-  git checkout $latestrelease
+$ git clone https://github.com/mempool/mempool
+$ cd mempool
+$ latestrelease=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
+$ git checkout $latestrelease
 ```
 
-#### 2. Configure Bitcoin Core
+### 2. Configure Bitcoin Core
 
 Enable RPC and txindex in `bitcoin.conf`:
 
 ```bash
-  rpcuser=mempool
-  rpcpassword=mempool
-  txindex=1
+rpcuser=mempool
+rpcpassword=mempool
+txindex=1
 ```
 
-#### 3. Get & Configure MySQL
+### 3. Get & Configure MySQL
 
 Install MariaDB from your OS package manager:
 
 ```bash
-  # Debian, Ubuntu, etc.
-  apt-get install mariadb-server mariadb-client
+# Debian, Ubuntu, etc.
+$ apt-get install mariadb-server mariadb-client
 
-  # macOS
-  brew install mariadb
-  mysql.server start
+# macOS
+$ brew install mariadb
+$ mysql.server start
 ```
 
 Create a database and grant privileges:
 
 ```bash
-  MariaDB [(none)]> drop database mempool;
-  Query OK, 0 rows affected (0.00 sec)
+MariaDB [(none)]> drop database mempool;
+Query OK, 0 rows affected (0.00 sec)
 
-  MariaDB [(none)]> create database mempool;
-  Query OK, 1 row affected (0.00 sec)
+MariaDB [(none)]> create database mempool;
+Query OK, 1 row affected (0.00 sec)
 
-  MariaDB [(none)]> grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';
-  Query OK, 0 rows affected (0.00 sec)
+MariaDB [(none)]> grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';
+Query OK, 0 rows affected (0.00 sec)
 ```
 
-#### 4. Build Mempool Backend
+### 4. Build Mempool Backend
 
-Install mempool dependencies from npm and build the backend:
+Install Mempool dependencies with npm and build the backend:
 
 ```bash
-  # backend
-  cd backend
-  npm install --prod
-  npm run build
+$ cd backend
+$ npm install --prod
+$ npm run build
 ```
 
 In the `backend` folder, make a copy of the sample config:
 
 ```bash
-  cp mempool-config.sample.json mempool-config.json
+$ cp mempool-config.sample.json mempool-config.json
 ```
 
 Edit `mempool-config.json` with your Bitcoin Core node RPC credentials:
@@ -134,63 +133,61 @@ Edit `mempool-config.json` with your Bitcoin Core node RPC credentials:
 Start the backend:
 
 ```bash
-  npm run start
+$ npm run start
 ```
 
 When it's running, you should see output like this:
 
 ```bash
-  Mempool updated in 0.189 seconds
-  Updating mempool
-  Mempool updated in 0.096 seconds
-  Updating mempool
-  Mempool updated in 0.099 seconds
-  Updating mempool
-  Calculated fee for transaction 1 / 10
-  Calculated fee for transaction 2 / 10
-  Calculated fee for transaction 3 / 10
-  Calculated fee for transaction 4 / 10
-  Calculated fee for transaction 5 / 10
-  Calculated fee for transaction 6 / 10
-  Calculated fee for transaction 7 / 10
-  Calculated fee for transaction 8 / 10
-  Calculated fee for transaction 9 / 10
-  Calculated fee for transaction 10 / 10
-  Mempool updated in 0.243 seconds
-  Updating mempool
+Mempool updated in 0.189 seconds
+Updating mempool
+Mempool updated in 0.096 seconds
+Updating mempool
+Mempool updated in 0.099 seconds
+Updating mempool
+Calculated fee for transaction 1 / 10
+Calculated fee for transaction 2 / 10
+Calculated fee for transaction 3 / 10
+Calculated fee for transaction 4 / 10
+Calculated fee for transaction 5 / 10
+Calculated fee for transaction 6 / 10
+Calculated fee for transaction 7 / 10
+Calculated fee for transaction 8 / 10
+Calculated fee for transaction 9 / 10
+Calculated fee for transaction 10 / 10
+Mempool updated in 0.243 seconds
+Updating mempool
 ```
 
-#### 5. Build Mempool Frontend
+### 5. Build Mempool Frontend
 
 Install the Mempool dependencies with npm and build the frontend:
 
 ```bash
-  # frontend
-  cd frontend
-  npm install --prod
-  npm run build
+$ cd frontend
+$ npm install --prod
+$ npm run build
 ```
 
 Install the output into the nginx webroot folder:
 
 ```bash
-  sudo rsync -av --delete dist/ /var/www/
+$ sudo rsync -av --delete dist/ /var/www/
 ```
 
-#### 6. `nginx` + `certbot`
+### 6. `nginx` + `certbot`
 
 Install the supplied `nginx.conf` and `nginx-mempool.conf` in `/etc/nginx`:
 
 ```bash
-  # install nginx and certbot
-  apt-get install -y nginx python3-certbot-nginx
+# install nginx and certbot
+$ apt-get install -y nginx python3-certbot-nginx
 
-  # install the mempool configuration for nginx
-  cp nginx.conf nginx-mempool.conf /etc/nginx/
+# install the mempool configuration for nginx
+$ cp nginx.conf nginx-mempool.conf /etc/nginx/
 
-  # replace example.com with your domain name
-  certbot --nginx -d example.com
-
+# replace example.com with your domain name
+$ certbot --nginx -d example.com
 ```
 
 If everything went well, you should see the beautiful mempool :grin:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # The Mempool Open Source Project™ [![mempool](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/ry4br7/master&style=flat-square)](https://dashboard.cypress.io/projects/ry4br7/runs)
 
-Mempool is the fully featured visualizer, explorer, and API service running on [mempool.space](https://mempool.space/), an open source project developed and operated for the benefit of the Bitcoin community, with a focus on the emerging transaction fee market to help our transition into a multi-layer ecosystem.
+Mempool is the fully-featured mempool visualizer, explorer, and API service running at [mempool.space](https://mempool.space/). 
+
+It is an open-source project developed and operated for the benefit of the Bitcoin community, with a focus on the emerging transaction fee market that is evolving Bitcoin into a multi-layer ecosystem.
 
 ![mempool](https://mempool.space/resources/screenshots/v2.3.0-dashboard.png)
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,24 @@ It is an open-source project developed and operated for the benefit of the Bitco
 
 ## Installation Methods
 
-Mempool can be self-hosted on a wide variety of your own hardware, ranging from a simple one-click installation on a Raspberry Pi distro, all the way to an advanced high availability cluster of powerful servers for a production instance. We support the following installation methods, ranked in order from simple to advanced:
+Mempool can be self-hosted on a wide variety of your own hardware, ranging from a simple one-click installation on a Raspberry Pi full-node distro all the way to a robust production instance on a powerful FreeBSD server. 
 
-1) One-click installation on: [Umbrel](https://github.com/getumbrel/umbrel), [RaspiBlitz](https://github.com/rootzoll/raspiblitz), [RoninDojo](https://code.samourai.io/ronindojo/RoninDojo), or [MyNode](https://github.com/mynodebtc/mynode).
-2) [Docker installation on Linux using docker-compose](https://github.com/mempool/mempool/tree/master/docker)
-3) [Manual installation on Linux or FreeBSD](https://github.com/mempool/mempool#manual-installation)
+We support the following installation methods, ranked in order from simple to advanced:
+
+1) [One-click installation on full-node distros](#one-click-installation)
+2) [Docker installation on Linux using docker-compose](#docker-installation)
+3) [Manual installation on Linux or FreeBSD](#manual-installation)
 4) [Production installation on a powerful FreeBSD server](https://github.com/mempool/mempool/tree/master/production)
-5) [High Availability cluster using powerful FreeBSD servers](https://github.com/mempool/mempool/tree/master/production#high-availability)
+
+<a id="one-click-installation"></a>
+### One-click installation on full-node distros
+
+Mempool can be conveniently installed on the following full-node distros: 
+- [Umbrel](https://github.com/getumbrel/umbrel)
+- [RaspiBlitz](https://github.com/rootzoll/raspiblitz)
+- [RoninDojo](https://code.samourai.io/ronindojo/RoninDojo)
+- [myNode](https://github.com/mynodebtc/mynode)
+- [Start9](https://github.com/Start9Labs/embassy-os)
 
 # Docker Installation
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,11 @@ Mempool can be conveniently installed on the following full-node distros:
 
 The following instructions are for a manual installation on Linux or FreeBSD. You may need to change file and directory paths to match your OS.
 
-Dependencies:
+You will need [Bitcoin](https://github.com/bitcoin/bitcoin), [Electrum](https://github.com/romanz/electrs), [Node.js](https://github.com/nodejs/node), [MariaDB](https://github.com/mariadb/server), and [Nginx](https://github.com/nginx/nginx). Below, we walk through how to configure each of these.
 
-* [Bitcoin](https://github.com/bitcoin/bitcoin)
-* [Electrum](https://github.com/romanz/electrs)
-* [NodeJS](https://github.com/nodejs/node)
-* [MariaDB](https://github.com/mariadb/server)
-* [Nginx](https://github.com/nginx/nginx)
+#### 1. Get Latest Mempool Release
 
-#### Get Latest Mempool Release
-
-Clone the mempool repo, and checkout the latest release tag:
+Clone the Mempool repo, and checkout the latest release tag:
 
 ```bash
   git clone https://github.com/mempool/mempool
@@ -53,7 +47,7 @@ Clone the mempool repo, and checkout the latest release tag:
   git checkout $latestrelease
 ```
 
-#### Configure Bitcoin Core
+#### 2. Configure Bitcoin Core
 
 Enable RPC and txindex in `bitcoin.conf`:
 
@@ -63,7 +57,7 @@ Enable RPC and txindex in `bitcoin.conf`:
   txindex=1
 ```
 
-#### Get & Configure MySQL
+#### 3. Get & Configure MySQL
 
 Install MariaDB from your OS package manager:
 
@@ -76,7 +70,7 @@ Install MariaDB from your OS package manager:
   mysql.server start
 ```
 
-Create database and grant privileges:
+Create a database and grant privileges:
 
 ```bash
   MariaDB [(none)]> drop database mempool;
@@ -89,7 +83,7 @@ Create database and grant privileges:
   Query OK, 0 rows affected (0.00 sec)
 ```
 
-#### Build Mempool Backend
+#### 4. Build Mempool Backend
 
 Install mempool dependencies from npm and build the backend:
 
@@ -100,7 +94,7 @@ Install mempool dependencies from npm and build the backend:
   npm run build
 ```
 
-In the `backend` folder, make a copy of the sample config and modify it to fit your settings.
+In the `backend` folder, make a copy of the sample config:
 
 ```bash
   cp mempool-config.sample.json mempool-config.json
@@ -166,7 +160,7 @@ When it's running, you should see output like this:
   Updating mempool
 ```
 
-#### Build Mempool Frontend
+#### 5. Build Mempool Frontend
 
 Install the Mempool dependencies with npm and build the frontend:
 
@@ -183,7 +177,7 @@ Install the output into the nginx webroot folder:
   sudo rsync -av --delete dist/ /var/www/
 ```
 
-#### `nginx` + `certbot`
+#### 6. `nginx` + `certbot`
 
 Install the supplied `nginx.conf` and `nginx-mempool.conf` in `/etc/nginx`:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,334 @@
+# Docker Installation
+
+This directory contains the Dockerfiles used to build and release the official images and a `docker-compose.yml` for end users to run a Mempool instance with minimal effort.
+
+You can choose to configure Mempool to run with a basic backend powered by just `bitcoind`, or with `bitcoind` along with an Electrum-compatible server for full functionality.
+
+## `bitcoind`-only Configuration
+
+_Note: address lookups require an Electrum server and will not work with this configuration._
+
+Make sure `bitcoind` is running and synced.
+
+The default Docker configuration assumes you have added RPC credentials for a `mempool` user with a `mempool` password in your `bitcoin.conf` file, like so:
+
+```
+rpcuser=mempool
+rpcpassword=mempool
+```
+
+If you want to use different credentials, specify them in the `docker-compose.yml` file:
+
+```
+  api:
+    environment:
+      MEMPOOL_BACKEND: "none"
+      CORE_RPC_HOST: "172.27.0.1"
+      CORE_RPC_PORT: "8332"
+      CORE_RPC_USERNAME: "customuser"
+      CORE_RPC_PASSWORD: "custompassword"
+```
+
+The IP address in the example above refers to Docker's default gateway IP address so that the container can hit the `bitcoind` instance running on the host machine. If your setup is different, update it accordingly.
+
+Now, run:
+
+```bash
+$ docker-compose up
+```
+
+Your Mempool instance should be running at http://localhost. The graphs will be populated as new transactions are detected.
+
+## `bitcoind` + Electrum Server Configuration
+
+First, configure `bitcoind` as specified above, and make sure your Electrum server is running and synced.
+
+Then, make sure the following variables are set in `docker-compose.yml`, as shown below, so Mempool can connect to your Electrum server:
+
+```
+  api:
+    environment:
+      MEMPOOL_BACKEND: "electrum"
+      ELECTRUM_HOST: "172.27.0.1"
+      ELECTRUM_PORT: "50002"
+      ELECTRUM_TLS_ENABLED: "false"
+```
+
+Of course, if your Docker host IP address is different, update accordingly.
+
+With `bitcoind` and Electrum Server set up, run Mempool with:
+
+```bash
+$ docker-compose up
+```
+
+## Further Configuration
+
+Optionally, you can override any other backend settings from `mempool-config.json`.
+
+Below we list all settings from `mempool-config.json` and the corresponding overrides you can make in the `api` > `environment` section of `docker-compose.yml`. 
+
+<br/>
+
+`mempool-config.json`:
+```
+  "MEMPOOL": {
+    "NETWORK": "mainnet",
+    "BACKEND": "electrum",
+    "HTTP_PORT": 8999,
+    "SPAWN_CLUSTER_PROCS": 0,
+    "API_URL_PREFIX": "/api/v1/",
+    "POLL_RATE_MS": 2000,
+    "CACHE_DIR": "./cache",
+    "CLEAR_PROTECTION_MINUTES": 20,
+    "RECOMMENDED_FEE_PERCENTILE": 50,
+    "BLOCK_WEIGHT_UNITS": 4000000,
+    "INITIAL_BLOCKS_AMOUNT": 8,
+    "MEMPOOL_BLOCKS_AMOUNT": 8,
+    "PRICE_FEED_UPDATE_INTERVAL": 600,
+    "USE_SECOND_NODE_FOR_MINFEE": false,
+    "EXTERNAL_ASSETS": ["https://raw.githubusercontent.com/mempool/mining-pools/master/pools.json"],
+    "STDOUT_LOG_MIN_PRIORITY": "info"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      MEMPOOL_NETWORK: ""
+      MEMPOOL_BACKEND: ""
+      MEMPOOL_HTTP_PORT: ""
+      MEMPOOL_SPAWN_CLUSTER_PROCS: ""
+      MEMPOOL_API_URL_PREFIX: ""
+      MEMPOOL_POLL_RATE_MS: ""
+      MEMPOOL_CACHE_DIR: ""
+      MEMPOOL_CLEAR_PROTECTION_MINUTES: ""
+      MEMPOOL_RECOMMENDED_FEE_PERCENTILE: ""
+      MEMPOOL_BLOCK_WEIGHT_UNITS: ""
+      MEMPOOL_INITIAL_BLOCKS_AMOUNT: ""
+      MEMPOOL_MEMPOOL_BLOCKS_AMOUNT: ""
+      MEMPOOL_PRICE_FEED_UPDATE_INTERVAL: ""
+      MEMPOOL_USE_SECOND_NODE_FOR_MINFEE: ""
+      MEMPOOL_EXTERNAL_ASSETS: ""
+      MEMPOOL_STDOUT_LOG_MIN_PRIORITY: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+"CORE_RPC": {
+    "HOST": "127.0.0.1",
+    "PORT": 8332,
+    "USERNAME": "mempool",
+    "PASSWORD": "mempool"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      CORE_RPC_HOST: ""
+      CORE_RPC_PORT: ""
+      CORE_RPC_USERNAME: ""
+      CORE_RPC_PASSWORD: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "ELECTRUM": {
+    "HOST": "127.0.0.1",
+    "PORT": 50002,
+    "TLS_ENABLED": true
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      ELECTRUM_HOST: ""
+      ELECTRUM_PORT: ""
+      ELECTRUM_TLS: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "ESPLORA": {
+    "REST_API_URL": "http://127.0.0.1:3000"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      ESPLORA_REST_API_URL: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "SECOND_CORE_RPC": {
+    "HOST": "127.0.0.1",
+    "PORT": 8332,
+    "USERNAME": "mempool",
+    "PASSWORD": "mempool"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      SECOND_CORE_RPC_HOST: ""
+      SECOND_CORE_RPC_PORT: ""
+      SECOND_CORE_RPC_USERNAME: ""
+      SECOND_CORE_RPC_PASSWORD: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "DATABASE": {
+    "ENABLED": true,
+    "HOST": "127.0.0.1",
+    "PORT": 3306,
+    "DATABASE": "mempool",
+    "USERNAME": "mempool",
+    "PASSWORD": "mempool"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      DATABASE_ENABLED: ""
+      DATABASE_HOST: ""
+      DATABASE_PORT: ""
+      DATABASE_DATABASE: ""
+      DATABASE_USERAME: ""
+      DATABASE_PASSWORD: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "SYSLOG": {
+    "ENABLED": true,
+    "HOST": "127.0.0.1",
+    "PORT": 514,
+    "MIN_PRIORITY": "info",
+    "FACILITY": "local7"
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      SYSLOG_ENABLED: ""
+      SYSLOG_HOST: ""
+      SYSLOG_PORT: ""
+      SYSLOG_MIN_PRIORITY: ""
+      SYSLOG_FACILITY: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "STATISTICS": {
+    "ENABLED": true,
+    "TX_PER_SECOND_SAMPLE_PERIOD": 150
+  },
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      STATISTICS_ENABLED: ""
+      STATISTICS_TX_PER_SECOND_SAMPLE_PERIOD: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "BISQ": {
+    "ENABLED": false,
+    "DATA_PATH": "/bisq/statsnode-data/btc_mainnet/db"
+  }
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      BISQ_ENABLED: ""
+      BISQ_DATA_PATH: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "SOCKS5PROXY": {
+    "ENABLED": false,
+    "HOST": "127.0.0.1",
+    "PORT": "9050",
+    "USERNAME": "",
+    "PASSWORD": ""
+  }
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      SOCKS5PROXY_ENABLED: ""
+      SOCKS5PROXY_HOST: ""
+      SOCKS5PROXY_PORT: ""
+      SOCKS5PROXY_USERNAME: ""
+      SOCKS5PROXY_PASSWORD: ""
+      ...
+```
+
+<br/>
+
+`mempool-config.json`:
+```
+  "PRICE_DATA_SERVER": {
+    "TOR_URL": "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/getAllMarketPrices",
+    "CLEARNET_URL": "https://price.bisq.wiz.biz/getAllMarketPrices"
+  }
+```
+
+Corresponding `docker-compose.yml` overrides:
+```
+  api:
+    environment:
+      PRICE_DATA_SERVER_TOR_URL: ""
+      PRICE_DATA_SERVER_CLEARNET_URL: ""
+      ...
+```


### PR DESCRIPTION
These changes overhaul the main README, which ended up including revisions to the Docker install notes since they currently live in the main README.

The goal was to make to make these docs better organized, more readable, and easier to follow.

Production install notes will be revised separately.

Notable changes:
- Add Start9 to one-click installation list
- Move Docker installation docs to `./docker/README`
- Correct Docker settings override example ([proposed changes](https://github.com/mempool/mempool/commit/b6c80c7dc395664752e63722da39d2c3d4fa9cca#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49R26-R29) vs [existing example](https://github.com/mempool/mempool#bitcoind-only-configuration))
- Remove HA deployment link