### PR TITLE
Add `economyFee` field in /api/fees/recommended API

### DIFF
--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -1,4 +1,3 @@
-import config from '../config';
 import { MempoolBlock } from '../mempool.interfaces';
 import { Common } from './common';
 import mempool from './mempool';
@@ -19,6 +18,7 @@ class FeeApi {
         'fastestFee': this.defaultFee,
         'halfHourFee': this.defaultFee,
         'hourFee': this.defaultFee,
+        'economyFee': minimumFee,
         'minimumFee': minimumFee,
       };
     }
@@ -31,6 +31,7 @@ class FeeApi {
       'fastestFee': firstMedianFee,
       'halfHourFee': secondMedianFee,
       'hourFee': thirdMedianFee,
+      'economyFee': Math.min(2 * minimumFee, thirdMedianFee),
       'minimumFee': minimumFee,
     };
   }

--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -4470,6 +4470,7 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
+  economyFee: 1,
   minimumFee: 1
 }`
         },
@@ -4481,6 +4482,7 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
+  economyFee: 1,
   minimumFee: 1
 }`
         },
@@ -4492,6 +4494,7 @@ export const restApiDocsData = [
   fastestFee: 1,
   halfHourFee: 1,
   hourFee: 1,
+  economyFee: 1,
   minimumFee: 1
 }`
         },
@@ -4503,7 +4506,8 @@ export const restApiDocsData = [
   fastestFee: 0.1,
   halfHourFee: 0.1,
   hourFee: 0.1,
-  minimumFee: 1
+  economyFee: 0.1,
+  minimumFee: 0.1
 }`
         },
         codeSampleLiquidTestnet: {
@@ -4514,7 +4518,8 @@ export const restApiDocsData = [
   fastestFee: 0.1,
   halfHourFee: 0.1,
   hourFee: 0.1,
-  minimumFee: 1
+  economyFee: 0.1,
+  minimumFee: 0.1
 }`
         },
         codeSampleBisq: emptyCodeSample,


### PR DESCRIPTION
Redo of https://github.com/mempool/mempool/pull/1734
Context https://github.com/mempool/mempool/issues/1726

Added `economyFee` field in `/api/fees/recommended` API which is always `2 x minimumFee`.