### PR TITLE
Improve transaction flow diagram drawing algorithm

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -191,12 +191,20 @@
     <br>
 
     <div class="title">
-      <h2 i18n="transaction.diagram|Transaction diagram">Diagram</h2>
+      <h2 i18n="transaction.flow|Transaction flow">Flow</h2>
     </div>
 
     <div class="box">
       <div class="graph-container" #graphContainer>
-        <tx-bowtie-graph [tx]="tx" [width]="graphWidth" [height]="graphExpanded ? (maxInOut * 15) : graphHeight" [maxStrands]="graphExpanded ? maxInOut : 24" [network]="network" [tooltip]="true"></tx-bowtie-graph>
+        <tx-bowtie-graph
+          [tx]="tx"
+          [width]="graphWidth"
+          [height]="graphExpanded ? (maxInOut * 15) : graphHeight"
+          [lineLimit]="inOutLimit"
+          [maxStrands]="graphExpanded ? maxInOut : 24"
+          [network]="network"
+          [tooltip]="true">
+        </tx-bowtie-graph>
       </div>
       <div class="toggle-wrapper" *ngIf="maxInOut > 24">
         <button class="btn btn-sm btn-primary graph-toggle" (click)="expandGraph();" *ngIf="!graphExpanded; else collapseBtn"><span i18n="show-more">Show more</span></button>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -50,7 +50,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   graphExpanded: boolean = false;
   graphWidth: number = 1000;
   graphHeight: number = 360;
+  inOutLimit: number = 150;
   maxInOut: number = 0;
+
   tooltipPosition: { x: number, y: number };
 
   @ViewChild('graphContainer')
@@ -298,7 +300,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   setupGraph() {
-    this.maxInOut = Math.min(250, Math.max(this.tx?.vin?.length || 1, this.tx?.vout?.length + 1 || 1));
+    this.maxInOut = Math.min(this.inOutLimit, Math.max(this.tx?.vin?.length || 1, this.tx?.vout?.length + 1 || 1));
     this.graphHeight = Math.min(360, this.maxInOut * 80);
   }
 


### PR DESCRIPTION
This PR fixes some flaws in the transaction diagram drawing algorithm which became apparent on smaller screens and taller aspect ratios:

1. On small screens, lines were far too thick.
2. Line endcaps could become misaligned.
3. Lines could overlap, which looks bad and obstructs user interactions.

The PR also changes the section title on the transaction page from 'Diagram' to 'Flow'.

#### Solutions

1. Line thicknesses are now proportional to the width of the diagram (up to the previous size).
2. The ends of the lines now include a short horizontal span to guarantee endcap alignment.
3. The curved parts of the lines are now horizontally offset from each other just far enough to prevent overlaps.

All of this makes calculating and drawing the lines slightly more complex, so the PR also reduces the maximum number of input/output lines drawn on the transaction page from 250 to 150 each to maintain performance.

| Before | After |
|-|-|
| ![mobile-before](https://user-images.githubusercontent.com/83316221/192039361-60afc5e9-a10d-4cb6-beb5-c7ee1755d2e1.png) | ![mobile-after](https://user-images.githubusercontent.com/83316221/192039373-2361daa4-c6e1-4b41-9378-400d8a89dca4.png) |
| ![highlighted-cropped-before](https://user-images.githubusercontent.com/83316221/192039397-28a24e6e-fdf0-4463-bbc8-7504abd0c290.png) | ![highlighted-cropped-after](https://user-images.githubusercontent.com/83316221/192039418-8257f6da-bb76-46db-adbc-bfdabaf2f248.png) |
| ![unfurler-before](https://user-images.githubusercontent.com/83316221/192039458-06971b35-4807-4567-a252-d06bf4723c64.png) | ![unfurler-after](https://user-images.githubusercontent.com/83316221/192039483-bce9dcae-0832-46e1-af45-139ed6b551ea.png) |
| ![unfurler2-before](https://user-images.githubusercontent.com/83316221/192039511-03e1e2e7-f5e7-49c5-9415-c3c257d16b08.png) | ![unfurler2-after](https://user-images.githubusercontent.com/83316221/192039531-5e8d527c-5bf3-4dd8-ba75-e9de9800d35e.png) |
