### PR TITLE
Fix anchor links and typos in faq

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs.component.html
@@ -179,11 +179,11 @@
 </ng-template>
 
 <ng-template type="host-my-own-instance-raspberry-pi">
-  We support one-click installation on a number of Raspberry Pi full-node distros including Umbrel, RaspiBlitz, MyNode, and RoninDojo.
+  We support one-click installation on a number of Raspberry Pi full-node distros including Umbrel, RaspiBlitz, MyNode, RoninDojo, and Start9's Embassy.
 </ng-template>
 
 <ng-template type="host-my-own-instance-linux-server">
-  You can manually install mempool on your own Linux server, but this requires advanced sysadmin skills since you will be manually configuring everything. We do not provide support for manual deployments.
+  You can manually install Mempool on your own Linux server, but this requires advanced sysadmin skills since you will be manually configuring everything. We do not provide support for manual deployments.
 </ng-template>
 
 <ng-template type="install-mempool-with-docker">

--- a/frontend/src/app/docs/api-docs/api-docs.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs.component.html
@@ -108,7 +108,7 @@
 </ng-container>
 
 <ng-template type="what-is-a-mempool">
-  <p>A mempool (short for "memory pool") the queue of pending and unconfirmed transactions for a cryptocurrency network node. There is no one global mempool: every node on the network maintains its own mempool, so different nodes may hold different transactions in their mempools.</p>
+  <p>A mempool (short for "memory pool") is the queue of pending and unconfirmed transactions for a cryptocurrency network node. There is no one global mempool: every node on the network maintains its own mempool, so different nodes may hold different transactions in their mempools.</p>
 </ng-template>
 
 <ng-template type="what-is-a-mempool-explorer">
@@ -127,7 +127,7 @@
 </ng-template>
 
 <ng-template type="what-is-mining">
-  Mining is the process by which unconfirmed transactions in a mempool are confirmed into a block on a blockchain. Miners select unconfirmed transactions from their mempools and arrange them into a block such that they solve a particular math problem.<p>The first miner on the network to find a suitable block earns all the transaction fees from the transactions in that block. As a result, miners tend to prioritize transactions with higher transaction fees.</p>
+  <p>Mining is the process by which unconfirmed transactions in a mempool are confirmed into a block on a blockchain. Miners select unconfirmed transactions from their mempools and arrange them into a block such that they solve a particular math problem.<p>The first miner on the network to find a suitable block earns all the transaction fees from the transactions in that block. As a result, miners tend to prioritize transactions with higher transaction fees.</p>
 </ng-template>
 
 <ng-template type="what-are-mining-pools">
@@ -135,7 +135,7 @@
 </ng-template>
 
 <ng-template type="what-is-full-mempool">
-  <p>When a Bitcoin transaction is made, it is stored in a Bitcoin node's mempool before it is confirmed into a block. When the rate of incoming transactions exceeds the rate transactions are confirmed, the mempool grows in size.</p><p>The default maximum size of a Bitcoin node's mempool is 300MB, so when there are 300MB of transactions in the mempool, we say it's \"full\".</p>
+  <p>When a Bitcoin transaction is made, it is stored in a Bitcoin node's mempool before it is confirmed into a block. When the rate of incoming transactions exceeds the rate transactions are confirmed, the mempool grows in size.</p><p>The default maximum size of a Bitcoin node's mempool is 300MB, so when there are 300MB of transactions in the mempool, we say it's "full".</p>
 </ng-template>
 
 <ng-template type="why-empty-blocks">
@@ -183,7 +183,7 @@
 </ng-template>
 
 <ng-template type="host-my-own-instance-linux-server">
-  You can manually install mempool on your own Linux server, but this requires advanced sysadmin skills since you will be manually configuring everything. We do not provide support for manual deployments."
+  You can manually install mempool on your own Linux server, but this requires advanced sysadmin skills since you will be manually configuring everything. We do not provide support for manual deployments.
 </ng-template>
 
 <ng-template type="install-mempool-with-docker">

--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -36,6 +36,7 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit() {
     const that = this;
+    this.faqTemplates.forEach((x) => this.dict[x.type] = x.template);
     setTimeout( () => {
       if( this.route.snapshot.fragment ) {
         this.openEndpointContainer( this.route.snapshot.fragment );
@@ -44,7 +45,6 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
       window.addEventListener('scroll', function() {
         that.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
       }, { passive: true} );
-      this.faqTemplates.forEach((x) => this.dict[x.type] = x.template);
     }, 1 );
   }
 


### PR DESCRIPTION
Commits 1 and 2 fix some issues resulting from #1874. FAQ content is loaded after `scrollIntoView()` fires, sometimes resulting in partially-scrolled pages when the browser directly requests the FAQ page with an anchor link (example: go directly to https://mempool.space/docs/faq#host-my-own-instance-linux-server in desktop Chrome).

Commit 3 makes 2 minor updates.