### PR TITLE
Tx page diagram

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -196,7 +196,7 @@
 
     <div class="box">
       <div class="graph-container" #graphContainer>
-        <tx-bowtie-graph [tx]="tx" [width]="graphWidth" [height]="graphExpanded ? (maxInOut * 15) : 360" [maxStrands]="graphExpanded ? maxInOut : 24" [network]="network"></tx-bowtie-graph>
+        <tx-bowtie-graph [tx]="tx" [width]="graphWidth" [height]="graphExpanded ? (maxInOut * 15) : graphHeight" [maxStrands]="graphExpanded ? maxInOut : 24" [network]="network" [tooltip]="true"></tx-bowtie-graph>
       </div>
       <div class="toggle-wrapper" *ngIf="maxInOut > 24">
         <button class="btn btn-sm btn-primary graph-toggle" (click)="expandGraph();" *ngIf="!graphExpanded; else collapseBtn"><span i18n="show-more">Show more</span></button>

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -190,6 +190,24 @@
 
     <br>
 
+    <div class="title">
+      <h2 i18n="transaction.diagram|Transaction diagram">Diagram</h2>
+    </div>
+
+    <div class="box">
+      <div class="graph-container" #graphContainer>
+        <tx-bowtie-graph [tx]="tx" [width]="graphWidth" [height]="graphExpanded ? (maxInOut * 15) : 360" [maxStrands]="graphExpanded ? maxInOut : 24" [network]="network"></tx-bowtie-graph>
+      </div>
+      <div class="toggle-wrapper" *ngIf="maxInOut > 24">
+        <button class="btn btn-sm btn-primary graph-toggle" (click)="expandGraph();" *ngIf="!graphExpanded; else collapseBtn"><span i18n="show-more">Show more</span></button>
+        <ng-template #collapseBtn>
+          <button class="btn btn-sm btn-primary graph-toggle" (click)="collapseGraph();"><span i18n="show-less">Show less</span></button>
+        </ng-template>
+      </div>
+    </div>
+
+    <br>
+
     <div class="title float-left">
       <h2 i18n="transaction.inputs-and-outputs|Transaction inputs and outputs">Inputs & Outputs</h2>
     </div>
@@ -273,6 +291,36 @@
               </tr>
               <tr>
                 <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="title">
+      <h2 i18n="transaction.diagram|Transaction diagram">Diagram</h2>
+    </div>
+
+    <div class="box">
+      <div class="graph-container" #graphContainer style="visibility: hidden;"></div>
+      <div class="row">
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr>
                 <td><span class="skeleton-loader"></span></td>
               </tr>
             </tbody>

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -73,6 +73,24 @@
 	}
 }
 
