### PR TITLE
Add LN charts into `/graphs` and add timespan selection

### DIFF
--- a/backend/src/api/explorer/general.routes.ts
+++ b/backend/src/api/explorer/general.routes.ts
@@ -10,7 +10,7 @@ class GeneralLightningRoutes {
     app
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/search', this.$searchNodesAndChannels)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/statistics/latest', this.$getGeneralStats)
-      .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/statistics', this.$getStatistics)
+      .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/statistics/:interval', this.$getStatistics)
     ;
   }
 
@@ -33,7 +33,12 @@ class GeneralLightningRoutes {
 
   private async $getStatistics(req: Request, res: Response) {
     try {
-      const statistics = await statisticsApi.$getStatistics();
+      const statistics = await statisticsApi.$getStatistics(req.params.interval);
+      const statisticsCount = await statisticsApi.$getStatisticsCount();
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.header('X-total-count', statisticsCount.toString());
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(statistics);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);

--- a/frontend/src/app/components/graphs/graphs.component.html
+++ b/frontend/src/app/components/graphs/graphs.component.html
@@ -1,7 +1,10 @@
-<div *ngIf="stateService.env.MINING_DASHBOARD" class="mb-3 d-inline-flex menu" style="padding: 0px 35px;">
+<div *ngIf="stateService.env.MINING_DASHBOARD || stateService.env.LIGHTNING" class="mb-3 d-flex menu"
+  style="padding: 0px 35px;">
+
   <a routerLinkActive="active" class="btn btn-primary w-50 mr-1"
     [routerLink]="['/graphs/mempool' | relativeUrl]">Mempool</a>
-  <div ngbDropdown class="w-50">
+
+  <div ngbDropdown class="w-50" *ngIf="stateService.env.MINING_DASHBOARD">
     <button class="btn btn-primary w-100" id="dropdownBasic1" ngbDropdownToggle i18n="mining">Mining</button>
     <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/pools' | relativeUrl]"
@@ -9,17 +12,28 @@
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/pools-dominance' | relativeUrl]"
         i18n="mining.pools-dominance">Pools Dominance</a>
       <a class="dropdown-item" routerLinkActive="active"
-        [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]" i18n="mining.hashrate-difficulty">Hashrate & Difficulty</a>
-      <a class="dropdown-item" routerLinkActive="active"
-        [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" i18n="mining.block-fee-rates">Block Fee Rates</a>
-      <a class="dropdown-item" routerLinkActive="active"
-        [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" i18n="mining.block-fees">Block Fees</a>
-      <a class="dropdown-item" routerLinkActive="active"
-        [routerLink]="['/graphs/mining/block-rewards' | relativeUrl]" i18n="mining.block-rewards">Block Rewards</a>
+        [routerLink]="['/graphs/mining/hashrate-difficulty' | relativeUrl]" i18n="mining.hashrate-difficulty">Hashrate &
+        Difficulty</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]"
+        i18n="mining.block-fee-rates">Block Fee Rates</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]"
+        i18n="mining.block-fees">Block Fees</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-rewards' | relativeUrl]"
+        i18n="mining.block-rewards">Block Rewards</a>
       <a class="dropdown-item" routerLinkActive="active"
         [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]" i18n="mining.block-sizes-weights">Block Sizes and Weights</a>
       <a class="dropdown-item" routerLinkActive="active"
         [routerLink]="['/graphs/mining/block-prediction' | relativeUrl]" i18n="mining.block-prediction-accuracy">Block Prediction Accuracy</a>
+    </div>
+  </div>
+
+  <div ngbDropdown class="w-50" *ngIf="stateService.env.LIGHTNING">
+    <button class="btn btn-primary w-100" id="dropdownBasic1" ngbDropdownToggle i18n="lightning">Lightning</button>
+    <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"
+        i18n="lightning.nodes-networks">Nodes per network</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"
+        i18n="lightning.capacity">Network capacity</a>
     </div>
   </div>
 </div>

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -18,6 +18,8 @@ import { StartComponent } from '../components/start/start.component';
 import { StatisticsComponent } from '../components/statistics/statistics.component';
 import { TelevisionComponent } from '../components/television/television.component';
 import { DashboardComponent } from '../dashboard/dashboard.component';
+import { NodesNetworksChartComponent } from '../lightning/nodes-networks-chart/nodes-networks-chart.component';
+import { LightningStatisticsChartComponent } from '../lightning/statistics-chart/lightning-statistics-chart.component';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -88,6 +90,14 @@ const routes: Routes = [
           {
             path: 'mining/block-sizes-weights',
             component: BlockSizesWeightsGraphComponent,
+          },
+          {
+            path: 'lightning/nodes-networks',
+            component: NodesNetworksChartComponent,
+          },
+          {
+            path: 'lightning/capacity',
+            component: LightningStatisticsChartComponent,
           },
           {
             path: '',

--- a/frontend/src/app/lightning/lightning-api.service.ts
+++ b/frontend/src/app/lightning/lightning-api.service.ts
@@ -56,7 +56,10 @@ export class LightningApiService {
     return this.httpClient.get<any>(this.apiBasePath + '/channels/' + publicKey + '/statistics');
   }
 
-  listStatistics$(): Observable<any> {
-    return this.httpClient.get<any>(this.apiBasePath + '/api/v1/lightning/statistics');
+  listStatistics$(interval: string | undefined): Observable<any> {
+    return this.httpClient.get<any>(
+      this.apiBasePath + '/api/v1/lightning/statistics' +
+      (interval !== undefined ? `/${interval}` : ''), { observe: 'response' }
+    );
   }
 }

--- a/frontend/src/app/lightning/lightning-dashboard/lightning-dashboard.component.html
+++ b/frontend/src/app/lightning/lightning-dashboard/lightning-dashboard.component.html
@@ -31,7 +31,8 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <app-lightning-statistics-chart [widget]=true></app-lightning-statistics-chart>
+          <app-nodes-networks-chart [widget]=true></app-nodes-networks-chart>
+          <div class="mt-1"><a [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>
       </div>
     </div>
@@ -39,7 +40,8 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <app-nodes-networks-chart [widget]=true></app-nodes-networks-chart>
+          <app-lightning-statistics-chart [widget]=true></app-lightning-statistics-chart>
+          <div class="mt-1"><a [routerLink]="['/graphs/lightning/capacity' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.html
+++ b/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.html
@@ -8,35 +8,26 @@
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(nodesNetworkObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 144">
-          <input ngbButton type="radio" [value]="'24h'" fragment="24h" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 24h
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 30">
+          <input ngbButton type="radio" [value]="'1m'" fragment="1m" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 1M
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 432">
-          <input ngbButton type="radio" [value]="'3d'" fragment="3d" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 3D
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 90">
+          <input ngbButton type="radio" [value]="'3m'" fragment="3m" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 3M
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 1008">
-          <input ngbButton type="radio" [value]="'1w'" fragment="1w" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 1W
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 180">
+          <input ngbButton type="radio" [value]="'6m'" fragment="6m" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 6M
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 4320">
-          <input ngbButton type="radio" [value]="'1m'" fragment="1m" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 1M
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 365">
+          <input ngbButton type="radio" [value]="'1y'" fragment="1y" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 1Y
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 12960">
-          <input ngbButton type="radio" [value]="'3m'" fragment="3m" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 3M
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 730">
+          <input ngbButton type="radio" [value]="'2y'" fragment="2y" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 2Y
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 25920">
-          <input ngbButton type="radio" [value]="'6m'" fragment="6m" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 6M
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 1095">
+          <input ngbButton type="radio" [value]="'3y'" fragment="3y" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> 3Y
         </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 52560">
-          <input ngbButton type="radio" [value]="'1y'" fragment="1y" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 1Y
-        </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 105120">
-          <input ngbButton type="radio" [value]="'2y'" fragment="2y" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 2Y
-        </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 157680">
-          <input ngbButton type="radio" [value]="'3y'" fragment="3y" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> 3Y
-        </label>
-        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount > 157680">
-          <input ngbButton type="radio" [value]="'all'" fragment="all" [routerLink]="['/graphs/mining/block-sizes-weights' | relativeUrl]"> ALL
+        <label ngbButtonLabel class="btn-primary btn-sm">
+          <input ngbButton type="radio" [value]="'all'" fragment="all" [routerLink]="['/graphs/lightning/nodes-networks' | relativeUrl]"> ALL
         </label>
       </div>
     </form>

--- a/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.html
+++ b/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.html
@@ -5,9 +5,43 @@
     <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
       <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
     </button>
+
+    <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(capacityObservable$ | async) as stats">
+      <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 30">
+          <input ngbButton type="radio" [value]="'1m'" fragment="1m"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 1M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 90">
+          <input ngbButton type="radio" [value]="'3m'" fragment="3m"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 3M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 180">
+          <input ngbButton type="radio" [value]="'6m'" fragment="6m"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 6M
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 365">
+          <input ngbButton type="radio" [value]="'1y'" fragment="1y"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 1Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 730">
+          <input ngbButton type="radio" [value]="'2y'" fragment="2y"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 2Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.days >= 1095">
+          <input ngbButton type="radio" [value]="'3y'" fragment="3y"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> 3Y
+        </label>
+        <label ngbButtonLabel class="btn-primary btn-sm">
+          <input ngbButton type="radio" [value]="'all'" fragment="all"
+            [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"> ALL
+        </label>
+      </div>
+    </form>
   </div>
 
-  <div [class]="!widget ? 'chart' : 'chart-widget'" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"></div>
+  <div [class]="!widget ? 'chart' : 'chart-widget'" echarts [initOpts]="chartInitOptions" [options]="chartOptions"
+    (chartInit)="onChartInit($event)"></div>
   <div class="text-center loadingGraphs" *ngIf="isLoading">
     <div class="spinner-border text-light"></div>
   </div>


### PR DESCRIPTION
**Depends on https://github.com/mempool/mempool/pull/1976 which must be merged first.**
Please review/merge https://github.com/mempool/mempool/pull/1978 before this one as well because this branch is forked off #1978 branch.

This PR adds timespan selection on the two existing LN charts. The LN dashboard will show the `1y` chart (same as the mining dashboard).
The two LN charts are also now available under the `/graphs` page.

<img width="1920" alt="Screen Shot 2022-07-06 at 3 15 42 PM" src="https://user-images.githubusercontent.com/9780671/177559106-1c1c2cd7-6678-47ba-9bd8-63802cbed8bd.png">

<img width="1123" alt="Screen Shot 2022-07-06 at 3 15 53 PM" src="https://user-images.githubusercontent.com/9780671/177559100-3d0703e9-a54a-426a-9b66-1b5ccf82a473.png">
