### PR TITLE
Minimum transaction fee is 0

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -114,7 +114,7 @@ export class Common {
       totalFees += tx.bestDescendant.fee;
     }
 
-    tx.effectiveFeePerVsize = Math.max(Common.isLiquid() ? 0.1 : 1, totalFees / (totalWeight / 4));
+    tx.effectiveFeePerVsize = Math.max(0, totalFees / (totalWeight / 4));
     tx.cpfpChecked = true;
 
     return {


### PR DESCRIPTION
A bug introduced in https://github.com/mempool/mempool/commit/ecbd18087b267ba61b74477c973281b740edaf30 was setting the minimum transaction fee rate to 0.1 sats/vb on Liquid and 1 sats/vb on Bitcoin.

However, those two networks allows lower fee rates (all the way down to `0`), so the minimum should be effectively `0` instead of `0.1` and `1`.