### PR TITLE
[ops] Fix prod nginx perma-cache URL patterns

### DIFF
--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -4,13 +4,13 @@ location /api/v1/statistics {
 location /api/v1/mining {
 	try_files /dev/null @mempool-api-v1-warmcache;
 }
-location /api/v1/block {
+location /api/v1/block/ {
 	try_files /dev/null @mempool-api-v1-forevercache;
 }
 location /api/v1 {
 	try_files /dev/null @mempool-api-v1-coldcache;
 }
-location /api/block {
+location /api/block/ {
 	rewrite ^/api/(.*) /$1 break;
 	try_files /dev/null @electrs-api-forevercache;
 }


### PR DESCRIPTION
Currently we perma-cache everything matching /api/block, but this is bad because it also matches /api/block-height and /api/blocks/ API endpoints, which shouldn't be perma-cached.

Add a trailing slash to prevent those from getting matched.