### PR TITLE
Run the mining indexer every hour to index missing/updated data

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -35,6 +35,8 @@ class Indexer {
     this.runIndexer = false;
     this.indexerRunning = true;
 
+    logger.debug(`Running mining indexer`);
+
     try {
       const chainValid = await blocks.$generateBlockDatabase();
       if (chainValid === false) {
@@ -54,9 +56,15 @@ class Indexer {
       this.indexerRunning = false;
       logger.err(`Indexer failed, trying again in 10 seconds. Reason: ` + (e instanceof Error ? e.message : e));
       setTimeout(() => this.reindex(), 10000);
+      this.indexerRunning = false;
+      return;
     }
 
     this.indexerRunning = false;
+
+    const runEvery = 1000 * 3600; // 1 hour
+    logger.debug(`Indexing completed. Next run planned at ${new Date(new Date().getTime() + runEvery).toUTCString()}`);
+    setTimeout(() => this.reindex(), runEvery);
   }
 
   async $resetHashratesIndexingState() {


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1992

This PR runs the mining indexer once per hour, to index potentially missing data or simply to index the latest hashrate and such.

### Testing
* Deploy the PR
* Start the backend
* Delete some data manually

```mysql
delete from blocks order by height desc limit 100;
delete from hashrates where type = 'daily' order by hashrate_timestamp desc limit 100;
delete from difficulty_adjustments order by height desc limit 100;
```

* After one ~1 hour you'll see `INFO: Running mining indexer` in the log
* Once indexing is done, check if the delete data is back (you can use charts for this purpose, or look directly into the database)