### PR TITLE
If price is not yet available, delay saving block rate

### DIFF
--- a/backend/src/api/blocks-rates.ts
+++ b/backend/src/api/blocks-rates.ts
@@ -1,0 +1,42 @@
+import logger from "../logger";
+import RatesRepository from "../repositories/RatesRepository";
+import fiatConversion from "./fiat-conversion";
+
+class BlocksRates {
+  private pendingBlocksRates: number[] = [];
+  private saveInProgress = false;
+
+  public async savePendingBlockRates() {
+    if (this.saveInProgress === false && fiatConversion.ratesInitialized === true) {
+      this.saveInProgress = true;
+
+      const pending = [...this.pendingBlocksRates];
+      this.pendingBlocksRates = [];
+
+      for (let height of pending) {
+        try {
+          await RatesRepository.$saveRate(height, fiatConversion.getConversionRates());
+        } catch (e) {
+          this.pendingBlocksRates.push(height);
+          logger.debug(`Cannot save pending block rates, trying again later`);
+        }
+      }
+    }
+
+    this.saveInProgress = false;
+  }
+
+  public async saveRateForBlock(height: number) {
+    if (fiatConversion.ratesInitialized === true) {
+      try {
+        await RatesRepository.$saveRate(height, fiatConversion.getConversionRates());
+      } catch (e) {
+        this.pendingBlocksRates.push(height);
+      }
+    } else {
+      this.pendingBlocksRates.push(height);
+    }
+  }
+}
+
+export default new BlocksRates();

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -17,7 +17,7 @@ import BlocksRepository from '../repositories/BlocksRepository';
 import HashratesRepository from '../repositories/HashratesRepository';
 import indexer from '../indexer';
 import fiatConversion from './fiat-conversion';
-import RatesRepository from '../repositories/RatesRepository';
+import blocksRates from './blocks-rates';
 
 class Blocks {
   private blocks: BlockExtended[] = [];
@@ -343,8 +343,11 @@ class Blocks {
           await blocksRepository.$saveBlockInDatabase(blockExtended);
         }
       }
-      if (fiatConversion.ratesInitialized === true && config.DATABASE.ENABLED === true) {
-        await RatesRepository.$saveRate(blockExtended.height, fiatConversion.getConversionRates());
+      if (config.DATABASE.ENABLED === true) {
+        const blockchainInfo = await bitcoinClient.getBlockchainInfo();
+        if (blockchainInfo.blocks === blockchainInfo.headers) {
+          await blocksRates.saveRateForBlock(blockExtended.height);
+        }
       }
 
       if (block.height % 2016 === 0) {

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -4,6 +4,7 @@ import mempool from './api/mempool';
 import mining from './api/mining';
 import logger from './logger';
 import HashratesRepository from './repositories/HashratesRepository';
+import blocksRates from './api/blocks-rates';
 
 class Indexer {
   runIndexer = true;
@@ -31,6 +32,7 @@ class Indexer {
       await this.$resetHashratesIndexingState();
       await mining.$generateNetworkHashrateHistory();
       await mining.$generatePoolHashrateHistory();
+      await blocksRates.savePendingBlockRates();
     } catch (e) {
       this.reindex();
       logger.err(`Indexer failed, trying again later. Reason: ` + (e instanceof Error ? e.message : e));


### PR DESCRIPTION
When you start the node backend, bisq rates may not yet be available. Instead of skipping it (current behavior), we now simply wait for bisq rates to be fetched before saving the exchange rate for a block.

We also wait for Core to be synced before saving exchange rate for new blocks, otherwise we may save today's exchange rate for blocks which are much older than today.

#### Testing

* Stop the node backend
* Clear your disk cache, so that `MEMPOOL.INITIAL_BLOCKS_AMOUNT` blocks are fetched at start
* If you already have exchange rate for the `MEMPOOL.INITIAL_BLOCKS_AMOUNT` most recent blocks in your `rates` table, delete their entries
* Start the node backend
* Check the `rates` table and confirm that the exchange rate has properly been inserted for the `MEMPOOL.INITIAL_BLOCKS_AMOUNT` most recent blocks

Without this PR, following the same step would most likely lead to missing exchange rates for the most recent blocks.
Also note that this does not solve the problem of backward filling the table for blocks older than `MEMPOOL.INITIAL_BLOCKS_AMOUNT`.