### PR TITLE
Tell git to ignore .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ sitemap
 data
 docker-compose.yml
 backend/mempool-config.json
+*.swp


### PR DESCRIPTION
Makes it easier to use tab completion to add a file to staging if it's open in vim.