### PR TITLE
NgBootstrap library import optimization

### DIFF
--- a/frontend/src/app/bisq/bisq.module.ts
+++ b/frontend/src/app/bisq/bisq.module.ts
@@ -7,7 +7,6 @@ import { LightweightChartsComponent } from './lightweight-charts/lightweight-cha
 import { LightweightChartsAreaComponent } from './lightweight-charts-area/lightweight-charts-area.component';
 import { BisqMarketComponent } from './bisq-market/bisq-market.component';
 import { BisqTransactionsComponent } from './bisq-transactions/bisq-transactions.component';
-import { NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
 import { BisqTransactionComponent } from './bisq-transaction/bisq-transaction.component';
 import { BisqBlockComponent } from './bisq-block/bisq-block.component';
 import { BisqDashboardComponent } from './bisq-dashboard/bisq-dashboard.component';
@@ -50,7 +49,6 @@ import { CommonModule } from '@angular/common';
     CommonModule,
     BisqRoutingModule,
     SharedModule,
-    NgbPaginationModule,
     FontAwesomeModule,
     NgxBootstrapMultiselectModule,
   ],

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCollapse, NgbCollapseModule, NgbRadioGroup, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, faChartArea, faCogs, faCubes, faHammer, faDatabase, faExchangeAlt, faInfoCircle,
   faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown,
@@ -146,11 +145,10 @@ import { IndexingProgressComponent } from '../components/indexing-progress/index
     NgbTooltipModule,
     NgbButtonsModule,
     NgbPaginationModule,
-    NgbDropdownModule,
-    NgbAccordionModule,
-    InfiniteScrollModule,
     NgbTypeaheadModule,
-    NgbModule,
+    NgbDropdownModule,
+    NgbCollapseModule,
+    InfiniteScrollModule,
     FontAwesomeModule,
   ],
   providers: [
@@ -162,17 +160,16 @@ import { IndexingProgressComponent } from '../components/indexing-progress/index
   ],
   exports: [
     RouterModule,
-    InfiniteScrollModule,
-    NgbTypeaheadModule,
-    NgbModule,
-    FontAwesomeModule,
-    NgbAccordionModule,
-    NgbNavModule,
     ReactiveFormsModule,
+    NgbNavModule,
     NgbTooltipModule,
     NgbButtonsModule,
     NgbPaginationModule,
+    NgbTypeaheadModule,
     NgbDropdownModule,
+    NgbCollapseModule,
+    InfiniteScrollModule,
+    FontAwesomeModule,
     TimeSinceComponent,
     TimeUntilComponent,
     ClipboardComponent,


### PR DESCRIPTION
Using the recommended import method from here https://ng-bootstrap.github.io/#/getting-started to only import the NgbBoostrap modules we are needed instead of the whole library.

I didn't see any immediate size differences in the bundle.. 