### PR TITLE
Add nodes per AS chart

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -96,10 +96,12 @@ class NodesApi {
 
   public async $getNodesAsShare() {
     try {
-      let query = `SELECT names, COUNT(*) as nodesCount from nodes
+      let query = `SELECT names, COUNT(DISTINCT nodes.public_key) as nodesCount, SUM(capacity) as capacity
+        FROM nodes
         JOIN geo_names ON geo_names.id = nodes.as_number
+        JOIN channels ON channels.node1_public_key = nodes.public_key OR channels.node2_public_key = nodes.public_key
         GROUP BY as_number
-        ORDER BY COUNT(*) DESC
+        ORDER BY COUNT(DISTINCT nodes.public_key) DESC
       `;
       const [nodesCountPerAS]: any = await DB.query(query);
 
@@ -112,6 +114,7 @@ class NodesApi {
           name: JSON.parse(as.names),
           count: as.nodesCount,
           share: Math.floor(as.nodesCount / nodesWithAS[0].total * 10000) / 100,
+          capacity: as.capacity,
         })
       }
 

--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -100,7 +100,6 @@ class NodesApi {
         JOIN geo_names ON geo_names.id = nodes.as_number
         GROUP BY as_number
         ORDER BY COUNT(*) DESC
-        LIMIT 20
       `;
       const [nodesCountPerAS]: any = await DB.query(query);
 

--- a/backend/src/api/explorer/nodes.routes.ts
+++ b/backend/src/api/explorer/nodes.routes.ts
@@ -8,6 +8,7 @@ class NodesRoutes {
     app
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/search/:search', this.$searchNode)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/top', this.$getTopNodes)
+      .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/asShare', this.$getNodesAsShare)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/:public_key/statistics', this.$getHistoricalNodeStats)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/:public_key', this.$getNode)
     ;
@@ -52,6 +53,18 @@ class NodesRoutes {
         topByCapacity: topCapacityNodes,
         topByChannels: topChannelsNodes,
       });
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
+  }
+
+  private async $getNodesAsShare(req: Request, res: Response) {
+    try {
+      const nodesPerAs = await nodesApi.$getNodesAsShare();
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 600).toUTCString());
+      res.json(nodesPerAs);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
     }

--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
@@ -2,10 +2,13 @@
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">
-    <span i18n="mining.block-fee-rates">Block Fee Rates</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.block-fee-rates">Block Fee Rates</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
+
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 144">

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
@@ -2,10 +2,13 @@
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">
-    <span i18n="mining.block-fees">Block Fees</span>
-      <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.block-fees">Block Fees</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
+
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 4320">

--- a/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.html
+++ b/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.html
@@ -2,10 +2,13 @@
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">
-    <span i18n="mining.block-prediction-accuracy">Block Prediction Accuracy</span>
-      <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.block-prediction-accuracy">Block Prediction Accuracy</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
+
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 144">

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.html
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.html
@@ -3,10 +3,13 @@
 <div class="full-container">
 
   <div class="card-header mb-0 mb-md-4">
-  <span i18n="mining.block-rewards">Block Rewards</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.block-rewards">Block Rewards</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
+  
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 4320">

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.html
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.html
@@ -1,10 +1,12 @@
 <div class="full-container">
 
   <div class="card-header mb-0 mb-md-4">
-    <span i18n="mining.block-sizes-weights">Block Sizes and Weights</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.block-sizes-weights">Block Sizes and Weights</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(blockSizesWeightsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">

--- a/frontend/src/app/components/graphs/graphs.component.html
+++ b/frontend/src/app/components/graphs/graphs.component.html
@@ -34,6 +34,8 @@
         i18n="lightning.nodes-networks">Nodes per network</a>
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"
         i18n="lightning.capacity">Network capacity</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/nodes-per-as' | relativeUrl]"
+        i18n="lightning.nodes-per-as">Nodes per AS</a>
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/graphs/graphs.component.html
+++ b/frontend/src/app/components/graphs/graphs.component.html
@@ -34,8 +34,8 @@
         i18n="lightning.nodes-networks">Nodes per network</a>
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/capacity' | relativeUrl]"
         i18n="lightning.capacity">Network capacity</a>
