### PR TITLE
Use bitcoin core to fetch blocks

### DIFF
--- a/backend/src/utils/blocks-utils.ts
+++ b/backend/src/utils/blocks-utils.ts
@@ -3,14 +3,14 @@ import { BlockExtended } from '../mempool.interfaces';
 export function prepareBlock(block: any): BlockExtended {
   return <BlockExtended>{
     id: block.id ?? block.hash, // hash for indexed block
-    timestamp: block.timestamp ?? block.blockTimestamp, // blockTimestamp for indexed block
+    timestamp: block.timestamp ?? block.time ?? block.blockTimestamp, // blockTimestamp for indexed block
     height: block.height,
     version: block.version,
-    bits: block.bits,
+    bits: (typeof block.bits === 'string' ? parseInt(block.bits, 16): block.bits),
     nonce: block.nonce,
     difficulty: block.difficulty,
-    merkle_root: block.merkle_root,
-    tx_count: block.tx_count,
+    merkle_root: block.merkle_root ?? block.merkleroot,
+    tx_count: block.tx_count ?? block.nTx,
     size: block.size,
     weight: block.weight,
     previousblockhash: block.previousblockhash,


### PR DESCRIPTION
This PR replaces querying blocks through esplora vs bitcoin core when it is requested by users from the frontend.

In very rare occasion, it was possible for the user to query a block right before we index it. Since we were using esplora, the block was indexed on the fly in the db using an rounded difficulty (esplora bug). This created a follow up bug on the difficulty adjustments table.

### Testing

* Deploy the PR, explore some blocks (some new, and some old to make sure they're not in memory cache). Confirm everything still works fine
* Delete 100 most recent blocks
```mysql
delete from blocks order by height desc limit 100;
```
* Explore a block you've just deleted, confirm everything works fine
* Open the block list page `/blocks`, confirm everything works fine, browse 6~7 pages
* Check if blocks are properly re-indexed on the fly
```mysql
select * from blocks order by height desc limit 100;
```
* **Clear your disk cache** and test with `config.DATABASE.ENABLED: false` and `MINING_DASHBOARD: false` (can still browse blocks, and see the blocks list)

Note: Bisq and liquid are not be impacted because it uses a different code branch (the legacy /blocks backend code)