### PR TITLE
Fix for transaction inputs being fetched recursively

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -2,7 +2,7 @@ import { IEsploraApi } from './esplora-api.interface';
 
 export interface AbstractBitcoinApi {
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
-  $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, blockHash?: string): Promise<IEsploraApi.Transaction>;
+  $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean): Promise<IEsploraApi.Transaction>;
   $getBlockHeightTip(): Promise<number>;
   $getTxIdsForBlock(hash: string): Promise<string[]>;
   $getBlockHash(height: number): Promise<string>;


### PR DESCRIPTION
This bug is affecting bitcoin core backend.

When calculating fees and getting the address by fetching the previous-transaction (prevouts), it recursively did the same for the prevout TXs without stopping. 

This PR adds a stop so it only goes 1 layer deep which is the only thing required.

The performance difference of loading the block transactions pages now is extremely noticeable. 