### PR TITLE
Import LN historical statistics (network wide + per node)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,7 @@
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
         "eslint-config-prettier": "^8.5.0",
+        "fast-xml-parser": "^4.0.9",
         "prettier": "^2.7.1"
       }
     },
@@ -1496,6 +1497,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
+      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "dev": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -2664,6 +2681,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -3973,6 +3996,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
+      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "dev": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -4815,6 +4847,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "text-table": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
+    "fast-xml-parser": "^4.0.9",
     "prettier": "^2.7.1"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "bitcoinjs-lib": "6.0.1",
     "crypto-js": "^4.0.0",
     "express": "^4.18.0",
+    "fast-xml-parser": "^4.0.9",
     "maxmind": "^4.3.6",
     "mysql2": "2.3.3",
     "node-worker-threads-pool": "^1.5.1",
@@ -53,7 +54,6 @@
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
-    "fast-xml-parser": "^4.0.9",
     "prettier": "^2.7.1"
   }
 }

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 33;
+  private static currentVersion = 34;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -310,6 +310,10 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 33 && isBitcoin == true) {
       await this.$executeQuery('ALTER TABLE `geo_names` CHANGE `type` `type` enum("city","country","division","continent","as_organization", "country_iso_code") NOT NULL');
+    }
+
+    if (databaseSchemaVersion < 34 && isBitcoin == true) {
+      await this.$executeQuery('ALTER TABLE `lightning_stats` ADD clearnet_tor_nodes int(11) NOT NULL DEFAULT "0"');
     }
   }
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -31,6 +31,7 @@ interface IConfig {
   LIGHTNING: {
     ENABLED: boolean;
     BACKEND: 'lnd' | 'cln' | 'ldk';
+    TOPOLOGY_FOLDER: string;
   };
   LND: {
     TLS_CERT_PATH: string;
@@ -177,7 +178,8 @@ const defaults: IConfig = {
   },
   'LIGHTNING': {
     'ENABLED': false,
-    'BACKEND': 'lnd'
+    'BACKEND': 'lnd',
+    'TOPOLOGY_FOLDER': '',
   },
   'LND': {
     'TLS_CERT_PATH': '',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,11 +29,11 @@ import channelsRoutes from './api/explorer/channels.routes';
 import generalLightningRoutes from './api/explorer/general.routes';
 import lightningStatsUpdater from './tasks/lightning/stats-updater.service';
 import nodeSyncService from './tasks/lightning/node-sync.service';
-import statisticsRoutes from "./api/statistics/statistics.routes";
-import miningRoutes from "./api/mining/mining-routes";
-import bisqRoutes from "./api/bisq/bisq.routes";
-import liquidRoutes from "./api/liquid/liquid.routes";
-import bitcoinRoutes from "./api/bitcoin/bitcoin.routes";
+import statisticsRoutes from './api/statistics/statistics.routes';
+import miningRoutes from './api/mining/mining-routes';
+import bisqRoutes from './api/bisq/bisq.routes';
+import liquidRoutes from './api/liquid/liquid.routes';
+import bitcoinRoutes from './api/bitcoin/bitcoin.routes';
 
 class Server {
   private wss: WebSocket.Server | undefined;

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -56,116 +56,21 @@ class LightningStatsUpdater {
   }
 
   private async $runTasks(): Promise<void> {
-    await this.$logLightningStatsDaily();
-    await this.$logNodeStatsDaily();
+    await this.$logStatsDaily();
 
     setTimeout(() => {
       this.$runTasks();
     }, this.timeUntilMidnight());
   }
 
-  private async $logLightningStatsDaily() {
-    try {
-      logger.info(`Running lightning daily stats log...`);
+  private async $logStatsDaily(): Promise<void> {
+    const date = new Date();
+    this.setDateMidnight(date);
+    date.setUTCHours(24);
 
-      const networkGraph = await lightningApi.$getNetworkGraph();
-      let total_capacity = 0;
-      for (const channel of networkGraph.edges) {
-        if (channel.capacity) {
-          total_capacity += parseInt(channel.capacity);
-        }
-      }
-
-      let clearnetNodes = 0;
-      let torNodes = 0;
-      let unannouncedNodes = 0;
-      for (const node of networkGraph.nodes) {
-        for (const socket of node.addresses) {
-          const hasOnion = socket.addr.indexOf('.onion') !== -1;
-          if (hasOnion) {
-            torNodes++;
-          }
-          const hasClearnet = [4, 6].includes(isIP(socket.split(':')[0]));
-          if (hasClearnet) {
-            clearnetNodes++;
-          }
-        }
-        if (node.addresses.length === 0) {
-          unannouncedNodes++;
-        }
-      }
-
-      const channelStats = await channelsApi.$getChannelsStats();
-
-      const query = `INSERT INTO lightning_stats(
-          added,
-          channel_count,
-          node_count,
-          total_capacity,
-          tor_nodes,
-          clearnet_nodes,
-          unannounced_nodes,
-          avg_capacity,
-          avg_fee_rate,
-          avg_base_fee_mtokens,
-          med_capacity,
-          med_fee_rate,
-          med_base_fee_mtokens
-        )
-        VALUES (NOW() - INTERVAL 1 DAY, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-
-      await DB.query(query, [
-        networkGraph.edges.length,
-        networkGraph.nodes.length,
-        total_capacity,
-        torNodes,
-        clearnetNodes,
-        unannouncedNodes,
-        channelStats.avgCapacity,
-        channelStats.avgFeeRate,
-        channelStats.avgBaseFee,
-        channelStats.medianCapacity,
-        channelStats.medianFeeRate,
-        channelStats.medianBaseFee,
-      ]);
-      logger.info(`Lightning daily stats done.`);
-    } catch (e) {
-      logger.err('$logLightningStatsDaily() error: ' + (e instanceof Error ? e.message : e));
-    }
-  }
-
-  private async $logNodeStatsDaily() {
-    try {
-      logger.info(`Running daily node stats update...`);
-
-      const query = `
-        SELECT nodes.public_key, c1.channels_count_left, c2.channels_count_right, c1.channels_capacity_left,
-          c2.channels_capacity_right
-        FROM nodes
-        LEFT JOIN (
-          SELECT node1_public_key, COUNT(id) AS channels_count_left, SUM(capacity) AS channels_capacity_left
-          FROM channels
-          WHERE channels.status = 1
-          GROUP BY node1_public_key
-        ) c1 ON c1.node1_public_key = nodes.public_key
-        LEFT JOIN (
-          SELECT node2_public_key, COUNT(id) AS channels_count_right, SUM(capacity) AS channels_capacity_right
-          FROM channels WHERE channels.status = 1 GROUP BY node2_public_key
-        ) c2 ON c2.node2_public_key = nodes.public_key
-      `;
-      
-      const [nodes]: any = await DB.query(query);
-
-      for (const node of nodes) {
-        await DB.query(
-          `INSERT INTO node_stats(public_key, added, capacity, channels) VALUES (?, NOW() - INTERVAL 1 DAY, ?, ?)`,
-          [node.public_key, (parseInt(node.channels_capacity_left || 0, 10)) + (parseInt(node.channels_capacity_right || 0, 10)),
-            node.channels_count_left + node.channels_count_right]);
-      }
-      logger.info('Daily node stats has updated.');
-    } catch (e) {
-      logger.err('$logNodeStatsDaily() error: ' + (e instanceof Error ? e.message : e));
-    }
+    logger.info(`Running lightning daily stats log...`);
+    const networkGraph = await lightningApi.$getNetworkGraph();
+    LightningStatsImporter.computeNetworkStats(date.getTime(), networkGraph);
   }
 }
 

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -1,9 +1,6 @@
-
 import DB from '../../database';
 import logger from '../../logger';
 import lightningApi from '../../api/lightning/lightning-api-factory';
-import channelsApi from '../../api/explorer/channels.api';
-import { isIP } from 'net';
 import LightningStatsImporter from './sync-tasks/stats-importer';
 
 class LightningStatsUpdater {
@@ -11,23 +8,6 @@ class LightningStatsUpdater {
 
   public async $startService(): Promise<void> {
     logger.info('Starting Lightning Stats service');
-    let isInSync = false;
-    let error: any;
-    try {
-      error = null;
-      isInSync = await this.$lightningIsSynced();
-    } catch (e) {
-      error = e;
-    }
-    if (!isInSync) {
-      if (error) {
-        logger.warn('Was not able to fetch Lightning Node status: ' + (error instanceof Error ? error.message : error) + '. Retrying in 1 minute...');
-      } else {
-        logger.notice('The Lightning graph is not yet in sync. Retrying in 1 minute...');
-      }
-      setTimeout(() => this.$startService(), 60 * 1000);
-      return;
-    }
 
     LightningStatsImporter.$run();
 
@@ -48,11 +28,6 @@ class LightningStatsUpdater {
     date.setUTCMinutes(0);
     date.setUTCSeconds(0);
     date.setUTCMilliseconds(0);
-  }
-
-  private async $lightningIsSynced(): Promise<boolean> {
-    const nodeInfo = await lightningApi.$getInfo();
-    return nodeInfo.synced_to_chain && nodeInfo.synced_to_graph;
   }
 
   private async $runTasks(): Promise<void> {

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -1,4 +1,3 @@
-import DB from '../../database';
 import logger from '../../logger';
 import lightningApi from '../../api/lightning/lightning-api-factory';
 import LightningStatsImporter from './sync-tasks/stats-importer';

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -4,11 +4,12 @@ import logger from '../../logger';
 import lightningApi from '../../api/lightning/lightning-api-factory';
 import channelsApi from '../../api/explorer/channels.api';
 import { isIP } from 'net';
+import LightningStatsImporter from './sync-tasks/stats-importer';
 
 class LightningStatsUpdater {
   hardCodedStartTime = '2018-01-12';
 
-  public async $startService() {
+  public async $startService(): Promise<void> {
     logger.info('Starting Lightning Stats service');
     let isInSync = false;
     let error: any;
@@ -27,6 +28,8 @@ class LightningStatsUpdater {
       setTimeout(() => this.$startService(), 60 * 1000);
       return;
     }
+
+    LightningStatsImporter.$run();
 
     setTimeout(() => {
       this.$runTasks();

--- a/backend/src/tasks/lightning/sync-tasks/funding-tx-fetcher.ts
+++ b/backend/src/tasks/lightning/sync-tasks/funding-tx-fetcher.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import bitcoinClient from '../../../api/bitcoin/bitcoin-client';
+import config from '../../../config';
+import logger from '../../../logger';
+
+const BLOCKS_CACHE_MAX_SIZE = 100;  
+const CACHE_FILE_NAME = config.MEMPOOL.CACHE_DIR + '/ln-funding-txs-cache.json';
+
+class FundingTxFetcher {
+  private running = false;
+  private blocksCache = {};
+  private channelNewlyProcessed = 0;
+  public fundingTxCache = {};
+
+  async $fetchChannelsFundingTxs(channelIds: string[]): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+
+    // Load funding tx disk cache
+    if (Object.keys(this.fundingTxCache).length === 0 && existsSync(CACHE_FILE_NAME)) {
+      try {
+        this.fundingTxCache = JSON.parse(readFileSync(CACHE_FILE_NAME, 'utf-8'));
+      } catch (e) {
+        logger.err(`Unable to parse channels funding txs disk cache. Starting from scratch`);
+        this.fundingTxCache = {};
+      }
+      logger.debug(`Imported ${Object.keys(this.fundingTxCache).length} funding tx amount from the disk cache`);
+    }
+    
+    const globalTimer = new Date().getTime() / 1000;
+    let cacheTimer = new Date().getTime() / 1000;
+    let loggerTimer = new Date().getTime() / 1000;
+    let channelProcessed = 0;
+    this.channelNewlyProcessed = 0;
+    for (const channelId of channelIds) {
+      await this.$fetchChannelOpenTx(channelId);
+      ++channelProcessed;
+
+      let elapsedSeconds = Math.round((new Date().getTime() / 1000) - loggerTimer);
+      if (elapsedSeconds > 10) {
+        elapsedSeconds = Math.round((new Date().getTime() / 1000) - globalTimer);
+        logger.debug(`Indexing channels funding tx ${channelProcessed + 1} of ${channelIds.length} ` +
+          `(${Math.floor(channelProcessed / channelIds.length * 10000) / 100}%) | ` +
+          `elapsed: ${elapsedSeconds} seconds`
+        );
+        loggerTimer = new Date().getTime() / 1000;
+      }
+
+      elapsedSeconds = Math.round((new Date().getTime() / 1000) - cacheTimer);
+      if (elapsedSeconds > 60) {
+        logger.debug(`Saving ${Object.keys(this.fundingTxCache).length} funding txs cache into disk`);
+        writeFileSync(CACHE_FILE_NAME, JSON.stringify(this.fundingTxCache));
+        cacheTimer = new Date().getTime() / 1000;
+      }
+    }
+
+    if (this.channelNewlyProcessed > 0) {
+      logger.info(`Indexed ${this.channelNewlyProcessed} additional channels funding tx`);
+      logger.debug(`Saving ${Object.keys(this.fundingTxCache).length} funding txs cache into disk`);
+      writeFileSync(CACHE_FILE_NAME, JSON.stringify(this.fundingTxCache));
+    }
+
+    this.running = false;
+  }
+  
+  public async $fetchChannelOpenTx(channelId: string): Promise<any> {
+    if (this.fundingTxCache[channelId]) {
+      return this.fundingTxCache[channelId];
+    }
+
+    const parts = channelId.split('x');
+    const blockHeight = parts[0];
+    const txIdx = parts[1];
+    const outputIdx = parts[2];
+
+    let block = this.blocksCache[blockHeight];
+    if (!block) {
+      const blockHash = await bitcoinClient.getBlockHash(parseInt(blockHeight, 10));
+      block = await bitcoinClient.getBlock(blockHash, 2);
+      this.blocksCache[block.height] = block;
+    }
+
+    const blocksCacheHashes = Object.keys(this.blocksCache).sort();
+    if (blocksCacheHashes.length > BLOCKS_CACHE_MAX_SIZE) {
+      for (let i = 0; i < 10; ++i) {
+        delete this.blocksCache[blocksCacheHashes[i]];
+      }
+    }
+
+    this.fundingTxCache[channelId] = {
+      timestamp: block.time,
+      txid: block.tx[txIdx].txid,
+      value: block.tx[txIdx].vout[outputIdx].value,
+    };
+
+    ++this.channelNewlyProcessed;
+
+    return this.fundingTxCache[channelId];
+  }
+}
+
+export default new FundingTxFetcher;

--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -151,9 +151,11 @@ class LightningStatsImporter {
     const alreadyCountedChannels = {};
     
     for (const channel of networkGraph.channels) {
-      const tx = await fundingTxFetcher.$fetchChannelOpenTx(channel.scid.slice(0, -2));
+      const short_id = channel.scid.slice(0, -2);
+
+      const tx = await fundingTxFetcher.$fetchChannelOpenTx(short_id);
       if (!tx) {
-        logger.err(`Unable to fetch funding tx for channel ${channel.scid}. Capacity and creation date will stay unknown.`);
+        logger.err(`Unable to fetch funding tx for channel ${short_id}. Capacity and creation date is unknown. Skipping channel.`);
         continue;
       }
 
@@ -175,10 +177,10 @@ class LightningStatsImporter {
       nodeStats[channel.destination].capacity += Math.round(tx.value * 100000000);
       nodeStats[channel.destination].channels++;
 
-      if (!alreadyCountedChannels[channel.scid.slice(0, -2)]) {
+      if (!alreadyCountedChannels[short_id]) {
         capacity += Math.round(tx.value * 100000000);
         capacities.push(Math.round(tx.value * 100000000));
-        alreadyCountedChannels[channel.scid.slice(0, -2)] = true;
+        alreadyCountedChannels[short_id] = true;
       }
 
       avgFeeRate += channel.fee_proportional_millionths;

--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -36,6 +36,8 @@ class LightningStatsImporter {
   latestNodeCount = 1; // Ignore gap in the data
 
   async $run(): Promise<void> {
+    logger.info(`Importing historical lightning stats`);
+
     // const [channels]: any[] = await DB.query('SELECT short_id from channels;');
     // logger.info('Caching funding txs for currently existing channels');
     // await fundingTxFetcher.$fetchChannelsFundingTxs(channels.map(channel => channel.short_id));
@@ -106,7 +108,7 @@ class LightningStatsImporter {
   /**
    * Generate LN network stats for one day
    */
-  async computeNetworkStats(timestamp: number, networkGraph): Promise<void> {
+  public async computeNetworkStats(timestamp: number, networkGraph): Promise<void> {
     // Node counts and network shares
     let clearnetNodes = 0;
     let torNodes = 0;

--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -1,0 +1,287 @@
+import DB from '../../../database';
+import { readdirSync, readFileSync } from 'fs';
+import { XMLParser } from 'fast-xml-parser';
+import logger from '../../../logger';
+import fundingTxFetcher from './funding-tx-fetcher';
+import config from '../../../config';
+
+interface Node {
+  id: string;
+  timestamp: number;
+  features: string;
+  rgb_color: string;
+  alias: string;
+  addresses: string;
+  out_degree: number;
+  in_degree: number;
+}
+
+interface Channel {
+  scid: string;
+  source: string;
+  destination: string;
+  timestamp: number;
+  features: string;
+  fee_base_msat: number;
+  fee_proportional_millionths: number;
+  htlc_minimim_msat: number;
+  cltv_expiry_delta: number;
+  htlc_maximum_msat: number;
+}
+
+const topologiesFolder = config.LIGHTNING.TOPOLOGY_FOLDER;
+const parser = new XMLParser();
+
+let latestNodeCount = 1; // Ignore gap in the data
+
+async function $run(): Promise<void> {
+  // const [channels]: any[] = await DB.query('SELECT short_id from channels;');
+  // logger.info('Caching funding txs for currently existing channels');
+  // await fundingTxFetcher.$fetchChannelsFundingTxs(channels.map(channel => channel.short_id));
+  
+  await $importHistoricalLightningStats();
+}
+
+/**
+ * Parse the file content into XML, and return a list of nodes and channels
+ */
+function parseFile(fileContent): any {
+  const graph = parser.parse(fileContent);
+  if (Object.keys(graph).length === 0) {
+    return null;
+  }
+
+  const nodes: Node[] = [];
+  const channels: Channel[] = [];
+
+  // If there is only one entry, the parser does not return an array, so we override this
+  if (!Array.isArray(graph.graphml.graph.node)) {
+    graph.graphml.graph.node = [graph.graphml.graph.node];
+  }
+  if (!Array.isArray(graph.graphml.graph.edge)) {
+    graph.graphml.graph.edge = [graph.graphml.graph.edge];
+  }
+
+  for (const node of graph.graphml.graph.node) {
+    if (!node.data) {
+      continue;
+    }
+    nodes.push({
+      id: node.data[0],
+      timestamp: node.data[1],
+      features: node.data[2],
+      rgb_color: node.data[3],
+      alias: node.data[4],
+      addresses: node.data[5],
+      out_degree: node.data[6],
+      in_degree: node.data[7],
+    });
+  }
+
+  for (const channel of graph.graphml.graph.edge) {
+    if (!channel.data) {
+      continue;
+    }
+    channels.push({
+      scid: channel.data[0],
+      source: channel.data[1],
+      destination: channel.data[2],
+      timestamp: channel.data[3],
+      features: channel.data[4],
+      fee_base_msat: channel.data[5],
+      fee_proportional_millionths: channel.data[6],
+      htlc_minimim_msat: channel.data[7],
+      cltv_expiry_delta: channel.data[8],
+      htlc_maximum_msat: channel.data[9],
+    });
+  }
+
+  return {
+    nodes: nodes,
+    channels: channels,
+  };
+}
+
+/**
+ * Generate LN network stats for one day
+ */
+async function computeNetworkStats(timestamp: number, networkGraph): Promise<void> {
+  // Node counts and network shares
+  let clearnetNodes = 0;
+  let torNodes = 0;
+  let clearnetTorNodes = 0;
+  let unannouncedNodes = 0;
+
+  for (const node of networkGraph.nodes) {
+    let hasOnion = false;
+    let hasClearnet = false;
+    let isUnnanounced = true;
+
+    const sockets = node.addresses.split(',');
+    for (const socket of sockets) {
+      hasOnion = hasOnion || (socket.indexOf('torv3://') !== -1);
+      hasClearnet = hasClearnet || (socket.indexOf('ipv4://') !== -1 || socket.indexOf('ipv6://') !== -1);
+    }
+    if (hasOnion && hasClearnet) {
+      clearnetTorNodes++;
+      isUnnanounced = false;
+    } else if (hasOnion) {
+      torNodes++;
+      isUnnanounced = false;
+    } else if (hasClearnet) {
+      clearnetNodes++;
+      isUnnanounced = false;
+    }
+    if (isUnnanounced) {
+      unannouncedNodes++;
+    }
+  }
+
+  // Channels and node historical stats
+  const nodeStats = {};
+  let capacity = 0;
+  let avgFeeRate = 0;
+  let avgBaseFee = 0;
+  const capacities: number[] = [];
+  const feeRates: number[] = [];
+  const baseFees: number[] = [];
+  for (const channel of networkGraph.channels) {
+    const tx = await fundingTxFetcher.$fetchChannelOpenTx(channel.scid.slice(0, -2));
+    if (!tx) {
+      logger.err(`Unable to fetch funding tx for channel ${channel.scid}. Capacity and creation date will stay unknown.`);
+      continue;
+    }
+
+    if (!nodeStats[channel.source]) {
+      nodeStats[channel.source] = {
+        capacity: 0,
+        channels: 0,
+      };
+    }
+    if (!nodeStats[channel.destination]) {
+      nodeStats[channel.destination] = {
+        capacity: 0,
+        channels: 0,
+      };
+    }
+    
+    nodeStats[channel.source].capacity += Math.round(tx.value * 100000000);
+    nodeStats[channel.source].channels++;
+    nodeStats[channel.destination].capacity += Math.round(tx.value * 100000000);
+    nodeStats[channel.destination].channels++;
+
+    capacity += Math.round(tx.value * 100000000);
+    avgFeeRate += channel.fee_proportional_millionths;
+    avgBaseFee += channel.fee_base_msat;
+    capacities.push(Math.round(tx.value * 100000000));
+    feeRates.push(channel.fee_proportional_millionths);
+    baseFees.push(channel.fee_base_msat);
+  }
+  
+  avgFeeRate /= networkGraph.channels.length;
+  avgBaseFee /= networkGraph.channels.length;
+  const medCapacity = capacities.sort((a, b) => b - a)[Math.round(capacities.length / 2 - 1)];
+  const medFeeRate = feeRates.sort((a, b) => b - a)[Math.round(feeRates.length / 2 - 1)];
+  const medBaseFee = baseFees.sort((a, b) => b - a)[Math.round(baseFees.length / 2 - 1)];
+  
+  let query = `INSERT INTO lightning_stats(
+    added,
+    channel_count,
+    node_count,
+    total_capacity,
+    tor_nodes,
+    clearnet_nodes,
+    unannounced_nodes,
+    clearnet_tor_nodes,
+    avg_capacity,
+    avg_fee_rate,
+    avg_base_fee_mtokens,
+    med_capacity,
+    med_fee_rate,
+    med_base_fee_mtokens
+  )
+  VALUES (FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+  await DB.query(query, [
+    timestamp,
+    networkGraph.channels.length,
+    networkGraph.nodes.length,
+    capacity,
+    torNodes,
+    clearnetNodes,
+    unannouncedNodes,
+    clearnetTorNodes,
+    Math.round(capacity / networkGraph.channels.length),
+    avgFeeRate,
+    avgBaseFee,
+    medCapacity,
+    medFeeRate,
+    medBaseFee,
+  ]);
+
+  for (const public_key of Object.keys(nodeStats)) {
+    query = `INSERT INTO node_stats(
+      public_key,
+      added,
+      capacity,
+      channels
+    )
+    VALUES (?, FROM_UNIXTIME(?), ?, ?)`;
+  
+    await DB.query(query, [
+      public_key,
+      timestamp,
+      nodeStats[public_key].capacity,
+      nodeStats[public_key].channels,
+    ]);
+  }
+}
+
+export async function $importHistoricalLightningStats(): Promise<void> {
+  const fileList = readdirSync(topologiesFolder);
+  fileList.sort().reverse();
+
+  const [rows]: any[] = await DB.query('SELECT UNIX_TIMESTAMP(added) as added FROM lightning_stats');
+  const existingStatsTimestamps = {};
+  for (const row of rows) {
+    existingStatsTimestamps[row.added] = true;
+  }
+
+  for (const filename of fileList) {
+    const timestamp = parseInt(filename.split('_')[1], 10);
+    const fileContent = readFileSync(`${topologiesFolder}/${filename}`, 'utf8');
+
+    const graph = parseFile(fileContent);
+    if (!graph) {
+      continue;
+    }
+
+    // Ignore drop of more than 90% of the node count as it's probably a missing data point
+    const diffRatio = graph.nodes.length / latestNodeCount;
+    if (diffRatio < 0.90) {
+      continue;
+    }
+    latestNodeCount = graph.nodes.length;
+
+    // Stats exist already, don't calculate/insert them
+    if (existingStatsTimestamps[timestamp] === true) {
+      continue;
+    }
+
+    logger.debug(`Processing ${topologiesFolder}/${filename}`);
+
+    const datestr = `${new Date(timestamp * 1000).toUTCString()} (${timestamp})`;
+    logger.debug(`${datestr}: Found ${graph.nodes.length} nodes and ${graph.channels.length} channels`);
+
+    // Cache funding txs
+    logger.debug(`Caching funding txs for ${datestr}`);
+    await fundingTxFetcher.$fetchChannelsFundingTxs(graph.channels.map(channel => channel.scid.slice(0, -2)));
+
+    logger.debug(`Generating LN network stats for ${datestr}`);
+    await computeNetworkStats(timestamp, graph);
+  }
+
+  logger.info(`Lightning network stats historical import completed`);
+}
+
+$run().then(() => process.exit(0));

--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -255,10 +255,10 @@ class LightningStatsImporter {
     const fileList = await fsPromises.readdir(this.topologiesFolder);
     fileList.sort().reverse();
 
-    const [rows]: any[] = await DB.query('SELECT UNIX_TIMESTAMP(added) AS added FROM lightning_stats');
+    const [rows]: any[] = await DB.query('SELECT UNIX_TIMESTAMP(added) as added, node_count FROM lightning_stats');
     const existingStatsTimestamps = {};
     for (const row of rows) {
-      existingStatsTimestamps[row.added] = true;
+      existingStatsTimestamps[row.added] = rows[0];
     }
 
     for (const filename of fileList) {
@@ -266,6 +266,7 @@ class LightningStatsImporter {
 
       // Stats exist already, don't calculate/insert them
       if (existingStatsTimestamps[timestamp] !== undefined) {
+        latestNodeCount = existingStatsTimestamps[timestamp].node_count;
         continue;
       }
 

--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -29,259 +29,261 @@ interface Channel {
   htlc_maximum_msat: number;
 }
 
-const topologiesFolder = config.LIGHTNING.TOPOLOGY_FOLDER;
-const parser = new XMLParser();
+class LightningStatsImporter {
+  topologiesFolder = config.LIGHTNING.TOPOLOGY_FOLDER;
+  parser = new XMLParser();
 
-let latestNodeCount = 1; // Ignore gap in the data
+  latestNodeCount = 1; // Ignore gap in the data
 
-async function $run(): Promise<void> {
-  // const [channels]: any[] = await DB.query('SELECT short_id from channels;');
-  // logger.info('Caching funding txs for currently existing channels');
-  // await fundingTxFetcher.$fetchChannelsFundingTxs(channels.map(channel => channel.short_id));
-  
-  await $importHistoricalLightningStats();
-}
-
-/**
- * Parse the file content into XML, and return a list of nodes and channels
- */
-function parseFile(fileContent): any {
-  const graph = parser.parse(fileContent);
-  if (Object.keys(graph).length === 0) {
-    return null;
+  async $run(): Promise<void> {
+    // const [channels]: any[] = await DB.query('SELECT short_id from channels;');
+    // logger.info('Caching funding txs for currently existing channels');
+    // await fundingTxFetcher.$fetchChannelsFundingTxs(channels.map(channel => channel.short_id));
+    
+    await this.$importHistoricalLightningStats();
   }
 
-  const nodes: Node[] = [];
-  const channels: Channel[] = [];
-
-  // If there is only one entry, the parser does not return an array, so we override this
-  if (!Array.isArray(graph.graphml.graph.node)) {
-    graph.graphml.graph.node = [graph.graphml.graph.node];
-  }
-  if (!Array.isArray(graph.graphml.graph.edge)) {
-    graph.graphml.graph.edge = [graph.graphml.graph.edge];
-  }
-
-  for (const node of graph.graphml.graph.node) {
-    if (!node.data) {
-      continue;
+  /**
+   * Parse the file content into XML, and return a list of nodes and channels
+   */
+  parseFile(fileContent): any {
+    const graph = this.parser.parse(fileContent);
+    if (Object.keys(graph).length === 0) {
+      return null;
     }
-    nodes.push({
-      id: node.data[0],
-      timestamp: node.data[1],
-      features: node.data[2],
-      rgb_color: node.data[3],
-      alias: node.data[4],
-      addresses: node.data[5],
-      out_degree: node.data[6],
-      in_degree: node.data[7],
-    });
-  }
 
-  for (const channel of graph.graphml.graph.edge) {
-    if (!channel.data) {
-      continue;
+    const nodes: Node[] = [];
+    const channels: Channel[] = [];
+
+    // If there is only one entry, the parser does not return an array, so we override this
+    if (!Array.isArray(graph.graphml.graph.node)) {
+      graph.graphml.graph.node = [graph.graphml.graph.node];
     }
-    channels.push({
-      scid: channel.data[0],
-      source: channel.data[1],
-      destination: channel.data[2],
-      timestamp: channel.data[3],
-      features: channel.data[4],
-      fee_base_msat: channel.data[5],
-      fee_proportional_millionths: channel.data[6],
-      htlc_minimim_msat: channel.data[7],
-      cltv_expiry_delta: channel.data[8],
-      htlc_maximum_msat: channel.data[9],
-    });
-  }
-
-  return {
-    nodes: nodes,
-    channels: channels,
-  };
-}
-
-/**
- * Generate LN network stats for one day
- */
-async function computeNetworkStats(timestamp: number, networkGraph): Promise<void> {
-  // Node counts and network shares
-  let clearnetNodes = 0;
-  let torNodes = 0;
-  let clearnetTorNodes = 0;
-  let unannouncedNodes = 0;
-
-  for (const node of networkGraph.nodes) {
-    let hasOnion = false;
-    let hasClearnet = false;
-    let isUnnanounced = true;
-
-    const sockets = node.addresses.split(',');
-    for (const socket of sockets) {
-      hasOnion = hasOnion || (socket.indexOf('torv3://') !== -1);
-      hasClearnet = hasClearnet || (socket.indexOf('ipv4://') !== -1 || socket.indexOf('ipv6://') !== -1);
+    if (!Array.isArray(graph.graphml.graph.edge)) {
+      graph.graphml.graph.edge = [graph.graphml.graph.edge];
     }
-    if (hasOnion && hasClearnet) {
-      clearnetTorNodes++;
-      isUnnanounced = false;
-    } else if (hasOnion) {
-      torNodes++;
-      isUnnanounced = false;
-    } else if (hasClearnet) {
-      clearnetNodes++;
-      isUnnanounced = false;
+
+    for (const node of graph.graphml.graph.node) {
+      if (!node.data) {
+        continue;
+      }
+      nodes.push({
+        id: node.data[0],
+        timestamp: node.data[1],
+        features: node.data[2],
+        rgb_color: node.data[3],
+        alias: node.data[4],
+        addresses: node.data[5],
+        out_degree: node.data[6],
+        in_degree: node.data[7],
+      });
     }
-    if (isUnnanounced) {
-      unannouncedNodes++;
+
+    for (const channel of graph.graphml.graph.edge) {
+      if (!channel.data) {
+        continue;
+      }
+      channels.push({
+        scid: channel.data[0],
+        source: channel.data[1],
+        destination: channel.data[2],
+        timestamp: channel.data[3],
+        features: channel.data[4],
+        fee_base_msat: channel.data[5],
+        fee_proportional_millionths: channel.data[6],
+        htlc_minimim_msat: channel.data[7],
+        cltv_expiry_delta: channel.data[8],
+        htlc_maximum_msat: channel.data[9],
+      });
     }
+
+    return {
+      nodes: nodes,
+      channels: channels,
+    };
   }
 
-  // Channels and node historical stats
-  const nodeStats = {};
-  let capacity = 0;
-  let avgFeeRate = 0;
-  let avgBaseFee = 0;
-  const capacities: number[] = [];
-  const feeRates: number[] = [];
-  const baseFees: number[] = [];
-  for (const channel of networkGraph.channels) {
-    const tx = await fundingTxFetcher.$fetchChannelOpenTx(channel.scid.slice(0, -2));
-    if (!tx) {
-      logger.err(`Unable to fetch funding tx for channel ${channel.scid}. Capacity and creation date will stay unknown.`);
-      continue;
+  /**
+   * Generate LN network stats for one day
+   */
+  async computeNetworkStats(timestamp: number, networkGraph): Promise<void> {
+    // Node counts and network shares
+    let clearnetNodes = 0;
+    let torNodes = 0;
+    let clearnetTorNodes = 0;
+    let unannouncedNodes = 0;
+
+    for (const node of networkGraph.nodes) {
+      let hasOnion = false;
+      let hasClearnet = false;
+      let isUnnanounced = true;
+
+      const sockets = node.addresses.split(',');
+      for (const socket of sockets) {
+        hasOnion = hasOnion || (socket.indexOf('torv3://') !== -1);
+        hasClearnet = hasClearnet || (socket.indexOf('ipv4://') !== -1 || socket.indexOf('ipv6://') !== -1);
+      }
+      if (hasOnion && hasClearnet) {
+        clearnetTorNodes++;
+        isUnnanounced = false;
+      } else if (hasOnion) {
+        torNodes++;
+        isUnnanounced = false;
+      } else if (hasClearnet) {
+        clearnetNodes++;
+        isUnnanounced = false;
+      }
+      if (isUnnanounced) {
+        unannouncedNodes++;
+      }
     }
 
-    if (!nodeStats[channel.source]) {
-      nodeStats[channel.source] = {
-        capacity: 0,
-        channels: 0,
-      };
-    }
-    if (!nodeStats[channel.destination]) {
-      nodeStats[channel.destination] = {
-        capacity: 0,
-        channels: 0,
-      };
+    // Channels and node historical stats
+    const nodeStats = {};
+    let capacity = 0;
+    let avgFeeRate = 0;
+    let avgBaseFee = 0;
+    const capacities: number[] = [];
+    const feeRates: number[] = [];
+    const baseFees: number[] = [];
+    for (const channel of networkGraph.channels) {
+      const tx = await fundingTxFetcher.$fetchChannelOpenTx(channel.scid.slice(0, -2));
+      if (!tx) {
+        logger.err(`Unable to fetch funding tx for channel ${channel.scid}. Capacity and creation date will stay unknown.`);
+        continue;
+      }
+
+      if (!nodeStats[channel.source]) {
+        nodeStats[channel.source] = {
+          capacity: 0,
+          channels: 0,
+        };
+      }
+      if (!nodeStats[channel.destination]) {
+        nodeStats[channel.destination] = {
+          capacity: 0,
+          channels: 0,
+        };
+      }
+      
+      nodeStats[channel.source].capacity += Math.round(tx.value * 100000000);
+      nodeStats[channel.source].channels++;
+      nodeStats[channel.destination].capacity += Math.round(tx.value * 100000000);
+      nodeStats[channel.destination].channels++;
+
+      capacity += Math.round(tx.value * 100000000);
+      avgFeeRate += channel.fee_proportional_millionths;
+      avgBaseFee += channel.fee_base_msat;
+      capacities.push(Math.round(tx.value * 100000000));
+      feeRates.push(channel.fee_proportional_millionths);
+      baseFees.push(channel.fee_base_msat);
     }
     
-    nodeStats[channel.source].capacity += Math.round(tx.value * 100000000);
-    nodeStats[channel.source].channels++;
-    nodeStats[channel.destination].capacity += Math.round(tx.value * 100000000);
-    nodeStats[channel.destination].channels++;
-
-    capacity += Math.round(tx.value * 100000000);
-    avgFeeRate += channel.fee_proportional_millionths;
-    avgBaseFee += channel.fee_base_msat;
-    capacities.push(Math.round(tx.value * 100000000));
-    feeRates.push(channel.fee_proportional_millionths);
-    baseFees.push(channel.fee_base_msat);
-  }
-  
-  avgFeeRate /= networkGraph.channels.length;
-  avgBaseFee /= networkGraph.channels.length;
-  const medCapacity = capacities.sort((a, b) => b - a)[Math.round(capacities.length / 2 - 1)];
-  const medFeeRate = feeRates.sort((a, b) => b - a)[Math.round(feeRates.length / 2 - 1)];
-  const medBaseFee = baseFees.sort((a, b) => b - a)[Math.round(baseFees.length / 2 - 1)];
-  
-  let query = `INSERT INTO lightning_stats(
-    added,
-    channel_count,
-    node_count,
-    total_capacity,
-    tor_nodes,
-    clearnet_nodes,
-    unannounced_nodes,
-    clearnet_tor_nodes,
-    avg_capacity,
-    avg_fee_rate,
-    avg_base_fee_mtokens,
-    med_capacity,
-    med_fee_rate,
-    med_base_fee_mtokens
-  )
-  VALUES (FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-
-  await DB.query(query, [
-    timestamp,
-    networkGraph.channels.length,
-    networkGraph.nodes.length,
-    capacity,
-    torNodes,
-    clearnetNodes,
-    unannouncedNodes,
-    clearnetTorNodes,
-    Math.round(capacity / networkGraph.channels.length),
-    avgFeeRate,
-    avgBaseFee,
-    medCapacity,
-    medFeeRate,
-    medBaseFee,
-  ]);
-
-  for (const public_key of Object.keys(nodeStats)) {
-    query = `INSERT INTO node_stats(
-      public_key,
+    avgFeeRate /= networkGraph.channels.length;
+    avgBaseFee /= networkGraph.channels.length;
+    const medCapacity = capacities.sort((a, b) => b - a)[Math.round(capacities.length / 2 - 1)];
+    const medFeeRate = feeRates.sort((a, b) => b - a)[Math.round(feeRates.length / 2 - 1)];
+    const medBaseFee = baseFees.sort((a, b) => b - a)[Math.round(baseFees.length / 2 - 1)];
+    
+    let query = `INSERT INTO lightning_stats(
       added,
-      capacity,
-      channels
+      channel_count,
+      node_count,
+      total_capacity,
+      tor_nodes,
+      clearnet_nodes,
+      unannounced_nodes,
+      clearnet_tor_nodes,
+      avg_capacity,
+      avg_fee_rate,
+      avg_base_fee_mtokens,
+      med_capacity,
+      med_fee_rate,
+      med_base_fee_mtokens
     )
-    VALUES (?, FROM_UNIXTIME(?), ?, ?)`;
-  
+    VALUES (FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
     await DB.query(query, [
-      public_key,
       timestamp,
-      nodeStats[public_key].capacity,
-      nodeStats[public_key].channels,
+      networkGraph.channels.length,
+      networkGraph.nodes.length,
+      capacity,
+      torNodes,
+      clearnetNodes,
+      unannouncedNodes,
+      clearnetTorNodes,
+      Math.round(capacity / networkGraph.channels.length),
+      avgFeeRate,
+      avgBaseFee,
+      medCapacity,
+      medFeeRate,
+      medBaseFee,
     ]);
+
+    for (const public_key of Object.keys(nodeStats)) {
+      query = `INSERT INTO node_stats(
+        public_key,
+        added,
+        capacity,
+        channels
+      )
+      VALUES (?, FROM_UNIXTIME(?), ?, ?)`;
+    
+      await DB.query(query, [
+        public_key,
+        timestamp,
+        nodeStats[public_key].capacity,
+        nodeStats[public_key].channels,
+      ]);
+    }
+  }
+
+  async $importHistoricalLightningStats(): Promise<void> {
+    const fileList = readdirSync(this.topologiesFolder);
+    fileList.sort().reverse();
+
+    const [rows]: any[] = await DB.query('SELECT UNIX_TIMESTAMP(added) as added FROM lightning_stats');
+    const existingStatsTimestamps = {};
+    for (const row of rows) {
+      existingStatsTimestamps[row.added] = true;
+    }
+
+    for (const filename of fileList) {
+      const timestamp = parseInt(filename.split('_')[1], 10);
+      const fileContent = readFileSync(`${this.topologiesFolder}/${filename}`, 'utf8');
+
+      const graph = this.parseFile(fileContent);
+      if (!graph) {
+        continue;
+      }
+
+      // Ignore drop of more than 90% of the node count as it's probably a missing data point
+      const diffRatio = graph.nodes.length / this.latestNodeCount;
+      if (diffRatio < 0.90) {
+        continue;
+      }
+      this.latestNodeCount = graph.nodes.length;
+
+      // Stats exist already, don't calculate/insert them
+      if (existingStatsTimestamps[timestamp] === true) {
+        continue;
+      }
+
+      logger.debug(`Processing ${this.topologiesFolder}/${filename}`);
+
+      const datestr = `${new Date(timestamp * 1000).toUTCString()} (${timestamp})`;
+      logger.debug(`${datestr}: Found ${graph.nodes.length} nodes and ${graph.channels.length} channels`);
+
+      // Cache funding txs
+      logger.debug(`Caching funding txs for ${datestr}`);
+      await fundingTxFetcher.$fetchChannelsFundingTxs(graph.channels.map(channel => channel.scid.slice(0, -2)));
+
+      logger.debug(`Generating LN network stats for ${datestr}`);
+      await this.computeNetworkStats(timestamp, graph);
+    }
+
+    logger.info(`Lightning network stats historical import completed`);
   }
 }
 
-export async function $importHistoricalLightningStats(): Promise<void> {
-  const fileList = readdirSync(topologiesFolder);
-  fileList.sort().reverse();
-
-  const [rows]: any[] = await DB.query('SELECT UNIX_TIMESTAMP(added) as added FROM lightning_stats');
-  const existingStatsTimestamps = {};
-  for (const row of rows) {
-    existingStatsTimestamps[row.added] = true;
-  }
-
-  for (const filename of fileList) {
-    const timestamp = parseInt(filename.split('_')[1], 10);
-    const fileContent = readFileSync(`${topologiesFolder}/${filename}`, 'utf8');
-
-    const graph = parseFile(fileContent);
-    if (!graph) {
-      continue;
-    }
-
-    // Ignore drop of more than 90% of the node count as it's probably a missing data point
-    const diffRatio = graph.nodes.length / latestNodeCount;
-    if (diffRatio < 0.90) {
-      continue;
-    }
-    latestNodeCount = graph.nodes.length;
-
-    // Stats exist already, don't calculate/insert them
-    if (existingStatsTimestamps[timestamp] === true) {
-      continue;
-    }
-
-    logger.debug(`Processing ${topologiesFolder}/${filename}`);
-
-    const datestr = `${new Date(timestamp * 1000).toUTCString()} (${timestamp})`;
-    logger.debug(`${datestr}: Found ${graph.nodes.length} nodes and ${graph.channels.length} channels`);
-
-    // Cache funding txs
-    logger.debug(`Caching funding txs for ${datestr}`);
-    await fundingTxFetcher.$fetchChannelsFundingTxs(graph.channels.map(channel => channel.scid.slice(0, -2)));
-
-    logger.debug(`Generating LN network stats for ${datestr}`);
-    await computeNetworkStats(timestamp, graph);
-  }
-
-  logger.info(`Lightning network stats historical import completed`);
-}
-
-$run().then(() => process.exit(0));
+export default new LightningStatsImporter;


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2124

This PR adds the historical LN stats import feature.

Database migration has been updated to add a new lightning_stats field named `clearnet_tor_nodes`, allowing to track properly LN nodes presence on different networks.

<img width="1453" alt="Screen Shot 2022-08-02 at 3 01 25 PM" src="https://user-images.githubusercontent.com/9780671/182381235-a4ef2f8b-5bf8-4ac3-9e16-0276935bcda9.png">

<img width="1406" alt="Screen Shot 2022-08-02 at 3 03 21 PM" src="https://user-images.githubusercontent.com/9780671/182381345-55cfd6e9-a6a6-4c48-8ae4-f727b3d36f1d.png">

### Testing

1. Generate network topology files
2. Update your mempool nodejs backend config

You need to indicate where your topology output has been written. You can do so by setting a full path of the output folder at `MEMPOOL.LIGHTNING.TOPOLOGY_FOLDER`.

#### Run the importer

Simply run the nodejs backend and you should notice the following messages in the logs
```
Aug  1 17:49:37 [7949] INFO: <lightning> Importing historical lightning stats
Aug  1 17:49:40 [7949] DEBUG: <lightning> Processing /Users/nymkappa/Documents/topologies/topology_1632009600
Aug  1 17:49:40 [7949] DEBUG: <lightning> Sun, 19 Sep 2021 00:00:00 GMT (1632009600): Found 13198 nodes and 102464 channels
Aug  1 17:49:40 [7949] DEBUG: <lightning> Caching funding txs for Sun, 19 Sep 2021 00:00:00 GMT (1632009600)
Aug  1 17:49:40 [7949] DEBUG: <lightning> Imported 53447 funding tx amount from the disk cache
Aug  1 17:50:12 [7949] DEBUG: <lightning> Indexing channels funding tx 25272 of 102464 (24.66%) | elapsed: 32 seconds
```

This process is very long. I had not done yet a full import from scratch so I can't give any number yet. We start with the most recent `topology_XXXXXX` timestamp, and back in time. Feel free to suggest which log message you are interested in seeing on INFO level.

Frontend is not yet aware of the progress, but to limit the scope of that PR I'll submit a future PR to indicate the import progress.