### PR TITLE
Set /block API cache duration according to block age

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -761,7 +761,19 @@ class Routes {
   public async getBlock(req: Request, res: Response) {
     try {
       const block = await blocks.$getBlock(req.params.hash);
-      res.setHeader('Expires', new Date(Date.now() + 1000 * 600).toUTCString());
+
+      const blockAge = new Date().getTime() / 1000 - block.timestamp;
+      const day = 24 * 3600;
+      let cacheDuration;
+      if (blockAge > 365 * day) {
+        cacheDuration = 30 * day;
+      } else if (blockAge > 30 * day) {
+        cacheDuration = 10 * day;
+      } else {
+        cacheDuration = 600
+      }
+
+      res.setHeader('Expires', new Date(Date.now() + 1000 * cacheDuration).toUTCString());
       res.json(block);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2053
**This is applied regardless of the network, should there be some filtering?**

### Testing

* Make sure to clear or disable your cache (currently /block API http cache is set to 10 minutes)
* Recent block (less than 30 days) 00000000000000000008923e0704d6851b10a909b7c29f2fbddcc87b198a18ed, cache set to 10 minutes

<img width="300" alt="Screen Shot 2022-07-11 at 9 55 44 AM" src="https://user-images.githubusercontent.com/9780671/178216021-80e863fe-23b7-4627-8077-916f82fb5c45.png">

* Older block (less than 365 days) 0000000000000000000590fc0f3eba193a278534220b2b37e9849e1a770ca959, cache set to 10 days

<img width="299" alt="Screen Shot 2022-07-11 at 9 56 54 AM" src="https://user-images.githubusercontent.com/9780671/178216419-7dd9b0d9-77f6-464b-8c86-c6267b027da7.png">

* Very old block (more than 365 years) 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f, cache set to 30 days

<img width="299" alt="Screen Shot 2022-07-11 at 9 57 29 AM" src="https://user-images.githubusercontent.com/9780671/178216447-087b670d-d5be-4b6b-a933-40d346ec2166.png">
