### PR TITLE
Switch charts to canvas rendering - download .png instead of .svg

### DIFF
--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
@@ -37,7 +37,6 @@ export class BlockFeeRatesGraphComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   statsObservable$: Observable<any>;
@@ -301,7 +300,7 @@ export class BlockFeeRatesGraphComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `block-fee-rates-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `block-fee-rates-${this.timespan}-${Math.round(now.getTime() / 100)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
@@ -33,7 +33,6 @@ export class BlockFeesGraphComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   statsObservable$: Observable<any>;
@@ -219,7 +218,7 @@ export class BlockFeesGraphComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `block-fees-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `block-fees-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
@@ -33,7 +33,6 @@ export class BlockRewardsGraphComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   statsObservable$: Observable<any>;
@@ -219,7 +218,7 @@ export class BlockRewardsGraphComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `block-rewards-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `block-rewards-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.ts
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.ts
@@ -35,7 +35,6 @@ export class BlockSizesWeightsGraphComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   @HostBinding('attr.dir') dir = 'ltr';
@@ -314,7 +313,7 @@ export class BlockSizesWeightsGraphComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `block-sizes-weights-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `block-sizes-weights-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
+++ b/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
@@ -15,7 +15,6 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges {
 
   mempoolVsizeFeesOptions: any;
   mempoolVsizeFeesInitOptions = {
-    renderer: 'svg'
   };
 
   constructor() { }

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -36,7 +36,7 @@ export class HashrateChartComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
+    renderer: 'canvas',
   };
 
   @HostBinding('attr.dir') dir = 'ltr';
@@ -359,7 +359,7 @@ export class HashrateChartComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `hashrate-difficulty-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `hashrate-difficulty-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -34,7 +34,6 @@ export class HashrateChartPoolsComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   @HostBinding('attr.dir') dir = 'ltr';
@@ -267,7 +266,7 @@ export class HashrateChartPoolsComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `pools-dominance-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `pools-dominance-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -31,7 +31,6 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
   isLoading = true;
   mempoolStatsChartOption: EChartsOption = {};
   mempoolStatsChartInitOption = {
-    renderer: 'svg'
   };
   windowPreference: string;
   chartInstance: any = undefined;
@@ -244,7 +243,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `incoming-vbytes-${timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `incoming-vbytes-${timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.mempoolStatsChartOption.grid.height = prevHeight;
     this.mempoolStatsChartOption.backgroundColor = 'none';

--- a/frontend/src/app/components/lbtc-pegs-graph/lbtc-pegs-graph.component.ts
+++ b/frontend/src/app/components/lbtc-pegs-graph/lbtc-pegs-graph.component.ts
@@ -29,7 +29,6 @@ export class LbtcPegsGraphComponent implements OnInit, OnChanges {
 
   pegsChartOption: EChartsOption = {};
   pegsChartInitOption = {
-    renderer: 'svg'
   };
 
   constructor(

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -37,7 +37,6 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
   mempoolVsizeFeesData: any;
   mempoolVsizeFeesOptions: EChartsOption;
   mempoolVsizeFeesInitOptions = {
-    renderer: 'svg',
   };
   windowPreference: string;
   hoverIndexSerie = 0;
@@ -401,7 +400,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `mempool-graph-${timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `mempool-graph-${timespan}-${Math.round(now.getTime() / 1000)}.png`);
     // @ts-ignore
     this.mempoolVsizeFeesOptions.grid.height = prevHeight;
     this.mempoolVsizeFeesOptions.backgroundColor = 'none';

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -28,7 +28,6 @@ export class PoolRankingComponent implements OnInit {
   isLoading = true;
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
   timespan = '';
   chartInstance: any = undefined;
@@ -288,7 +287,7 @@ export class PoolRankingComponent implements OnInit {
     download(this.chartInstance.getDataURL({
       pixelRatio: 2,
       excludeComponents: ['dataZoom'],
-    }), `pools-ranking-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    }), `pools-ranking-${this.timespan}-${Math.round(now.getTime() / 1000)}.png`);
     this.chartOptions.backgroundColor = 'none';
     this.chartInstance.setOption(this.chartOptions);
   }

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -29,7 +29,6 @@ export class PoolComponent implements OnInit {
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
-    renderer: 'svg',
   };
 
   blocks: BlockExtended[] = [];


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1845

This PR switches back chart to canvas rendering. [It was set to `svg` a while back](https://github.com/mempool/mempool/commit/9020c618f034e0ca9384377e29a2bf23beb22ed9) apparently because: `believed it was something in Brave browser not allowing canvas`.

Tested with:
* Desktop: Brave, Chrome, Firefox and Safari
* Mobile: Brave, Chrome, Firefox

Let me know if it does not work, or if performances are bad on your mobile device.

Additional resource: https://apache.github.io/echarts-handbook/en/best-practices/canvas-vs-svg/#