### PR TITLE
Refactor ISP pie chart to make it more consitent

### DIFF
--- a/backend/src/api/explorer/nodes.routes.ts
+++ b/backend/src/api/explorer/nodes.routes.ts
@@ -71,15 +71,7 @@ class NodesRoutes {
 
   private async $getISPRanking(req: Request, res: Response): Promise<void> {
     try {
-      const groupBy = req.query.groupBy as string;
-      const showTor = req.query.showTor as string === 'true' ? true : false;
-
-      if (!['capacity', 'node-count'].includes(groupBy)) {
-        res.status(400).send(`groupBy must be one of 'capacity' or 'node-count'`);
-        return;
-      }
-
-      const nodesPerAs = await nodesApi.$getNodesISPRanking(groupBy, showTor);
+      const nodesPerAs = await nodesApi.$getNodesISPRanking();
 
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.html
@@ -3,21 +3,24 @@
   <div *ngIf="widget">
     <div class="pool-distribution" *ngIf="(nodesPerAsObservable$ | async) as stats; else loadingReward">
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.tagged-isp">Tagged ISPs</h5>
-        <p class="card-text">
-          {{ stats.taggedISP }}
+        <h5 class="card-title d-inline-block" i18n="lightning.clearnet-capacity">Clearnet capacity</h5>
+        <p class="card-text" i18n-ngbTooltip="lightning.clearnet-capacity-desc"
+          ngbTooltip="How much liquidity is running on nodes advertising at least one clearnet IP address" placement="bottom">
+          <app-amount [satoshis]="stats.clearnetCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.tagged-nodes">Tagged nodes</h5>
-        <p class="card-text" i18n-ngbTooltip="mining.pools-count-desc">
-          {{ stats.taggedNodeCount }}
+        <h5 class="card-title d-inline-block">Unknown capacity</h5>
+        <p class="card-text" i18n-ngbTooltip="lightning.unknown-capacity-desc"
+        ngbTooltip="How much liquidity is running on nodes which ISP was not identifiable" placement="bottom">
+          <app-amount [satoshis]="stats.unknownCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.tagged-capacity">Tagged capacity</h5>
-        <p class="card-text" i18n-ngbTooltip="mining.blocks-count-desc">
-          <app-amount [satoshis]="stats.taggedCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
+        <h5 class="card-title d-inline-block">Tor capacity</h5>
+        <p class="card-text" i18n-ngbTooltip="lightning.tor-capacity-desc"
+        ngbTooltip="How much liquidity is running on nodes advertising only Tor addresses" placement="bottom">
+          <app-amount [satoshis]="stats.torCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
         </p>
       </div>
     </div>
@@ -25,13 +28,13 @@
 
   <div class="card-header" *ngIf="!widget">
     <div class="d-flex d-md-block align-items-baseline" style="margin-bottom: -5px">
-      <span i18n="lightning.nodes-per-isp">Lightning nodes per ISP</span>
+      <span i18n="lightning.top-100-isp-ln">Top 100 ISP hosting LN nodes</span>
       <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
         <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
       </button>
     </div>
     <small class="d-block" style="color: #ffffff66; min-height: 25px" i18n="lightning.tor-nodes-excluded">
-      <span *ngIf="!(showTorObservable$ | async)">(Tor nodes excluded)</span>
+      <span>(Tor nodes excluded)</span>
     </small>
   </div>
 
@@ -44,9 +47,8 @@
       <div class="spinner-border text-light"></div>
     </div>
 
-    <div class="d-flex toggle" *ngIf="!widget">
-      <app-toggle [textLeft]="'Show Tor'" [textRight]="" (toggleStatusChanged)="onTorToggleStatusChanged($event)"></app-toggle>
-      <app-toggle [textLeft]="'Nodes'" [textRight]="'Capacity'" (toggleStatusChanged)="onGroupToggleStatusChanged($event)"></app-toggle>
+    <div class="d-flex justify-content-md-end toggle" *ngIf="!widget">
+      <app-toggle [textLeft]="'Sort by nodes'" [textRight]="'capacity'" [checked]="true" (toggleStatusChanged)="onGroupToggleStatusChanged($event)"></app-toggle>
     </div>
 
     <table class="table table-borderless text-center m-auto" style="max-width: 900px"  *ngIf="!widget">
@@ -59,16 +61,15 @@
           <th class="capacity text-right pr-0" i18n="lightning.capacity">Capacity</th>
         </tr>
       </thead>
-      <tbody [attr.data-cy]="'pools-table'" *ngIf="(nodesPerAsObservable$ | async) as asList">
-        <tr *ngFor="let asEntry of asList.data">
-          <td class="rank text-left pl-0">{{ asEntry.rank }}</td>
+      <tbody [attr.data-cy]="'pools-table'" *ngIf="(nodesPerAsObservable$ | async) as result">
+        <tr *ngFor="let isp of result.ispRanking">
+          <td class="rank text-left pl-0">{{ isp[5] }}</td>
           <td class="name text-left text-truncate">
-            <a *ngIf="asEntry.ispId" [routerLink]="[('/lightning/nodes/isp/' + asEntry.ispId) | relativeUrl]">{{ asEntry.name }}</a>
-            <span *ngIf="!asEntry.ispId">{{ asEntry.name }}</span>
+            <a [routerLink]="[('/lightning/nodes/isp/' + isp[0]) | relativeUrl]">{{ isp[1] }}</a>
           </td>
-          <td class="share text-right">{{ asEntry.share }}%</td>
-          <td class="nodes text-right">{{ asEntry.count }}</td>
-          <td class="capacity text-right pr-0"><app-amount [satoshis]="asEntry.capacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount></td>
+          <td class="share text-right">{{ sortBy === 'capacity' ? isp[7] : isp[6] }}%</td>
+          <td class="nodes text-right">{{ isp[4] }}</td>
+          <td class="capacity text-right pr-0"><app-amount [satoshis]="isp[2]" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount></td>
         </tr>
       </tbody>
     </table>

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
@@ -149,7 +149,8 @@
 }
 
 .name {
-  width: 25%;
+  width: 35%;
+  max-width: 300px;
   @media (max-width: 576px) {
     width: 70%;
     max-width: 150px;
@@ -159,14 +160,14 @@
 }
 
 .share {
-  width: 20%;
+  width: 15%;
   @media (max-width: 576px) {
     display: none
   }
 }
 
 .nodes {
-  width: 20%;
+  width: 15%;
   @media (max-width: 576px) {
     width: 10%;
   }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -255,9 +255,8 @@ export class ApiService {
     return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/search', { params });
   }
 
-  getNodesPerAs(groupBy: 'capacity' | 'node-count', showTorNodes: boolean): Observable<any> {
-    return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/isp-ranking'
-      + `?groupBy=${groupBy}&showTor=${showTorNodes}`);
+  getNodesPerIsp(): Observable<any> {
+    return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/isp-ranking');
   }
 
   getNodeForCountry$(country: string): Observable<any> {

--- a/frontend/src/app/shared/components/toggle/toggle.component.html
+++ b/frontend/src/app/shared/components/toggle/toggle.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex align-items-center">
   <span style="margin-bottom: 0.5rem">{{ textLeft }}</span>&nbsp;
   <label class="switch">
-    <input type="checkbox" (change)="onToggleStatusChanged($event)">
+    <input type="checkbox" [checked]="checked" (change)="onToggleStatusChanged($event)">
     <span class="slider round"></span>
   </label>
   &nbsp;<span style="margin-bottom: 0.5rem">{{ textRight }}</span>

--- a/frontend/src/app/shared/components/toggle/toggle.component.ts
+++ b/frontend/src/app/shared/components/toggle/toggle.component.ts
@@ -10,6 +10,7 @@ export class ToggleComponent implements AfterViewInit {
   @Output() toggleStatusChanged = new EventEmitter<boolean>();
   @Input() textLeft: string;
   @Input() textRight: string;
+  @Input() checked: boolean = false;
 
   ngAfterViewInit(): void {
     this.toggleStatusChanged.emit(false);


### PR DESCRIPTION
In the LN dashboard, show on which dominant network the liquidity is (clearnet vs tor).
In the ISP chart, show ISP ranked by capacity by default.
Added tooltips.

<img width="561" alt="Screen Shot 2022-08-16 at 6 20 03 PM" src="https://user-images.githubusercontent.com/9780671/184929466-785c18a5-a14c-405c-9638-75b633ab2e71.png">
<img width="218" alt="Screen Shot 2022-08-16 at 6 39 41 PM" src="https://user-images.githubusercontent.com/9780671/184933016-137cfee1-9000-482c-a92c-4777496ba78b.png">
<img width="1496" alt="Screen Shot 2022-08-16 at 6 38 23 PM" src="https://user-images.githubusercontent.com/9780671/184932792-fb5f7e0c-6012-46f7-9477-1ddfddbf700a.png">
<img width="1496" alt="Screen Shot 2022-08-16 at 6 38 17 PM" src="https://user-images.githubusercontent.com/9780671/184932795-52083000-9d75-4842-875a-103288d92cf9.png">

