### PR TITLE
Update latest stats every 10 minutes

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -70,7 +70,7 @@ class NodesApi {
       const latestDate = rows[0].maxAdded;
 
       const query = `
-        SELECT nodes.public_key, nodes.alias, node_stats.capacity, node_stats.channels
+        SELECT nodes.public_key, IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias, node_stats.capacity, node_stats.channels
         FROM node_stats
         JOIN nodes ON nodes.public_key = node_stats.public_key
         WHERE added = FROM_UNIXTIME(${latestDate})
@@ -92,7 +92,7 @@ class NodesApi {
       const latestDate = rows[0].maxAdded;
 
       const query = `
-        SELECT nodes.public_key, nodes.alias, node_stats.capacity, node_stats.channels
+        SELECT nodes.public_key, IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias, node_stats.capacity, node_stats.channels
         FROM node_stats
         JOIN nodes ON nodes.public_key = node_stats.public_key
         WHERE added = FROM_UNIXTIME(${latestDate})

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -32,6 +32,7 @@ interface IConfig {
     ENABLED: boolean;
     BACKEND: 'lnd' | 'cln' | 'ldk';
     TOPOLOGY_FOLDER: string;
+    NODE_STATS_REFRESH_INTERVAL: number;
   };
   LND: {
     TLS_CERT_PATH: string;
@@ -183,6 +184,7 @@ const defaults: IConfig = {
     'ENABLED': false,
     'BACKEND': 'lnd',
     'TOPOLOGY_FOLDER': '',
+    'NODE_STATS_REFRESH_INTERVAL': 600,
   },
   'LND': {
     'TLS_CERT_PATH': '',

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -2,25 +2,14 @@ import DB from '../../database';
 import logger from '../../logger';
 import lightningApi from '../../api/lightning/lightning-api-factory';
 import LightningStatsImporter from './sync-tasks/stats-importer';
+import config from '../../config';
 
 class LightningStatsUpdater {
-  hardCodedStartTime = '2018-01-12';
-
   public async $startService(): Promise<void> {
     logger.info('Starting Lightning Stats service');
 
-    LightningStatsImporter.$run();
-    
-    setTimeout(() => {
-      this.$runTasks();
-    }, this.timeUntilMidnight());
-  }
-
-  private timeUntilMidnight(): number {
-    const date = new Date();
-    this.setDateMidnight(date);
-    date.setUTCHours(24);
-    return date.getTime() - new Date().getTime();
+    // LightningStatsImporter.$run();
+    this.$runTasks();
   }
 
   private setDateMidnight(date: Date): void {
@@ -35,20 +24,18 @@ class LightningStatsUpdater {
 
     setTimeout(() => {
       this.$runTasks();
-    }, this.timeUntilMidnight());
+    }, 1000 * config.LIGHTNING.NODE_STATS_REFRESH_INTERVAL);
   }
 
+  /**
+   * Update the latest entry for each node every config.LIGHTNING.NODE_STATS_REFRESH_INTERVAL seconds
+   */
   private async $logStatsDaily(): Promise<void> {
     const date = new Date();
     this.setDateMidnight(date);
     date.setUTCHours(24);
 
-    const [rows] = await DB.query(`SELECT UNIX_TIMESTAMP(MAX(added)) as lastAdded from lightning_stats`);
-    if ((rows[0].lastAdded ?? 0) === date.getTime() / 1000) {
-      return;
-    }
-
-    logger.info(`Running lightning daily stats log...`);
+    logger.info(`Updating latest node stats`);
     const networkGraph = await lightningApi.$getNetworkGraph();
     LightningStatsImporter.computeNetworkStats(date.getTime() / 1000, networkGraph);
   }


### PR DESCRIPTION
**Depends on https://github.com/mempool/mempool/pull/2244**

Refresh the stats (network + nodes) every 10 minutes (by querying the network graph) and update the current day entries. When a new day starts, we create a new entry and update it for the next 24h, etc...

This will allow to display more up to date stats on the dashboard and in node lists while keeping the table size not to massive.