### PR TITLE
Align charts timestamp selector with charts menus

### DIFF
--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.scss
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.scss
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.scss
+++ b/frontend/src/app/components/block-prediction-graph/block-prediction-graph.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.scss
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.scss
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 1130px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 1130px) {
     position: relative;

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.scss
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.scss
@@ -55,7 +55,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.scss
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.scss
@@ -39,7 +39,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -11,7 +11,7 @@
           </div>  
 
           <form [formGroup]="radioGroupForm" class="formRadioGroup"
-            [class]="stateService.env.MINING_DASHBOARD ? 'mining' : ''" (click)="saveGraphPreference()">
+            [class]="(stateService.env.MINING_DASHBOARD || stateService.env.LIGHTNING) ? 'mining' : 'no-menu'" (click)="saveGraphPreference()">
             <div *ngIf="!isMobile()" class="btn-group btn-group-toggle">
               <label ngbButtonLabel class="btn-primary btn-sm mr-2">
                 <a [routerLink]="['/tv' | relativeUrl]" style="color: white" id="btn-tv">

--- a/frontend/src/app/components/statistics/statistics.component.scss
+++ b/frontend/src/app/components/statistics/statistics.component.scss
@@ -55,11 +55,17 @@
 .formRadioGroup.mining {
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;
     top: 0px;
+  }
+}
+.formRadioGroup.no-menu {
+  @media (min-width: 991px) {
+    position: relative;
+    top: -33px;
   }
 }
 

--- a/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.scss
@@ -60,7 +60,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
@@ -40,7 +40,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;

--- a/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.scss
+++ b/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.scss
@@ -60,7 +60,7 @@
   flex-direction: column;
   @media (min-width: 991px) {
     position: relative;
-    top: -65px;
+    top: -100px;
   }
   @media (min-width: 830px) and (max-width: 991px) {
     position: relative;


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2434

This PR move the charts timespan controls upper so that it properly aligns with the chart selection buttons or the chart title.

It fixes the alignment when menus are shown (if the mining dashboard or the lightning dashboard are enabled), and fixes the alignment with the component title if no menus are shown (liquid).

### Master

**Timespan selector is not aligned with graph menus**
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9780671/187251122-17e761f7-a725-46d4-9b4b-0dbb5e47705a.png">

**Timespan selector is not aligned with the component title**
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9780671/187257867-b9f63e37-231e-41c1-a0bc-64f6c12cae2b.png">


### PR, alignment fixed

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9780671/187251171-a0604152-cdb4-432c-a3d1-89bf6e5fe038.png">

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9780671/187257981-efde00ed-0ea5-472e-8f55-db39b34fcfff.png">
