### PR TITLE
Consider channels updates as well for node updated at field

### DIFF
--- a/backend/src/api/explorer/channels.api.ts
+++ b/backend/src/api/explorer/channels.api.ts
@@ -522,6 +522,23 @@ class ChannelsApi {
       logger.err('$setChannelsInactive() error: ' + (e instanceof Error ? e.message : e));
     }
   }
+
+  public async $getLatestChannelUpdateForNode(publicKey: string): Promise<number> {
+    try {
+      const query = `
+        SELECT MAX(UNIX_TIMESTAMP(updated_at)) as updated_at
+        FROM channels
+        WHERE node1_public_key = ?
+      `;
+      const [rows]: any[] = await DB.query(query, [publicKey]);
+      if (rows.length > 0) {
+        return rows[0].updated_at;
+      }
+    } catch (e) {
+      logger.err(`Can't getLatestChannelUpdateForNode for ${publicKey}. Reason ${e instanceof Error ? e.message : e}`);
+    }
+    return 0;
+  }
 }
 
 export default new ChannelsApi();

--- a/backend/src/tasks/lightning/network-sync.service.ts
+++ b/backend/src/tasks/lightning/network-sync.service.ts
@@ -63,6 +63,9 @@ class NetworkSyncService {
     let deletedSockets = 0;
     const graphNodesPubkeys: string[] = [];
     for (const node of nodes) {
+      const latestUpdated = await channelsApi.$getLatestChannelUpdateForNode(node.pub_key);
+      node.last_update = Math.max(node.last_update, latestUpdated);
+
       await nodesApi.$saveNode(node);
       graphNodesPubkeys.push(node.pub_key);
       ++progress;


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2463

Currently we're only showing latest node update (color, alias etc...)

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/9780671/187521125-320ed3a7-7758-43c6-85ef-aebbddd1214f.png">

With this PR, we also consider channels update timestamps

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/9780671/187520734-cc8e5f4b-531d-4aaa-be49-be0c590034ad.png">
