### PR TITLE
Only attempt to save fx rate if database is enabled

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -343,7 +343,7 @@ class Blocks {
           await blocksRepository.$saveBlockInDatabase(blockExtended);
         }
       }
-      if (fiatConversion.ratesInitialized === true) {
+      if (fiatConversion.ratesInitialized === true && config.DATABASE.ENABLED === true) {
         await RatesRepository.$saveRate(blockExtended.height, fiatConversion.getConversionRates());
       }
 


### PR DESCRIPTION
Fix bisq instances stuck because they're trying to save the BTC fx rate even though the database is disabled.