### PR TITLE
Handle nonstandard inputs

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -66,13 +66,16 @@
                         </ng-template>
                       </ng-template>
                       <ng-template #defaultAddress>
-                        <a [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey_address]" title="{{ vin.prevout.scriptpubkey_address }}">
+                        <a *ngIf="vin.prevout.scriptpubkey_address; else vinScriptPubkeyType" [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey_address]" title="{{ vin.prevout.scriptpubkey_address }}">
                           <span class="d-block d-lg-none">{{ vin.prevout.scriptpubkey_address | shortenString : 16 }}</span>
                           <span class="d-none d-lg-flex justify-content-start">
                             <span class="addr-left flex-grow-1" [style]="vin.prevout.scriptpubkey_address.length > 40 ? 'max-width: 235px' : ''">{{ vin.prevout.scriptpubkey_address }}</span>
                             <span *ngIf="vin.prevout.scriptpubkey_address.length > 40" class="addr-right">{{ vin.prevout.scriptpubkey_address | capAddress: 40: 10 }}</span>
                           </span>
                         </a>
+                        <ng-template #vinScriptPubkeyType>
+                          {{ vin.prevout.scriptpubkey_type?.toUpperCase() }}
+                        </ng-template>
                         <div>
                           <app-address-labels [vin]="vin"></app-address-labels>
                         </div>


### PR DESCRIPTION
fixes #1744

**Problem**
Blank row when there is no input address, (and js crash).

**This fix**
Same as we already handle outputs. When the address is non existent instead print out the type which in the reported test case is NONSTANDARD from Bitcoin Core... Note that on Esplora the type is UNKNOWN.

Testnet TX
86d5de9fd4e284d285e547216576ca94cdf6fddfe8a7afc9b9dc67fa5afec2db

<img width="581" alt="Screen Shot 2022-05-31 at 04 12 32" src="https://user-images.githubusercontent.com/8561090/171070243-b51a3d61-7bde-4a8f-a653-33eaa0e45996.png">

