### PR TITLE
Fix for reward stats race condition trigger

### DIFF
--- a/frontend/src/app/components/reward-stats/reward-stats.component.ts
+++ b/frontend/src/app/components/reward-stats/reward-stats.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { concat, Observable } from 'rxjs';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { merge, Observable } from 'rxjs';
+import { map, skip, switchMap } from 'rxjs/operators';
 import { ApiService } from 'src/app/services/api.service';
 import { StateService } from 'src/app/services/state.service';
 
@@ -12,30 +12,22 @@ import { StateService } from 'src/app/services/state.service';
 })
 export class RewardStatsComponent implements OnInit {
   public $rewardStats: Observable<any>;
-  private lastBlockHeight: number;
 
-  constructor(private apiService: ApiService, private stateService: StateService) { }
+  constructor(
+    private apiService: ApiService,
+    private stateService: StateService
+    ) { }
 
   ngOnInit(): void {
-    this.$rewardStats = concat(
+    this.$rewardStats = merge(
       // We fetch the latest reward stats when the page load and
       // wait for the API response before listening to websocket blocks
-      this.apiService.getRewardStats$()
-        .pipe(
-          tap((stats) => {
-            this.lastBlockHeight = stats.endBlock;
-          })
-        ),
+      this.apiService.getRewardStats$(),
       // Or when we receive a newer block, newer than the latest reward stats api call
       this.stateService.blocks$
         .pipe(
-          switchMap((block) => {
-            if (block[0].height <= this.lastBlockHeight) {
-              return []; // Return an empty stream so the last pipe is not executed
-            }
-            this.lastBlockHeight = block[0].height;
-            return this.apiService.getRewardStats$();
-          })
+          skip(this.stateService.env.KEEP_BLOCKS_AMOUNT),
+          switchMap(() => this.apiService.getRewardStats$()),
         )
       )
       .pipe(


### PR DESCRIPTION
Reward stats was sometimes triggered multiple times.

This fix should make sure that reward stats is fetched only first time, and then on new blocks.

**EDIT** I am not able to reproduce the race condition bug... So the original code "should" work fine. I can't explain the reason for the blocks$ to get triggered before the $getRewardStats$ has returned any result.