### PR TITLE
frontend: Don't copy `resources`, shrink static size

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -170,6 +170,10 @@
           },
           "configurations": {
             "production": {
+              "assets": [
+                "src/favicon.ico",
+                "src/robots.txt"
+              ],
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "start:local-staging": "npm run generate-config && npm run sync-assets-dev && npm run ng -- serve -c local-staging",
     "start:mixed": "npm run generate-config && npm run sync-assets-dev && npm run ng -- serve -c mixed",
     "build": "npm run generate-config && npm run ng -- build --configuration production --localize && npm run sync-assets && npm run build-mempool.js",
-    "sync-assets": "node sync-assets.js && rsync -av ./dist/mempool/browser/en-US/resources ./dist/mempool/browser/resources",
+    "sync-assets": "rsync -av ./src/resources ./dist/mempool/browser && node sync-assets.js",
     "sync-assets-dev": "node sync-assets.js dev",
     "generate-config": "node generate-config.js",
     "build-mempool.js": "npm run build-mempool-js && npm run build-mempool-liquid-js && npm run build-mempool-bisq-js",

--- a/frontend/sync-assets.js
+++ b/frontend/sync-assets.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 const CONFIG_FILE_NAME = 'mempool-frontend-config.json';
 let configContent = {};
 
-var PATH = 'dist/mempool/browser/en-US/resources/';
+var PATH = 'dist/mempool/browser/resources/';
 if (process.argv[2] && process.argv[2] === 'dev') {
   PATH = 'src/resources/';
 }

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -18,7 +18,7 @@
 		expires 10m;
 	}
 	location /resources {
-		try_files /$lang/$uri /$lang/$uri/ $uri $uri/ /en-US/$uri @index-redirect;
+		try_files $uri @index-redirect;
 		expires 1h;
 	}
 	location @index-redirect {
@@ -27,10 +27,6 @@
 
 	# location block using regex are matched in order
 
-	# used to rewrite resources from /<lang>/ to /en-US/
-	location ~ ^/(ar|bg|bs|ca|cs|da|de|et|el|es|eo|eu|fa|fr|gl|ko|hr|id|it|he|ka|lv|lt|hu|mk|ms|nl|ja|nb|nn|pl|pt|pt-BR|ro|ru|sk|sl|sr|sh|fi|sv|th|tr|uk|vi|zh|hi)/resources/ {
-		rewrite ^/[a-zA-Z-]*/resources/(.*) /en-US/resources/$1;
-	}
 	# used for cookie override
 	location ~ ^/(ar|bg|bs|ca|cs|da|de|et|el|es|eo|eu|fa|fr|gl|ko|hr|id|it|he|ka|lv|lt|hu|mk|ms|nl|ja|nb|nn|pl|pt|pt-BR|ro|ru|sk|sl|sr|sh|fi|sv|th|tr|uk|vi|zh|hi)/ {
 		try_files $uri $uri/ /$1/index.html =404;

--- a/production/mempool.crontab
+++ b/production/mempool.crontab
@@ -5,5 +5,5 @@
 37 13 * * * sleep 30 ; /mempool/mempool.space/backup >/dev/null 2>&1 &
 
 # hourly liquid asset update
-6 * * * * cd $HOME/liquid/frontend && npm run sync-assets && rsync -av $HOME/liquid/frontend/dist/mempool/browser/en-US/resources/assets* $HOME/public_html/liquid/en-US/resources/ >/dev/null 2>&1
+6 * * * * cd $HOME/liquid/frontend && npm run sync-assets && rsync -av $HOME/liquid/frontend/dist/mempool/browser/resources/assets* $HOME/public_html/liquid/resources/ >/dev/null 2>&1
 

--- a/production/nginx/server-common.conf
+++ b/production/nginx/server-common.conf
@@ -58,12 +58,6 @@ location = / {
 	expires 5m;
 }
 
-# used to rewrite resources from /<lang>/ to /en-US/
-# cache /resources/** for 1 week since they don't change often
-location ~ ^/[a-z][a-z]/resources/(.*) {
-	try_files $uri /en-US/resources/$1 =404;
-	expires 1w;
-}
 # cache /<lang>/main.f40e91d908a068a2.js forever since they never change
 location ~ ^/([a-z][a-z])/(.+\..+\.(js|css)) {
 	try_files $uri =404;
@@ -84,7 +78,7 @@ location ~ ^/([a-z][a-z])/ {
 
 # cache /resources/** for 1 week since they don't change often
 location /resources {
-	try_files $uri /en-US/$uri /en-US/index.html;
+	try_files $uri /en-US/index.html;
 	expires 1w;
 }
 # cache /main.f40e91d908a068a2.js forever since they never change


### PR DESCRIPTION
This PR can be merged as soon as it's certain that the frontend no longer accesses `resources` in language dirs (like `/fr/resources/bitcoin-logo.png`).
This should be the case since #2070.

This PR is currently deployed at https://mempool.nixbitcoin.org

#### Copy of commit msg
Since 355e89ce5, the frontend references resources via root-relative URLs.
This means that `resources` dirs in the language dirs are no longer accessed and can be removed.

As of fd35c8f4a, this shrinks the frontend size by 55% (279M -> 124M).

Also, the nginx location configs now can be simplified.