### PR TITLE
Set pagination font to monospace

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1046,3 +1046,7 @@ th {
   box-shadow: -10px -15px 75px rgba(#eba814, 1);
   transition: 100ms all ease-in;
 }
+
+.page-item {
+  font-family: monospace;
+}


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/1957

Pagination font set to monospace

#### Before

https://user-images.githubusercontent.com/9780671/177044806-db37aaad-7545-4090-b6d7-edef2cfa9aca.mov

#### After

https://user-images.githubusercontent.com/9780671/177768597-1c5ea350-2207-4e38-adf8-b328b7f75372.mov


