### PR TITLE
Make `Latest blocks` and `Adjustments` widget title clickable

### DIFF
--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -49,7 +49,9 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+          <a class="no-effect" href="" [routerLink]="['/blocks' | relativeUrl]">
+            <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+          </a>
           <app-blocks-list [widget]=true></app-blocks-list>
           <div><a [routerLink]="['/blocks' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>
@@ -60,7 +62,9 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <h5 class="card-title" i18n="dashboard.adjustments">Adjustments</h5>
+          <a class="no-effect" href="" [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]">
+            <h5 class="card-title" i18n="dashboard.adjustments">Adjustments</h5>
+          </a>
           <app-difficulty-adjustments-table></app-difficulty-adjustments-table>
           <div><a [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
@@ -97,3 +97,8 @@
 .card-text {
   font-size: 22px;
 }
+
+.no-effect, .no-effect:hover, .no-effect:focus, .no-effect:active {
+  text-decoration: none;
+  color: inherit;
+}

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -106,7 +106,9 @@
       <div class="col">
         <div class="card">
           <div class="card-body">
-            <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+            <a class="no-effect" href="" [routerLink]="['/blocks' | relativeUrl]">
+              <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+            </a>
             <table class="table lastest-blocks-table">
               <thead>
                 <th class="table-cell-height" i18n="dashboard.latest-blocks.height">Height</th>

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -317,3 +317,8 @@
   vertical-align: text-top;
   padding-left: 10px;
 }
+
+.no-effect, .no-effect:hover, .no-effect:focus, .no-effect:active {
+    text-decoration: none;
+    color: inherit;
+}


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1862

I made some widget title clickable, but disable all `<a>` css effect so that the overall design stays the same. Let me know if you wanna to add more links somehwere else.