### PR TITLE
Re-enabled channels world map click event

### DIFF
--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
@@ -98,7 +98,7 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
     }
 
     this.chartOptions = {
-      silent: true,
+      silent: this.style === 'widget' ? true : false,
       title: title ?? undefined,
       geo3D: {
         map: 'world',


### PR DESCRIPTION
Right now you cannot click on nodes in /graphs/lightning/nodes-channels-map