+.graph-container {
+  position: relative;
+  width: 100%;
+  background: #181b2d;
+  padding: 10px;
+  padding-bottom: 0;
+}
+
+.toggle-wrapper {
+  width: 100%;
+  text-align: center;
+  margin: 1.25em 0 0;
+}
+
+.graph-toggle {
+  margin: auto;
+}
+
 @media (max-width: 767.98px) {
 	.mobile-bottomcol {
 		margin-top: 15px;

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -49,7 +49,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   outputIndex: number;
   graphExpanded: boolean = false;
   graphWidth: number = 1000;
+  graphHeight: number = 360;
   maxInOut: number = 0;
+  tooltipPosition: { x: number, y: number };
 
   @ViewChild('graphContainer')
   graphContainer: ElementRef;
@@ -296,7 +298,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   setupGraph() {
-    this.maxInOut = Math.min(250, Math.max(this.tx?.vin?.length || 1, this.tx?.vout?.length || 1));
+    this.maxInOut = Math.min(250, Math.max(this.tx?.vin?.length || 1, this.tx?.vout?.length + 1 || 1));
+    this.graphHeight = Math.min(360, this.maxInOut * 80);
   }
 
   expandGraph() {
@@ -309,7 +312,6 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @HostListener('window:resize', ['$event'])
   setGraphSize(): void {
-    console.log('resize', this.graphContainer);
     if (this.graphContainer) {
       this.graphWidth = this.graphContainer.nativeElement.clientWidth - 24;
     }

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -6,28 +6,51 @@
   [style.left]="tooltipPosition.x + 'px'"
   [style.top]="tooltipPosition.y + 'px'"
 >
-  <ng-container *ngIf="!line.rest; else restMsg">
-    <p>
-      <ng-container [ngSwitch]="line.type">
-        <span *ngSwitchCase="'input'" i18n="transaction.input">Input</span>
-        <span *ngSwitchCase="'output'" i18n="transaction.output">Output</span>
-        <span *ngSwitchCase="'fee'" i18n="transaction.fee">Fee</span>
-      </ng-container>
-      <span *ngIf="line.type !== 'fee'"> #{{ line.index }}</span>
-    </p>
-    <p *ngIf="line.value != null"><app-amount [satoshis]="line.value"></app-amount></p>
-  </ng-container>
-
-  <ng-template #restMsg>
+  <ng-container *ngIf="line.rest; else coinbase">
     <span>{{ line.rest }} </span>
     <ng-container [ngSwitch]="line.type">
       <span *ngSwitchCase="'input'" i18n="transaction.other-inputs">other inputs</span>
       <span *ngSwitchCase="'output'" i18n="transaction.other-outputs">other outputs</span>
     </ng-container>
+  </ng-container>
+
+  <ng-template #coinbase>
+    <ng-container *ngIf="line.coinbase; else pegin">
+      <p>Coinbase</p>
+    </ng-container>
   </ng-template>
 
-  <p *ngIf="line.type !== 'fee' && line.address" class="address">
-    <span class="first">{{ line.address.slice(0, -4) }}</span>
-    <span class="last-four">{{ line.address.slice(-4) }}</span>
-  </p>
+  <ng-template #pegin>
+    <ng-container *ngIf="line.pegin; else pegout">
+      <p>Peg In</p>
+    </ng-container>
+  </ng-template>
+
+  <ng-template #pegout>
+    <ng-container *ngIf="line.pegout; else normal">
+      <p>Peg Out</p>
+      <p *ngIf="line.value != null"><app-amount [satoshis]="line.value"></app-amount></p>
+      <p class="address">
+        <span class="first">{{ line.pegout.slice(0, -4) }}</span>
+        <span class="last-four">{{ line.pegout.slice(-4) }}</span>
+      </p>
+    </ng-container>
+  </ng-template>
+
+  <ng-template #normal>
+      <p>
+        <ng-container [ngSwitch]="line.type">
+          <span *ngSwitchCase="'input'" i18n="transaction.input">Input</span>
+          <span *ngSwitchCase="'output'" i18n="transaction.output">Output</span>
+          <span *ngSwitchCase="'fee'" i18n="transaction.fee">Fee</span>
+        </ng-container>
+        <span *ngIf="line.type !== 'fee'"> #{{ line.index }}</span>
+      </p>
+      <p *ngIf="line.value == null && line.confidential" i18n="shared.confidential">Confidential</p>
+      <p *ngIf="line.value != null"><app-amount [satoshis]="line.value"></app-amount></p>
+      <p *ngIf="line.type !== 'fee' && line.address" class="address">
+        <span class="first">{{ line.address.slice(0, -4) }}</span>
+        <span class="last-four">{{ line.address.slice(-4) }}</span>
+      </p>
+  </ng-template>
 </div>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -1,0 +1,33 @@
+<div
+  #tooltip
+  *ngIf="line"
+  class="bowtie-graph-tooltip"
+  [style.visibility]="line ? 'visible' : 'hidden'"
+  [style.left]="tooltipPosition.x + 'px'"
+  [style.top]="tooltipPosition.y + 'px'"
+>
+  <ng-container *ngIf="!line.rest; else restMsg">
+    <p>
+      <ng-container [ngSwitch]="line.type">
+        <span *ngSwitchCase="'input'" i18n="transaction.input">Input</span>
+        <span *ngSwitchCase="'output'" i18n="transaction.output">Output</span>
+        <span *ngSwitchCase="'fee'" i18n="transaction.fee">Fee</span>
+      </ng-container>
+      <span *ngIf="line.type !== 'fee'"> #{{ line.index }}</span>
+    </p>
+    <p *ngIf="line.value != null"><app-amount [satoshis]="line.value"></app-amount></p>
+  </ng-container>
+
+  <ng-template #restMsg>
+    <span>{{ line.rest }} </span>
+    <ng-container [ngSwitch]="line.type">
+      <span *ngSwitchCase="'input'" i18n="transaction.other-inputs">other inputs</span>
+      <span *ngSwitchCase="'output'" i18n="transaction.other-outputs">other outputs</span>
+    </ng-container>
+  </ng-template>
+
+  <p *ngIf="line.type !== 'fee' && line.address" class="address">
+    <span class="first">{{ line.address.slice(0, -4) }}</span>
+    <span class="last-four">{{ line.address.slice(-4) }}</span>
+  </p>
+</div>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.scss
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.scss
@@ -1,0 +1,38 @@
+.bowtie-graph-tooltip {
+  position: absolute;
+  background: rgba(#11131f, 0.95);
+  border-radius: 4px;
+  box-shadow: 1px 1px 10px rgba(0,0,0,0.5);
+  color: #b1b1b1;
+  padding: 10px 15px;
+  text-align: left;
+  pointer-events: none;
+  max-width: 300px;
+
+  p {
+    margin: 0;
+    white-space: nowrap;
+  }
+
+  .address {
+    width: 100%;
+    max-width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-start;
+
+    .first {
+      flex-grow: 0;
+      flex-shrink: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-right: -2px;
+    }
+
+    .last-four {
+      flex-shrink: 0;
+      flex-grow: 0;
+    }
+  }
+}

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
@@ -1,13 +1,25 @@
 import { Component, ElementRef, ViewChild, Input, OnChanges, ChangeDetectionStrategy } from '@angular/core';
 import { TransactionStripped } from 'src/app/interfaces/websocket.interface';
 
+interface Xput {
+  type: 'input' | 'output' | 'fee';
+  value?: number;
+  index?: number;
+  address?: string;
+  rest?: number;
+  coinbase?: boolean;
+  pegin?: boolean;
+  pegout?: string;
+  confidential?: boolean;
+}
+
 @Component({
   selector: 'app-tx-bowtie-graph-tooltip',
   templateUrl: './tx-bowtie-graph-tooltip.component.html',
   styleUrls: ['./tx-bowtie-graph-tooltip.component.scss'],
 })
 export class TxBowtieGraphTooltipComponent implements OnChanges {
-  @Input() line: { type: string, value?: number, index?: number, address?: string, rest?: number } | void;
+  @Input() line: Xput | void;
   @Input() cursorPosition: { x: number, y: number };
 
   tooltipPosition = { x: 0, y: 0 };

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
@@ -1,0 +1,36 @@
+import { Component, ElementRef, ViewChild, Input, OnChanges, ChangeDetectionStrategy } from '@angular/core';
+import { TransactionStripped } from 'src/app/interfaces/websocket.interface';
+
+@Component({
+  selector: 'app-tx-bowtie-graph-tooltip',
+  templateUrl: './tx-bowtie-graph-tooltip.component.html',
+  styleUrls: ['./tx-bowtie-graph-tooltip.component.scss'],
+})
+export class TxBowtieGraphTooltipComponent implements OnChanges {
+  @Input() line: { type: string, value?: number, index?: number, address?: string, rest?: number } | void;
+  @Input() cursorPosition: { x: number, y: number };
+
+  tooltipPosition = { x: 0, y: 0 };
+
+  @ViewChild('tooltip') tooltipElement: ElementRef<HTMLCanvasElement>;
+
+  constructor() {}
+
+  ngOnChanges(changes): void {
+    if (changes.cursorPosition && changes.cursorPosition.currentValue) {
+      let x = Math.max(10, changes.cursorPosition.currentValue.x - 50);
+      let y = changes.cursorPosition.currentValue.y + 20;
+      if (this.tooltipElement) {
+        const elementBounds = this.tooltipElement.nativeElement.getBoundingClientRect();
+        const parentBounds = this.tooltipElement.nativeElement.offsetParent.getBoundingClientRect();
+        if ((parentBounds.left + x + elementBounds.width) > parentBounds.right) {
+          x = Math.max(0, parentBounds.width - elementBounds.width - 10);
+        }
+        if (y + elementBounds.height > parentBounds.height) {
+          y = y - elementBounds.height - 20;
+        }
+      }
+      this.tooltipPosition = { x, y };
+    }
+  }
+}

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
@@ -1,44 +1,82 @@
-<svg *ngIf="inputs && outputs" class="bowtie" [attr.height]="(height + 10) + 'px'" [attr.width]="width + 'px'">
-  <defs>
-    <marker id="input-arrow" viewBox="-5 -5 10 10"
-        refX="0" refY="0"
-        markerUnits="strokeWidth"
-        markerWidth="1.5" markerHeight="1"
-        orient="auto">
-      <path d="M -5 -5 L 0 0 L -5 5 L 1 5 L 1 -5 Z" stroke-width="0" [attr.fill]="gradient[0]"/>
-    </marker>
-    <marker id="output-arrow" viewBox="-5 -5 10 10"
-        refX="0" refY="0"
-        markerUnits="strokeWidth"
-        markerWidth="1.5" markerHeight="1"
-        orient="auto">
-      <path d="M 1 -5 L 0 -5 L -5 0 L 0 5 L 1 5 Z" stroke-width="0" [attr.fill]="gradient[0]"/>
-    </marker>
-    <marker id="fee-arrow" viewBox="-5 -5 10 10"
-        refX="0" refY="0"
-        markerUnits="strokeWidth"
-        markerWidth="1.5" markerHeight="1"
-        orient="auto">
-    </marker>
-    <linearGradient id="input-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+<div class="bowtie-graph">
+  <svg *ngIf="inputs && outputs" class="bowtie" [attr.height]="(height + 10) + 'px'" [attr.width]="width + 'px'">
+    <defs>
+      <marker id="input-arrow" viewBox="-5 -5 10 10"
+          refX="0" refY="0"
+          markerUnits="strokeWidth"
+          markerWidth="1.5" markerHeight="1"
+          orient="auto">
+        <path d="M -5 -5 L 0 0 L -5 5 L 1 5 L 1 -5 Z" stroke-width="0" [attr.fill]="gradient[0]"/>
+      </marker>
+      <marker id="output-arrow" viewBox="-5 -5 10 10"
+          refX="0" refY="0"
+          markerUnits="strokeWidth"
+          markerWidth="1.5" markerHeight="1"
+          orient="auto">
+        <path d="M 1 -5 L 0 -5 L -5 0 L 0 5 L 1 5 Z" stroke-width="0" [attr.fill]="gradient[0]"/>
+      </marker>
+      <marker id="fee-arrow" viewBox="-5 -5 10 10"
+          refX="0" refY="0"
+          markerUnits="strokeWidth"
+          markerWidth="1.5" markerHeight="1"
+          orient="auto">
+      </marker>
+      <linearGradient id="input-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" [attr.stop-color]="gradient[0]" />
+        <stop offset="100%" [attr.stop-color]="gradient[1]" />
+      </linearGradient>
+      <linearGradient id="output-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" [attr.stop-color]="gradient[1]" />
+        <stop offset="100%" [attr.stop-color]="gradient[0]" />
+      </linearGradient>
+      <linearGradient id="input-hover-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" [attr.stop-color]="gradient[0]" />
-      <stop offset="100%" [attr.stop-color]="gradient[1]" />
-    </linearGradient>
-    <linearGradient id="output-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" [attr.stop-color]="gradient[1]" />
-      <stop offset="100%" [attr.stop-color]="gradient[0]" />
-    </linearGradient>
-    <linearGradient id="fee-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" [attr.stop-color]="gradient[1]" />
-      <stop offset="50%" [attr.stop-color]="gradient[1]" />
-      <stop offset="100%" stop-color="transparent" />
-    </linearGradient>
-  </defs>
-  <path [attr.d]="middle.path" class="line middle" [style]="middle.style"/>
-  <ng-container *ngFor="let input of inputs">
-    <path [attr.d]="input.path" class="line {{input.class}}" [style]="input.style" attr.marker-start="url(#{{input.class}}-arrow)"/>
-  </ng-container>
-  <ng-container *ngFor="let output of outputs">
-    <path [attr.d]="output.path" class="line {{output.class}}" [style]="output.style" attr.marker-start="url(#{{output.class}}-arrow)" />
-  </ng-container>
-</svg>
+      <stop offset="2%" [attr.stop-color]="gradient[0]" />
+        <stop offset="30%" stop-color="white" />
+        <stop offset="100%" [attr.stop-color]="gradient[1]" />
+      </linearGradient>
+      <linearGradient id="output-hover-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" [attr.stop-color]="gradient[1]" />
+        <stop offset="70%" stop-color="white" />
+        <stop offset="98%" [attr.stop-color]="gradient[0]" />
+        <stop offset="100%" [attr.stop-color]="gradient[0]" />
+      </linearGradient>
+      <linearGradient id="fee-hover-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" [attr.stop-color]="gradient[1]" />
+        <stop offset="100%" stop-color="white" />
+      </linearGradient>
+      <linearGradient id="fee-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" [attr.stop-color]="gradient[1]" />
+        <stop offset="50%" [attr.stop-color]="gradient[1]" />
+        <stop offset="100%" stop-color="transparent" />
+      </linearGradient>
+    </defs>
+    <path [attr.d]="middle.path" class="line middle" [style]="middle.style"/>
+    <ng-container *ngFor="let input of inputs; let i = index">
+      <path
+        [attr.d]="input.path"
+        class="line {{input.class}}"
+        [style]="input.style"
+        attr.marker-start="url(#{{input.class}}-arrow)"
+        (pointerover)="onHover($event, 'input', i);"
+        (pointerout)="onBlur($event, 'input', i);"
+      />
+    </ng-container>
+    <ng-container *ngFor="let output of outputs; let i = index">
+      <path
+        [attr.d]="output.path"
+        class="line {{output.class}}"
+        [style]="output.style"
+        attr.marker-start="url(#{{output.class}}-arrow)"
+        (pointerover)="onHover($event, 'output', i);"
+        (pointerout)="onBlur($event, 'output', i);"
+      />
+    </ng-container>
+  </svg>
+
+  <app-tx-bowtie-graph-tooltip
+    *ngIf=[tooltip]
+    [line]="hoverLine"
+    [cursorPosition]="tooltipPosition"
+  ></app-tx-bowtie-graph-tooltip>
+</div>

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.scss
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.scss
@@ -11,5 +11,19 @@
     &.fee {
       stroke: url(#fee-gradient);
     }
+
+    &:hover {
+      z-index: 10;
+      cursor: pointer;
+      &.input {
+        stroke: url(#input-hover-gradient);
+      }
+      &.output {
+        stroke: url(#output-hover-gradient);
+      }
+      &.fee {
+        stroke: url(#fee-hover-gradient);
+      }
+    }
   }
 }

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -13,6 +13,10 @@ interface Xput {
   index?: number;
   address?: string;
   rest?: number;
+  coinbase?: boolean;
+  pegin?: boolean;
+  pegout?: string;
+  confidential?: boolean;
 }
 
 const lineLimit = 250;
@@ -78,6 +82,8 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
         type: v.scriptpubkey_type === 'fee' ? 'fee' : 'output',
         value: v?.value,
         address: v?.scriptpubkey_address || v?.scriptpubkey_type?.toUpperCase(),
+        pegout: v?.pegout?.scriptpubkey_address,
+        confidential: (this.isLiquid && v?.value === undefined),
       } as Xput;
     });
 
@@ -91,6 +97,9 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
         type: 'input',
         value: v?.prevout?.value,
         address: v?.prevout?.scriptpubkey_address || v?.prevout?.scriptpubkey_type?.toUpperCase(),
+        coinbase: v?.is_coinbase,
+        pegin: v?.is_pegin,
+        confidential: (this.isLiquid && v?.prevout?.value === undefined),
       } as Xput;
     });
 

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, OnChanges } from '@angular/core';
+import { Component, OnInit, Input, OnChanges, HostListener } from '@angular/core';
 import { Transaction } from '../../interfaces/electrs.interface';
 
 interface SvgLine {
@@ -10,6 +10,9 @@ interface SvgLine {
 interface Xput {
   type: 'input' | 'output' | 'fee';
   value?: number;
+  index?: number;
+  address?: string;
+  rest?: number;
 }
 
 const lineLimit = 250;
@@ -27,12 +30,17 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
   @Input() combinedWeight = 100;
   @Input() minWeight = 2; //
   @Input() maxStrands = 24; // number of inputs/outputs to keep fully on-screen.
+  @Input() tooltip = false;
 
+  inputData: Xput[];
+  outputData: Xput[];
   inputs: SvgLine[];
   outputs: SvgLine[];
   middle: SvgLine;
   midWidth: number;
   isLiquid: boolean = false;
+  hoverLine: Xput | void = null;
+  tooltipPosition = { x: 0, y: 0 };
 
   gradientColors = {
     '': ['#9339f4', '#105fb0'],
@@ -59,33 +67,50 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
   ngOnChanges(): void {
     this.isLiquid = (this.network === 'liquid' || this.network === 'liquidtestnet');
     this.gradient = this.gradientColors[this.network];
+    this.midWidth = Math.min(50, Math.ceil(this.width / 20));
     this.initGraph();
   }
 
   initGraph(): void {
     const totalValue = this.calcTotalValue(this.tx);
-    let voutWithFee = this.tx.vout.map(v => { return { type: v.scriptpubkey_type === 'fee' ? 'fee' : 'output', value: v?.value } as Xput; });
+    let voutWithFee = this.tx.vout.map(v => {
+      return {
+        type: v.scriptpubkey_type === 'fee' ? 'fee' : 'output',
+        value: v?.value,
+        address: v?.scriptpubkey_address || v?.scriptpubkey_type?.toUpperCase(),
+      } as Xput;
+    });
 
     if (this.tx.fee && !this.isLiquid) {
       voutWithFee.unshift({ type: 'fee', value: this.tx.fee });
     }
+    const outputCount = voutWithFee.length;
 
-    let truncatedInputs = this.tx.vin.map(v => { return {type: 'input', value: v?.prevout?.value } as Xput; });
+    let truncatedInputs = this.tx.vin.map(v => {
+      return {
+        type: 'input',
+        value: v?.prevout?.value,
+        address: v?.prevout?.scriptpubkey_address || v?.prevout?.scriptpubkey_type?.toUpperCase(),
+      } as Xput;
+    });
 
     if (truncatedInputs.length > lineLimit) {
       const valueOfRest = truncatedInputs.slice(lineLimit).reduce((r, v) => {
         return r + (v.value || 0);
       }, 0);
       truncatedInputs = truncatedInputs.slice(0, lineLimit);
-      truncatedInputs.push({ type: 'input', value: valueOfRest });
+      truncatedInputs.push({ type: 'input', value: valueOfRest, rest: this.tx.vin.length - lineLimit });
     }
     if (voutWithFee.length > lineLimit) {
       const valueOfRest = voutWithFee.slice(lineLimit).reduce((r, v) => {
         return r + (v.value || 0);
       }, 0);
       voutWithFee = voutWithFee.slice(0, lineLimit);
-      voutWithFee.push({ type: 'output', value: valueOfRest });
+      voutWithFee.push({ type: 'output', value: valueOfRest, rest: outputCount - lineLimit });
     }
+
+    this.inputData = truncatedInputs;
+    this.outputData = voutWithFee;
 
     this.inputs = this.initLines('in', truncatedInputs, totalValue, this.maxStrands);
     this.outputs = this.initLines('out', voutWithFee, totalValue, this.maxStrands);
@@ -195,9 +220,32 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
 
   makeStyle(minWeight, type): string {
     if (type === 'fee') {
-      return `stroke-width: ${minWeight}; stroke: url(#fee-gradient)`;
+      return `stroke-width: ${minWeight}`;
     } else {
       return `stroke-width: ${minWeight}`;
     }
+  }
+
+  @HostListener('pointermove', ['$event'])
+  onPointerMove(event) {
+    this.tooltipPosition = { x: event.offsetX, y: event.offsetY };
+  }
+
+  onHover(event, side, index): void {
+    if (side === 'input') {
+      this.hoverLine = {
+        ...this.inputData[index],
+        index
+      };
+    } else {
+      this.hoverLine = {
+        ...this.outputData[index],
+        index
+      };
+    }
+  }
+
+  onBlur(event, side, index): void {
+    this.hoverLine = null;
   }
 }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -61,6 +61,7 @@ import { FeesBoxComponent } from '../components/fees-box/fees-box.component';
 import { DifficultyComponent } from '../components/difficulty/difficulty.component';
 import { TermsOfServiceComponent } from '../components/terms-of-service/terms-of-service.component';
 import { TxBowtieGraphComponent } from '../components/tx-bowtie-graph/tx-bowtie-graph.component';
+import { TxBowtieGraphTooltipComponent } from '../components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component';
 import { PrivacyPolicyComponent } from '../components/privacy-policy/privacy-policy.component';
 import { TrademarkPolicyComponent } from '../components/trademark-policy/trademark-policy.component';
 import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
@@ -134,6 +135,7 @@ import { GeolocationComponent } from '../shared/components/geolocation/geolocati
     FeesBoxComponent,
     DifficultyComponent,
     TxBowtieGraphComponent,
+    TxBowtieGraphTooltipComponent,
     TermsOfServiceComponent,
     PrivacyPolicyComponent,
     TrademarkPolicyComponent,
@@ -236,6 +238,7 @@ import { GeolocationComponent } from '../shared/components/geolocation/geolocati
     FeesBoxComponent,
     DifficultyComponent,
     TxBowtieGraphComponent,
+    TxBowtieGraphTooltipComponent,
     TermsOfServiceComponent,
     PrivacyPolicyComponent,
     TrademarkPolicyComponent,


### PR DESCRIPTION
(builds on PR #2561)

This PR explores adding the sankey diagram from the transaction previews to the main transaction page.

### Summary

By default the diagram works the same way as in the previews, showing up to 24 inputs/outputs in full, with the remainder spilling off the bottom of the graphic.

If there are >24 inputs or outputs, a toggle button is shown which can expand the graphic to fit up to 250 inputs/outputs.

Hovering the mouse over a line highlights it, and displays a tooltip with a simple summary.

![show-more](https://user-images.githubusercontent.com/83316221/190880655-e94512d2-dd79-4dfd-9fe5-b0e75f53aedb.png)


### Limitations

There are a few obvious areas for improvement, which I haven't focused much effort on yet:

##### Mouseover UX
The SVG lines can be as little as 1 or 2 pixels thick, so it can be awkward to select the right line because the hover event is only triggered by an exact hit.

##### Mouseover highlight effect
The current effect is mostly a placeholder. It's tricky to restyle line endcaps on hover, so I've sidestepped that for now by applying a gradient to the middle of the line instead.

##### Expand/collapse UX
A bit jumpy - we probably want to adjust the page scroll after changing the diagram height.

