### PR TITLE
nginx: Fix errors found by gixy (nginx conf static analyzer)

### DIFF
--- a/production/nginx/location-api-v1-lightning.conf
+++ b/production/nginx/location-api-v1-lightning.conf
@@ -5,7 +5,7 @@ location /api/v1/lightning {
 location @mempool-api-v1-lightning {
 	proxy_pass $mempoolMainnetLightning;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -48,7 +48,7 @@ location @mempool-api-v1-websocket {
 	proxy_pass $mempoolMainnet;
 	proxy_http_version 1.1;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
@@ -59,7 +59,7 @@ location @mempool-api-v1-websocket {
 location @mempool-api-v1-cache-forever {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -76,7 +76,7 @@ location @mempool-api-v1-cache-forever {
 location @mempool-api-v1-cache-warm {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -91,7 +91,7 @@ location @mempool-api-v1-cache-warm {
 location @mempool-api-v1-cache-normal {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -106,7 +106,7 @@ location @mempool-api-v1-cache-normal {
 location @mempool-api-v1-cache-disabled {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -120,7 +120,7 @@ location @mempool-api-v1-cache-disabled {
 location @esplora-api-cache-disabled {
 	proxy_pass $esploraMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -134,7 +134,7 @@ location @esplora-api-cache-disabled {
 location @esplora-api-cache-forever {
 	proxy_pass $esploraMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-liquid-api.conf
+++ b/production/nginx/location-liquid-api.conf
@@ -49,7 +49,7 @@ location @mempool-liquid-api-v1-websocket {
 	proxy_pass $mempoolMainnet;
 	proxy_http_version 1.1;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
@@ -60,7 +60,7 @@ location @mempool-liquid-api-v1-websocket {
 location @mempool-liquid-api-v1-cache-forever {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -77,7 +77,7 @@ location @mempool-liquid-api-v1-cache-forever {
 location @mempool-liquid-api-v1-cache-warm {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -92,7 +92,7 @@ location @mempool-liquid-api-v1-cache-warm {
 location @mempool-liquid-api-v1-cache-normal {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -107,7 +107,7 @@ location @mempool-liquid-api-v1-cache-normal {
 location @mempool-liquid-api-v1-cache-disabled {
 	proxy_pass $mempoolMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -121,7 +121,7 @@ location @mempool-liquid-api-v1-cache-disabled {
 location @esplora-liquid-api-cache-disabled {
 	proxy_pass $esploraMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -135,7 +135,7 @@ location @esplora-liquid-api-cache-disabled {
 location @esplora-liquid-api-cache-forever {
 	proxy_pass $esploraMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-liquidtestnet-api.conf
+++ b/production/nginx/location-liquidtestnet-api.conf
@@ -53,7 +53,7 @@ location @mempool-liquidtestnet-api-v1-websocket {
 	proxy_pass $mempoolTestnet;
 	proxy_http_version 1.1;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
@@ -64,7 +64,7 @@ location @mempool-liquidtestnet-api-v1-websocket {
 location @mempool-liquidtestnet-api-v1-cache-forever {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -81,7 +81,7 @@ location @mempool-liquidtestnet-api-v1-cache-forever {
 location @mempool-liquidtestnet-api-v1-cache-warm {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -96,7 +96,7 @@ location @mempool-liquidtestnet-api-v1-cache-warm {
 location @mempool-liquidtestnet-api-v1-cache-normal {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -111,7 +111,7 @@ location @mempool-liquidtestnet-api-v1-cache-normal {
 location @mempool-liquidtestnet-api-v1-cache-disabled {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -125,7 +125,7 @@ location @mempool-liquidtestnet-api-v1-cache-disabled {
 location @esplora-liquidtestnet-api-cache-disabled {
 	proxy_pass $esploraTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -139,7 +139,7 @@ location @esplora-liquidtestnet-api-cache-disabled {
 location @esplora-liquidtestnet-api-cache-forever {
 	proxy_pass $esploraTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-signet-api-v1-lightning.conf
+++ b/production/nginx/location-signet-api-v1-lightning.conf
@@ -6,7 +6,7 @@ location /signet/api/v1/lightning {
 location @mempool-signet-api-v1-lightning {
 	proxy_pass $mempoolSignetLightning;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-signet-api.conf
+++ b/production/nginx/location-signet-api.conf
@@ -53,7 +53,7 @@ location @mempool-signet-api-v1-websocket {
 	proxy_pass $mempoolSignet;
 	proxy_http_version 1.1;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
@@ -64,7 +64,7 @@ location @mempool-signet-api-v1-websocket {
 location @mempool-signet-api-v1-cache-forever {
 	proxy_pass $mempoolSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -81,7 +81,7 @@ location @mempool-signet-api-v1-cache-forever {
 location @mempool-signet-api-v1-cache-warm {
 	proxy_pass $mempoolSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -96,7 +96,7 @@ location @mempool-signet-api-v1-cache-warm {
 location @mempool-signet-api-v1-cache-normal {
 	proxy_pass $mempoolSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -111,7 +111,7 @@ location @mempool-signet-api-v1-cache-normal {
 location @mempool-signet-api-v1-cache-disabled {
 	proxy_pass $mempoolSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -125,7 +125,7 @@ location @mempool-signet-api-v1-cache-disabled {
 location @esplora-signet-api-cache-disabled {
 	proxy_pass $esploraSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -139,7 +139,7 @@ location @esplora-signet-api-cache-disabled {
 location @esplora-signet-api-cache-forever {
 	proxy_pass $esploraSignet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-testnet-api-v1-lightning.conf
+++ b/production/nginx/location-testnet-api-v1-lightning.conf
@@ -6,7 +6,7 @@ location /testnet/api/v1/lightning {
 location @mempool-testnet-api-v1-lightning {
 	proxy_pass $mempoolSignetLightning;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/location-testnet-api.conf
+++ b/production/nginx/location-testnet-api.conf
@@ -53,7 +53,7 @@ location @mempool-testnet-api-v1-websocket {
 	proxy_pass $mempoolTestnet;
 	proxy_http_version 1.1;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Upgrade $http_upgrade;
@@ -64,7 +64,7 @@ location @mempool-testnet-api-v1-websocket {
 location @mempool-testnet-api-v1-cache-forever {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -81,7 +81,7 @@ location @mempool-testnet-api-v1-cache-forever {
 location @mempool-testnet-api-v1-cache-warm {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -96,7 +96,7 @@ location @mempool-testnet-api-v1-cache-warm {
 location @mempool-testnet-api-v1-cache-normal {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -111,7 +111,7 @@ location @mempool-testnet-api-v1-cache-normal {
 location @mempool-testnet-api-v1-cache-disabled {
 	proxy_pass $mempoolTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -125,7 +125,7 @@ location @mempool-testnet-api-v1-cache-disabled {
 location @esplora-testnet-api-cache-disabled {
 	proxy_pass $esploraTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -139,7 +139,7 @@ location @esplora-testnet-api-cache-disabled {
 location @esplora-testnet-api-cache-forever {
 	proxy_pass $esploraTestnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/server-bisq.conf
+++ b/production/nginx/server-bisq.conf
@@ -78,7 +78,7 @@ location @mempool-bisq-websocket {
 location @mempool-bisq {
 	proxy_pass $mempoolBisq;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
@@ -89,7 +89,7 @@ location @mempool-bisq {
 location @esplora-api-cache-disabled {
 	proxy_pass $esploraMainnet;
 
-	proxy_set_header Host $http_host;
+	proxy_set_header Host $host;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;

--- a/production/nginx/server-common.conf
+++ b/production/nginx/server-common.conf
@@ -49,7 +49,7 @@ add_header Vary Cookie;
 # cache redirect for 10 minutes
 location = / {
 	if ($lang != '') {
-		return 302 $scheme://$host/$lang$uri;
+		return 302 $scheme://$host/$lang/;
 	}
 	try_files /en-US/index.html =404;
 	expires 10m;


### PR DESCRIPTION
Besides removing some nginx antipatterns, this allows users who check their nginx config with [gixy](https://github.com/yandex/gixy) (e.g. users of the NixOS `nginx` module) to include mempool files in their nginx config.

Here's how to repro the gixy errors:
```bash
cd production/nginx
# Fix includes
find . -type f -exec sed -i 's|include mempool/production/nginx/|include |g' {} \;
# Disable `origins` check which can't be fixed in mempool
gixy nginx.conf --skips origins
```