### PR TITLE
Fix open/close channel list button alignment

### DIFF
--- a/frontend/src/app/lightning/channels-list/channels-list.component.html
+++ b/frontend/src/app/lightning/channels-list/channels-list.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="channels$ | async as response; else skeleton">
+<div *ngIf="channels$ | async as response; else skeleton" style="position: relative;">
   <form [formGroup]="channelStatusForm" class="formRadioGroup">
     <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="status">
       <label ngbButtonLabel class="btn-primary btn-sm">

--- a/frontend/src/app/lightning/channels-list/channels-list.component.html
+++ b/frontend/src/app/lightning/channels-list/channels-list.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="channels$ | async as response; else skeleton">
-  <form [formGroup]="channelStatusForm" class="formRadioGroup float-right">
+  <form [formGroup]="channelStatusForm" class="formRadioGroup">
     <div class="btn-group btn-group-toggle" ngbRadioGroup name="radioBasic" formControlName="status">
       <label ngbButtonLabel class="btn-primary btn-sm">
         <input ngbButton type="radio" [value]="'open'" fragment="open" i18n="open">Open

--- a/frontend/src/app/lightning/channels-list/channels-list.component.scss
+++ b/frontend/src/app/lightning/channels-list/channels-list.component.scss
@@ -10,8 +10,8 @@
 
 .formRadioGroup {
   @media (min-width: 435px) {
-    float: right;
-    position: relative;
+    position: absolute;
+    right: 0;
     top: -46px;
   }
   @media (max-width: 435px) {

--- a/frontend/src/app/lightning/channels-list/channels-list.component.scss
+++ b/frontend/src/app/lightning/channels-list/channels-list.component.scss
@@ -7,3 +7,20 @@
   font-size: 12px;
   top: 0px;
 }
+
+.formRadioGroup {
+  @media (min-width: 435px) {
+    float: right;
+    position: relative;
+    top: -46px;
+  }
+  @media (max-width: 435px) {
+    display: flex;
+  }
+}
+
+.btn-group {
+  @media (max-width: 435px) {
+    flex-grow: 1;
+  }
+}


### PR DESCRIPTION
Replaces https://github.com/mempool/mempool/pull/2411

This PR aims to properly align the open/close buttons with the `Channels (XXXX)` title in the node page.

### Master

**Desktop, alignment is broken**
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/9780671/187262003-54943df3-dbc8-457e-868e-da7baf7109d0.png">

**Mobile, alignment is broken**
<img width="372" alt="image" src="https://user-images.githubusercontent.com/9780671/187262060-aaaf4be9-9fb2-4a9a-b451-30f30d92d1d3.png">

### PR, realigned

**Desktop**
<img width="1154" alt="Screen Shot 2022-08-29 at 7 25 56 PM" src="https://user-images.githubusercontent.com/9780671/187261891-47d161ae-5963-4105-8e88-6ac0d734fb94.png">

**Mobile**
<img width="371" alt="Screen Shot 2022-08-29 at 7 26 17 PM" src="https://user-images.githubusercontent.com/9780671/187261888-52caa72e-a6be-41fb-86c8-4ab34649f05b.png">
