### PR TITLE
Fix difficulty adjustment

### DIFF
--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -47,8 +47,8 @@ class DifficultyAdjustmentApi {
     }
 
     const timeAvg = timeAvgMins * 60 * 1000 ;
-    const remainingTime = (remainingBlocks * timeAvg) + (now * 1000);
-    const estimatedRetargetDate = remainingTime + now;
+    const remainingTime = remainingBlocks * timeAvg;
+    const estimatedRetargetDate = remainingTime + now * 1000;
 
     return {
       progressPercent,

--- a/contributors/junderw.txt
+++ b/contributors/junderw.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of August 19, 2022.
+
+Signed: junderw


### PR DESCRIPTION
This fixes remaining time and estimated retarged date.
Just moving `now * 1000` from line 50 to 51 where it should be.

I'm not going to create the contribution file nor am I going to sign the commits because I don't use it atm.
If you want this fix, take it. If you don't, just close it.