### PR TITLE
If a channel is closed, stop updating it

### DIFF
--- a/backend/src/tasks/lightning/network-sync.service.ts
+++ b/backend/src/tasks/lightning/network-sync.service.ts
@@ -95,11 +95,19 @@ class NetworkSyncService {
    */
   private async $updateChannelsList(channels: ILightningApi.Channel[]): Promise<void> {
     try {
+      const [closedChannelsRaw]: any[] = await DB.query(`SELECT id FROM channels WHERE status = 2`);
+      const closedChannels = {};
+      for (const closedChannel of closedChannelsRaw) {
+        closedChannels[Common.channelShortIdToIntegerId(closedChannel.id)] = true;
+      }
+
       let progress = 0;
 
       const graphChannelsIds: string[] = [];
       for (const channel of channels) {
-        await channelsApi.$saveChannel(channel);
+        if (!closedChannels[channel.channel_id]) {
+          await channelsApi.$saveChannel(channel);
+        }
         graphChannelsIds.push(channel.channel_id);
         ++progress;
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2307

Currently, even if a channel is closed (funding tx has been spent), the channel may still exist in the network graph. Therefore its status will be reset to 1 'active' upon the network lightning graph sync.

This PR makes sure that when we tag a channel as closed, we stop updating it.