### PR TITLE
Hardcode some condition to invalidate imported topology files

### DIFF
--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -367,6 +367,12 @@ class LightningStatsImporter {
           continue;
         }
     
+        if (this.isIncorrectSnapshot(timestamp, graph)) {
+          logger.debug(`Ignoring ${this.topologiesFolder}/${filename}, because we defined it as an incorrect snapshot`);
+          ++totalProcessed;
+          continue;
+        }
+
         if (!logStarted) {
           logger.info(`Founds a topology file that we did not import. Importing historical lightning stats now.`);
           logStarted = true;
@@ -397,7 +403,7 @@ class LightningStatsImporter {
     }
   }
 
-  async cleanupTopology(graph) {
+  cleanupTopology(graph): ILightningApi.NetworkGraph {
     const newGraph = {
       nodes: <ILightningApi.Node[]>[],
       edges: <ILightningApi.Channel[]>[],
@@ -455,6 +461,29 @@ class LightningStatsImporter {
     }
 
     return newGraph;
+  }
+
+  private isIncorrectSnapshot(timestamp, graph): boolean {
+    if (timestamp >= 1549065600 /* 2019-02-02 */ && timestamp <= 1550620800 /* 2019-02-20 */ && graph.nodes.length < 2600) {
+        return true;
+    }
+    if (timestamp >= 1552953600 /* 2019-03-19 */ && timestamp <= 1556323200 /* 2019-05-27 */ && graph.nodes.length < 4000) {
+      return true;
+    }
+    if (timestamp >= 1557446400 /* 2019-05-10 */ && timestamp <= 1560470400 /* 2019-06-14 */ && graph.nodes.length < 4000) {
+      return true;
+    }
+    if (timestamp >= 1561680000 /* 2019-06-28 */ && timestamp <= 1563148800 /* 2019-07-15 */ && graph.nodes.length < 4000) {
+      return true;
+    }
+    if (timestamp >= 1574035200 /* 2019-11-18 */ && timestamp <= 1579305600 /* 2020-01-18 */ && graph.nodes.length < 3000) {
+      return true;
+    }
+    if (timestamp >= 1591142400 /* 2020-06-03 */ && timestamp <= 1592006400 /* 2020-06-13 */ && graph.nodes.length < 5500) {
+      return true;
+    }
+
+    return false;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2384

During the topology import, we ignore some files based on their timestamp and node count. If the node count is too low based on our hard coded estimates, we skip the file.

#### Testing

* You need to delete the historical data from your db. Make sure to keep non recoverable historical data. You can run the following queries to delete only historical data:
```mysql
# Delete data before July 16th 2022
delete from lightning_stats where UNIX_TIMESTAMP(added) < 1657929600;
delete from node_stats where UNIX_TIMESTAMP(added) < 1657929600; # This will take some time
```
* Restart the lightning nodejs backend and wait for the historical import to complete
* Visually confirm the expected following result
* In node pages, the same "interpolated gaps" in the channels/capacity charts should be visually present

#### Result

Raw data
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9780671/187059937-c1a31cfa-54cc-46c2-aba4-c8b038be1cf4.png">
Cleaned up
<img width="1496" alt="Screen Shot 2022-08-28 at 7 50 29 AM" src="https://user-images.githubusercontent.com/9780671/187059897-6847585f-e67f-4ab3-9714-9d4f4be4e191.png">

Raw data
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/9780671/187059993-9e16106e-cd46-456d-a49f-d78dd8fdc1fe.png">
Cleaned up
<img width="1496" alt="Screen Shot 2022-08-28 at 7 50 37 AM" src="https://user-images.githubusercontent.com/9780671/187059895-78d3a0ce-aeb8-4c08-999a-b1d51605504e.png">

Raw data
<img width="557" alt="image" src="https://user-images.githubusercontent.com/9780671/187059978-52b0cefe-e86e-438a-8a57-c9eb16b1f367.png">
Cleaned up
<img width="553" alt="Screen Shot 2022-08-28 at 7 50 55 AM" src="https://user-images.githubusercontent.com/9780671/187059894-95cb6cd2-5973-48e6-a237-80c33a15e1ff.png">
