### PR TITLE
Use Bitcoin Core's ZMQ publisher to instantly discover new blocks

### DIFF
--- a/backend/mempool-config.sample.json
+++ b/backend/mempool-config.sample.json
@@ -27,6 +27,10 @@
     "USERNAME": "mempool",
     "PASSWORD": "mempool"
   },
+  "CORE_ZMQ": {
+    "ENABLED": true,
+    "HOST": "tcp://127.0.0.1:8433"
+  },
   "ELECTRUM": {
     "HOST": "127.0.0.1",
     "PORT": 50002,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,8 @@
         "node-worker-threads-pool": "^1.5.1",
         "socks-proxy-agent": "^6.2.0",
         "typescript": "~4.7.2",
-        "ws": "~8.7.0"
+        "ws": "~8.7.0",
+        "zeromq": "^6.0.0-beta.6"
       },
       "devDependencies": {
         "@types/compression": "^1.7.2",
@@ -1037,6 +1038,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-worker-threads-pool": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/node-worker-threads-pool/-/node-worker-threads-pool-1.5.1.tgz",
@@ -1555,6 +1566,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/zeromq": {
+      "version": "6.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
+      "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.2"
+      }
     }
   },
   "dependencies": {
@@ -2381,6 +2404,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
+    "node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
+    },
     "node-worker-threads-pool": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/node-worker-threads-pool/-/node-worker-threads-pool-1.5.1.tgz",
@@ -2764,6 +2792,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "zeromq": {
+      "version": "6.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
+      "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
+      "requires": {
+        "node-gyp-build": "^4.1.0"
+      }
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,8 @@
     "node-worker-threads-pool": "^1.5.1",
     "socks-proxy-agent": "^6.2.0",
     "typescript": "~4.7.2",
-    "ws": "~8.7.0"
+    "ws": "~8.7.0",
+    "zeromq": "^6.0.0-beta.6"
   },
   "devDependencies": {
     "@types/compression": "^1.7.2",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -37,6 +37,10 @@ interface IConfig {
     USERNAME: string;
     PASSWORD: string;
   };
+  CORE_ZMQ: {
+    ENABLED: boolean;
+    HOST: string;
+  };
   SECOND_CORE_RPC: {
     HOST: string;
     PORT: number;
@@ -126,6 +130,10 @@ const defaults: IConfig = {
     'USERNAME': 'mempool',
     'PASSWORD': 'mempool'
   },
+  'CORE_ZMQ': {
+    'ENABLED': true,
+    'HOST': 'tcp://127.0.0.1:8433'
+  },
   'SECOND_CORE_RPC': {
     'HOST': '127.0.0.1',
     'PORT': 8332,
@@ -183,6 +191,7 @@ class Config implements IConfig {
   ESPLORA: IConfig['ESPLORA'];
   ELECTRUM: IConfig['ELECTRUM'];
   CORE_RPC: IConfig['CORE_RPC'];
+  CORE_ZMQ: IConfig['CORE_ZMQ'];
   SECOND_CORE_RPC: IConfig['SECOND_CORE_RPC'];
   DATABASE: IConfig['DATABASE'];
   SYSLOG: IConfig['SYSLOG'];
@@ -198,6 +207,7 @@ class Config implements IConfig {
     this.ESPLORA = configs.ESPLORA;
     this.ELECTRUM = configs.ELECTRUM;
     this.CORE_RPC = configs.CORE_RPC;
+    this.CORE_ZMQ = configs.CORE_ZMQ;
     this.SECOND_CORE_RPC = configs.SECOND_CORE_RPC;
     this.DATABASE = configs.DATABASE;
     this.SYSLOG = configs.SYSLOG;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "esnext",
-    "lib": ["es2019", "dom"],
+    "lib": ["es2021", "dom"],
     "strict": true,
     "noImplicitAny": false,
     "sourceMap": false,


### PR DESCRIPTION
This PR adds zmq support to get updates _pushed_ from bitcoind instead of _pulling_ them every `POLL_RATE_MS` (2 seconds)

some readme on how to set this up on the bitcoin core side can be helpful but haven't made it (yet)

previously, mempool would poll bitcoind every 2 seconds, i put a zmq subscriber in between that skips the rest of the ongoing 2 seconds when a new block is discovered by bitcoind. blocks end up up to 2 seconds faster on the website

i decided to use `Promise.any` for the delay + zmq, to return which one of the 2 triggers, either the first after 2 seconds or the second after a block has been discovered. when zmq is disabled in mempool (i made a config thingy for that) `this.newBlockTrigger` will stay `undefined` forever and do nothing. es2021 is required for `Promise.any` (tsconfig.json)

to test:

add 
```
zmqpubhashblock=tcp://127.0.0.1:<some port>
```
to bitcoin.conf

and
```json
  "CORE_ZMQ": {
    "ENABLED": true,
    "HOST": "tcp://127.0.0.1:<port>"
  },
```
to mempool-config.json on regtest

start everything (database nginx backend etc)

run 
```
bitcoin-cli -regtest -generate
```
to mine a block and it will instantly appear in mempool