### PR TITLE
Fix the socks5 connection after updating the socks lib

### DIFF
--- a/backend/src/api/fiat-conversion.ts
+++ b/backend/src/api/fiat-conversion.ts
@@ -43,7 +43,7 @@ class FiatConversion {
           agentOptions: {
             keepAlive: true,
           },
-          host: config.SOCKS5PROXY.HOST,
+          hostname: config.SOCKS5PROXY.HOST,
           port: config.SOCKS5PROXY.PORT
         };
 

--- a/backend/src/sync-assets.ts
+++ b/backend/src/sync-assets.ts
@@ -29,7 +29,7 @@ class SyncAssets {
             agentOptions: {
               keepAlive: true,
             },
-            host: config.SOCKS5PROXY.HOST,
+            hostname: config.SOCKS5PROXY.HOST,
             port: config.SOCKS5PROXY.PORT
           };
 


### PR DESCRIPTION
The `host` field was renamed to `hostname` in a recent release