### PR TITLE
Use monospace font for addresses on mobile

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -705,6 +705,10 @@ th {
 .locktime { color: #ff8c00 }
 .reserved { color: #ff8c00 }
 
+.shortable-address {
+  font-family: monospace;
+}
+
 .rtl-layout {
 
   .navbar-brand {
@@ -881,6 +885,7 @@ th {
 
   .shortable-address {
     direction: ltr;
+    font-family: monospace;
   }
 
   .lastest-blocks-table {


### PR DESCRIPTION
Currently addresses on mobile are not using monospace font

### Master

<img width="390" alt="image" src="https://user-images.githubusercontent.com/9780671/187170692-b117060b-0dcd-478b-be43-b427b5814450.png">

### PR

<img width="390" alt="image" src="https://user-images.githubusercontent.com/9780671/187170718-a6745737-1aaf-4d73-957d-2f00a81f639d.png">
