### PR TITLE
Fix overflowing tx on mobile

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -18,7 +18,7 @@
     <div *ngIf="errorUnblinded" class="error-unblinded">{{ errorUnblinded }}</div>
     <div class="row">
       <div class="col">
-        <table class="table table-borderless smaller-text table-sm table-tx-vin">
+        <table class="table table-borderless smaller-text table-sm table-tx-vin table-fixed">
           <tbody>
             <ng-template ngFor let-vin let-vindex="index" [ngForOf]="tx['@vinLimit'] ? ((tx.vin.length > rowLimit) ? tx.vin.slice(0, rowLimit - 2) : tx.vin.slice(0, rowLimit)) : tx.vin" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{
@@ -156,7 +156,7 @@
       </div>
       <div class="w-100 d-block d-md-none"></div>
       <div class="col mobile-bottomcol">
-        <table class="table table-borderless smaller-text table-sm table-tx-vout">
+        <table class="table table-borderless smaller-text table-sm table-tx-vout table-fixed">
           <tbody>
             <ng-template ngFor let-vout let-vindex="index" [ngForOf]="tx['@voutLimit'] && !outputIndex ? ((tx.vout.length > rowLimit) ? tx.vout.slice(0, rowLimit - 2) : tx.vout.slice(0, rowLimit)) : tx.vout" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{


### PR DESCRIPTION
This PR should be carefully reviewed by at least two persons because it touches the transaction component.

#### Currently the tx list overflows because of the tx tags

<img width="392" alt="image" src="https://user-images.githubusercontent.com/9780671/187166750-cc1221fe-b94e-4a69-8f32-aaf6a06b21ea.png">

#### PR result

**Mobile channel page**
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9780671/187713058-185f352d-1343-487a-b3bf-4fde606ea38f.png">

**Desktop channel page**
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/9780671/187713198-39418627-de24-4612-82d5-a5182dfa8aa6.png">

