### PR TITLE
fixes for 0 sat/vB minimum fee

### DIFF
--- a/frontend/src/app/components/fees-box/fees-box.component.ts
+++ b/frontend/src/app/components/fees-box/fees-box.component.ts
@@ -33,11 +33,11 @@ export class FeesBoxComponent implements OnInit {
         tap((fees) => {
           let feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.minimumFee >= feeLvl);
           feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-          const startColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+          const startColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[0]);
 
           feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.fastestFee >= feeLvl);
           feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-          const endColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+          const endColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[0]);
 
           this.gradient = `linear-gradient(to right, ${startColor}, ${endColor})`;
           this.noPriority = startColor;

--- a/frontend/src/app/components/fees-box/fees-box.component.ts
+++ b/frontend/src/app/components/fees-box/fees-box.component.ts
@@ -31,13 +31,11 @@ export class FeesBoxComponent implements OnInit {
     this.recommendedFees$ = this.stateService.recommendedFees$
       .pipe(
         tap((fees) => {
-          let feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.minimumFee >= feeLvl);
-          feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-          const startColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[0]);
+          const startColorIndex = feeLevels.findIndex((feeLvl) => fees.minimumFee <= feeLvl);
+          const startColor = '#' + mempoolFeeColors[startColorIndex === -1 ? mempoolFeeColors.length - 1 : startColorIndex];
 
-          feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.fastestFee >= feeLvl);
-          feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-          const endColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[0]);
+          const endColorIndex = feeLevels.findIndex((feeLvl) => fees.fastestFee <= feeLvl);
+          const endColor = '#' + mempoolFeeColors[endColorIndex === -1 ? mempoolFeeColors.length - 1 : endColorIndex];
 
           this.gradient = `linear-gradient(to right, ${startColor}, ${endColor})`;
           this.noPriority = startColor;

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -185,10 +185,10 @@
 <ng-template #mempoolTable let-mempoolInfoData>
   <div class="mempool-info-data">
     <div class="item">
-      <h5 *ngIf="!mempoolInfoData.value || mempoolInfoData.value.memPoolInfo.mempoolminfee === 0.00001 || (stateService.env.BASE_MODULE === 'liquid' && mempoolInfoData.value.memPoolInfo.mempoolminfee === 0.000001) else purgingText" class="card-title" i18n="dashboard.minimum-fee|Minimum mempool fee">Minimum fee</h5>
+      <h5 *ngIf="!mempoolInfoData.value || mempoolInfoData.value.memPoolInfo.mempoolminfee === mempoolInfoData.value.memPoolInfo.minrelaytxfee else purgingText" class="card-title" i18n="dashboard.minimum-fee|Minimum mempool fee">Minimum fee</h5>
       <ng-template #purgingText><h5 class="card-title" i18n="dashboard.purging|Purgin below fee">Purging</h5></ng-template>
       <p class="card-text" *ngIf="(isLoadingWebSocket$ | async) === false && mempoolInfoData.value; else loading">
-        <ng-template [ngIf]="mempoolInfoData.value.memPoolInfo.mempoolminfee > 0.00001">&lt; </ng-template>{{ mempoolInfoData.value.memPoolInfo.mempoolminfee * 100000 | feeRounding }} <span><ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container></span>
+        <ng-template [ngIf]="mempoolInfoData.value.memPoolInfo.mempoolminfee !== mempoolInfoData.value.memPoolInfo.minrelaytxfee">&lt; </ng-template>{{ mempoolInfoData.value.memPoolInfo.mempoolminfee * 100000 | feeRounding }} <span><ng-container i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container></span>
       </p>
     </div>
     <div class="item">


### PR DESCRIPTION
2 fixes for mempool when running bitcoind with `minrelaytxfee=0.00000000` (i do for testnet)

1. No Priority color
2. always says Purging

1
there was no color for 0 sat/vB, so `feeLevelIndex` in frontend/src/app/components/fees-box/fees-box.component.ts:31 was `-1` which set it to the last color of the list (meant for the highest fee rate)

2
it before always said `Purging` because minrelaytxfee was not equal to a hardcoded value, but bitcoind has a way to see if the mempool if overflowing and pruning:

```json
$ bitcoin-cli -testnet getmempoolinfo
{
  "loaded": true,
  "size": 11,
  "bytes": 2913,
  "usage": 16976,
  "total_fee": 0.00049031,
  "maxmempool": 300000000,
  "mempoolminfee": 0.00000000,   <-- minimum fee needed to enter the mempool
  "minrelaytxfee": 0.00000000,   <-- minrelaytxfee from the config
  "unbroadcastcount": 0
}
```

if those 2 values are not equal bitcoind is pruning

i didnt test with liquid but i think this should be fine because elementsd has this same rpc (its a fork of bitcoind)


another color for 0 sat/vB is also possible of course to let those transaction stick out (coinbase txs, txs from miners etc) but i just copied the color from 1 sat/vB


before:
![image](https://user-images.githubusercontent.com/49868160/176463950-30a95c0c-c634-43f8-9249-a3debd21fd55.png)


after:
![image](https://user-images.githubusercontent.com/49868160/176464022-24dd18c4-0fd5-48a1-8302-4aa52f7cdc0b.png)
