### PR TITLE
Do not fetch node stats for channel tree graph

### DIFF
--- a/backend/src/api/explorer/channels.api.ts
+++ b/backend/src/api/explorer/channels.api.ts
@@ -288,21 +288,36 @@ class ChannelsApi {
 
       const channels: any[] = []
       for (const row of allChannels) {
-        const activeChannelsStats: any = await nodesApi.$getActiveChannelsStats(row.public_key);
-        channels.push({
-          status: row.status,
-          closing_reason: row.closing_reason,
-          capacity: row.capacity ?? 0,
-          short_id: row.short_id,
-          id: row.id,
-          fee_rate: row.node1_fee_rate ?? row.node2_fee_rate ?? 0,
-          node: {
-            alias: row.alias.length > 0 ? row.alias : row.public_key.slice(0, 20),
-            public_key: row.public_key,
-            channels: activeChannelsStats.active_channel_count ?? 0,
-            capacity: activeChannelsStats.capacity ?? 0,
-          }
-        });
+        let channel;
+        if (index >= 0) {
+          const activeChannelsStats: any = await nodesApi.$getActiveChannelsStats(row.public_key);
+          channel = {
+            status: row.status,
+            closing_reason: row.closing_reason,
+            capacity: row.capacity ?? 0,
+            short_id: row.short_id,
+            id: row.id,
+            fee_rate: row.node1_fee_rate ?? row.node2_fee_rate ?? 0,
+            node: {
+              alias: row.alias.length > 0 ? row.alias : row.public_key.slice(0, 20),
+              public_key: row.public_key,
+              channels: activeChannelsStats.active_channel_count ?? 0,
+              capacity: activeChannelsStats.capacity ?? 0,
+            }
+          };
+        } else if (index === -1) {
+          channel = {
+            capacity: row.capacity ?? 0,
+            short_id: row.short_id,
+            id: row.id,
+            node: {
+              alias: row.alias.length > 0 ? row.alias : row.public_key.slice(0, 20),
+              public_key: row.public_key,
+            }
+          };
+        }
+
+        channels.push(channel);
       }
 
       return channels;

--- a/backend/src/api/explorer/channels.routes.ts
+++ b/backend/src/api/explorer/channels.routes.ts
@@ -47,8 +47,17 @@ class ChannelsRoutes {
         res.status(400).send('Missing parameter: public_key');
         return;
       }
+
       const index = parseInt(typeof req.query.index === 'string' ? req.query.index : '0', 10) || 0;
       const status: string = typeof req.query.status === 'string' ? req.query.status : '';
+
+      if (index < -1) {
+        res.status(400).send('Invalid index');
+      }
+      if (['open', 'active', 'closed'].includes(status) === false) {
+        res.status(400).send('Invalid status');
+      }
+
       const channels = await channelsApi.$getChannelsForNode(req.query.public_key, index, 10, status);
       const channelsCount = await channelsApi.$getChannelsCountForNode(req.query.public_key, status);
       res.header('Pragma', 'public');


### PR DESCRIPTION
Fixes an issue described by @softsimon which make the loading time for the node page very long.
The issue was introduced in https://github.com/mempool/mempool/pull/2366.

The issue is that [we fetch extra node stats](https://github.com/mempool/mempool/blob/8c885e87d41bc23e91811be09109f0b97b1208d3/backend/src/api/explorer/channels.api.ts#L291) for 1000 channels, which represent 1 db query for each of them in the backend, before returning the API response.

This PR makes sure [we don't run those extra query for the tree chart](https://github.com/mempool/mempool/pull/2381/files#diff-8fc84f80a2d1d6fd7c59b59be37355bdae8054c086a9d3148fa6538216d80ed3R308) (since we don't need that data at all).

Also, I [trimmed the fields returned by the API](https://github.com/mempool/mempool/pull/2381/files#diff-8fc84f80a2d1d6fd7c59b59be37355bdae8054c086a9d3148fa6538216d80ed3R309) for the tree chart because we don't use those, so the api response will be lighter as well.

The API endpoint in question is `/api/v1/lightning/channels?public_key=03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f&index=-1&status=active`