### PR TITLE
Allow address label to overflow without pushing UI

### DIFF
--- a/frontend/src/app/components/address-labels/address-labels.component.html
+++ b/frontend/src/app/components/address-labels/address-labels.component.html
@@ -1,9 +1,16 @@
-<a *ngIf="channel; else default" [routerLink]="['/lightning/channel' | relativeUrl, channel.id]">
-  <span
-    *ngIf="label"
-    class="badge badge-pill badge-warning"
-  >{{ label }}</span>
-</a>
+<ng-template [ngIf]="channel" [ngIfElse]="default">
+  <div>
+    <div class="badge-positioner">
+      <a [routerLink]="['/lightning/channel' | relativeUrl, channel.id]">
+        <span 
+          *ngIf="label"
+          class="badge badge-pill badge-warning"
+        >{{ label }}</span>
+      </a>
+    </div>
+    &nbsp;
+  </div>
+</ng-template>
 
 <ng-template #default>
   <span

--- a/frontend/src/app/components/address-labels/address-labels.component.scss
+++ b/frontend/src/app/components/address-labels/address-labels.component.scss
@@ -1,3 +1,7 @@
 .badge {
   margin-right: 2px;
 }
+
+.badge-positioner {
+  position: absolute;
+}


### PR DESCRIPTION
fixes #2544

Using absolute position to let the lightning label to overflow.

<img width="545" alt="Screen Shot 2022-09-18 at 20 50 26" src="https://user-images.githubusercontent.com/8561090/190923639-32994cc6-d833-4fb2-b63a-aa9ff1875d21.png">
