### PR TITLE
Set /mining/blocks/xxx APIs expiration to 60 seconds instead of 5 min

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -645,7 +645,7 @@ class Routes {
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.header('X-total-count', blockCount.toString());
-      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(blockFees);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
@@ -659,7 +659,7 @@ class Routes {
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.header('X-total-count', blockCount.toString());
-      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(blockRewards);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
@@ -672,7 +672,7 @@ class Routes {
       const oldestIndexedBlockTimestamp = await BlocksRepository.$oldestBlockTimestamp();
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
-      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json({
         oldestIndexedBlockTimestamp: oldestIndexedBlockTimestamp,
         blockFeeRates: blockFeeRates,
@@ -690,7 +690,7 @@ class Routes {
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.header('X-total-count', blockCount.toString());
-      res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json({
         sizes: blockSizes,
         weights: blockWeights


### PR DESCRIPTION
I'm not sure why I've set those API endpoint expiration to 5 minutes since they depend on blocks. I've set them to 60 seconds now.

```
/mining/blocks/fees/:interval
/mining/blocks/rewards/:interval
/mining/blocks/fee-rates/:interval
/mining/blocks/sizes-weights/:interval
```