### PR TITLE
Use new mempool preview image as default

### DIFF
--- a/unfurler/src/routes.ts
+++ b/unfurler/src/routes.ts
@@ -56,8 +56,7 @@ const routes = {
 
 const networks = {
   bitcoin: {
-    fallbackImg: '/resources/mempool-space-preview.png',
-    staticImg: '/resources/previews/dashboard.png',
+    fallbackImg: '/resources/previews/dashboard.png',
     routes: {
       ...routes // all routes supported
     }


### PR DESCRIPTION
Replaces the old default mempool preview image with the new dashboard preview, to be more consistent.

before:
| dashboard only (https://mempool.space/, https://mempool.space/testnet/ etc) | default/fallback for other routes (https://mempool.space/docs or https://mempool.space/block/<invalid>, etc) |
|-|-|
| <img width="1000" alt="dashboard" src="https://user-images.githubusercontent.com/83316221/187778447-17234533-4568-4dee-982c-f890a451579c.png"> | <img width="1000" alt="mempool-space-preview" src="https://user-images.githubusercontent.com/83316221/187778332-a699abe4-60ee-470f-8df3-8c86260966e6.png"> |

after:
| both dashboards and general default/fallback |
|-|
| <img width="1000" alt="dashboard" src="https://user-images.githubusercontent.com/83316221/187778447-17234533-4568-4dee-982c-f890a451579c.png"> |