-      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/nodes-per-as' | relativeUrl]"
-        i18n="lightning.nodes-per-as">Nodes per AS</a>
+      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/lightning/nodes-per-isp' | relativeUrl]"
+        i18n="lightning.nodes-per-isp">Lightning nodes per ISP</a>
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.html
@@ -23,10 +23,12 @@
   </div>
 
   <div class="card-header mb-0 mb-md-4" [style]="widget ? 'display:none' : ''">
-    <span i18n="mining.hashrate-difficulty">Hashrate & Difficulty</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.hashrate-difficulty">Hashrate & Difficulty</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.html
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.html
@@ -2,11 +2,14 @@
 
 <div class="full-container">
 
-  <div class="card-header  mb-0 mb-md-4">
-    <span i18n="mining.pools-dominance">Pools Dominance</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+  <div class="card-header mb-0 mb-md-4">
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.pools-dominance">Pools Dominance</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
+
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(hashrateObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">
         <label ngbButtonLabel class="btn-primary btn-sm" *ngIf="stats.blockCount >= 25920">

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -32,10 +32,12 @@
   </div>
 
   <div class="card-header" *ngIf="!widget">
-    <span i18n="mining.pools">Pools Ranking</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.pools">Pools Ranking</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
     <form [formGroup]="radioGroupForm" class="formRadioGroup"
       *ngIf="!widget && (miningStatsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">

--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -3,11 +3,12 @@
     <div>
       <div class="card mb-3">
         <div class="card-header">
-          <i class="fa fa-area-chart"></i>
-          <span i18n="statistics.memory-by-vBytes">Mempool by vBytes (sat/vByte)</span>
-          <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart('mempool')">
-            <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-          </button>
+          <div class="d-flex d-md-block align-items-baseline">
+            <span i18n="statistics.memory-by-vBytes">Mempool by vBytes (sat/vByte)</span>
+            <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart('mempool')">
+              <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+            </button>
+          </div>  
 
           <form [formGroup]="radioGroupForm" class="formRadioGroup"
             [class]="stateService.env.MINING_DASHBOARD ? 'mining' : ''" (click)="saveGraphPreference()">
@@ -84,11 +85,12 @@
     <div>
       <div class="card mb-3">
         <div class="card-header">
-          <i class="fa fa-area-chart"></i>
-          <span i18n="statistics.transaction-vbytes-per-second">Transaction vBytes per second (vB/s)</span>
-          <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart('incoming')">
-            <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-          </button>
+          <div class="d-flex d-md-block align-items-baseline">
+            <span i18n="statistics.transaction-vbytes-per-second">Transaction vBytes per second (vB/s)</span>
+            <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart('incoming')">
+              <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+            </button>
+          </div>  
         </div>
 
         <div class="card-body">

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -20,6 +20,7 @@ import { TelevisionComponent } from '../components/television/television.compone
 import { DashboardComponent } from '../dashboard/dashboard.component';
 import { NodesNetworksChartComponent } from '../lightning/nodes-networks-chart/nodes-networks-chart.component';
 import { LightningStatisticsChartComponent } from '../lightning/statistics-chart/lightning-statistics-chart.component';
+import { NodesPerAsChartComponent } from '../lightning/nodes-per-as-chart/nodes-per-as-chart.component';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -98,6 +99,10 @@ const routes: Routes = [
           {
             path: 'lightning/capacity',
             component: LightningStatisticsChartComponent,
+          },
+          {
+            path: 'lightning/nodes-per-as',
+            component: NodesPerAsChartComponent,
           },
           {
             path: '',

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -101,7 +101,7 @@ const routes: Routes = [
             component: LightningStatisticsChartComponent,
           },
           {
-            path: 'lightning/nodes-per-as',
+            path: 'lightning/nodes-per-isp',
             component: NodesPerAsChartComponent,
           },
           {

--- a/frontend/src/app/lightning/lightning.module.ts
+++ b/frontend/src/app/lightning/lightning.module.ts
@@ -18,6 +18,7 @@ import { NodeStatisticsChartComponent } from './node-statistics-chart/node-stati
 import { GraphsModule } from '../graphs/graphs.module';
 import { NodesNetworksChartComponent } from './nodes-networks-chart/nodes-networks-chart.component';
 import { ChannelsStatisticsComponent } from './channels-statistics/channels-statistics.component';
+import { NodesPerAsChartComponent } from '../lightning/nodes-per-as-chart/nodes-per-as-chart.component';
 @NgModule({
   declarations: [
     LightningDashboardComponent,
@@ -33,6 +34,7 @@ import { ChannelsStatisticsComponent } from './channels-statistics/channels-stat
     LightningStatisticsChartComponent,
     NodesNetworksChartComponent,
     ChannelsStatisticsComponent,
+    NodesPerAsChartComponent,
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.html
+++ b/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.html
@@ -1,10 +1,12 @@
 <div [class]="widget === false ? 'full-container' : ''">
 
   <div class="card-header mb-0 mb-md-4" [style]="widget ? 'display:none' : ''">
-    <span i18n="mining.nodes-networks">Nodes count by network</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.nodes-networks">Nodes count by network</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>  
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(nodesNetworkObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
@@ -1,10 +1,12 @@
 <div class="full-container h-100">
 
   <div class="card-header">
-    <span i18n="lightning.nodes-per-as">Nodes per AS</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="lightning.nodes-per-as">Nodes per AS</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>
   </div>
 
   <div class="container pb-lg-0 bottom-padding">

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
@@ -1,12 +1,13 @@
 <div class="full-container h-100">
 
   <div class="card-header">
-    <div class="d-flex d-md-block align-items-baseline">
-      <span i18n="lightning.nodes-per-as">Nodes per AS</span>
+    <div class="d-flex d-md-block align-items-baseline" style="margin-bottom: -5px">
+      <span i18n="lightning.nodes-per-isp">Lightning nodes per ISP</span>
       <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
         <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
       </button>
     </div>
+    <small style="color: #ffffff66" i18n="lightning.tor-nodes-excluded">(Tor nodes excluded)</small>
   </div>
 
   <div class="container pb-lg-0 bottom-padding">
@@ -26,7 +27,7 @@
           <th *ngIf="!isMobile()" i18n="mining.rank">Rank</th>
           <th i18n="lightning.as-name">Name</th>
           <th *ngIf="!isMobile()" i18n="lightning.share">Share</th>
-          <th i18n="lightning.nodes">Nodes</th>
+          <th i18n="lightning.nodes-count">Nodes</th>
           <th i18n="lightning.capacity">Capacity</th>
         </tr>
       </thead>

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
@@ -21,18 +21,20 @@
     <table class="table table-borderless text-center">
       <thead>
         <tr>
-          <th class="d-none d-md-block" i18n="mining.rank">Rank</th>
-          <th class="" i18n="lightning.as-name">Name</th>
-          <th class="" i18n="lightning.share">Hashrate</th>
-          <th class="" i18n="lightning.nodes">Nodes</th>
+          <th *ngIf="!isMobile()" i18n="mining.rank">Rank</th>
+          <th i18n="lightning.as-name">Name</th>
+          <th *ngIf="!isMobile()" i18n="lightning.share">Share</th>
+          <th i18n="lightning.nodes">Nodes</th>
+          <th i18n="lightning.capacity">Capacity</th>
         </tr>
       </thead>
       <tbody [attr.data-cy]="'pools-table'" *ngIf="(nodesPerAsObservable$ | async) as asList">
         <tr *ngFor="let asEntry of asList">
-          <td class="d-none d-md-block">{{ asEntry.rank }}</td>
+          <td *ngIf="!isMobile()">{{ asEntry.rank }}</td>
           <td class="text-truncate" style="max-width: 100px">{{ asEntry.name }}</td>
-          <td class="">{{ asEntry.share }}%</td>
-          <td class="">{{ asEntry.count }}</td>
+          <td *ngIf="!isMobile()">{{ asEntry.share }}%</td>
+          <td>{{ asEntry.count }}</td>
+          <td><app-amount [satoshis]="asEntry.capacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount></td>
         </tr>
       </tbody>
     </table>

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.html
@@ -1,0 +1,41 @@
+<div class="full-container h-100">
+
+  <div class="card-header">
+    <span i18n="lightning.nodes-per-as">Nodes per AS</span>
+    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+    </button>
+  </div>
+
+  <div class="container pb-lg-0 bottom-padding">
+    <div class="pb-lg-5" *ngIf="nodesPerAsObservable$ | async">
+      <div class="chart w-100" echarts [initOpts]="chartInitOptions" [options]="chartOptions"
+        (chartInit)="onChartInit($event)">
+      </div>
+    </div>
+
+    <div class="text-center loadingGraphs" *ngIf="isLoading">
+      <div class="spinner-border text-light"></div>
+    </div>
+
+    <table class="table table-borderless text-center">
+      <thead>
+        <tr>
+          <th class="d-none d-md-block" i18n="mining.rank">Rank</th>
+          <th class="" i18n="lightning.as-name">Name</th>
+          <th class="" i18n="lightning.share">Hashrate</th>
+          <th class="" i18n="lightning.nodes">Nodes</th>
+        </tr>
+      </thead>
+      <tbody [attr.data-cy]="'pools-table'" *ngIf="(nodesPerAsObservable$ | async) as asList">
+        <tr *ngFor="let asEntry of asList">
+          <td class="d-none d-md-block">{{ asEntry.rank }}</td>
+          <td class="text-truncate" style="max-width: 100px">{{ asEntry.name }}</td>
+          <td class="">{{ asEntry.share }}%</td>
+          <td class="">{{ asEntry.count }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.scss
@@ -1,0 +1,36 @@
+.card-header {
+  border-bottom: 0;
+  font-size: 18px;
+  @media (min-width: 465px) {
+    font-size: 20px;
+  }
+}
+
+.full-container {
+  padding: 0px 15px;
+  width: 100%;
+  height: calc(100% - 140px);
+  @media (max-width: 992px) {
+    height: calc(100% - 190px);
+  };
+  @media (max-width: 575px) {
+    height: calc(100% - 230px);
+  };
+}
+
+.chart {
+  max-height: 400px;
+  @media (max-width: 767.98px) {
+    max-height: 230px;
+    margin-top: -35px;
+  }
+}
+
+.bottom-padding {
+  @media (max-width: 992px) {
+    padding-bottom: 65px
+  };
+  @media (max-width: 576px) {
+    padding-bottom: 65px
+  };
+}

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
@@ -1,0 +1,210 @@
+import { ChangeDetectionStrategy, Component, OnInit, HostBinding } from '@angular/core';
+import { EChartsOption, PieSeriesOption } from 'echarts';
+import { map, Observable, share, tap } from 'rxjs';
+import { chartColors } from 'src/app/app.constants';
+import { ApiService } from 'src/app/services/api.service';
+import { SeoService } from 'src/app/services/seo.service';
+import { download } from 'src/app/shared/graphs.utils';
+
+@Component({
+  selector: 'app-nodes-per-as-chart',
+  templateUrl: './nodes-per-as-chart.component.html',
+  styleUrls: ['./nodes-per-as-chart.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NodesPerAsChartComponent implements OnInit {
+  miningWindowPreference: string;
+
+  isLoading = true;
+  chartOptions: EChartsOption = {};
+  chartInitOptions = {
+    renderer: 'svg',
+  };
+  timespan = '';
+  chartInstance: any = undefined;
+
+  @HostBinding('attr.dir') dir = 'ltr';
+
+  nodesPerAsObservable$: Observable<any>;
+
+  constructor(
+    private apiService: ApiService,
+    private seoService: SeoService,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.seoService.setTitle($localize`Nodes per AS`);
+
+    this.nodesPerAsObservable$ = this.apiService.getNodesPerAs()
+      .pipe(
+        tap(data => {
+          this.isLoading = false;
+          this.prepareChartOptions(data);
+        }),
+        map(data => {
+          for (let i = 0; i < data.length; ++i) {
+            data[i].rank = i + 1;
+          }
+          return data.slice(0, 100);
+        }),
+        share()
+      );
+  }
+
+  generateChartSerieData(as) {
+    const shareThreshold = this.isMobile() ? 2 : 1;
+    const data: object[] = [];
+    let totalShareOther = 0;
+    let totalNodeOther = 0;
+
+    let edgeDistance: string | number = '10%';
+    if (this.isMobile()) {
+      edgeDistance = 0;
+    }
+
+    as.forEach((as) => {
+      if (as.share < shareThreshold) {
+        totalShareOther += as.share;
+        totalNodeOther += as.count;
+        return;
+      }
+      data.push({
+        value: as.share,
+        name: as.name + (this.isMobile() ? `` : ` (${as.share}%)`),
+        label: {
+          overflow: 'truncate',
+          color: '#b1b1b1',
+          alignTo: 'edge',
+          edgeDistance: edgeDistance,
+        },
+        tooltip: {
+          show: !this.isMobile(),
+          backgroundColor: 'rgba(17, 19, 31, 1)',
+          borderRadius: 4,
+          shadowColor: 'rgba(0, 0, 0, 0.5)',
+          textStyle: {
+            color: '#b1b1b1',
+          },
+          borderColor: '#000',
+          formatter: () => {
+            return `<b style="color: white">${as.name} (${as.share}%)</b><br>` +
+              $localize`${as.count.toString()} nodes`;
+          }
+        },
+        data: as.slug,
+      } as PieSeriesOption);
+    });
+
+    // 'Other'
+    data.push({
+      itemStyle: {
+        color: 'grey',
+      },
+      value: totalShareOther,
+      name: 'Other' + (this.isMobile() ? `` : ` (${totalShareOther.toFixed(2)}%)`),
+      label: {
+        overflow: 'truncate',
+        color: '#b1b1b1',
+        alignTo: 'edge',
+        edgeDistance: edgeDistance
+      },
+      tooltip: {
+        backgroundColor: 'rgba(17, 19, 31, 1)',
+        borderRadius: 4,
+        shadowColor: 'rgba(0, 0, 0, 0.5)',
+        textStyle: {
+          color: '#b1b1b1',
+        },
+        borderColor: '#000',
+        formatter: () => {
+          return `<b style="color: white">${'Other'} (${totalShareOther.toFixed(2)}%)</b><br>` +
+            totalNodeOther.toString() + ` nodes`;
+        }
+      },
+    } as PieSeriesOption);
+
+    return data;
+  }
+
+  prepareChartOptions(as) {
+    let pieSize = ['20%', '80%']; // Desktop
+    if (this.isMobile()) {
+      pieSize = ['15%', '60%'];
+    }
+
+    this.chartOptions = {
+      color: chartColors,
+      tooltip: {
+        trigger: 'item',
+        textStyle: {
+          align: 'left',
+        }
+      },
+      series: [
+        {
+          zlevel: 0,
+          minShowLabelAngle: 3.6,
+          name: 'Mining pool',
+          type: 'pie',
+          radius: pieSize,
+          data: this.generateChartSerieData(as),
+          labelLine: {
+            lineStyle: {
+              width: 2,
+            },
+            length: this.isMobile() ? 1 : 20,
+            length2: this.isMobile() ? 1 : undefined,
+          },
+          label: {
+            fontSize: 14,
+          },
+          itemStyle: {
+            borderRadius: 1,
+            borderWidth: 1,
+            borderColor: '#000',
+          },
+          emphasis: {
+            itemStyle: {
+              shadowBlur: 40,
+              shadowColor: 'rgba(0, 0, 0, 0.75)',
+            },
+            labelLine: {
+              lineStyle: {
+                width: 4,
+              }
+            }
+          }
+        }
+      ],
+    };
+  }
+
+  isMobile() {
+    return (window.innerWidth <= 767.98);
+  }
+
+  onChartInit(ec) {
+    if (this.chartInstance !== undefined) {
+      return;
+    }
+    this.chartInstance = ec;
+  }
+
+  onSaveChart() {
+    const now = new Date();
+    this.chartOptions.backgroundColor = '#11131f';
+    this.chartInstance.setOption(this.chartOptions);
+    download(this.chartInstance.getDataURL({
+      pixelRatio: 2,
+      excludeComponents: ['dataZoom'],
+    }), `ln-nodes-per-as-${this.timespan}-${Math.round(now.getTime() / 1000)}.svg`);
+    this.chartOptions.backgroundColor = 'none';
+    this.chartInstance.setOption(this.chartOptions);
+  }
+
+  isEllipsisActive(e) {
+    return (e.offsetWidth < e.scrollWidth);
+  }
+}
+

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
@@ -5,6 +5,7 @@ import { chartColors } from 'src/app/app.constants';
 import { ApiService } from 'src/app/services/api.service';
 import { SeoService } from 'src/app/services/seo.service';
 import { download } from 'src/app/shared/graphs.utils';
+import { AmountShortenerPipe } from 'src/app/shared/pipes/amount-shortener.pipe';
 
 @Component({
   selector: 'app-nodes-per-as-chart',
@@ -30,6 +31,7 @@ export class NodesPerAsChartComponent implements OnInit {
   constructor(
     private apiService: ApiService,
     private seoService: SeoService,
+    private amountShortenerPipe: AmountShortenerPipe
   ) {
   }
 
@@ -89,7 +91,9 @@ export class NodesPerAsChartComponent implements OnInit {
           borderColor: '#000',
           formatter: () => {
             return `<b style="color: white">${as.name} (${as.share}%)</b><br>` +
-              $localize`${as.count.toString()} nodes`;
+              $localize`${as.count.toString()} nodes<br>` +
+              $localize`${this.amountShortenerPipe.transform(as.capacity / 100000000, 2)} BTC capacity`
+            ;
           }
         },
         data: as.slug,

--- a/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-as-chart/nodes-per-as-chart.component.ts
@@ -36,7 +36,7 @@ export class NodesPerAsChartComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.seoService.setTitle($localize`Nodes per AS`);
+    this.seoService.setTitle($localize`Lightning nodes per ISP`);
 
     this.nodesPerAsObservable$ = this.apiService.getNodesPerAs()
       .pipe(

--- a/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.html
+++ b/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.html
@@ -1,10 +1,12 @@
 <div [class]="widget === false ? 'full-container' : ''">
 
   <div class="card-header mb-0 mb-md-4" [style]="widget ? 'display:none' : ''">
-    <span i18n="mining.hashrate-difficulty">Hashrate & Difficulty</span>
-    <button class="btn" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
-      <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
-    </button>
+    <div class="d-flex d-md-block align-items-baseline">
+      <span i18n="mining.channels-and-capacity">Channels & Capacity</span>
+      <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
+        <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
+      </button>
+    </div>
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(capacityObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="dateSpan">

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -251,4 +251,7 @@ export class ApiService {
     return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/search', { params });
   }
 
+  getNodesPerAs(): Observable<any> {
+    return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/asShare');
+  }
 }


### PR DESCRIPTION
This PR add a new chart for the lightning explorer, which show which AS are used the most by clearnet LN nodes.

<img width="1492" alt="Screen Shot 2022-07-16 at 11 31 15 AM" src="https://user-images.githubusercontent.com/9780671/179349244-2dc549fe-4327-4e86-aef9-bfa0939a0983.png">

<img width="337" alt="Screen Shot 2022-07-16 at 11 31 24 AM" src="https://user-images.githubusercontent.com/9780671/179349241-2c21b5b7-99f8-4b78-9ff0-03d10c6c1b94.png">

@softsimon Could you please double check if [that query](https://github.com/mempool/mempool/pull/2097/files#diff-f84fbb84918b2fec7a767289be371d57ae68dc0fb1bf4e42ba01b750f368aea8R99) makes sense, to get the "running capacity" per AS?