### PR TITLE
Fix infinite loading spinner in channel map when no active channel exists

### DIFF
--- a/frontend/src/app/lightning/nodes-channels/node-channels.component.ts
+++ b/frontend/src/app/lightning/nodes-channels/node-channels.component.ts
@@ -44,13 +44,13 @@ export class NodeChannels implements OnChanges {
         switchMap((response) => {
           this.isLoading = true;
           if ((response.body?.length ?? 0) <= 0) {
-            return [];
+            this.isLoading = false;
+            return [''];
           }
           return [response.body];
         }),
         tap((body: any[]) => {
-          if (body.length === 0) {
-            this.isLoading = false;
+          if (body.length === 0 || body[0].length === 0) {
             return;
           }
           const biggestCapacity = body[0].capacity;


### PR DESCRIPTION
`If there are no open channels then the channel`~map~`tree chart fails to load and loading spinner stays forever`

### Testing

* Load /lightning/node/0283de1355ab232080de2904edc77388c6651e2d81a0336bfb739f893b35aa76ce
* Confirm that the channel tree chart is not shown and the loading spinner is gone
* Load /lightning/node/026c795878725bed713c36511857ecb67557516376174fbb8c8c54e117f02d8143
* Confirm that the channel tree chart is shown and the loading spinner is gone