### PR TITLE
Option to disable puppeteer in unfurler

### DIFF
--- a/unfurler/config.sample.json
+++ b/unfurler/config.sample.json
@@ -9,6 +9,7 @@
     "NETWORK": "bitcoin" // "bitcoin" | "liquid" | "bisq" (optional - defaults to "bitcoin")
   },
   "PUPPETEER": {
+    "DISABLE": false, // optional, boolean, disables puppeteer and /render endpoints
     "CLUSTER_SIZE": 2,
     "EXEC_PATH": "/usr/local/bin/chrome", // optional
     "MAX_PAGE_AGE": 86400, // maximum lifetime of a page session (in seconds)

--- a/unfurler/src/config.ts
+++ b/unfurler/src/config.ts
@@ -11,6 +11,7 @@ interface IConfig {
     NETWORK?: string;
   };
   PUPPETEER: {
+    DISABLE: boolean;
     CLUSTER_SIZE: number;
     EXEC_PATH?: string;
     MAX_PAGE_AGE?: number;
@@ -28,6 +29,7 @@ const defaults: IConfig = {
     'HTTP_PORT': 4200,
   },
   'PUPPETEER': {
+    'DISABLE': false,
     'CLUSTER_SIZE': 1,
   },
 };


### PR DESCRIPTION
Adds an optional `PUPPETEER.DISABLE` config setting, which disables puppeteer and /render api endpoints (defaults to false).