### PR TITLE
Hide bottom axis label for mempool and incoming tx charts on widgets

### DIFF
--- a/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
+++ b/frontend/src/app/components/incoming-transactions-graph/incoming-transactions-graph.component.ts
@@ -127,7 +127,7 @@ export class IncomingTransactionsGraphComponent implements OnInit, OnChanges {
       },
       xAxis: [
         {
-          name: formatterXAxisLabel(this.locale, this.windowPreference),
+          name: this.template === 'widget' ? '' : formatterXAxisLabel(this.locale, this.windowPreference),
           nameLocation: 'middle',
           nameTextStyle: {
             padding: [20, 0, 0, 0],

--- a/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
+++ b/frontend/src/app/components/mempool-graph/mempool-graph.component.ts
@@ -319,7 +319,7 @@ export class MempoolGraphComponent implements OnInit, OnChanges {
       },
       xAxis: [
         {
-          name: formatterXAxisLabel(this.locale, this.windowPreference),
+          name: this.template === 'widget' ? '' : formatterXAxisLabel(this.locale, this.windowPreference),
           nameLocation: 'middle',
           nameTextStyle: {
             padding: [20, 0, 0, 0],


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1880

@antonilol let me know if that fixes your issue