### PR TITLE
Fix latest blocks rewards column not large enough to fit high reward

### DIFF
--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -141,7 +141,7 @@ tr, td, th {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 100px;
+  max-width: 130px;
 }
 .reward.widget {
   width: 20%;


### PR DESCRIPTION
Fixes the following

#### Now

<img width="436" alt="Screen Shot 2022-06-10 at 11 54 20 PM" src="https://user-images.githubusercontent.com/9780671/173156008-8ecf8036-5738-46ae-bb3d-afbce5202dc6.png">

#### With the PR

<img width="310" alt="Screen Shot 2022-06-10 at 11 55 05 PM" src="https://user-images.githubusercontent.com/9780671/173156080-1ccdd045-5aaa-41ad-a431-21f649d36c0a.png">

