### PR TITLE
Fix block visualization color for txs with 0 < feerate < 1 sat/vb

### DIFF
--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -140,9 +140,8 @@ export default class TxView implements TransactionStripped {
   }
 
   getColor(): Color {
-    let feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => (this.feerate || 1) >= feeLvl);
-    feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-    return hexToColor(mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+    const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, this.feerate) < feeLvl) - 1;
+    return hexToColor(mempoolFeeColors[feeLevelIndex] || mempoolFeeColors[mempoolFeeColors.length - 1]);
   }
 }
 


### PR DESCRIPTION
Fixes a bug where transactions in the visualization with fee rates more than 0 but less than 1 sat/vb were colored incorrectly (pink, instead of green).

This never happens in the mempool visualization, but mined blocks do occasionally have transactions in this fee range.

Most obviously reproducible with block 421770, where a large transaction pays 0.6 sats/vb.