### PR TITLE
Make sure lightning stats are not duplicated in db

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 34;
+  private static currentVersion = 35;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -314,6 +314,11 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 34 && isBitcoin == true) {
       await this.$executeQuery('ALTER TABLE `lightning_stats` ADD clearnet_tor_nodes int(11) NOT NULL DEFAULT "0"');
+    }
+
+    if (databaseSchemaVersion < 35 && isBitcoin == true) {
+      await this.$executeQuery('DELETE from `lightning_stats` WHERE added > "2021-09-19"');
+      await this.$executeQuery('ALTER TABLE `lightning_stats` ADD CONSTRAINT added_unique UNIQUE (added);');
     }
   }
 

--- a/backend/src/tasks/lightning/stats-updater.service.ts
+++ b/backend/src/tasks/lightning/stats-updater.service.ts
@@ -8,8 +8,8 @@ class LightningStatsUpdater {
   public async $startService(): Promise<void> {
     logger.info('Starting Lightning Stats service');
 
-    // LightningStatsImporter.$run();
-    this.$runTasks();
+    await this.$runTasks();
+    LightningStatsImporter.$run();
   }
 
   private setDateMidnight(date: Date): void {
@@ -35,7 +35,7 @@ class LightningStatsUpdater {
     this.setDateMidnight(date);
     date.setUTCHours(24);
 
-    logger.info(`Updating latest node stats`);
+    logger.info(`Updating latest networks stats`);
     const networkGraph = await lightningApi.$getNetworkGraph();
     LightningStatsImporter.computeNetworkStats(date.getTime() / 1000, networkGraph);
   }


### PR DESCRIPTION
DB migration 35

Make sure `lightning_stats` does not contain duplicated entries.
Also re-enabled the stats importer mistakenly disabled in https://github.com/mempool/mempool/pull/2255/files#diff-255243b45526bd8c0838fb9c6e4d51b658cc67293348fcefdc6b077945013746R11 lol