### PR TITLE
Fix for empty tx value

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -105,10 +105,10 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       }, 10);
     }
 
-    this.transactions.forEach((tx, i) => {
+    this.transactions.forEach((tx) => {
       tx['@voutLimit'] = true;
       tx['@vinLimit'] = true;
-      if (this.outspends[i]) {
+      if (tx['addressValue'] !== undefined) {
         return;
       }
 


### PR DESCRIPTION
fixes #2263

This happens when new transactions come in to an existing list of transactions (address page).

Before
<img width="537" alt="Screen Shot 2022-08-25 at 17 25 40" src="https://user-images.githubusercontent.com/8561090/186677141-4ff5f3e2-5329-4901-9633-64d465fc4c06.png">


After
<img width="547" alt="Screen Shot 2022-08-25 at 17 26 02" src="https://user-images.githubusercontent.com/8561090/186677153-1b7b9c5a-94fb-4eb0-8979-2a412b0a54cf.png">

