### PR TITLE
Faster unfurls

### DIFF
--- a/frontend/src/app/components/address/address-preview.component.html
+++ b/frontend/src/app/components/address/address-preview.component.html
@@ -44,7 +44,7 @@
     <div class="w-100 d-block d-md-none"></div>
     <div class="col-md qrcode-col">
       <div class="qr-wrapper">
-        <app-qrcode [data]="address.address" [size]="370"></app-qrcode>
+        <app-qrcode [data]="address.address" [size]="448"></app-qrcode>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/address/address-preview.component.scss
+++ b/frontend/src/app/components/address/address-preview.component.scss
@@ -1,5 +1,5 @@
 h1 {
-  font-size: 42px;
+  font-size: 52px;
   margin: 0;
 }
 
@@ -11,23 +11,26 @@ h1 {
 }
 
 .qrcode-col {
-  width: 420px;
-  min-width: 420px;
+  width: 468px;
+  min-width: 468px;
   flex-grow: 0;
   flex-shrink: 0;
   text-align: center;
+  padding: 0;
+  margin-left: 2px;
+  margin-right: 15px;
 }
 
 .table {
-  font-size: 24px;
+  font-size: 32px;
 
   ::ng-deep .symbol {
-    font-size: 18px;
+    font-size: 24px;
   }
 }
 
 .address-link {
-  font-size: 20px;
+  font-size: 24px;
   margin-bottom: 0.5em;
   display: flex;
   flex-direction: row;
@@ -35,7 +38,7 @@ h1 {
   .truncated-address {
     text-overflow: ellipsis;
     overflow: hidden;
-    max-width: calc(505px - 4em);
+    max-width: calc(640px - 4em);
     display: inline-block;
     white-space: nowrap;
   }

--- a/frontend/src/app/components/address/address-preview.component.ts
+++ b/frontend/src/app/components/address/address-preview.component.ts
@@ -73,7 +73,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
                 this.isLoadingAddress = false;
                 this.error = err;
                 console.log(err);
-                this.openGraphService.waitOver('address-data');
+                this.openGraphService.fail('address-data');
                 return of(null);
               })
             );
@@ -99,7 +99,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
           console.log(error);
           this.error = error;
           this.isLoadingAddress = false;
-          this.openGraphService.waitOver('address-data');
+          this.openGraphService.fail('address-data');
         }
       );
   }

--- a/frontend/src/app/components/address/address-preview.component.ts
+++ b/frontend/src/app/components/address/address-preview.component.ts
@@ -73,6 +73,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
                 this.isLoadingAddress = false;
                 this.error = err;
                 console.log(err);
+                this.openGraphService.waitOver('address-data');
                 return of(null);
               })
             );
@@ -98,6 +99,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
           console.log(error);
           this.error = error;
           this.isLoadingAddress = false;
+          this.openGraphService.waitOver('address-data');
         }
       );
   }

