### PR TITLE
Disable country highlight - Update node styling

### DIFF
--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
@@ -146,7 +146,7 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
         center: this.center,
         zoom: this.zoom,
         tooltip: {
-          show: true
+          show: false
         },
         map: 'world',
         roam: this.style === 'widget' ? false : true,
@@ -157,6 +157,9 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
         scaleLimit: {
           min: 1.3,
           max: 100000,
+        },
+        emphasis: {
+          disabled: true,
         }
       },
       series: [
@@ -169,6 +172,7 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
           geoIndex: 0,
           symbolSize: 4,
           tooltip: {
+            show: true,
             backgroundColor: 'rgba(17, 19, 31, 1)',
             borderRadius: 4,
             shadowColor: 'rgba(0, 0, 0, 0.5)',
@@ -185,12 +189,12 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
           },
           itemStyle: {
             color: 'white',
-            borderColor: 'black',
-            borderWidth: 2,
             opacity: 1,
+            borderColor: 'black',
+            borderWidth: 0,
           },
           blendMode: 'lighter',
-          zlevel: 1,
+          zlevel: 2,
         },
         {
           large: true,
@@ -209,7 +213,7 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
           tooltip: {
             show: false,
           },
-          zlevel: 2,
+          zlevel: 1,
         }
       ]
     };
@@ -250,12 +254,19 @@ export class NodesChannelsMap implements OnInit, OnDestroy {
         series: this.chartOptions.series
       };
 
+      let nodeBorder = 0;
+      if (this.chartInstance.getOption().geo[0].zoom > 5000) {
+        nodeBorder = 2;
+      }
+
+      chartOptions.series[0].itemStyle.borderWidth = nodeBorder;
+      chartOptions.series[0].symbolSize += e.zoom > 1 ? speed * 15 : -speed * 15;
+      chartOptions.series[0].symbolSize = Math.max(4, Math.min(7, chartOptions.series[0].symbolSize));
+
       chartOptions.series[1].lineStyle.opacity += e.zoom > 1 ? speed : -speed;
       chartOptions.series[1].lineStyle.width += e.zoom > 1 ? speed : -speed;
-      chartOptions.series[0].symbolSize += e.zoom > 1 ? speed * 10 : -speed * 10;
       chartOptions.series[1].lineStyle.opacity = Math.max(0.05, Math.min(0.5, chartOptions.series[1].lineStyle.opacity));
       chartOptions.series[1].lineStyle.width = Math.max(0.5, Math.min(1, chartOptions.series[1].lineStyle.width));
-      chartOptions.series[0].symbolSize = Math.max(4, Math.min(5.5, chartOptions.series[0].symbolSize));
 
       this.chartInstance.setOption(chartOptions);
     });


### PR DESCRIPTION
Make sure no country is highlighted in the channel map (I could not reproduce)
Update node styling

#### Fixes(tm)
![image](https://user-images.githubusercontent.com/9780671/183930742-e4780d5e-e92c-43a2-a93d-c8180fc471b9.png)

#### Show nodes in the front instead of the back

Master

<img width="1312" alt="Screen Shot 2022-08-10 at 4 43 53 PM" src="https://user-images.githubusercontent.com/9780671/183931644-a1d8acdc-ddb3-4c84-8eb8-a79d5e50974a.png">

PR

<img width="1312" alt="Screen Shot 2022-08-10 at 4 43 58 PM" src="https://user-images.githubusercontent.com/9780671/183931676-927dbded-7639-43f3-872c-fc6b1162c563.png">

