### PR TITLE
Only show `(1w)` on `Blocks` in pool ranking widget and add tooltips

### DIFF
--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -5,24 +5,27 @@
   <div *ngIf="widget">
     <div class="pool-distribution" *ngIf="(miningStatsObservable$ | async) as miningStats; else loadingReward">
       <div class="item">
-        <h5 class="card-title" i18n="mining.miners-luck" i18n-ngbTooltip="mining.miners-luck"
-        ngbTooltip="Pools Luck (1w)" placement="bottom" #minersluck [disableTooltip]="!isEllipsisActive(minersluck)">Pools Luck (1w)</h5>
-        <p class="card-text">
+        <h5 class="card-title d-inline-block" i18n="mining.miners-luck" i18n-ngbTooltip="mining.miners-luck-1w"
+        ngbTooltip="Pools luck (1 week)" placement="bottom" #minersluck [disableTooltip]="!isEllipsisActive(minersluck)">Pools luck</h5>
+        <p class="card-text" i18n-ngbTooltip="mining.pools-luck-desc"
+        ngbTooltip="The overall luck of all mining pools over the past week. A luck bigger than 100% means the average block time for the current epoch is less than 10 minutes." placement="bottom">
           {{ miningStats['minersLuck'] }}%
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title" i18n="master-page.blocks" i18n-ngbTooltip="master-page.blocks"
-        ngbTooltip="Blocks (1w)" placement="bottom" #blockscount [disableTooltip]="!isEllipsisActive(blockscount)">Blocks (1w)</h5>
-        <p class="card-text">
-          {{ miningStats.blockCount }}
+        <h5 class="card-title d-inline-block" i18n="mining.miners-count" i18n-ngbTooltip="mining.miners-count-1w"
+        ngbTooltip="Pools count (1w)" placement="bottom" #poolscount [disableTooltip]="!isEllipsisActive(poolscount)">Pools count</h5>
+        <p class="card-text" i18n-ngbTooltip="mining.pools-count-desc"
+        ngbTooltip="How many unique pools found at least one block over the past week." placement="bottom">
+          {{ miningStats.pools.length }}
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title" i18n="mining.miners-count" i18n-ngbTooltip="mining.miners-count"
-        ngbTooltip="Pools Count (1w)" placement="bottom" #poolscount [disableTooltip]="!isEllipsisActive(poolscount)">Pools Count (1w)</h5>
-        <p class="card-text">
-          {{ miningStats.pools.length }}
+        <h5 class="card-title d-inline-block" i18n="master-page.blocks" i18n-ngbTooltip="master-page.blocks"
+        ngbTooltip="Blocks (1w)" placement="bottom" #blockscount [disableTooltip]="!isEllipsisActive(blockscount)">Blocks (1w)</h5>
+        <p class="card-text" i18n-ngbTooltip="mining.blocks-count-desc"
+        ngbTooltip="The number of blocks found over the past week." placement="bottom">
+          {{ miningStats.blockCount }}
         </p>
       </div>
     </div>

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.scss
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.scss
@@ -89,7 +89,7 @@
     flex-direction: row;
   }
   h5 {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
   }
   .item {
     max-width: 160px;
@@ -103,6 +103,7 @@
       }
     }
     &:nth-child(3) {
+      width: 50%;
       order: 3;
       @media (min-width: 485px) {
         order: 2;


### PR DESCRIPTION
#### Before

<img width="583" alt="Screen Shot 2022-06-11 at 12 04 48 AM" src="https://user-images.githubusercontent.com/9780671/173156851-f73d6a6a-d1eb-48f8-b313-2469df1828c5.png">

#### After

<img width="519" alt="Screen Shot 2022-06-11 at 12 05 18 AM" src="https://user-images.githubusercontent.com/9780671/173156861-b37aeed1-ef34-4c36-b3c3-ec02284bf2b2.png">
