### PR TITLE
Dashboard node statistics skeleton loader fix

### DIFF
--- a/frontend/src/app/lightning/node-statistics/node-statistics.component.html
+++ b/frontend/src/app/lightning/node-statistics/node-statistics.component.html
@@ -44,6 +44,13 @@
 <ng-template #loadingReward>
   <div class="fee-estimation-container loading-container">
     <div class="item">
+      <h5 class="card-title" i18n="lightning.capacity">Capacity</h5>
+      <div class="card-text">
+        <div class="skeleton-loader"></div>
+        <div class="skeleton-loader"></div>
+      </div>
+    </div>
+    <div class="item">
       <h5 class="card-title" i18n="lightning.nodes">Nodes</h5>
       <div class="card-text">
         <div class="skeleton-loader"></div>
@@ -52,13 +59,6 @@
     </div>
     <div class="item">
       <h5 class="card-title" i18n="lightning.channels">Channels</h5>
-      <div class="card-text">
-        <div class="skeleton-loader"></div>
-        <div class="skeleton-loader"></div>
-      </div>
-    </div>
-    <div class="item">
-      <h5 class="card-title" i18n="lightning.average-channels">Average Channel</h5>
       <div class="card-text">
         <div class="skeleton-loader"></div>
         <div class="skeleton-loader"></div>


### PR DESCRIPTION
Skeleton loader titles didn't match on the node statistic dashboard component.