### PR TITLE
limit pulsing blocks animation frame rate to 30FPS

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -114,7 +114,11 @@
 }
 
 .flashing {
-  animation: opacityPulse 2s ease-out;
+  /* force compositing */
+  will-change: opacity;
+  transform: translateZ(0);
+  /* effective max frame rate = (#keyframes - 1) x steps / duration */
+  animation: opacityPulse 2s steps(30, end);
   animation-iteration-count: infinite;
   opacity: 1;
 }

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -17,7 +17,11 @@
 }
 
 .flashing {
-  animation: opacityPulse 2s ease-out;
+  /* force compositing */
+  will-change: opacity;
+  transform: translateZ(0);
+  /* effective max frame rate = (#keyframes - 1) x steps / duration */
+  animation: opacityPulse 2s steps(30, end);
   animation-iteration-count: infinite;
   opacity: 1;
 }


### PR DESCRIPTION
This PR applies the CSS `steps()` timing function to effectively limit the maximum frame rate of the 'breathing' blocks effect, and reduce the high CPU and GPU usage reported in #1941.

`steps()` is [about as well supported as CSS animations in general](https://caniuse.com/?search=steps), so compatibility should be fine.

30 FPS seemed like a good compromise between smoothness and performance, but we can adjust up or down as needed.

note that this method requires *linear* interpolation, instead of *ease-out*, which changes the overall effect slightly.