### PR TITLE
Reduce maximum size of mined block visualization

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -43,10 +43,9 @@
 
 
   <div class="box" *ngIf="!error">
-    <div class="row">
+    <div class="row no-stretch">
       <ng-template [ngIf]="!isLoadingBlock">
-        <div class="col-sm">
-          <table class="table table-borderless table-striped">
+          <table class="col-sm col-table table table-borderless table-striped">
             <tbody>
               <tr>
                 <td class="td-width" i18n="block.hash">Hash</td>
@@ -128,7 +127,6 @@
               </ng-template>
             </tbody>
           </table>
-        </div>
       </ng-template>
       <ng-template [ngIf]="isLoadingBlock">
         <div class="col-sm">

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -64,6 +64,9 @@ h1 {
 	flex-direction: column;
 	@media (min-width: 768px) {
 		flex-direction: row;
+		&.no-stretch {
+			align-items: flex-start;
+		}
 	}
 }
 @media (max-width: 767.98px) {
@@ -149,9 +152,19 @@ h1 {
   }
 }
 
-.chart-container{
-  margin: 20px auto;
+.chart-container {
+  margin: 20px auto 0;
   @media (min-width: 768px) {
-    margin: auto;
+    margin: 0 auto;
+    min-width: 330px;
+    max-width: calc(24rem + 30px);
+  }
+}
+
+.col-table {
+  width: calc(100% - 30px);
+  margin: 0 15px;
+  @media (min-width: 768px) {
+    width: 0;
   }
 }


### PR DESCRIPTION
Shrinks the mined block visualization to eliminate dead space below the block info table on larger screens.

![after-layout](https://user-images.githubusercontent.com/83316221/175571654-cef240d2-7d52-48ba-ac9a-2f09efa5edea.png)