### PR TITLE
Ony consider channel stats = 1 for stats calculation

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -12,13 +12,13 @@ class NodesApi {
           WHERE channels.status = 2 AND ( channels.node1_public_key = ? OR channels.node2_public_key = ? )) AS channel_closed_count,
           (SELECT Count(*)
           FROM channels
-          WHERE channels.status < 2 AND ( channels.node1_public_key = ? OR channels.node2_public_key = ? )) AS channel_active_count,
+          WHERE channels.status = 1 AND ( channels.node1_public_key = ? OR channels.node2_public_key = ? )) AS channel_active_count,
           (SELECT Sum(capacity)
           FROM channels
-          WHERE channels.status < 2 AND ( channels.node1_public_key = ? OR channels.node2_public_key = ? )) AS capacity,
+          WHERE channels.status = 1 AND ( channels.node1_public_key = ? OR channels.node2_public_key = ? )) AS capacity,
           (SELECT Avg(capacity)
           FROM channels
-          WHERE status < 2 AND ( node1_public_key = ? OR node2_public_key = ? )) AS channels_capacity_avg
+          WHERE status = 1 AND ( node1_public_key = ? OR node2_public_key = ? )) AS channels_capacity_avg
         FROM nodes
         LEFT JOIN geo_names geo_names_as on geo_names_as.id = as_number
         LEFT JOIN geo_names geo_names_city on geo_names_city.id = city_id

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -141,7 +141,22 @@ class LightningStatsUpdater {
     try {
       logger.info(`Running daily node stats update...`);
 
-      const query = `SELECT nodes.public_key, c1.channels_count_left, c2.channels_count_right, c1.channels_capacity_left, c2.channels_capacity_right FROM nodes LEFT JOIN (SELECT node1_public_key, COUNT(id) AS channels_count_left, SUM(capacity) AS channels_capacity_left FROM channels WHERE channels.status < 2 GROUP BY node1_public_key) c1 ON c1.node1_public_key = nodes.public_key LEFT JOIN (SELECT node2_public_key, COUNT(id) AS channels_count_right, SUM(capacity) AS channels_capacity_right FROM channels WHERE channels.status < 2 GROUP BY node2_public_key) c2 ON c2.node2_public_key = nodes.public_key`;
+      const query = `
+        SELECT nodes.public_key, c1.channels_count_left, c2.channels_count_right, c1.channels_capacity_left,
+          c2.channels_capacity_right
+        FROM nodes
+        LEFT JOIN (
+          SELECT node1_public_key, COUNT(id) AS channels_count_left, SUM(capacity) AS channels_capacity_left
+          FROM channels
+          WHERE channels.status = 1
+          GROUP BY node1_public_key
+        ) c1 ON c1.node1_public_key = nodes.public_key
+        LEFT JOIN (
+          SELECT node2_public_key, COUNT(id) AS channels_count_right, SUM(capacity) AS channels_capacity_right
+          FROM channels WHERE channels.status = 1 GROUP BY node2_public_key
+        ) c2 ON c2.node2_public_key = nodes.public_key
+      `;
+      
       const [nodes]: any = await DB.query(query);
 
       for (const node of nodes) {


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2199

When we run any kind of calculation using channels (capacity, channel count, and other things), we should only consider `active` channels (channel.status = 1).