### PR TITLE
Fix daily LN stats crash

### DIFF
--- a/backend/src/api/lightning/clightning/clightning-convert.ts
+++ b/backend/src/api/lightning/clightning/clightning-convert.ts
@@ -1,5 +1,6 @@
 import { ILightningApi } from '../lightning-api.interface';
 import FundingTxFetcher from '../../../tasks/lightning/sync-tasks/funding-tx-fetcher';
+import logger from '../../../logger';
 
 /**
  * Convert a clightning "listnode" entry to a lnd node entry
@@ -23,12 +24,17 @@ export function convertNode(clNode: any): ILightningApi.Node {
 /**
  * Convert clightning "listchannels" response to lnd "describegraph.edges" format
  */
- export async function convertAndmergeBidirectionalChannels(clChannels: any[]): Promise<ILightningApi.Channel[]> {
+export async function convertAndmergeBidirectionalChannels(clChannels: any[]): Promise<ILightningApi.Channel[]> {
+  logger.info('Converting clightning nodes and channels to lnd graph format');
+
+  let loggerTimer = new Date().getTime() / 1000;
+  let channelProcessed = 0;
+
   const consolidatedChannelList: ILightningApi.Channel[] = [];
   const clChannelsDict = {};
   const clChannelsDictCount = {};
 
-  for (const clChannel of clChannels) {    
+  for (const clChannel of clChannels) {
     if (!clChannelsDict[clChannel.short_channel_id]) {
       clChannelsDict[clChannel.short_channel_id] = clChannel;
       clChannelsDictCount[clChannel.short_channel_id] = 1;
@@ -39,9 +45,26 @@ export function convertNode(clNode: any): ILightningApi.Node {
       delete clChannelsDict[clChannel.short_channel_id];
       clChannelsDictCount[clChannel.short_channel_id]++;
     }
+
+    const elapsedSeconds = Math.round((new Date().getTime() / 1000) - loggerTimer);
+    if (elapsedSeconds > 10) {
+      logger.info(`Building complete channels from clightning output. Channels processed: ${channelProcessed + 1} of ${clChannels.length}`);
+      loggerTimer = new Date().getTime() / 1000;
+    }
+
+    ++channelProcessed;
   }
-  for (const short_channel_id of Object.keys(clChannelsDict)) {
+
+  channelProcessed = 0;
+  const keys = Object.keys(clChannelsDict);
+  for (const short_channel_id of keys) {
     consolidatedChannelList.push(await buildIncompleteChannel(clChannelsDict[short_channel_id]));
+
+    const elapsedSeconds = Math.round((new Date().getTime() / 1000) - loggerTimer);
+    if (elapsedSeconds > 10) {
+      logger.info(`Building partial channels from clightning output. Channels processed: ${channelProcessed + 1} of ${keys.length}`);
+      loggerTimer = new Date().getTime() / 1000;
+    }
   }
 
   return consolidatedChannelList;
@@ -79,7 +102,7 @@ async function buildFullChannel(clChannelA: any, clChannelB: any): Promise<ILigh
  * Convert one clightning "getchannels" entry into a full a lnd "describegraph.edges" format
  * In this case, clightning knows the channel policy of only one node
  */
- async function buildIncompleteChannel(clChannel: any): Promise<ILightningApi.Channel> {
+async function buildIncompleteChannel(clChannel: any): Promise<ILightningApi.Channel> {
   const tx = await FundingTxFetcher.$fetchChannelOpenTx(clChannel.short_channel_id);
   const parts = clChannel.short_channel_id.split('x');
   const outputIdx = parts[2];
@@ -99,7 +122,7 @@ async function buildFullChannel(clChannelA: any, clChannelB: any): Promise<ILigh
 /**
  * Convert a clightning "listnode" response to a lnd channel policy format
  */
- function convertPolicy(clChannel: any): ILightningApi.RoutingPolicy {
+function convertPolicy(clChannel: any): ILightningApi.RoutingPolicy {
   return {
     time_lock_delta: 0, // TODO
     min_htlc: clChannel.htlc_minimum_msat.slice(0, -4),

--- a/backend/src/tasks/lightning/sync-tasks/funding-tx-fetcher.ts
+++ b/backend/src/tasks/lightning/sync-tasks/funding-tx-fetcher.ts
@@ -45,7 +45,7 @@ class FundingTxFetcher {
       let elapsedSeconds = Math.round((new Date().getTime() / 1000) - loggerTimer);
       if (elapsedSeconds > 10) {
         elapsedSeconds = Math.round((new Date().getTime() / 1000) - globalTimer);
-        logger.debug(`Indexing channels funding tx ${channelProcessed + 1} of ${channelIds.length} ` +
+        logger.info(`Indexing channels funding tx ${channelProcessed + 1} of ${channelIds.length} ` +
           `(${Math.floor(channelProcessed / channelIds.length * 10000) / 100}%) | ` +
           `elapsed: ${elapsedSeconds} seconds`
         );


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2243

This PR also wraps the LN backend into a try/catch/retry logic in case there is an unhanded crash in there, to avoid crashing the whole nodejs backend at once.

### Testing

* Run the PR and see if a new `lightning_stats` entry and one new entry per node in `nodes_stats` are properly inserted in the db around midnight without crashing, using both lnd and cln