### PR TITLE
Remove unused config from nginx

### DIFF
--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -44,25 +44,6 @@
 		try_files $uri $uri/ /en-US/index.html =404;
 	}
 
-	# mainnet API
-	location /api/v1/donations {
-		proxy_pass https://mempool.space;
-	}
-	location /api/v1/donations/images {
-		proxy_pass https://mempool.space;
-	}
-	location /api/v1/contributors {
-		proxy_pass https://mempool.space;
-	}
-	location /api/v1/contributors/images {
-		proxy_pass https://mempool.space;
-	}
-	location /api/v1/translators {
-		proxy_pass https://mempool.space;
-	}
-	location /api/v1/translators/images {
-		proxy_pass https://mempool.space;
-	}
 	location /api/v1/ws {
 		proxy_pass http://127.0.0.1:8999/;
 		proxy_http_version 1.1;


### PR DESCRIPTION
Since the express router does the proxy for backend api endpoint https://github.com/mempool/mempool/blob/master/backend/src/index.ts#L231,

I think it would be good to remove the proxy_pass directive to avoid confusion for users installing mempool instances.