### PR TITLE
Move logo to LHS on mining pool preview

### DIFF
--- a/frontend/src/app/components/pool/pool-preview.component.html
+++ b/frontend/src/app/components/pool/pool-preview.component.html
@@ -3,13 +3,13 @@
     <span i18n="mining.pools">mining pool</span>
   </app-preview-title>
   <div class="row d-flex justify-content-between full-width-row">
-    <div class="title-wrapper">
-      <h1 class="title">{{ poolStats.pool.name }}</h1>
-    </div>
     <div class="logo-wrapper">
       <img width="62" height="62" src="/resources/mining-pools/default.svg">
       <img [class.noimg]="!imageLoaded" width="62" height="62" src="{{ poolStats['logo'] }}"
         (load)="onImageLoad()" (error)="onImageFail()">
+    </div>
+    <div class="title-wrapper">
+      <h1 class="title">{{ poolStats.pool.name }}</h1>
     </div>
   </div>
   <div class="row full-width-row">

--- a/frontend/src/app/components/pool/pool-preview.component.scss
+++ b/frontend/src/app/components/pool/pool-preview.component.scss
@@ -59,7 +59,7 @@
   position: relative;
   width: 62px;
   height: 62px;
-  margin-left: 1em;
+  margin-right: 1em;
 
   img {
     position: absolute;


### PR DESCRIPTION
Moves logos to the left hand side of the pool name on the mining pool preview, to better match the main page.

| before | after |
|-|-|
| ![pool-before](https://user-images.githubusercontent.com/83316221/193076025-4db76b34-ea5e-4231-8236-9e9d8ea89b89.png) | ![pool-after](https://user-images.githubusercontent.com/83316221/193076050-f49aaea5-8f92-4d6a-8d96-7c8f814d80db.png) |
