### PR TITLE
Add nodes per country table page

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 32;
+  private static currentVersion = 33;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -301,6 +301,10 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 32 && isBitcoin == true) {
       await this.$executeQuery('ALTER TABLE `blocks_summaries` ADD `template` JSON DEFAULT "[]"');
+    }
+
+    if (databaseSchemaVersion < 33 && isBitcoin == true) {
+      await this.$executeQuery('ALTER TABLE `geo_names` CHANGE `type` `type` enum("city","country","division","continent","as_organization", "country_iso_code") NOT NULL');
     }
   }
 

--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -124,6 +124,21 @@ class NodesApi {
       throw e;
     }
   }
+
+  public async $getNodesPerCountry(country: string) {
+    try {
+      const query = `SELECT nodes.* FROM nodes
+        JOIN geo_names ON geo_names.id = nodes.country_id
+        WHERE LOWER(json_extract(names, '$.en')) = ?
+      `;
+
+      const [rows]: any = await DB.query(query, [`"${country}"`]);
+      return rows;
+    } catch (e) {
+      logger.err(`Cannot get nodes for country ${country}. Reason: ${e instanceof Error ? e.message : e}`);
+      throw e;
+    }
+  }
 }
 
 export default new NodesApi();

--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -127,12 +127,27 @@ class NodesApi {
 
   public async $getNodesPerCountry(country: string) {
     try {
-      const query = `SELECT nodes.* FROM nodes
-        JOIN geo_names ON geo_names.id = nodes.country_id
-        WHERE LOWER(json_extract(names, '$.en')) = ?
+      const query = `
+        SELECT node_stats.public_key, node_stats.capacity, node_stats.channels, nodes.alias,
+          UNIX_TIMESTAMP(nodes.first_seen) as first_seen, UNIX_TIMESTAMP(nodes.updated_at) as updated_at,
+          geo_names_city.names as city
+        FROM node_stats
+        JOIN (
+          SELECT public_key, MAX(added) as last_added
+          FROM node_stats
+          GROUP BY public_key
+        ) as b ON b.public_key = node_stats.public_key AND b.last_added = node_stats.added
+        LEFT JOIN nodes ON nodes.public_key = node_stats.public_key
+        LEFT JOIN geo_names geo_names_country ON geo_names_country.id = nodes.country_id
+        LEFT JOIN geo_names geo_names_city ON geo_names_city.id = nodes.city_id
+        WHERE LOWER(JSON_EXTRACT(geo_names_country.names, '$.en')) = ?
+        ORDER BY capacity DESC
       `;
 
       const [rows]: any = await DB.query(query, [`"${country}"`]);
+      for (let i = 0; i < rows.length; ++i) {
+        rows[i].city = JSON.parse(rows[i].city);
+      }
       return rows;
     } catch (e) {
       logger.err(`Cannot get nodes for country ${country}. Reason: ${e instanceof Error ? e.message : e}`);

--- a/backend/src/api/explorer/nodes.routes.ts
+++ b/backend/src/api/explorer/nodes.routes.ts
@@ -6,6 +6,7 @@ class NodesRoutes {
 
   public initRoutes(app: Application) {
     app
+      .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/country/:country', this.$getNodesPerCountry)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/search/:search', this.$searchNode)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/top', this.$getTopNodes)
       .get(config.MEMPOOL.API_URL_PREFIX + 'lightning/nodes/asShare', this.$getNodesAsShare)
@@ -65,6 +66,18 @@ class NodesRoutes {
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 600).toUTCString());
       res.json(nodesPerAs);
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
+    }
+  }
+
+  private async $getNodesPerCountry(req: Request, res: Response) {
+    try {
+      const nodes = await nodesApi.$getNodesPerCountry(req.params.country.toLowerCase());
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
+      res.json(nodes);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
     }

--- a/backend/src/tasks/lightning/sync-tasks/node-locations.ts
+++ b/backend/src/tasks/lightning/sync-tasks/node-locations.ts
@@ -39,6 +39,13 @@ export async function $lookupNodeLocation(): Promise<void> {
                 [city.country?.geoname_id, JSON.stringify(city.country?.names)]);
              }
 
+            // Store Country ISO code
+            if (city.country?.iso_code) {
+              await DB.query(
+               `INSERT IGNORE INTO geo_names (id, type, names) VALUES (?, 'country_iso_code', ?)`,
+               [city.country?.geoname_id, city.country?.iso_code]);
+            }
+
             // Store Division
             if (city.subdivisions && city.subdivisions[0]) {
               await DB.query(

--- a/frontend/src/app/lightning/lightning.module.ts
+++ b/frontend/src/app/lightning/lightning.module.ts
@@ -19,6 +19,7 @@ import { GraphsModule } from '../graphs/graphs.module';
 import { NodesNetworksChartComponent } from './nodes-networks-chart/nodes-networks-chart.component';
 import { ChannelsStatisticsComponent } from './channels-statistics/channels-statistics.component';
 import { NodesPerAsChartComponent } from '../lightning/nodes-per-as-chart/nodes-per-as-chart.component';
+import { NodesPerCountry } from './nodes-per-country/nodes-per-country.component';
 @NgModule({
   declarations: [
     LightningDashboardComponent,
@@ -35,6 +36,7 @@ import { NodesPerAsChartComponent } from '../lightning/nodes-per-as-chart/nodes-
     NodesNetworksChartComponent,
     ChannelsStatisticsComponent,
     NodesPerAsChartComponent,
+    NodesPerCountry,
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/lightning/lightning.routing.module.ts
+++ b/frontend/src/app/lightning/lightning.routing.module.ts
@@ -4,6 +4,7 @@ import { LightningDashboardComponent } from './lightning-dashboard/lightning-das
 import { LightningWrapperComponent } from './lightning-wrapper/lightning-wrapper.component';
 import { NodeComponent } from './node/node.component';
 import { ChannelComponent } from './channel/channel.component';
+import { NodesPerCountry } from './nodes-per-country/nodes-per-country.component';
 
 const routes: Routes = [
     {
@@ -21,6 +22,10 @@ const routes: Routes = [
         {
           path: 'channel/:short_id',
           component: ChannelComponent,
+        },
+        {
+          path: 'nodes/country/:country',
+          component: NodesPerCountry,
         },
         {
           path: '**',

--- a/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.html
+++ b/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.html
@@ -1,5 +1,5 @@
 <div class="container-xl full-height" style="min-height: 335px">
-  <h1 class="float-left" i18n="lightning.nodes-in-country">Nodes in {{ country }}</h1>
+  <h1 class="float-left" i18n="lightning.nodes-in-country">Lightning nodes in {{ country }}</h1>
 
   <div style="min-height: 295px">
     <table class="table table-borderless">

--- a/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.html
+++ b/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.html
@@ -1,0 +1,42 @@
+<div class="container-xl full-height" style="min-height: 335px">
+  <h1 class="float-left" i18n="lightning.nodes-in-country">Nodes in {{ country }}</h1>
+
+  <div style="min-height: 295px">
+    <table class="table table-borderless">
+      <thead>
+        <th class="alias text-left" i18n="lightning.alias">Alias</th>
+        <th class="timestamp-first text-left" i18n="lightning.first_seen">First seen</th>
+        <th class="timestamp-update text-left" i18n="lightning.last_update">Last update</th>
+        <th class="capacity text-right" i18n="lightning.capacity">Capacity</th>
+        <th class="channels text-right" i18n="lightning.channels">Channels</th>
+        <th class="city text-right" i18n="lightning.city">City</th>
+      </thead>
+      <tbody *ngIf="nodes$ | async as nodes">
+        <tr *ngFor="let node of nodes; let i= index; trackBy: trackByPublicKey">
+          <td class="alias text-left text-truncate">
+            <a [routerLink]="['/lightning/node/' | relativeUrl, node.public_key]">{{ node.alias }}</a>
+          </td>
+          <td class="timestamp-first text-left">
+            <app-timestamp [customFormat]="'yyyy-MM-dd'" [unixTime]="node.first_seen"></app-timestamp>
+          </td>
+          <td class="timestamp-update text-left">
+            <app-timestamp [customFormat]="'yyyy-MM-dd'" [unixTime]="node.updated_at"></app-timestamp>
+          </td>
+          <td class="capacity text-right">
+            <app-amount *ngIf="node.capacity > 100000000; else smallchannel" [satoshis]="node.capacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
+            <ng-template #smallchannel>
+              {{ node.capacity | amountShortener: 1 }}
+              <span class="sats" i18n="shared.sats">sats</span>
+            </ng-template>
+          </td>
+          <td class="channels text-right">
+            {{ node.channels }}
+          </td>
+          <td class="city text-right text-truncate">
+            {{ node?.city?.en ?? '-' }}
+          </td>
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.scss
+++ b/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.scss
@@ -1,0 +1,62 @@
+.container-xl {
+  max-width: 1400px;
+  padding-bottom: 100px;
+}
+
+.sats {
+  color: #ffffff66;
+  font-size: 12px;
+  top: 0px;
+}
+
+.alias {
+  width: 30%;
+  max-width: 400px;
+  padding-right: 70px;
+
+  @media (max-width: 576px) {
+    width: 50%;
+    max-width: 150px;
+    padding-right: 0px;
+  }
+}
+
+.timestamp-first {
+  width: 20%;
+
+  @media (max-width: 576px) {
+    display: none
+  }
+}
+
+.timestamp-update {
+  width: 16%;
+
+  @media (max-width: 576px) {
+    display: none
+  }
+}
+
+.capacity {
+  width: 10%;
+
+  @media (max-width: 576px) {
+    width: 25%;
+  }
+}
+
+.channels {
+  width: 10%;
+
+  @media (max-width: 576px) {
+    width: 25%;
+  }
+}
+
+.city {
+  max-width: 150px;
+
+  @media (max-width: 576px) {
+    display: none
+  }
+}

--- a/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.ts
+++ b/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core
 import { ActivatedRoute } from '@angular/router';
 import { map, Observable } from 'rxjs';
 import { ApiService } from 'src/app/services/api.service';
+import { SeoService } from 'src/app/services/seo.service';
 
 @Component({
   selector: 'app-nodes-per-country',
@@ -15,18 +16,17 @@ export class NodesPerCountry implements OnInit {
 
   constructor(
     private apiService: ApiService,
+    private seoService: SeoService,
     private route: ActivatedRoute,
   ) { }
 
   ngOnInit(): void {
-    this.country = this.route.snapshot.params.country;
-    this.country = this.country.charAt(0).toUpperCase() + this.country.slice(1);
-
     this.nodes$ = this.apiService.getNodeForCountry$(this.route.snapshot.params.country)
       .pipe(
-        map(nodes => {
-          console.log(nodes);
-          return nodes;
+        map(response => {
+          this.country = response.country.en
+          this.seoService.setTitle($localize`Lightning nodes in ${this.country}`);
+          return response.nodes;
         })
       );
   }

--- a/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.ts
+++ b/frontend/src/app/lightning/nodes-per-country/nodes-per-country.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map, Observable } from 'rxjs';
+import { ApiService } from 'src/app/services/api.service';
+
+@Component({
+  selector: 'app-nodes-per-country',
+  templateUrl: './nodes-per-country.component.html',
+  styleUrls: ['./nodes-per-country.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NodesPerCountry implements OnInit {
+  nodes$: Observable<any>;
+  country: string;
+
+  constructor(
+    private apiService: ApiService,
+    private route: ActivatedRoute,
+  ) { }
+
+  ngOnInit(): void {
+    this.country = this.route.snapshot.params.country;
+    this.country = this.country.charAt(0).toUpperCase() + this.country.slice(1);
+
+    this.nodes$ = this.apiService.getNodeForCountry$(this.route.snapshot.params.country)
+      .pipe(
+        map(nodes => {
+          console.log(nodes);
+          return nodes;
+        })
+      );
+  }
+
+  trackByPublicKey(index: number, node: any) {
+    return node.public_key;
+  }
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -254,4 +254,8 @@ export class ApiService {
   getNodesPerAs(): Observable<any> {
     return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/asShare');
   }
+
+  getNodeForCountry$(country: string): Observable<any> {
+    return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/country/' + country);
+  }
 }

--- a/frontend/src/app/shared/components/timestamp/timestamp.component.html
+++ b/frontend/src/app/shared/components/timestamp/timestamp.component.html
@@ -1,4 +1,4 @@
-&lrm;{{ seconds * 1000 | date:'yyyy-MM-dd HH:mm' }}
+&lrm;{{ seconds * 1000 | date: customFormat ?? 'yyyy-MM-dd HH:mm' }}
 <div class="lg-inline">
   <i class="symbol">(<app-time-since [time]="seconds" [fastRender]="true"></app-time-since>)</i>
 </div>

--- a/frontend/src/app/shared/components/timestamp/timestamp.component.ts
+++ b/frontend/src/app/shared/components/timestamp/timestamp.component.ts
@@ -9,6 +9,7 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/c
 export class TimestampComponent implements OnChanges {
   @Input() unixTime: number;
   @Input() dateString: string;
+  @Input() customFormat: string;
 
   seconds: number;
 


### PR DESCRIPTION
This PR adds a very simple page to browser a list of nodes per country (no pagination). You can access it via the following url `/lightning/nodes/country/:country`.

For example `/lightning/nodes/country/france` or `/lightning/nodes/country/sweden`

<img width="1493" alt="Screen Shot 2022-07-16 at 3 57 43 PM" src="https://user-images.githubusercontent.com/9780671/179357956-19dbf5bd-77e0-42cc-89bb-abc50c86d51d.png">
<img width="1493" alt="Screen Shot 2022-07-16 at 3 58 48 PM" src="https://user-images.githubusercontent.com/9780671/179357997-3b4a8977-16f2-49ef-9a18-f0b4214dcda6.png">

<img width="335" alt="Screen Shot 2022-07-16 at 3 56 48 PM" src="https://user-images.githubusercontent.com/9780671/179357943-132f4e33-e051-4442-bd60-c0348d86ed9c.png">
<img width="335" alt="Screen Shot 2022-07-16 at 3 59 04 PM" src="https://user-images.githubusercontent.com/9780671/179357998-8bbe5b70-817c-4bdf-8459-5a24d2a95c2c.png">

