### PR TITLE
Updating info button styling

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -10,7 +10,7 @@ $nav-tabs-link-active-bg: #11131f;
 $primary: #105fb0;
 $secondary: #2d3348;
 $success: #1a9436;
-$info: #1bd8f4;
+$info: #5f4ab8;
 
 $h5-font-size: 1.15rem !default;
 


### PR DESCRIPTION
Updating `btn-info` styling to mempool pink, not affecting any current design.