### PR TITLE
Fix lightning map heights on preview pages

### DIFF
--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.html
@@ -1,5 +1,5 @@
-<div [style]="style === 'widget' ? 'height: 250px' : ''">
-  <div *ngIf="channelsObservable | async">
+<div class="map-wrapper" [class]="style">
+  <ng-container *ngIf="channelsObservable | async">
     <div *ngIf="chartOptions" [class]="'full-container ' + style + (fitContainer ? ' fit-container' : '')">
       <div *ngIf="style === 'graph'" class="card-header">
         <div class="d-flex d-md-block align-items-baseline" style="margin-bottom: -5px">
@@ -18,5 +18,5 @@
     <div class="text-center loading-spinner" [class]="style" *ngIf="isLoading">
       <div class="spinner-border text-light"></div>
     </div>
-  </div>
+  </ng-container>
 </div>

--- a/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
+++ b/frontend/src/app/lightning/nodes-channels-map/nodes-channels-map.component.scss
@@ -1,3 +1,15 @@
+.map-wrapper {
+  height: 100%;
+
+  &.widget {
+    height: 250px;
+  }
+
+  &.graph {
+    height: auto;
+  }
+}
+
 .card-header {
   border-bottom: 0;
   font-size: 18px;


### PR DESCRIPTION
Fixes [broken map heights in node/channel unfurls](https://github.com/mempool/mempool/pull/2354#issuecomment-1223601772)


Before:
![map-height-before](https://user-images.githubusercontent.com/83316221/186184275-cce72eb4-108c-4390-979b-159312941674.png)


After:
![map-height-after](https://user-images.githubusercontent.com/83316221/186184284-083e14fd-ef36-459e-923d-cd1529f82692.png)
