### PR TITLE
Handle languages in network regex detection

### DIFF
--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -153,8 +153,8 @@ export class StateService {
     if (this.env.BASE_MODULE !== 'mempool' && this.env.BASE_MODULE !== 'liquid') {
       return;
     }
-    const networkMatches = url.match(/^\/(bisq|testnet|liquidtestnet|liquid|signet)/);
-    switch (networkMatches && networkMatches[1]) {
+    const networkMatches = url.match(/^\/([A-z-]+\/)?(bisq|testnet|liquidtestnet|liquid|signet)/);
+    switch (networkMatches && networkMatches[2]) {
       case 'liquid':
         if (this.network !== 'liquid') {
           this.network = 'liquid';


### PR DESCRIPTION
fixes #2396

Going to` /sv/testnet` was broken as it expected the network name to be the first.

Now this should detect "testnet" 

`/testnet/`
`/jp/testnet/`
`/pt-BR/testnet/`