### PR TITLE
Handle occasional blank side nav on desktop docs

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -37,6 +37,7 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     const that = this;
     this.faqTemplates.forEach((x) => this.dict[x.type] = x.template);
+    this.desktopDocsNavPosition = ( window.pageYOffset > 182 ) ? "fixed" : "relative";
     setTimeout( () => {
       if( this.route.snapshot.fragment ) {
         this.openEndpointContainer( this.route.snapshot.fragment );


### PR DESCRIPTION
Sometimes (not sure exactly why) the desktop view's side navigation menu doesn't appear on load, but it appears as soon as the user scrolls.

This change forces the browser to show the side nav on load instead of waiting for a scroll event.

Example of the issue:

https://user-images.githubusercontent.com/93150691/175832022-f9aa66a9-3c1e-4009-adec-e1b4d95af95d.mp4


