### PR TITLE
Refactor LN stats import

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,6 @@
         "bitcoinjs-lib": "6.0.2",
         "crypto-js": "^4.0.0",
         "express": "^4.18.0",
-        "fast-xml-parser": "^4.0.9",
         "maxmind": "^4.3.6",
         "mysql2": "2.3.3",
         "node-worker-threads-pool": "^1.5.1",
@@ -3136,21 +3135,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -5635,11 +5619,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8556,14 +8535,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
-      "requires": {
-        "strnum": "^1.0.5"
-      }
-    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -10397,11 +10368,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,6 @@
     "bitcoinjs-lib": "6.0.2",
     "crypto-js": "^4.0.0",
     "express": "^4.18.0",
-    "fast-xml-parser": "^4.0.9",
     "maxmind": "^4.3.6",
     "mysql2": "2.3.3",
     "node-worker-threads-pool": "^1.5.1",


### PR DESCRIPTION
Redo of https://github.com/mempool/mempool/pull/2261

This will avoid the spam on topology file opening everytime we restart as well. Trying to keep thing simple and smooth for now.
Before we deploy to prod I'll add a small piece of code that run after the import which cleans up the corrupted data (hardcoded query).

Fixes https://github.com/mempool/mempool/issues/2290
Fixes https://github.com/mempool/mempool/issues/2245

If we need to regenerate json files for the future historical import with updated backups, we'll use my patched topology script to do so and I will update the code to match the exported json format.