### PR TITLE
Hide features before feature activated

### DIFF
--- a/frontend/src/app/components/tx-features/tx-features.component.html
+++ b/frontend/src/app/components/tx-features/tx-features.component.html
@@ -1,3 +1,4 @@
+<ng-template [ngIf]="!tx.status.confirmed || tx.status.block_height >= 477120">
 <span *ngIf="segwitGains.realizedSegwitGains && !segwitGains.potentialSegwitGains; else segwitTwo" class="badge badge-success mr-1" i18n-ngbTooltip="ngbTooltip about segwit gains" ngbTooltip="This transaction saved {{ segwitGains.realizedSegwitGains * 100 | number:  '1.0-0' }}% on fees by using native SegWit" placement="bottom" i18n="tx-features.tag.segwit|SegWit">SegWit</span>
 <ng-template #segwitTwo>
   <span *ngIf="segwitGains.realizedSegwitGains && segwitGains.potentialSegwitGains; else potentialP2shSegwitGains" class="badge badge-warning mr-1" i18n-ngbTooltip="ngbTooltip about double segwit gains" ngbTooltip="This transaction saved {{ segwitGains.realizedSegwitGains * 100 | number:  '1.0-0' }}% on fees by using SegWit and could save {{ segwitGains.potentialSegwitGains * 100 | number : '1.0-0' }}% more by fully upgrading to native SegWit" placement="bottom" i18n="tx-features.tag.segwit|SegWit">SegWit</span>
@@ -5,7 +6,9 @@
     <span *ngIf="segwitGains.potentialP2shSegwitGains" class="badge badge-danger mr-1" i18n-ngbTooltip="ngbTooltip about missed out gains" ngbTooltip="This transaction could save {{ segwitGains.potentialSegwitGains * 100 | number : '1.0-0' }}% on fees by upgrading to native SegWit or {{ segwitGains.potentialP2shSegwitGains * 100 | number:  '1.0-0' }}% by upgrading to SegWit-P2SH" placement="bottom"><del i18n="tx-features.tag.segwit|SegWit">SegWit</del></span>
   </ng-template>
 </ng-template>
+</ng-template>
 
+<ng-template [ngIf]="!tx.status.confirmed || tx.status.block_height >= 709632">
 <span *ngIf="segwitGains.realizedTaprootGains && !segwitGains.potentialTaprootGains; else notFullyTaproot" class="badge badge-success mr-1" i18n-ngbTooltip="Tooltip about privacy and fees saved with taproot" ngbTooltip="This transaction uses Taproot and thereby increased the user's privacy and saved at least {{ segwitGains.realizedTaprootGains * 100 | number: '1.0-0' }}% on fees" placement="bottom" i18n="tx-features.tag.taproot|Taproot">Taproot</span>
 <ng-template #notFullyTaproot>
   <span *ngIf="segwitGains.realizedTaprootGains && segwitGains.potentialTaprootGains; else noTaproot" class="badge badge-warning mr-1" i18n-ngbTooltip="Tooltip about privacy and more fees that could be saved with more taproot" ngbTooltip="This transaction uses Taproot and thereby increased the user's privacy and already saved at least {{ segwitGains.realizedTaprootGains * 100 | number: '1.0-0' }}% on fees, but could save an additional {{ segwitGains.potentialTaprootGains * 100 | number: '1.0-0' }}% by fully using Taproot" placement="bottom" i18n="tx-features.tag.taproot|Taproot">Taproot</span>
@@ -16,6 +19,9 @@
     </ng-template>
   </ng-template>
 </ng-template>
+</ng-template>
 
+<ng-template [ngIf]="!tx.status.confirmed || tx.status.block_height > 399700">
 <span *ngIf="isRbfTransaction; else rbfDisabled" class="badge badge-success" i18n-ngbTooltip="RBF tooltip" ngbTooltip="This transaction supports Replace-By-Fee (RBF) allowing fee bumping" placement="bottom" i18n="tx-features.tag.rbf|RBF">RBF</span>
 <ng-template #rbfDisabled><span class="badge badge-danger mr-1" i18n-ngbTooltip="RBF disabled tooltip" ngbTooltip="This transaction does NOT support Replace-By-Fee (RBF) and cannot be fee bumped using this method" placement="bottom"><del i18n="tx-features.tag.rbf|RBF">RBF</del></span></ng-template>
+</ng-template>


### PR DESCRIPTION
Now hiding feature flags Taproot, Segwit and RBF on transactions before the feature was activated.

Taproot visible from activation block 709632
Segwit badges visible after activation block 477120
RBF was introduced in Bitcoin Core 0.12 February 23, 2016 so I picked the arbitrary block 399700.

Example:

Before taproot
<img width="405" alt="Screen Shot 2022-08-18 at 22 46 57" src="https://user-images.githubusercontent.com/8561090/185471102-4d7d4f04-c8b5-428e-a7cb-5add60fc927e.png">

Before segwit:
<img width="408" alt="Screen Shot 2022-08-18 at 22 47 11" src="https://user-images.githubusercontent.com/8561090/185471132-513e168a-9c70-41e8-b5ab-5458c6f572f9.png">

Before RBF (Downside is empty feature row)

<img width="408" alt="Screen Shot 2022-08-18 at 22 46 36" src="https://user-images.githubusercontent.com/8561090/185471188-04d9e9a9-49a1-4b74-a6f8-330894417515.png">

