### PR TITLE
Fix unfurler navigation race condition

### DIFF
--- a/unfurler/src/index.ts
+++ b/unfurler/src/index.ts
@@ -97,15 +97,20 @@ class Server {
           throw new Error('failed to access open graph service');
         }
       }
+      // wait for navigation to complete
+      await page.waitForFunction(
+        (path) => window.location.pathname.includes(path),
+        {},
+        path
+      );
+      // wait for preview component to initialize
+      await page.waitForSelector('meta[property="og:preview:loading"]', { timeout: config.PUPPETEER.RENDER_TIMEOUT || 3000 })
 
-      const waitForReady = await page.$('meta[property="og:preview:loading"]');
       let success = true;
-      if (waitForReady != null) {
-        success = await Promise.race([
-          page.waitForSelector('meta[property="og:preview:ready"]', { timeout: config.PUPPETEER.RENDER_TIMEOUT || 3000 }).then(() => true),
-          page.waitForSelector('meta[property="og:preview:fail"]', { timeout: config.PUPPETEER.RENDER_TIMEOUT || 3000 }).then(() => false)
-        ])
-      }
+      success = await Promise.race([
+        page.waitForSelector('meta[property="og:preview:ready"]', { timeout: config.PUPPETEER.RENDER_TIMEOUT || 3000 }).then(() => true),
+        page.waitForSelector('meta[property="og:preview:fail"]', { timeout: config.PUPPETEER.RENDER_TIMEOUT || 3000 }).then(() => false)
+      ])
       if (success) {
         const screenshot = await page.screenshot();
         return screenshot;


### PR DESCRIPTION
Fixes a race condition in the unfurler, which could sometimes cause previews (usually lightning previews) to render incorrectly on the first request after a restart or puppeteer page crash.