### PR TITLE
Fix clipboard for node pubkey on channel page

### DIFF
--- a/frontend/src/app/lightning/channel/channel-box/channel-box.component.html
+++ b/frontend/src/app/lightning/channel/channel-box/channel-box.component.html
@@ -4,7 +4,7 @@
     <a [routerLink]="['/lightning/node' | relativeUrl, channel.public_key]" >
       {{ channel.public_key | shortenString : 12 }}
     </a>
-    <app-clipboard [text]="channel.node1_public_key"></app-clipboard>
+    <app-clipboard [text]="channel.public_key"></app-clipboard>
   </div>
   <div class="box-right">
     <div class="second-line">{{ channel.channels }} channels</div>


### PR DESCRIPTION
Copy-to-clipboard doesn't work because of a misnamed variable in the channel template.

Test by trying to copy node pubkey on any channel page using the click-to-copy button. Example I tested with was `lightning/channel/824803045759582209`.

![copy-node-pubkey](https://user-images.githubusercontent.com/93150691/187078533-373bf606-681b-4709-95d9-81b57ef50886.png)
