### PR TITLE
Send fee info with init data

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -200,6 +200,7 @@ class WebsocketHandler {
       'backendInfo': backendInfo.getBackendInfo(),
       'loadingIndicators': loadingIndicators.getLoadingIndicators(),
       'da': difficultyAdjustment.getDifficultyAdjustment(),
+      'fees': feeApi.getRecommendedFee(),
       ...this.extraInitProperties
     };
   }
@@ -403,6 +404,9 @@ class WebsocketHandler {
       block.extras.matchRate = matchRate;
     }
 
+    const da = difficultyAdjustment.getDifficultyAdjustment();
+    const fees = feeApi.getRecommendedFee();
+
     this.wss.clients.forEach((client) => {
       if (client.readyState !== WebSocket.OPEN) {
         return;
@@ -415,8 +419,8 @@ class WebsocketHandler {
       const response = {
         'block': block,
         'mempoolInfo': memPool.getMempoolInfo(),
-        'da': difficultyAdjustment.getDifficultyAdjustment(),
-        'fees': feeApi.getRecommendedFee(),
+        'da': da,
+        'fees': fees,
       };
 
       if (mBlocks && client['want-mempool-blocks']) {


### PR DESCRIPTION
* Send current fees with init data, otherwise a mempool update is required before fees are visible
* Moved the Difficulty and Fee calculation outside the client loop to optimize on new blocks