### PR TITLE
Node history chart full width if we can't display channel map

### DIFF
--- a/frontend/src/app/lightning/node/node.component.html
+++ b/frontend/src/app/lightning/node/node.component.html
@@ -119,13 +119,16 @@
   </div>
 
   <div *ngIf="!error">
-    <div class="row">
+    <div class="row" *ngIf="node.as_number">
       <div class="col-sm">
         <app-nodes-channels-map [style]="'nodepage'" [publicKey]="node.public_key"></app-nodes-channels-map>
       </div>
       <div class="col-sm">
         <app-node-statistics-chart [publicKey]="node.public_key"></app-node-statistics-chart>
       </div>
+    </div>
+    <div *ngIf="!node.as_number">
+      <app-node-statistics-chart [publicKey]="node.public_key"></app-node-statistics-chart>
     </div>
 
     <h2 i18n="lightning.active-channels-map">Active channels map</h2>


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2376

<img width="1496" alt="Screen Shot 2022-08-23 at 6 01 04 PM" src="https://user-images.githubusercontent.com/9780671/186206344-dbe7dae6-c5b6-43de-817f-0b1f97b4b443.png">
<img width="1496" alt="Screen Shot 2022-08-23 at 6 00 59 PM" src="https://user-images.githubusercontent.com/9780671/186206351-0bd3d865-6f89-4f27-888a-b19954d5cf3f.png">

