### PR TITLE
Fix CLN channel short_id conversion

### DIFF
--- a/backend/src/api/lightning/clightning/clightning-convert.ts
+++ b/backend/src/api/lightning/clightning/clightning-convert.ts
@@ -71,8 +71,11 @@ export async function convertAndmergeBidirectionalChannels(clChannels: any[]): P
 }
 
 export function convertChannelId(channelId): string {
-  const s = channelId.split('x').map(part => parseInt(part));
-  return BigInt((s[0] << 40) | (s[1] << 16) | s[2]).toString();
+  if (channelId.indexOf('/') !== -1) {
+    channelId = channelId.slice(0, -2);
+  }
+  const s = channelId.split('x').map(part => BigInt(part));
+  return ((s[0] << 40n) | (s[1] << 16n) | s[2]).toString();
 }
 
 /**

--- a/backend/src/tasks/lightning/network-sync.service.ts
+++ b/backend/src/tasks/lightning/network-sync.service.ts
@@ -430,10 +430,13 @@ class NetworkSyncService {
   }
 
   private toIntegerId(id: string): string {
-    if (config.LIGHTNING.BACKEND === 'lnd') {
+    if (config.LIGHTNING.BACKEND === 'cln') {
+      return convertChannelId(id);
+    }
+    else if (config.LIGHTNING.BACKEND === 'lnd') {
       return id;
     }
-    return convertChannelId(id);
+    return '';
   }
 
   /** Decodes a channel id returned by lnd as uint64 to a short channel id */


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2249

I directly imported source code from 2 repositories. There were originally backend 3rd party deps before https://github.com/mempool/mempool/pull/2221 got merged
* https://github.com/alexbosworth/bolt07/blob/master/ids/encode_chan_id.js

You should now be able to switch between `cln` and `lnd` backend smoothly without having to truncate the channels table.

**NOTE: You need to truncate your `channels` table because it may contains duplicated channels due to this bug, leading to inconsistent results between nodes per isp/country lists and node pages.**