### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-issue.md
@@ -1,14 +1,13 @@
 ---
 name: 🐛 Bug Report
-about: Report bugs or other issues to us on GitHub
+about: Report bugs (no support requests, please)
 ---
 
 <!--
    SUPPORT REQUESTS:
    This is for reporting bugs in Mempool, not for support requests. 
-   If you have a support request, please join our Keybase or Matrix:
-   https://keybase.io/team/mempool
-   https://matrix.to/#/#mempool:bitcoin.kyoto
+   If you have a support request, please reach out on Matrix:
+   https://matrix.to/#/#mempool.support:bitcoin.kyoto
 -->
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/30-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/30-feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: ✨ Feature Request
-about: Request a feature or suggest other enhancements 💡
+about: Request a feature or suggest other enhancements
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/30-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/30-feature-request.md
@@ -6,9 +6,8 @@ about: Request a feature or suggest other enhancements 💡
 <!--
    SUPPORT REQUESTS:
    This is for requesting features in Mempool, not for support requests. 
-   If you have a support request, please join our Keybase or Matrix:
-   https://keybase.io/team/mempool
-   https://matrix.to/#/#mempool:bitcoin.kyoto
+   If you have a support request, please reach out on Matrix:
+   https://matrix.to/#/#mempool.support:bitcoin.kyoto
 -->
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Need help? Chat with us on Matrix
-    url: https://matrix.to/#/#mempool:bitcoin.kyoto
-    about: For support requests or general questions
-  - name: 💬 Need help? Chat with us on Keybase
-    url: https://keybase.io/team/mempool
+  - name: 🙋 Need help? Chat with us on Matrix
+    url: https://matrix.to/#/#mempool.support:bitcoin.kyoto
     about: For support requests or general questions


### PR DESCRIPTION
Goals:
- Remove links to Keybase
- Link to `#mempool.support` room instead of `#mempool` room
- Encourage people to chat on Matrix for help instead of opening an issue

Another goal was to make the support link the first option, but it doesn't seem like that's possible. You can reorder issue templates and you can reorder links, but all issue template are shown before all links. 

![Screenshot from 2022-05-09 12-13-39-2](https://user-images.githubusercontent.com/93150691/167732748-6e932394-4154-4c1a-949e-6fac29a0b2c9.png)

