### PR TITLE
Add `economyFee` field in /api/fees/recommended API

### DIFF
--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -20,6 +20,7 @@ class FeeApi {
         'halfHourFee': this.defaultFee,
         'hourFee': this.defaultFee,
         'minimumFee': minimumFee,
+        'economyFee': 2 * minimumFee,
       };
     }
 
@@ -32,6 +33,7 @@ class FeeApi {
       'halfHourFee': secondMedianFee,
       'hourFee': thirdMedianFee,
       'minimumFee': minimumFee,
+      'economyFee': 2 * minimumFee,
     };
   }
 

--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -4470,7 +4470,8 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
-  minimumFee: 1
+  minimumFee: 1,
+  economyFee: 1
 }`
         },
         codeSampleTestnet: {
@@ -4481,7 +4482,8 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
-  minimumFee: 1
+  minimumFee: 1,
+  economyFee: 1
 }`
         },
         codeSampleSignet: {
@@ -4492,7 +4494,8 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
-  minimumFee: 1
+  minimumFee: 1,
+  economyFee: 1
 }`
         },
         codeSampleLiquid: {
@@ -4503,7 +4506,8 @@ export const restApiDocsData = [
   fastestFee: 0.1,
   halfHourFee: 0.1,
   hourFee: 0.1,
-  minimumFee: 1
+  minimumFee: 1,
+  economyFee: 1
 }`
         },
         codeSampleLiquidTestnet: {
@@ -4514,7 +4518,8 @@ export const restApiDocsData = [
   fastestFee: 0.1,
   halfHourFee: 0.1,
   hourFee: 0.1,
-  minimumFee: 1
+  minimumFee: 1,
+  economyFee: 1
 }`
         },
         codeSampleBisq: emptyCodeSample,


### PR DESCRIPTION
Context https://github.com/mempool/mempool/issues/1726

Added `economyFee` field in `/api/fees/recommended` API which is always `2 x minimumFee`.