### PR TITLE
Fix block predition graph x axis labels

### DIFF
--- a/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.ts
+++ b/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.ts
@@ -143,7 +143,7 @@ export class BlockPredictionGraphComponent implements OnInit {
         boundaryGap: false,
         axisLine: { onZero: true },
         axisLabel: {
-          formatter: val => formatterXAxisTimeCategory(this.locale, this.timespan, parseInt(val, 10)),
+          formatter: val => formatterXAxisTimeCategory(this.locale, this.timespan, parseInt(val, 10) * 1000),
           align: 'center',
           fontSize: 11,
           lineHeight: 12,


### PR DESCRIPTION
Bring 3dc37dc34dad41995f2f6beed6a63b505f03c51a into the 2.4 branch