### PR TITLE
Improve channels world map performances

### DIFF
--- a/backend/src/api/explorer/channels.api.ts
+++ b/backend/src/api/explorer/channels.api.ts
@@ -17,32 +17,60 @@ class ChannelsApi {
     }
   }
 
-  public async $getAllChannelsGeo(publicKey?: string): Promise<any[]> {
+  public async $getAllChannelsGeo(publicKey?: string, style?: string): Promise<any[]> {
     try {
+      let select: string;
+      if (style === 'widget') {
+        select = `
+          nodes_1.latitude AS node1_latitude, nodes_1.longitude AS node1_longitude,
+          nodes_2.latitude AS node2_latitude, nodes_2.longitude AS node2_longitude
+        `;
+      } else {
+        select = `
+          nodes_1.public_key as node1_public_key, nodes_1.alias AS node1_alias,
+          nodes_1.latitude AS node1_latitude, nodes_1.longitude AS node1_longitude,
+          nodes_2.public_key as node2_public_key, nodes_2.alias AS node2_alias,
+          nodes_2.latitude AS node2_latitude, nodes_2.longitude AS node2_longitude
+        `;
+      }
+
       const params: string[] = [];
-      let query = `SELECT nodes_1.public_key as node1_public_key, nodes_1.alias AS node1_alias,
-        nodes_1.latitude AS node1_latitude, nodes_1.longitude AS node1_longitude,
-        nodes_2.public_key as node2_public_key, nodes_2.alias AS node2_alias,
-        nodes_2.latitude AS node2_latitude, nodes_2.longitude AS node2_longitude,
-        channels.capacity
-      FROM channels
-      JOIN nodes AS nodes_1 on nodes_1.public_key = channels.node1_public_key
-      JOIN nodes AS nodes_2 on nodes_2.public_key = channels.node2_public_key
-      WHERE nodes_1.latitude IS NOT NULL AND nodes_1.longitude IS NOT NULL
-        AND nodes_2.latitude IS NOT NULL AND nodes_2.longitude IS NOT NULL
+      let query = `SELECT ${select}
+        FROM channels
+        JOIN nodes AS nodes_1 on nodes_1.public_key = channels.node1_public_key
+        JOIN nodes AS nodes_2 on nodes_2.public_key = channels.node2_public_key
+        WHERE nodes_1.latitude IS NOT NULL AND nodes_1.longitude IS NOT NULL
+          AND nodes_2.latitude IS NOT NULL AND nodes_2.longitude IS NOT NULL
       `;
 
       if (publicKey !== undefined) {
         query += ' AND (nodes_1.public_key = ? OR nodes_2.public_key = ?)';
         params.push(publicKey);
         params.push(publicKey);
+      } else {
+        query += ` AND channels.capacity > 1000000
+          GROUP BY nodes_1.public_key, nodes_2.public_key
+          ORDER BY channels.capacity DESC
+          LIMIT 10000
+        `;        
       }
 
       const [rows]: any = await DB.query(query, params);
-      return rows.map((row) => [
-        row.node1_public_key, row.node1_alias, row.node1_longitude, row.node1_latitude,
-        row.node2_public_key, row.node2_alias, row.node2_longitude, row.node2_latitude,
-        row.capacity]);
+      return rows.map((row) => {
+        if (style === 'widget') {
+          return [
+            row.node1_longitude, row.node1_latitude,
+            row.node2_longitude, row.node2_latitude,
+          ];
+        } else {
+          return [
+            row.node1_public_key, row.node1_alias,
+            row.node1_longitude, row.node1_latitude,
+            row.node2_public_key, row.node2_alias,
+            row.node2_longitude, row.node2_latitude,
+          ];
+        }
+      });
     } catch (e) {
       logger.err('$getAllChannelsGeo error: ' + (e instanceof Error ? e.message : e));
       throw e;

--- a/backend/src/api/explorer/channels.routes.ts
+++ b/backend/src/api/explorer/channels.routes.ts
@@ -102,7 +102,11 @@ class ChannelsRoutes {
 
   private async $getAllChannelsGeo(req: Request, res: Response) {
     try {
-      const channels = await channelsApi.$getAllChannelsGeo(req.params?.publicKey);
+      const style: string = typeof req.query.style === 'string' ? req.query.style : '';
+      const channels = await channelsApi.$getAllChannelsGeo(req.params?.publicKey, style);
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
       res.json(channels);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);

--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
@@ -8,7 +8,7 @@
         <small style="color: #ffffff66" i18n="lightning.tor-nodes-excluded">(Tor nodes excluded)</small>
       </div>
 
-      <div class="chart" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"
+      <div class="chart" [class]="style" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"
         (chartFinished)="onChartFinished($event)">
       </div>
     </div>

--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
@@ -1,16 +1,22 @@
-<div *ngIf="channelsObservable | async">
-  <div *ngIf="chartOptions" [class]="'full-container ' + style + (fitContainer ? ' fit-container' : '')">
-    <div *ngIf="style === 'graph'" class="card-header">
-      <div class="d-flex d-md-block align-items-baseline" style="margin-bottom: -5px">
-        <span i18n="lightning.nodes-channels-world-map">Lightning nodes channels world map</span>
+<div [style]="style === 'widget' ? 'height: 250px' : ''">
+  <div *ngIf="channelsObservable | async">
+    <div *ngIf="chartOptions" [class]="'full-container ' + style + (fitContainer ? ' fit-container' : '')">
+      <div *ngIf="style === 'graph'" class="card-header">
+        <div class="d-flex d-md-block align-items-baseline" style="margin-bottom: -5px">
+          <span i18n="lightning.nodes-channels-world-map">Lightning nodes channels world map</span>
+        </div>
+        <small style="color: #ffffff66" i18n="lightning.tor-nodes-excluded">(Tor nodes excluded)</small>
       </div>
-      <small style="color: #ffffff66" i18n="lightning.tor-nodes-excluded">(Tor nodes excluded)</small>
+
+      <div class="chart" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"
+        (chartFinished)="onChartFinished($event)">
+      </div>
     </div>
 
-    <div class="chart" echarts [initOpts]="chartInitOptions" [options]="chartOptions" (chartInit)="onChartInit($event)"
-      (chartFinished)="onChartFinished($event)">
-    </div>
+    <div *ngIf="!chartOptions && style === 'nodepage'" style="padding-top: 30px"></div>
   </div>
 
-  <div *ngIf="!chartOptions && style === 'nodepage'" style="padding-top: 30px"></div>
+  <div class="text-center loading-spinner" [class]="style" *ngIf="isLoading">
+    <div class="spinner-border text-light"></div>
+  </div>
 </div>

--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
@@ -10,7 +10,7 @@
 .full-container {
   padding: 0px 15px;
   width: 100%;
-  min-height: 500px;
+  min-height: 600px;
   height: calc(100% - 150px);
 
   @media (max-width: 992px) {
@@ -18,17 +18,20 @@
     padding-bottom: 100px;
   }
 }
-
 .full-container.nodepage {
+  min-height: 400px;
   margin-top: 25px;
   margin-bottom: 25px;
 }
-
+.full-container.channelpage {
+  min-height: 400px;
+  margin-top: 25px;
+  margin-bottom: 25px;
+}
 .full-container.widget {
   height: 250px;
   min-height: 250px;
 }
-
 .full-container.fit-container {
   margin: 0;
   padding: 0;
@@ -38,25 +41,6 @@
   .chart {
     padding: 0;
     min-height: 100px;
-  }
-}
-
-.widget {
-  width: 90vw;
-  margin-left: auto;
-  margin-right: auto;
-  height: 250px;
-  -webkit-mask: linear-gradient(0deg, #11131f00 5%, #11131fff 25%);
-  @media (max-width: 767.98px) {
-    width: 100vw;
-  }
-}
-
-.widget > .chart {
-  min-height: 250px;
-  -webkit-mask: linear-gradient(180deg, #11131f00 0%, #11131fff 20%);
-  @media (max-width: 767.98px) {
-    padding-bottom: 0px;
   }
 }
 
@@ -78,6 +62,33 @@
   }
   @media (max-width: 567px) {
     padding-bottom: 55px;
+  }
+}
+.chart.graph {
+  min-height: 600px;
+}
+.chart.nodepage {
+  min-height: 400px;
+}
+.chart.channelpage {
+  min-height: 400px;
+}
+
+.widget {
+  width: 90vw;
+  margin-left: auto;
+  margin-right: auto;
+  height: 250px;
+  -webkit-mask: linear-gradient(0deg, #11131f00 5%, #11131fff 25%);
+  @media (max-width: 767.98px) {
+    width: 100vw;
+  }
+}
+.widget > .chart {
+  min-height: 250px;
+  -webkit-mask: linear-gradient(180deg, #11131f00 0%, #11131fff 20%);
+  @media (max-width: 767.98px) {
+    padding-bottom: 0px;
   }
 }
 

--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
@@ -80,3 +80,20 @@
     padding-bottom: 55px;
   }
 }
+
+.loading-spinner {
+  position: absolute;
+  top: 50%;
+  left: calc(50% - 15px);
+  z-index: 100;
+}
+.loading-spinner.widget {
+  position: absolute;
+  top: 200px;
+  z-index: 100;
+  width: 100%;
+  left: 0;
+  @media (max-width: 767.98px) {
+    top: 250px;
+  }
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -271,10 +271,11 @@ export class ApiService {
     return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/nodes/countries');
   }
 
-  getChannelsGeo$(publicKey?: string): Observable<any> {
+  getChannelsGeo$(publicKey?: string, style?: 'graph' | 'nodepage' | 'widget' | 'channelpage'): Observable<any> {
     return this.httpClient.get<any[]>(
       this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/channels-geo' +
-        (publicKey !== undefined ? `/${publicKey}` : '')
+        (publicKey !== undefined ? `/${publicKey}`   : '') +
+        (style     !== undefined ? `?style=${style}` : '')
     );
   }
 }

--- a/production/nginx-cache-warmer
+++ b/production/nginx-cache-warmer
@@ -77,6 +77,8 @@ do for url in / \
 	'/api/v1/mining/difficulty-adjustments/2y' \
 	'/api/v1/mining/difficulty-adjustments/3y' \
 	'/api/v1/mining/difficulty-adjustments/all' \
+	'/api/v1/lightning/channels-geo?style=widget' \
+	'/api/v1/lightning/channels-geo?style=graph' \
 
 	do
 		curl -s "https://${hostname}${url}" >/dev/null


### PR DESCRIPTION
#### Changes

- Warm cache `/api/v1/lightning/channels-geo?style=widget`  and `/api/v1/lightning/channels-geo?style=graph`
- For the lightning dashboard, since the map is not interactive, don't send all public keys and alias
- Limit the number of channels returned by the API to the top 10,000 biggest channels
- Ignore multiple channels between the same nodes in the same direction
- Added loading spinner animation while the map is loading and rendering all channels. When all channels are done rendering we remove the loading spinner
- API response is cached for 1 minute in the web browser

#### Impact

- Previously the API response for the map in the LN dashboard was 10.27mb uncompressed (transferred 2.14mb). Now it is 986.56kb while testing locally (no compression).
- It is also more visually pleasing now that we don't render all channels

**Before**

https://user-images.githubusercontent.com/9780671/185927978-b7c778aa-4789-4488-a7c0-dbff0275bf40.mov

**After**

https://user-images.githubusercontent.com/9780671/185927985-b440c5cb-8a97-41f2-b4fa-d2e6e2215d88.mov

#### Testing

* After deploying the PR open a private tab
* Open the network debugger
* Load the mining dashboard and confirm the API response for `/api/v1/lightning/channels-geo` is much lighter than before
* Confirm that the dashboard loading time "feels" faster
