### PR TITLE
Remove useless api call in channel page

### DIFF
--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.ts
@@ -74,7 +74,7 @@ export class NodesChannelsMap implements OnInit {
        switchMap((params: ParamMap) => {
         return zip(
           this.assetsService.getWorldMapJson$,
-          this.apiService.getChannelsGeo$(params.get('public_key') ?? undefined),
+          this.style !== 'channelpage' ? this.apiService.getChannelsGeo$(params.get('public_key') ?? undefined) : [''],
           [params.get('public_key') ?? undefined]
         ).pipe(tap((data) => {
           registerMap('world', data[0]);


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2346

#### Testing

* Open the browser network debugger
* After deploying the PR, open any channel page, for example `/lightning/channel/818244458842292224`
* Confirm that there is not call to `/api/v1/lightning/channels-geo` anymore
* Page should load much faster now