### PR TITLE
Change unfurler puppeteer config toggle to ENABLED

### DIFF
--- a/unfurler/config.sample.json
+++ b/unfurler/config.sample.json
@@ -9,8 +9,8 @@
     "NETWORK": "bitcoin" // "bitcoin" | "liquid" | "bisq" (optional - defaults to "bitcoin")
   },
   "PUPPETEER": {
-    "DISABLE": false, // optional, boolean, disables puppeteer and /render endpoints
-    "CLUSTER_SIZE": 2,
+    "ENABLED": false, // optional, boolean, enables puppeteer and /render endpoints (default true)
+    "CLUSTER_SIZE": 2, // maximum number of parallel chromium pages. CLUSTER_SIZE=0 implies ENABLED=false
     "EXEC_PATH": "/usr/local/bin/chrome", // optional
     "MAX_PAGE_AGE": 86400, // maximum lifetime of a page session (in seconds)
     "RENDER_TIMEOUT": 3000, // timeout for preview image rendering (in ms) (optional)

--- a/unfurler/src/config.ts
+++ b/unfurler/src/config.ts
@@ -11,7 +11,7 @@ interface IConfig {
     NETWORK?: string;
   };
   PUPPETEER: {
-    DISABLE: boolean;
+    ENABLED: boolean;
     CLUSTER_SIZE: number;
     EXEC_PATH?: string;
     MAX_PAGE_AGE?: number;
@@ -29,7 +29,7 @@ const defaults: IConfig = {
     'HTTP_PORT': 4200,
   },
   'PUPPETEER': {
-    'DISABLE': false,
+    'ENABLED': true,
     'CLUSTER_SIZE': 1,
   },
 };


### PR DESCRIPTION
Changes the unfurler config setting to disable puppeteer from `PUPPETEER.DISABLE=true` to `PUPPETEER.ENABLED=false`. Defaults to ENABLED=true.

Also disables puppeteer if `PUPPETEER.CLUSTER_SIZE` is set to zero, since it would fail in that case anyway.