### PR TITLE
Numbers not included in node alias search

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -260,7 +260,7 @@ class NodesApi {
   public async $searchNodeByPublicKeyOrAlias(search: string) {
     try {
       const publicKeySearch = search.replace('%', '') + '%';
-      const aliasSearch = search.replace(/[-_.]/g, ' ').replace(/[^a-zA-Z ]/g, '').split(' ').map((search) => '+' + search + '*').join(' ');
+      const aliasSearch = search.replace(/[-_.]/g, ' ').replace(/[^a-zA-Z0-9 ]/g, '').split(' ').map((search) => '+' + search + '*').join(' ');
       const query = `SELECT nodes.public_key, nodes.alias, node_stats.capacity FROM nodes LEFT JOIN node_stats ON node_stats.public_key = nodes.public_key WHERE nodes.public_key LIKE ? OR MATCH nodes.alias_search AGAINST (? IN BOOLEAN MODE) GROUP BY nodes.public_key ORDER BY node_stats.capacity DESC LIMIT 10`;
       const [rows]: any = await DB.query(query, [publicKeySearch, aliasSearch]);
       return rows;
@@ -555,7 +555,7 @@ class NodesApi {
   }
 
   private aliasToSearchText(str: string): string {
-    return str.replace(/[-_.]/g, ' ').replace(/[^a-zA-Z ]/g, '');
+    return str.replace(/[-_.]/g, ' ').replace(/[^a-zA-Z0-9 ]/g, '');
   }
 }
 


### PR DESCRIPTION
Forgot to allow numbers in the Alias name search index.

Before
<img width="251" alt="Screen Shot 2022-08-25 at 15 12 16" src="https://user-images.githubusercontent.com/8561090/186650401-160de3f6-3c57-482f-ab12-ab6156f004af.png">

After
<img width="277" alt="Screen Shot 2022-08-25 at 15 12 32" src="https://user-images.githubusercontent.com/8561090/186650412-c2ff7a9d-f7e5-44a0-ab0d-2832c39c74c2.png">

