### PR TITLE
Only show active channels on world map

### DIFF
--- a/backend/src/api/explorer/channels.api.ts
+++ b/backend/src/api/explorer/channels.api.ts
@@ -39,7 +39,8 @@ class ChannelsApi {
         FROM channels
         JOIN nodes AS nodes_1 on nodes_1.public_key = channels.node1_public_key
         JOIN nodes AS nodes_2 on nodes_2.public_key = channels.node2_public_key
-        WHERE nodes_1.latitude IS NOT NULL AND nodes_1.longitude IS NOT NULL
+        WHERE channels.status = 1
+          AND nodes_1.latitude IS NOT NULL AND nodes_1.longitude IS NOT NULL
           AND nodes_2.latitude IS NOT NULL AND nodes_2.longitude IS NOT NULL
       `;
 

--- a/frontend/src/app/lightning/node/node.component.html
+++ b/frontend/src/app/lightning/node/node.component.html
@@ -120,7 +120,7 @@
   </div>
 
   <div *ngIf="!error">
-    <div class="row" *ngIf="node.as_number">
+    <div class="row" *ngIf="node.as_number && node.active_channel_count">
       <div class="col-sm">
         <app-nodes-channels-map [style]="'nodepage'" [publicKey]="node.public_key" [hasLocation]="!!node.as_number"></app-nodes-channels-map>
       </div>
@@ -128,7 +128,7 @@
         <app-node-statistics-chart [publicKey]="node.public_key"></app-node-statistics-chart>
       </div>
     </div>
-    <div *ngIf="!node.as_number">
+    <div *ngIf="!node.as_number || !node.active_channel_count">
       <app-node-statistics-chart [publicKey]="node.public_key"></app-node-statistics-chart>
     </div>
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2498

This node `034dee6a84aadb411a7ab40ece6f6777ba20d4e7a575035b49c374b4e112466cc6` has currently 3 active channels (display in the header, tree chart and channel list).

But if you zoom in the node in the channel map, you actually see 5
<img width="264" alt="image" src="https://user-images.githubusercontent.com/9780671/187519779-e2c17261-40bb-4b51-974b-045c275fcf31.png">

Some of those channels are actually closed channels. So this PR updated the mysql query to make sure we only show active channels in the world map.
