### PR TITLE
Fix anchor link scrolling on load (chrome)

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -35,6 +35,7 @@ export class ApiDocsComponent implements OnInit {
     setTimeout( () => {
       if( this.route.snapshot.fragment ) {
         this.openEndpointContainer( this.route.snapshot.fragment );
+        document.getElementById( this.route.snapshot.fragment ).scrollIntoView();
       }
       window.addEventListener('scroll', function() {
         that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";


### PR DESCRIPTION
Tested on desktop and mobile on Firefox and Chrome.