--- a/frontend/src/app/components/address/address-preview.component.ts
+++ b/frontend/src/app/components/address/address-preview.component.ts
@@ -44,7 +44,6 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit() {
-    this.openGraphService.setPreviewLoading();
     this.stateService.networkChanged$.subscribe((network) => this.network = network);
 
     this.addressLoadingStatus$ = this.route.paramMap
@@ -56,6 +55,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
     this.mainSubscription = this.route.paramMap
       .pipe(
         switchMap((params: ParamMap) => {
+          this.openGraphService.waitFor('address-data');
           this.error = undefined;
           this.isLoadingAddress = true;
           this.loadedConfirmedTxCount = 0;
@@ -90,7 +90,7 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
           this.address = address;
           this.updateChainStats();
           this.isLoadingAddress = false;
-          this.openGraphService.setPreviewReady();
+          this.openGraphService.waitOver('address-data');
         })
       )
       .subscribe(() => {},

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -18,6 +18,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy {
   @Input() orientation = 'left';
   @Input() flip = true;
   @Output() txClickEvent = new EventEmitter<TransactionStripped>();
+  @Output() readyEvent = new EventEmitter();
 
   @ViewChild('blockCanvas')
   canvas: ElementRef<HTMLCanvasElement>;
@@ -36,6 +37,8 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy {
   hoverTx: TxView | void;
   selectedTx: TxView | void;
   tooltipPosition: Position;
+
+  readyNextFrame = false;
 
   constructor(
     readonly ngZone: NgZone,
@@ -78,6 +81,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy {
   setup(transactions: TransactionStripped[]): void {
     if (this.scene) {
       this.scene.setup(transactions);
+      this.readyNextFrame = true;
       this.start();
     }
   }
@@ -257,6 +261,11 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy {
         if (pointArray.length) {
           this.gl.drawArrays(this.gl.TRIANGLES, 0, pointArray.length / TxSprite.vertexSize);
         }
+      }
+
+      if (this.readyNextFrame) {
+        this.readyNextFrame = false;
+        this.readyEvent.emit();
       }
     }
 

--- a/frontend/src/app/components/block/block-preview.component.html
+++ b/frontend/src/app/components/block/block-preview.component.html
@@ -30,44 +30,42 @@
             <td i18n="block.weight">Weight</td>
             <td [innerHTML]="'&lrm;' + (block?.weight | wuBytes: 2)"></td>
           </tr>
-          <ng-template [ngIf]="webGlEnabled">
-            <tr *ngIf="block?.extras?.medianFee != undefined">
-              <td class="td-width" i18n="block.median-fee">Median fee</td>
-              <td>~{{ block?.extras?.medianFee | number:'1.0-0' }} <span class="symbol" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></td>
-            </tr>
-            <ng-template [ngIf]="fees !== undefined">
-              <tr>
-                <td i18n="block.total-fees|Total fees in a block">Total fees</td>
-                <td *ngIf="network !== 'liquid' && network !== 'liquidtestnet'; else liquidTotalFees">
-                  <app-amount [satoshis]="block?.extras.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
+          <tr *ngIf="block?.extras?.medianFee != undefined">
+            <td class="td-width" i18n="block.median-fee">Median fee</td>
+            <td>~{{ block?.extras?.medianFee | number:'1.0-0' }} <span class="symbol" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></td>
+          </tr>
+          <ng-template [ngIf]="fees !== undefined">
+            <tr>
+              <td i18n="block.total-fees|Total fees in a block">Total fees</td>
+              <td *ngIf="network !== 'liquid' && network !== 'liquidtestnet'; else liquidTotalFees">
+                <app-amount [satoshis]="block?.extras.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
+              </td>
+              <ng-template #liquidTotalFees>
+                <td>
+                  <app-amount [satoshis]="fees * 100000000" digitsInfo="1.2-2" [noFiat]="true"></app-amount>
                 </td>
-                <ng-template #liquidTotalFees>
-                  <td>
-                    <app-amount [satoshis]="fees * 100000000" digitsInfo="1.2-2" [noFiat]="true"></app-amount>
-                  </td>
-                </ng-template>
-              </tr>
-            </ng-template>
-            <tr *ngIf="network !== 'liquid' && network !== 'liquidtestnet'">
-              <td i18n="block.miner">Miner</td>
-              <td *ngIf="stateService.env.MINING_DASHBOARD">
-                <a [attr.data-cy]="'block-details-miner-badge'" placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, block?.extras.pool.slug]" class="badge"
-                  [class]="block?.extras.pool.name === 'Unknown' ? 'badge-secondary' : 'badge-primary'">
-                  {{ block?.extras.pool.name }}
-                </a>
-              </td>
-              <td *ngIf="!stateService.env.MINING_DASHBOARD && stateService.env.BASE_MODULE === 'mempool'">
-                <span [attr.data-cy]="'block-details-miner-badge'" placement="bottom" class="badge"
-                  [class]="block?.extras.pool.name === 'Unknown' ? 'badge-secondary' : 'badge-primary'">
-                  {{ block?.extras.pool.name }}
-              </span>
-              </td>
+              </ng-template>
             </tr>
           </ng-template>
+          <tr *ngIf="network !== 'liquid' && network !== 'liquidtestnet'">
+            <td i18n="block.miner">Miner</td>
+            <td *ngIf="stateService.env.MINING_DASHBOARD">
+              <a [attr.data-cy]="'block-details-miner-badge'" placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, block?.extras.pool.slug]" class="badge"
+                [class]="block?.extras.pool.name === 'Unknown' ? 'badge-secondary' : 'badge-primary'">
+                {{ block?.extras.pool.name }}
+              </a>
+            </td>
+            <td *ngIf="!stateService.env.MINING_DASHBOARD && stateService.env.BASE_MODULE === 'mempool'">
+              <span [attr.data-cy]="'block-details-miner-badge'" placement="bottom" class="badge"
+                [class]="block?.extras.pool.name === 'Unknown' ? 'badge-secondary' : 'badge-primary'">
+                {{ block?.extras.pool.name }}
+            </span>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
-    <div class="col-sm chart-container" *ngIf="webGlEnabled">
+    <div class="col-sm chart-container">
       <app-block-overview-graph
         #blockGraph
         [isLoading]="false"
@@ -75,7 +73,7 @@
         [blockLimit]="stateService.blockVSize"
         [orientation]="'top'"
         [flip]="false"
-        (txClickEvent)="onTxClick($event)"
+        (readyEvent)="onGraphReady()"
       ></app-block-overview-graph>
     </div>
   </div>

--- a/frontend/src/app/components/block/block-preview.component.scss
+++ b/frontend/src/app/components/block/block-preview.component.scss
@@ -1,23 +1,25 @@
 .block-title {
-  margin-bottom: 0.75em;
-  font-size: 42px;
+  margin-bottom: 48px;
+  font-size: 52px;
 
   ::ng-deep .next-previous-blocks {
-    font-size: 42px;
+    font-size: 52px;
   }
 }
 
 .table {
-  font-size: 24px;
+  font-size: 32px;
 }
 
 .chart-container {
   flex-grow: 0;
   flex-shrink: 0;
-  width: 420px;
-  min-width: 420px;
+  width: 470px;
+  min-width: 470px;
+  padding: 0;
+  margin-right: 15px;
 }
 
 ::ng-deep .symbol {
-  font-size: 18px;
+  font-size: 24px;
 }

--- a/frontend/src/app/components/block/block-preview.component.ts
+++ b/frontend/src/app/components/block/block-preview.component.ts
@@ -1,11 +1,153 @@
-import { Component } from '@angular/core';
-import { BlockComponent } from './block.component';
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+import { ElectrsApiService } from '../../services/electrs-api.service';
+import { switchMap, tap, throttleTime, catchError, shareReplay, startWith, pairwise } from 'rxjs/operators';
+import { of, Subscription, asyncScheduler } from 'rxjs';
+import { StateService } from '../../services/state.service';
+import { SeoService } from 'src/app/services/seo.service';
+import { OpenGraphService } from 'src/app/services/opengraph.service';
+import { BlockExtended, TransactionStripped } from 'src/app/interfaces/node-api.interface';
+import { ApiService } from 'src/app/services/api.service';
+import { BlockOverviewGraphComponent } from 'src/app/components/block-overview-graph/block-overview-graph.component';
 
 @Component({
   selector: 'app-block-preview',
   templateUrl: './block-preview.component.html',
-  styleUrls: ['./block.component.scss', './block-preview.component.scss']
+  styleUrls: ['./block-preview.component.scss']
 })
-export class BlockPreviewComponent extends BlockComponent {
-  
+export class BlockPreviewComponent implements OnInit, OnDestroy {
+  network = '';
+  block: BlockExtended;
+  blockHeight: number;
+  blockHash: string;
+  isLoadingBlock = true;
+  strippedTransactions: TransactionStripped[];
+  overviewTransitionDirection: string;
+  isLoadingOverview = true;
+  error: any;
+  blockSubsidy: number;
+  fees: number;
+  overviewError: any = null;
+
+  overviewSubscription: Subscription;
+  networkChangedSubscription: Subscription;
+
+  @ViewChild('blockGraph') blockGraph: BlockOverviewGraphComponent;
+
+  constructor(
+    private route: ActivatedRoute,
+    private electrsApiService: ElectrsApiService,
+    public stateService: StateService,
+    private seoService: SeoService,
+    private openGraphService: OpenGraphService,
+    private apiService: ApiService
+  ) { }
+
+  ngOnInit() {
+    this.network = this.stateService.network;
+
+    const block$ = this.route.paramMap.pipe(
+      switchMap((params: ParamMap) => {
+        this.openGraphService.waitFor('block-viz');
+        this.openGraphService.waitFor('block-data');
+
+        const blockHash: string = params.get('id') || '';
+        this.block = undefined;
+        this.error = undefined;
+        this.fees = undefined;
+
+        let isBlockHeight = false;
+        if (/^[0-9]+$/.test(blockHash)) {
+          isBlockHeight = true;
+        } else {
+          this.blockHash = blockHash;
+        }
+
+        this.isLoadingBlock = true;
+        this.isLoadingOverview = true;
+
+        if (isBlockHeight) {
+          return this.electrsApiService.getBlockHashFromHeight$(parseInt(blockHash, 10))
+            .pipe(
+              switchMap((hash) => {
+                this.blockHash = hash;
+                return this.apiService.getBlock$(hash);
+              })
+            );
+        }
+        return this.apiService.getBlock$(blockHash);
+      }),
+      tap((block: BlockExtended) => {
+        this.block = block;
+        this.blockHeight = block.height;
+
+        this.seoService.setTitle($localize`:@@block.component.browser-title:Block ${block.height}:BLOCK_HEIGHT:: ${block.id}:BLOCK_ID:`);
+        this.isLoadingBlock = false;
+        this.setBlockSubsidy();
+        if (block?.extras?.reward !== undefined) {
+          this.fees = block.extras.reward / 100000000 - this.blockSubsidy;
+        }
+        this.stateService.markBlock$.next({ blockHeight: this.blockHeight });
+        this.isLoadingOverview = true;
+        this.overviewError = null;
+
+        this.openGraphService.waitOver('block-data');
+      }),
+      throttleTime(50, asyncScheduler, { leading: true, trailing: true }),
+      shareReplay(1)
+    );
+
+    this.overviewSubscription = block$.pipe(
+      startWith(null),
+      pairwise(),
+      switchMap(([prevBlock, block]) => this.apiService.getStrippedBlockTransactions$(block.id)
+        .pipe(
+          catchError((err) => {
+            this.overviewError = err;
+            return of([]);
+          }),
+          switchMap((transactions) => {
+            return of({ transactions, direction: 'down' });
+          })
+        )
+      ),
+    )
+    .subscribe(({transactions, direction}: {transactions: TransactionStripped[], direction: string}) => {
+      this.strippedTransactions = transactions;
+      this.isLoadingOverview = false;
+      if (this.blockGraph) {
+        this.blockGraph.destroy();
+        this.blockGraph.setup(this.strippedTransactions);
+      }
+    },
+    (error) => {
+      this.error = error;
+      this.isLoadingOverview = false;
+      if (this.blockGraph) {
+        this.blockGraph.destroy();
+      }
+    });
+
+    this.networkChangedSubscription = this.stateService.networkChanged$
+      .subscribe((network) => this.network = network);
+  }
+
+  ngOnDestroy() {
+    if (this.overviewSubscription) {
+      this.overviewSubscription.unsubscribe();
+    }
+    if (this.networkChangedSubscription) {
+      this.networkChangedSubscription.unsubscribe();
+    }
+  }
+
+  // TODO - Refactor this.fees/this.reward for liquid because it is not
+  // used anymore on Bitcoin networks (we use block.extras directly)
+  setBlockSubsidy() {
+    this.blockSubsidy = 0;
+  }
+
+  onGraphReady(): void {
+    this.openGraphService.waitOver('block-viz');
+  }
 }

--- a/frontend/src/app/components/block/block-preview.component.ts
+++ b/frontend/src/app/components/block/block-preview.component.ts
@@ -80,8 +80,8 @@ export class BlockPreviewComponent implements OnInit, OnDestroy {
               }),
               catchError((err) => {
                 this.error = err;
-                this.openGraphService.waitOver('block-data');
-                this.openGraphService.waitOver('block-viz');
+                this.openGraphService.fail('block-data');
+                this.openGraphService.fail('block-viz');
                 return of(null);
               }),
             );
@@ -116,7 +116,7 @@ export class BlockPreviewComponent implements OnInit, OnDestroy {
         .pipe(
           catchError((err) => {
             this.overviewError = err;
-            this.openGraphService.waitOver('block-viz');
+            this.openGraphService.fail('block-viz');
             return of([]);
           }),
           switchMap((transactions) => {
@@ -136,8 +136,8 @@ export class BlockPreviewComponent implements OnInit, OnDestroy {
     (error) => {
       this.error = error;
       this.isLoadingOverview = false;
-      this.openGraphService.waitOver('block-viz');
-      this.openGraphService.waitOver('block-data');
+      this.openGraphService.fail('block-viz');
+      this.openGraphService.fail('block-data');
       if (this.blockGraph) {
         this.blockGraph.destroy();
       }

--- a/frontend/src/app/components/master-page-preview/master-page-preview.component.html
+++ b/frontend/src/app/components/master-page-preview/master-page-preview.component.html
@@ -1,21 +1,20 @@
 <ng-container *ngIf="{ val: network$ | async } as network">
 <div class="preview-wrapper">
-  <router-outlet></router-outlet>
-
-  <footer>
-    <span class="footer-brand" style="position: relative;">
-      <img *ngIf="!officialMempoolSpace" src="/resources/mempool-logo.png" height="35" width="140" class="logo">
-      <app-svg-images *ngIf="officialMempoolSpace" name="officialMempoolSpace" style="width: 140px; height: 35px" width="500" height="126" viewBox="0 0 500 126"></app-svg-images>
+  <header>
+    <span class="header-brand" style="position: relative;">
+      <img *ngIf="!officialMempoolSpace" src="/resources/mempool-logo.png" height="50" width="200" class="logo">
+      <app-svg-images *ngIf="officialMempoolSpace" name="officialMempoolSpace" style="width: 200px; height: 50px" width="500" height="126" viewBox="0 0 500 126"></app-svg-images>
     </span>
 
     <div [ngSwitch]="network.val">
-      <span *ngSwitchCase="'signet'" class="network signet"><img src="/resources/signet-logo.png" style="width: 30px;" class="signet mr-1" alt="logo"> Signet</span>
-      <span *ngSwitchCase="'testnet'" class="network testnet"><img src="/resources/testnet-logo.png" style="width: 30px;" class="mr-1" alt="testnet logo"> Testnet</span>
-      <span *ngSwitchCase="'bisq'" class="network bisq"><img src="/resources/bisq-logo.png" style="width: 30px;" class="mr-1" alt="bisq logo"> Bisq</span>
-      <span *ngSwitchCase="'liquid'" class="network liquid"><img src="/resources/liquid-logo.png" style="width: 30px;" class="mr-1" alt="liquid mainnet logo"> Liquid</span>
-      <span *ngSwitchCase="'liquidtestnet'" class="network liquidtestnet"><img src="/resources/liquidtestnet-logo.png" style="width: 30px;" class="mr-1" alt="liquid testnet logo"> Liquid Testnet</span>
-      <span *ngSwitchDefault class="network mainnet"><img src="/resources/bitcoin-logo.png" style="width: 30px;" class="mainnet mr-1" alt="bitcoin logo"> Mainnet</span>
+      <span *ngSwitchCase="'signet'" class="network signet"><img src="/resources/signet-logo.png" style="width: 45px;" class="signet mr-1" alt="logo"> Signet</span>
+      <span *ngSwitchCase="'testnet'" class="network testnet"><img src="/resources/testnet-logo.png" style="width: 45px;" class="mr-1" alt="testnet logo"> Testnet</span>
+      <span *ngSwitchCase="'bisq'" class="network bisq"><img src="/resources/bisq-logo.png" style="width: 45px;" class="mr-1" alt="bisq logo"> Bisq</span>
+      <span *ngSwitchCase="'liquid'" class="network liquid"><img src="/resources/liquid-logo.png" style="width: 45px;" class="mr-1" alt="liquid mainnet logo"> Liquid</span>
+      <span *ngSwitchCase="'liquidtestnet'" class="network liquidtestnet"><img src="/resources/liquidtestnet-logo.png" style="width: 45px;" class="mr-1" alt="liquid testnet logo"> Liquid Testnet</span>
+      <span *ngSwitchDefault class="network mainnet"><img src="/resources/bitcoin-logo.png" style="width: 45px;" class="mainnet mr-1" alt="bitcoin logo"> Mainnet</span>
     </div>
-  </footer>
+  </header>
+  <router-outlet></router-outlet>
 </div>
 </ng-container>

--- a/frontend/src/app/components/master-page-preview/master-page-preview.component.scss
+++ b/frontend/src/app/components/master-page-preview/master-page-preview.component.scss
@@ -2,28 +2,28 @@
   position: relative;
   display: block;
   margin: auto;
-  max-width: 1024px;
-  max-height: 512px;
-  padding-bottom: 64px;
+  max-width: 1200px;
+  max-height: 600px;
+  padding-top: 80px;
 
-  footer {
+  header {
     position: absolute;
     left: 0;
     right: 0;
-    bottom: 0;
+    top: 0;
     z-index: 100;
-    min-height: 64px;
-    padding: 0rem 2rem;
+    min-height: 80px;
+    padding: 0rem 3rem;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     background: #11131f;
     text-align: start;
-    font-size: 1.2em;
+    font-size: 1.8em;
   }
 
-  .footer-brand {
+  .header-brand {
     width: 60%;
   }
 

--- a/frontend/src/app/services/opengraph.service.ts
+++ b/frontend/src/app/services/opengraph.service.ts
@@ -43,8 +43,10 @@ export class OpenGraphService {
       }
     });
 
-    // expose this service to global scope, so we can access it from the unfurler
-    window['ogService'] = this;
+    // expose routing method to global scope, so we can access it from the unfurler
+    window['ogService'] = {
+      loadPage: (path) => { return this.loadPage(path) }
+    };
   }
 
   setOgImage() {

--- a/frontend/src/app/services/opengraph.service.ts
+++ b/frontend/src/app/services/opengraph.service.ts
@@ -53,8 +53,8 @@ export class OpenGraphService {
     this.metaService.updateTag({ property: 'og:image', content: ogImageUrl });
     this.metaService.updateTag({ property: 'twitter:image:src', content: ogImageUrl });
     this.metaService.updateTag({ property: 'og:image:type', content: 'image/png' });
-    this.metaService.updateTag({ property: 'og:image:width', content: '1024' });
-    this.metaService.updateTag({ property: 'og:image:height', content: '512' });
+    this.metaService.updateTag({ property: 'og:image:width', content: '1200' });
+    this.metaService.updateTag({ property: 'og:image:height', content: '600' });
   }
 
   clearOgImage() {

--- a/frontend/src/app/services/opengraph.service.ts
+++ b/frontend/src/app/services/opengraph.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Meta } from '@angular/platform-browser';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { filter, map, switchMap } from 'rxjs/operators';
@@ -12,8 +12,11 @@ import { LanguageService } from './language.service';
 export class OpenGraphService {
   network = '';
   defaultImageUrl = '';
+  previewLoadingEvents = {};
+  previewLoadingCount = 0;
 
   constructor(
+    private ngZone: NgZone,
     private metaService: Meta,
     private stateService: StateService,
     private LanguageService: LanguageService,
@@ -39,6 +42,9 @@ export class OpenGraphService {
         this.clearOgImage();
       }
     });
+
+    // expose this service to global scope, so we can access it from the unfurler
+    window['ogService'] = this;
   }
 
   setOgImage() {
@@ -59,13 +65,44 @@ export class OpenGraphService {
     this.metaService.updateTag({ property: 'og:image:height', content: '500' });
   }
 
-  /// signal that the unfurler should wait for a 'ready' signal before taking a screenshot
-  setPreviewLoading() {
-    this.metaService.updateTag({ property: 'og:loading', content: 'loading'});
+  /// register an event that needs to resolve before we can take a screenshot
+  waitFor(event) {
+    if (!this.previewLoadingEvents[event]) {
+      this.previewLoadingEvents[event] = 1;
+      this.previewLoadingCount++;
+    } else {
+      this.previewLoadingEvents[event]++;
+    }
+    this.metaService.updateTag({ property: 'og:preview:loading', content: 'loading'});
   }
 
-  // signal to the unfurler that the page is ready for a screenshot
-  setPreviewReady() {
-    this.metaService.updateTag({ property: 'og:ready', content: 'ready'});
+  // signal that an event has resolved
+  // if all registered events have resolved, signal we are ready for a screenshot
+  waitOver(event) {
+    if (this.previewLoadingEvents[event]) {
+      this.previewLoadingEvents[event]--;
+      if (this.previewLoadingEvents[event] === 0) {
+        delete this.previewLoadingEvents[event]
+        this.previewLoadingCount--;
+      }
+    }
+    if (this.previewLoadingCount === 0) {
+      this.metaService.updateTag({ property: 'og:preview:ready', content: 'ready'});
+    }
+  }
+
+  resetLoading() {
+    this.previewLoadingEvents = {};
+    this.previewLoadingCount = 0;
+    this.metaService.removeTag("property='og:preview:loading'");
+    this.metaService.removeTag("property='og:preview:ready'");
+    this.metaService.removeTag("property='og:meta:ready'");
+  }
+
+  loadPage(path) {
+    this.resetLoading();
+    this.ngZone.run(() => {
+      this.router.navigateByUrl(path);
+    })
   }
 }

--- a/frontend/src/app/services/opengraph.service.ts
+++ b/frontend/src/app/services/opengraph.service.ts
@@ -93,11 +93,18 @@ export class OpenGraphService {
     }
   }
 
+  fail(event) {
+    if (this.previewLoadingEvents[event]) {
+      this.metaService.updateTag({ property: 'og:preview:fail', content: 'fail'});
+    }
+  }
+
   resetLoading() {
     this.previewLoadingEvents = {};
     this.previewLoadingCount = 0;
     this.metaService.removeTag("property='og:preview:loading'");
     this.metaService.removeTag("property='og:preview:ready'");
+    this.metaService.removeTag("property='og:preview:fail'");
     this.metaService.removeTag("property='og:meta:ready'");
   }
 

--- a/frontend/src/app/services/opengraph.service.ts
+++ b/frontend/src/app/services/opengraph.service.ts
@@ -76,7 +76,7 @@ export class OpenGraphService {
     this.metaService.updateTag({ property: 'og:preview:loading', content: 'loading'});
   }
 
-  // signal that an event has resolved
+  // mark an event as resolved
   // if all registered events have resolved, signal we are ready for a screenshot
   waitOver(event) {
     if (this.previewLoadingEvents[event]) {
@@ -100,9 +100,11 @@ export class OpenGraphService {
   }
 
   loadPage(path) {
-    this.resetLoading();
-    this.ngZone.run(() => {
-      this.router.navigateByUrl(path);
-    })
+    if (path !== this.router.url) {
+      this.resetLoading();
+      this.ngZone.run(() => {
+        this.router.navigateByUrl(path);
+      })
+    }
   }
 }

--- a/frontend/src/app/services/seo.service.ts
+++ b/frontend/src/app/services/seo.service.ts
@@ -21,12 +21,14 @@ export class SeoService {
     this.titleService.setTitle(newTitle + ' - ' + this.getTitle());
     this.metaService.updateTag({ property: 'og:title', content: newTitle});
     this.metaService.updateTag({ property: 'twitter:title', content: newTitle});
+    this.metaService.updateTag({ property: 'og:meta:ready', content: 'ready'});
   }
 
   resetTitle(): void {
     this.titleService.setTitle(this.getTitle());
     this.metaService.updateTag({ property: 'og:title', content: this.getTitle()});
     this.metaService.updateTag({ property: 'twitter:title', content: this.getTitle()});
+    this.metaService.updateTag({ property: 'og:meta:ready', content: 'ready'});
   }
 
   setEnterpriseTitle(title: string) {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -88,8 +88,8 @@ body {
 }
 
 .preview-box {
-  min-height: 512px;
-  padding: 2rem 3rem;
+  min-height: 520px;
+  padding: 1.5rem 3rem;
 }
 
 @media (max-width: 767.98px) {

--- a/unfurler/config.sample.json
+++ b/unfurler/config.sample.json
@@ -5,11 +5,13 @@
   },
   "MEMPOOL": {
     "HTTP_HOST": "http://localhost",
-    "HTTP_PORT": 4200
+    "HTTP_PORT": 4200,
+    "NETWORK": "bitcoin" // "bitcoin" | "liquid" | "bisq" (optional - defaults to "bitcoin")
   },
   "PUPPETEER": {
     "CLUSTER_SIZE": 2,
     "EXEC_PATH": "/usr/local/bin/chrome", // optional
-    "MAX_PAGE_AGE": 86400 // maximum lifetime of a page session (in seconds)
+    "MAX_PAGE_AGE": 86400, // maximum lifetime of a page session (in seconds)
+    "RENDER_TIMEOUT": 3000, // timeout for preview image rendering (in ms) (optional)
   }
 }

--- a/unfurler/config.sample.json
+++ b/unfurler/config.sample.json
@@ -9,6 +9,7 @@
   },
   "PUPPETEER": {
     "CLUSTER_SIZE": 2,
-    "EXEC_PATH": "/usr/local/bin/chrome" // optional
+    "EXEC_PATH": "/usr/local/bin/chrome", // optional
+    "MAX_PAGE_AGE": 86400 // maximum lifetime of a page session (in seconds)
   }
 }

--- a/unfurler/package.json
+++ b/unfurler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mempool-unfurl",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Renderer for mempool open graph link preview images",
   "repository": {
     "type": "git",

--- a/unfurler/puppeteer.config.json
+++ b/unfurler/puppeteer.config.json
@@ -1,11 +1,11 @@
 {
   "headless": true,
   "defaultViewport": {
-    "width": 1024,
-    "height": 512
+    "width": 1200,
+    "height": 600
   },
   "args": [
-    "--window-size=1024,512",
+    "--window-size=1200,600",
     "--autoplay-policy=user-gesture-required",
     "--disable-background-networking",
     "--disable-background-timer-throttling",

--- a/unfurler/src/concurrency/ReusablePage.ts
+++ b/unfurler/src/concurrency/ReusablePage.ts
@@ -1,0 +1,119 @@
+import * as puppeteer from 'puppeteer';
+import ConcurrencyImplementation, { ResourceData } from 'puppeteer-cluster/dist/concurrency/ConcurrencyImplementation';
+import { timeoutExecute } from 'puppeteer-cluster/dist/util';
+
+import config from '../config';
+const mempoolHost = config.MEMPOOL.HTTP_HOST + (config.MEMPOOL.HTTP_PORT ? ':' + config.MEMPOOL.HTTP_PORT : '');
+
+const BROWSER_TIMEOUT = 5000;
+// maximum lifetime of a single page session
+const maxAgeMs = (config.PUPPETEER.MAX_PAGE_AGE || (24 * 60 * 60)) * 1000;
+
+interface repairablePage extends puppeteer.Page {
+  repairRequested?: boolean;
+}
+
+export default class ReusablePage extends ConcurrencyImplementation {
+
+  protected browser: puppeteer.Browser | null = null;
+  protected currentPage: repairablePage | null = null;
+  protected pageCreatedAt: number = 0;
+  private repairing: boolean = false;
+  private repairRequested: boolean = false;
+  private openInstances: number = 0;
+  private waitingForRepairResolvers: (() => void)[] = [];
+
+  public constructor(options: puppeteer.LaunchOptions, puppeteer: any) {
+    super(options, puppeteer);
+  }
+
+  private async repair() {
+    if (this.openInstances !== 0 || this.repairing) {
+      // already repairing or there are still pages open? wait for start/finish
+      await new Promise<void>(resolve => this.waitingForRepairResolvers.push(resolve));
+      return;
+    }
+
+    this.repairing = true;
+    console.log('Starting repair');
+
+    try {
+      // will probably fail, but just in case the repair was not necessary
+      await (<puppeteer.Browser>this.browser).close();
+    } catch (e) {
+      console.log('Unable to close browser.');
+    }
+
+    try {
+      this.browser = await this.puppeteer.launch(this.options) as puppeteer.Browser;
+    } catch (err) {
+      throw new Error('Unable to restart chrome.');
+    }
+    this.currentPage = null;
+    this.repairRequested = false;
+    this.repairing = false;
+    this.waitingForRepairResolvers.forEach(resolve => resolve());
+    this.waitingForRepairResolvers = [];
+    await this.createResources();
+  }
+
+  public async init() {
+    this.browser = await this.puppeteer.launch(this.options);
+  }
+
+  public async close() {
+    await (this.browser as puppeteer.Browser).close();
+  }
+
+  protected async createResources(): Promise<ResourceData> {
+    if (!this.currentPage) {
+      this.currentPage = await (this.browser as puppeteer.Browser).newPage();
+      this.pageCreatedAt = Date.now();
+      const defaultUrl = mempoolHost + '/preview/block/1';
+      this.currentPage.on('pageerror', (err) => {
+        this.repairRequested = true;
+      });
+      await this.currentPage.goto(defaultUrl, { waitUntil: "load" });
+    }
+    return {
+      page: this.currentPage
+    }
+  }
+
+  public async workerInstance() {
+    let resources: ResourceData;
+
+    return {
+      jobInstance: async () => {
+        if (this.repairRequested || this.currentPage?.repairRequested) {
+          await this.repair();
+        }
+
+        await timeoutExecute(BROWSER_TIMEOUT, (async () => {
+          resources = await this.createResources();
+        })());
+        this.openInstances += 1;
+
+        return {
+          resources,
+
+          close: async () => {
+            this.openInstances -= 1; // decrement first in case of error
+
+            if (this.repairRequested || this.currentPage?.repairRequested || (Date.now() - this.pageCreatedAt > maxAgeMs)) {
+              await this.repair();
+            }
+          },
+        };
+      },
+
+      close: async () => {},
+
+      repair: async () => {
+        console.log('Repair requested');
+        this.repairRequested = true;
+        await this.repair();
+      },
+    };
+  }
+}

--- a/unfurler/src/config.ts
+++ b/unfurler/src/config.ts
@@ -8,11 +8,13 @@ interface IConfig {
   MEMPOOL: {
     HTTP_HOST: string;
     HTTP_PORT: number;
+    NETWORK?: string;
   };
   PUPPETEER: {
     CLUSTER_SIZE: number;
     EXEC_PATH?: string;
     MAX_PAGE_AGE?: number;
+    RENDER_TIMEOUT?: number;
   };
 }
 

--- a/unfurler/src/config.ts
+++ b/unfurler/src/config.ts
@@ -12,6 +12,7 @@ interface IConfig {
   PUPPETEER: {
     CLUSTER_SIZE: number;
     EXEC_PATH?: string;
+    MAX_PAGE_AGE?: number;
   };
 }
 

--- a/unfurler/src/index.ts
+++ b/unfurler/src/index.ts
@@ -51,8 +51,6 @@ class Server {
     this.server.listen(config.SERVER.HTTP_PORT, () => {
       console.log(`Mempool Unfurl Server is running on port ${config.SERVER.HTTP_PORT}`);
     });
-
-    this.initClusterPages();
   }
 
   async stopServer() {
@@ -70,16 +68,7 @@ class Server {
     this.app.get('*', (req, res) => { return this.renderHTML(req, res) })
   }
 
-  async initClusterPages() {
-    for (let i = 0; i < config.PUPPETEER.CLUSTER_SIZE; i++) {
-      this.cluster?.execute({ action: 'init' });
-    }
-  }
-
   async clusterTask({ page, data: { url, path, action } }) {
-    if (action === 'init') {
-      return;
-    }
     try {
       const urlParts = parseLanguageUrl(path);
       if (page.language !== urlParts.lang) {

--- a/unfurler/src/index.ts
+++ b/unfurler/src/index.ts
@@ -48,6 +48,16 @@ class Server {
     });
   }
 
+  async stopServer() {
+    if (this.cluster) {
+      await this.cluster.idle();
+      await this.cluster.close();
+    }
+    if (this.server) {
+      await this.server.close();
+    }
+  }
+
   setUpRoutes() {
     this.app.get('/render*', async (req, res) => { return this.renderPreview(req, res) })
     this.app.get('*', (req, res) => { return this.renderHTML(req, res) })
@@ -133,3 +143,9 @@ class Server {
 }
 
 const server = new Server();
+
+process.on('SIGTERM', async () => {
+  console.info('Shutting down Mempool Unfurl Server');
+  await server.stopServer();
+  process.exit(0);
+});

--- a/unfurler/src/index.ts
+++ b/unfurler/src/index.ts
@@ -193,11 +193,11 @@ class Server {
   getDefaultImageUrl() {
     switch (this.network) {
       case 'liquid':
-        return '/resources/liquid/liquid-network-preview.png';
+        return this.mempoolHost + '/resources/liquid/liquid-network-preview.png';
       case 'bisq':
-        return '/resources/bisq/bisq-markets-preview.png';
+        return this.mempoolHost + '/resources/bisq/bisq-markets-preview.png';
       default:
-        return '/resources/mempool-space-preview.png';
+        return this.mempoolHost + '/resources/mempool-space-preview.png';
     }
   }
 }

--- a/unfurler/src/language/lang.ts
+++ b/unfurler/src/language/lang.ts
@@ -1,0 +1,79 @@
+export interface Language {
+  code: string;
+  name: string;
+}
+
+const languageList: Language[] = [
+  { code: 'ar', name: 'العربية' },         // Arabic
+  { code: 'bg', name: 'Български' },       // Bulgarian
+  { code: 'bs', name: 'Bosanski' },        // Bosnian
+  { code: 'ca', name: 'Català' },          // Catalan
+  { code: 'cs', name: 'Čeština' },         // Czech
+  { code: 'da', name: 'Dansk' },           // Danish
+  { code: 'de', name: 'Deutsch' },         // German
+  { code: 'et', name: 'Eesti' },           // Estonian
+  { code: 'el', name: 'Ελληνικά' },        // Greek
+  { code: 'en', name: 'English' },         // English
+  { code: 'es', name: 'Español' },         // Spanish
+  { code: 'eo', name: 'Esperanto' },       // Esperanto
+  { code: 'eu', name: 'Euskara' },         // Basque
+  { code: 'fa', name: 'فارسی' },           // Persian
+  { code: 'fr', name: 'Français' },        // French
+  { code: 'gl', name: 'Galego' },          // Galician
+  { code: 'ko', name: '한국어' },          // Korean
+  { code: 'hr', name: 'Hrvatski' },        // Croatian
+  { code: 'id', name: 'Bahasa Indonesia' },// Indonesian
+  { code: 'hi', name: 'हिन्दी' },             // Hindi
+  { code: 'it', name: 'Italiano' },        // Italian
+  { code: 'he', name: 'עברית' },           // Hebrew
+  { code: 'ka', name: 'ქართული' },         // Georgian
+  { code: 'lv', name: 'Latviešu' },        // Latvian
+  { code: 'lt', name: 'Lietuvių' },        // Lithuanian
+  { code: 'hu', name: 'Magyar' },          // Hungarian
+  { code: 'mk', name: 'Македонски' },      // Macedonian
+  { code: 'ms', name: 'Bahasa Melayu' },   // Malay
+  { code: 'nl', name: 'Nederlands' },      // Dutch
+  { code: 'ja', name: '日本語' },          // Japanese
+  { code: 'nb', name: 'Norsk' },           // Norwegian Bokmål
+  { code: 'nn', name: 'Norsk Nynorsk' },   // Norwegian Nynorsk
+  { code: 'pl', name: 'Polski' },          // Polish
+  { code: 'pt', name: 'Português' },       // Portuguese
+  { code: 'pt-BR', name: 'Português (Brazil)' }, // Portuguese (Brazil)
+  { code: 'ro', name: 'Română' },          // Romanian
+  { code: 'ru', name: 'Русский' },         // Russian
+  { code: 'sk', name: 'Slovenčina' },      // Slovak
+  { code: 'sl', name: 'Slovenščina' },     // Slovenian
+  { code: 'sr', name: 'Српски / srpski' }, // Serbian
+  { code: 'sh', name: 'Srpskohrvatski / српскохрватски' },// Serbo-Croatian
+  { code: 'fi', name: 'Suomi' },           // Finnish
+  { code: 'sv', name: 'Svenska' },         // Swedish
+  { code: 'th', name: 'ไทย' },             // Thai
+  { code: 'tr', name: 'Türkçe' },          // Turkish
+  { code: 'uk', name: 'Українська' },      // Ukrainian
+  { code: 'vi', name: 'Tiếng Việt' },      // Vietnamese
+  { code: 'zh', name: '中文' },            // Chinese
+];
+
+const languageDict = {};
+languageList.forEach(lang => {
+  languageDict[lang.code] = lang
+});
+export const languages = languageDict;
+
+// expects path to start with a leading '/'
+export function parseLanguageUrl(path) {
+  const parts = path.split('/');
+  let lang;
+  let rest;
+  if (languages[parts[1]]) {
+    lang = parts[1];
+    rest = '/' + parts.slice(2).join('/');
+  } else {
+    lang = null;
+    rest = path;
+  }
+  if (lang === 'en') {
+    lang = null;
+  }
+  return { lang, path: rest };
+}


### PR DESCRIPTION
This PR reworks the unfurler implementation to improve response times (now <250ms on my machine), and also tweaks the preview image layouts & size:

![555555](https://user-images.githubusercontent.com/83316221/182648713-27e103b0-ddfb-4ea5-87f7-44ca42b73b55.png)

### Implementation

#### Preview images

The preview image rendering process now reuses puppeteer chrome pages instead of spinning up a new page for each request, preloads mempool.space, and avoids reloading the page between screenshots when possible.

Frontend preview pages now explicitly signal screenshot readiness, so the unfurler can take a screenshot as soon as possible instead of relying on heuristics.

#### Meta tags

Switches back to simple templating for serving html meta tags, eliminating all of the puppeteer-related overhead for these requests.

Unlike server-side rendering in puppeteer, this approach doesn't provide automatic localization of open graph link titles and descriptions, but it's much faster and preview images do remain localized:

| ![block-localization](https://user-images.githubusercontent.com/83316221/182661828-b2c96def-64db-4b89-a446-3c5803e8336e.png) | ![address-localization](https://user-images.githubusercontent.com/83316221/182661847-1e601cf0-83ea-48c0-b354-e2e2ade09ec3.png) |
|-|-|

### Config

This PR adds a few new optional variables to `unfurler/config.json`:

`MEMPOOL.NETWORK`: either "bitcoin", "liquid" or "bisq" - used to customize the open graph titles & descriptions and choose an appropriate fallback image.

`PUPPETEER.MAX_PAGE_AGE`: the maximum time in seconds that a puppeteer instance can reuse a mempool.space session before loading a fresh page.

`PUPPETEER.RENDER_TIMEOUT` maximum time in milliseconds to wait before abandoning an attempt to render an image preview.