### PR TITLE
Update mouse UX on LN map in dashboard

### DIFF
--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
@@ -36,6 +36,7 @@
 
 .widget > .chart {
   -webkit-mask: linear-gradient(180deg, #11131f00 0%, #11131fff 20%);
+  min-height: 250px;
 }
 
 .chart {
@@ -43,23 +44,18 @@
   width: 100%;
   height: 100%;
   padding-right: 10px;
-
   @media (max-width: 992px) {
     padding-bottom: 25px;
   }
-
   @media (max-width: 829px) {
     padding-bottom: 50px;
   }
-
   @media (max-width: 767px) {
     padding-bottom: 25px;
   }
-
   @media (max-width: 629px) {
     padding-bottom: 55px;
   }
-
   @media (max-width: 567px) {
     padding-bottom: 55px;
   }


### PR DESCRIPTION
This PR removes the LN world map interactions from the LN dashboard.

The scroll is a bit broken/weird specially when using a mouse, but I'm gonna improve it later. At least now you can scroll the page properly without triggering the map zoom feature.

You can click on the map and it will open the graph map page.