### PR TITLE
Additional expiration header for mining pool API endpoints

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -723,6 +723,7 @@ class Routes {
   public async getBlocksExtras(req: Request, res: Response) {
     try {
       const height = req.params.height === undefined ? undefined : parseInt(req.params.height, 10);
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(await blocks.$getBlocksExtras(height, 15));
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
@@ -1002,6 +1003,7 @@ class Routes {
   public async $getRewardStats(req: Request, res: Response) {
     try {
       const response = await mining.$getRewardStats(parseInt(req.params.blockCount, 10));
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(response);
     } catch (e) {
       res.status(500).end();


### PR DESCRIPTION
* `/blocks-extras` set to 1 min expiration
* `/blocks-extras/:height` set to 1 min expiration
* `/mining/reward-stats/:blockCount` set to 1 min expiration (:blockCount is set to 144 in the frontend currently)

Fixes the issue described here https://github.com/mempool/mempool/pull/1675