### PR TITLE
Add LN node info to search placeholder

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.html
+++ b/frontend/src/app/components/search-form/search-form.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="searchForm" (submit)="searchForm.valid && search()" novalidate>
   <div class="d-flex">
     <div class="search-box-container mr-2">
-      <input (focus)="focus$.next($any($event).target.value)" (click)="click$.next($any($event).target.value)" formControlName="searchText" type="text" class="form-control" i18n-placeholder="search-form.searchbar-placeholder" placeholder="TXID, block height, hash or address">
+      <input (focus)="focus$.next($any($event).target.value)" (click)="click$.next($any($event).target.value)" formControlName="searchText" type="text" class="form-control" i18n-placeholder="search-form.searchbar-placeholder" placeholder="TXID, address, LN node info, etc.">
       
       <app-search-results #searchResults [results]="typeAhead$ | async" [searchTerm]="searchForm.get('searchText').value" (selectedResult)="selectedResult($event)"></app-search-results>
     


### PR DESCRIPTION
### Background

1. The new LN search feature should be featured more prominently on the search bar's placeholder. "LN node info" is vague enough to be short, but specific enough to where most people (technical and not) will likely think of node pubkey, node alias, or maybe node IP.
2. The majority of new users / non-technical users that just want a block explorer will likely never search for a block hash or block height.
3. There is access to the block UI via clicking on a recent block in the recent blocks queue at the top, so anyone who wants to browse recent blocks already has an obvious visual cue and thing to click.
4. Anyone who actually needs to search for block height and or hash via the search box will most likely try it anyways without the placeholder telling them (since the "unwritten rule" of block explorer veterans clues them in that at least a block hash should work.

### Points of discussion

1. Ideas for any additional UI elements we could add that might add more information if we need it. (ie. a mouse-over pop up etc.)

### Todo

- [ ] Make the placeholder variable base on Lightning environment variable.