### PR TITLE
Set default values when pubkey, capacity and channels are missing from top nodes

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -66,7 +66,15 @@ class NodesApi {
 
   public async $getTopCapacityNodes(): Promise<any> {
     try {
-      const query = `SELECT nodes.*, node_stats.capacity, node_stats.channels FROM nodes LEFT JOIN node_stats ON node_stats.public_key = nodes.public_key ORDER BY node_stats.added DESC, node_stats.capacity DESC LIMIT 10`;
+      const query = `
+        SELECT IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias, nodes.public_key,
+          CAST(COALESCE(node_stats.capacity, 0) as INT) as capacity,
+          CAST(COALESCE(node_stats.channels, 0) as INT) as channels
+        FROM nodes
+        LEFT JOIN node_stats ON node_stats.public_key = nodes.public_key
+        ORDER BY node_stats.added DESC, node_stats.capacity DESC
+        LIMIT 10
+      `;
       const [rows]: any = await DB.query(query);
       return rows;
     } catch (e) {
@@ -77,7 +85,15 @@ class NodesApi {
 
   public async $getTopChannelsNodes(): Promise<any> {
     try {
-      const query = `SELECT nodes.*, node_stats.capacity, node_stats.channels FROM nodes LEFT JOIN node_stats ON node_stats.public_key = nodes.public_key ORDER BY node_stats.added DESC, node_stats.channels DESC LIMIT 10`;
+      const query = `
+        SELECT IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias, nodes.public_key,
+          CAST(COALESCE(node_stats.capacity, 0) as INT) as capacity,
+          CAST(COALESCE(node_stats.channels, 0) as INT) as channels
+        FROM nodes
+        LEFT JOIN node_stats
+        ON node_stats.public_key = nodes.public_key
+        ORDER BY node_stats.added DESC, node_stats.channels DESC
+        LIMIT 10`;
       const [rows]: any = await DB.query(query);
       return rows;
     } catch (e) {


### PR DESCRIPTION
The top nodes component may show empty data if node has an empty alias, display the 20 first char of the public key. Also send zeroes value instead of missing fields.

Fixes https://github.com/mempool/mempool/issues/2229

May be present in other components, will submit other PR when I see them.
