### PR TITLE
Liquid always uses esplora (regression of #2039)

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -527,13 +527,12 @@ class Blocks {
       }
     }
 
-    let block = await bitcoinClient.getBlock(hash);
-
     // Not Bitcoin network, return the block as it
     if (['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) === false) {
-      return block;
+      return await bitcoinApi.$getBlock(hash);
     }
 
+    let block = await bitcoinClient.getBlock(hash);
     block = prepareBlock(block);
 
     // Bitcoin network, add our custom data on top
@@ -547,8 +546,8 @@ class Blocks {
     return blockExtended;
   }
 
-  public async $getStrippedBlockTransactions(hash: string, skipMemoryCache: boolean = false,
-    skipDBLookup: boolean = false): Promise<TransactionStripped[]>
+  public async $getStrippedBlockTransactions(hash: string, skipMemoryCache = false,
+    skipDBLookup = false): Promise<TransactionStripped[]>
   {
     if (skipMemoryCache === false) {
       // Check the memory cache

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -172,7 +172,7 @@ export class Common {
 
   static indexingEnabled(): boolean {
     return (
-      ['mainnet', 'testnet', 'signet', 'regtest'].includes(config.MEMPOOL.NETWORK) &&
+      ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) &&
       config.DATABASE.ENABLED === true &&
       config.MEMPOOL.INDEXING_BLOCKS_AMOUNT !== 0
     );


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2060
Regression introduced in https://github.com/mempool/mempool/issues/2039

* Tested locally with liquidtestnet (liquid node only)
```
    "NETWORK": "liquidtestnet",
    "BACKEND": "none",
```