### PR TITLE
Fix spacing on websocket api examples

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -17,27 +17,27 @@ export const wsApiDocsData = {
   codeTemplate: {
     curl: `/api/v1/ws`,
     commonJS: `
-  const { %{0}: { websocket } } = mempoolJS();
+        const { %{0}: { websocket } } = mempoolJS();
 
-  const ws = websocket.initClient({
-    options: ['blocks', 'stats', 'mempool-blocks', 'live-2h-chart'],
-  });
+        const ws = websocket.initClient({
+          options: ['blocks', 'stats', 'mempool-blocks', 'live-2h-chart'],
+        });
 
-  ws.addEventListener('message', function incoming({data}) {
-    const res = JSON.parse(data.toString());
-    if (res.block) {
-      document.getElementById("result-blocks").textContent = JSON.stringify(res.block, undefined, 2);
-    }
-    if (res.mempoolInfo) {
-      document.getElementById("result-mempool-info").textContent = JSON.stringify(res.mempoolInfo, undefined, 2);
-    }
-    if (res.transactions) {
-      document.getElementById("result-transactions").textContent = JSON.stringify(res.transactions, undefined, 2);
-    }
-    if (res["mempool-blocks"]) {
-      document.getElementById("result-mempool-blocks").textContent = JSON.stringify(res["mempool-blocks"], undefined, 2);
-    }
-  });
+        ws.addEventListener('message', function incoming({data}) {
+          const res = JSON.parse(data.toString());
+          if (res.block) {
+            document.getElementById("result-blocks").textContent = JSON.stringify(res.block, undefined, 2);
+          }
+          if (res.mempoolInfo) {
+            document.getElementById("result-mempool-info").textContent = JSON.stringify(res.mempoolInfo, undefined, 2);
+          }
+          if (res.transactions) {
+            document.getElementById("result-transactions").textContent = JSON.stringify(res.transactions, undefined, 2);
+          }
+          if (res["mempool-blocks"]) {
+            document.getElementById("result-mempool-blocks").textContent = JSON.stringify(res["mempool-blocks"], undefined, 2);
+          }
+        });
   `,
     esModule: `
 const { %{0}: { websocket } } = mempoolJS();

--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -40,27 +40,27 @@ export const wsApiDocsData = {
         });
   `,
     esModule: `
-const { %{0}: { websocket } } = mempoolJS();
+  const { %{0}: { websocket } } = mempoolJS();
 
-const ws = websocket.initServer({
-options: ["blocks", "stats", "mempool-blocks", "live-2h-chart"],
-});
+  const ws = websocket.initServer({
+    options: ["blocks", "stats", "mempool-blocks", "live-2h-chart"],
+  });
 
-ws.on("message", function incoming(data) {
-const res = JSON.parse(data.toString());
-if (res.block) {
-console.log(res.block);
-}
-if (res.mempoolInfo) {
-console.log(res.mempoolInfo);
-}
-if (res.transactions) {
-console.log(res.transactions);
-}
-if (res["mempool-blocks"]) {
-console.log(res["mempool-blocks"]);
-}
-});
+  ws.on("message", function incoming(data) {
+    const res = JSON.parse(data.toString());
+    if (res.block) {
+      console.log(res.block);
+    }
+    if (res.mempoolInfo) {
+      console.log(res.mempoolInfo);
+    }
+    if (res.transactions) {
+      console.log(res.transactions);
+    }
+    if (res["mempool-blocks"]) {
+      console.log(res["mempool-blocks"]);
+    }
+  });
     `,
   },
   codeSampleMainnet: emptyCodeSample,

--- a/frontend/src/app/docs/code-template/code-template.component.ts
+++ b/frontend/src/app/docs/code-template/code-template.component.ts
@@ -152,6 +152,7 @@ export class CodeTemplateComponent implements OnInit {
 const init = async () => {
   ${codeText}
 };
+
 init();`;
     }
   }


### PR DESCRIPTION
This PR adjusts spacing on WebSocket API examples to look more presentable.

The PR diff looks weird so I suggest looking at the individual diffs for each commit instead.

## Current

![Screenshot from 2022-09-13 07-40-33](https://user-images.githubusercontent.com/93150691/189892332-9ee4d44f-be68-4685-8bae-2cedc522123c.png)

## Proposed

![Screenshot from 2022-09-13 07-40-57](https://user-images.githubusercontent.com/93150691/189892341-e38f8897-70a0-4a0c-9a51-b4d13d70f739.png)
