### PR TITLE
Make `Latest blocks` and `Adjustments` widget title clickable

### DIFF
--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.html
@@ -49,9 +49,12 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+          <a class="title-link" href="" [routerLink]="['/blocks' | relativeUrl]">
+            <h5 class="card-title d-inline" i18n="dashboard.latest-blocks">Latest blocks</h5>
+            <span>&nbsp;</span>
+            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
+          </a>
           <app-blocks-list [widget]=true></app-blocks-list>
-          <div><a [routerLink]="['/blocks' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>
       </div>
     </div>
@@ -60,9 +63,12 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <h5 class="card-title" i18n="dashboard.adjustments">Adjustments</h5>
+          <a class="title-link" href="" [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]">
+            <h5 class="card-title d-inline" i18n="dashboard.adjustments">Adjustments</h5>
+            <span>&nbsp;</span>
+            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
+          </a>
           <app-difficulty-adjustments-table></app-difficulty-adjustments-table>
-          <div><a [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
@@ -97,3 +97,10 @@
 .card-text {
   font-size: 22px;
 }
+
+.title-link, .title-link:hover, .title-link:focus, .title-link:active {
+  display: block;
+  margin-bottom: 10px;
+  text-decoration: none;
+  color: inherit;
+}

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -103,10 +103,14 @@
         </div>
       </div>
       <ng-template [ngIf]="collapseLevel === 'one'">
-      <div class="col">
+      <div class="col" style="max-height: 410px">
         <div class="card">
           <div class="card-body">
-            <h5 class="card-title" i18n="dashboard.latest-blocks">Latest blocks</h5>
+            <a class="title-link" href="" [routerLink]="['/blocks' | relativeUrl]">
+              <h5 class="card-title d-inline" i18n="dashboard.latest-blocks">Latest blocks</h5>
+              <span>&nbsp;</span>
+              <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
+            </a>
             <table class="table lastest-blocks-table">
               <thead>
                 <th class="table-cell-height" i18n="dashboard.latest-blocks.height">Height</th>
@@ -136,11 +140,10 @@
                 </tr>
               </tbody>
             </table>
-            <div class=""><a href="" [routerLink]="['/blocks' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col" style="max-height: 410px">
         <div class="card">
           <div class="card-body">
             <h5 class="card-title" i18n="dashboard.latest-transactions">Latest transactions</h5>
@@ -160,7 +163,6 @@
                 </tr>
               </tbody>
             </table>
-            <div class="">&nbsp;</div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -317,3 +317,10 @@
   vertical-align: text-top;
   padding-left: 10px;
 }
+
+.title-link, .title-link:hover, .title-link:focus, .title-link:active {
+  display: block;
+  margin-bottom: 10px;
+  text-decoration: none;
+  color: inherit;
+}


### PR DESCRIPTION
Second attempt 👍🏻 

Fixes https://github.com/mempool/mempool/issues/1862 @Xekyo

#### Main dashboard

<img width="1061" alt="Screen Shot 2022-06-14 at 10 36 21 AM" src="https://user-images.githubusercontent.com/9780671/173532979-449f107e-f91e-4ad5-a44f-ca3ad0040ecf.png">

#### Mining dashboard

<img width="1059" alt="Screen Shot 2022-06-14 at 10 36 52 AM" src="https://user-images.githubusercontent.com/9780671/173533060-1cf2990b-e29a-45c9-ba52-b5f0ac9fc787.png">