### PR TITLE
Fix network regex matching

### DIFF
--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -153,7 +153,7 @@ export class StateService {
     if (this.env.BASE_MODULE !== 'mempool' && this.env.BASE_MODULE !== 'liquid') {
       return;
     }
-    const networkMatches = url.match(/\/(bisq|testnet|liquidtestnet|liquid|signet)/);
+    const networkMatches = url.match(/^\/(bisq|testnet|liquidtestnet|liquid|signet)/);
     switch (networkMatches && networkMatches[1]) {
       case 'liquid':
         if (this.network !== 'liquid') {


### PR DESCRIPTION
This fixes the the bug in the URL network matching in the scenario of the name "liquid" for example appears later in the URL as in:

/lightning/nodes/rankings/**liquid**ity

Now matching from the root of the url only.

Make sure subnetworks still work like /testnet and /liquid