### PR TITLE
Toggle option for transaction flow diagram with query param

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -190,39 +190,55 @@
 
     <br>
 
-    <div class="title">
-      <h2 i18n="transaction.flow|Transaction flow">Flow</h2>
-    </div>
-
-    <div class="box">
-      <div class="graph-container" #graphContainer>
-        <tx-bowtie-graph
-          [tx]="tx"
-          [width]="graphWidth"
-          [height]="graphExpanded ? (maxInOut * 15) : graphHeight"
-          [lineLimit]="inOutLimit"
-          [maxStrands]="graphExpanded ? maxInOut : 24"
-          [network]="network"
-          [tooltip]="true">
-        </tx-bowtie-graph>
+    <ng-container *ngIf="showFlow; else flowPlaceholder">
+      <div class="title float-left">
+        <h2 id="flow" i18n="transaction.flow|Transaction flow">Flow</h2>
       </div>
-      <div class="toggle-wrapper" *ngIf="maxInOut > 24">
-        <button class="btn btn-sm btn-primary graph-toggle" (click)="expandGraph();" *ngIf="!graphExpanded; else collapseBtn"><span i18n="show-more">Show more</span></button>
-        <ng-template #collapseBtn>
-          <button class="btn btn-sm btn-primary graph-toggle" (click)="collapseGraph();"><span i18n="show-less">Show less</span></button>
-        </ng-template>
+
+      <button type="button" class="btn btn-outline-info flow-toggle btn-sm float-right" (click)="toggleGraph()" i18n="hide-flow-diagram">Hide flow diagram</button>
+
+      <div class="clearfix"></div>
+
+      <div class="box">
+        <div class="graph-container" #graphContainer>
+          <tx-bowtie-graph
+            [tx]="tx"
+            [width]="graphWidth"
+            [height]="graphExpanded ? (maxInOut * 15) : graphHeight"
+            [lineLimit]="inOutLimit"
+            [maxStrands]="graphExpanded ? maxInOut : 24"
+            [network]="network"
+            [tooltip]="true">
+          </tx-bowtie-graph>
+        </div>
+        <div class="toggle-wrapper" *ngIf="maxInOut > 24">
+          <button class="btn btn-sm btn-primary graph-toggle" (click)="expandGraph();" *ngIf="!graphExpanded; else collapseBtn"><span i18n="show-more">Show more</span></button>
+          <ng-template #collapseBtn>
+            <button class="btn btn-sm btn-primary graph-toggle" (click)="collapseGraph();"><span i18n="show-less">Show less</span></button>
+          </ng-template>
+        </div>
+      </div>
+
+      <br>
+    </ng-container>
+    <ng-template #flowPlaceholder>
+      <div class="box hidden">
+        <div class="graph-container" #graphContainer>
+        </div>
+      </div>
+    </ng-template>
+
+    <div class="subtitle-block">
+      <div class="title">
+        <h2 i18n="transaction.inputs-and-outputs|Transaction inputs and outputs">Inputs & Outputs</h2>
+      </div>
+
+      <div class="title-buttons">
+        <button *ngIf="!showFlow" type="button" class="btn btn-outline-info flow-toggle btn-sm" (click)="toggleGraph()" i18n="show">Show flow diagram</button>
+        <button type="button" class="btn btn-outline-info btn-sm" (click)="txList.toggleDetails()" i18n="transaction.details|Transaction Details">Details</button>
       </div>
     </div>
 
-    <br>
-
-    <div class="title float-left">
-      <h2 i18n="transaction.inputs-and-outputs|Transaction inputs and outputs">Inputs & Outputs</h2>
-    </div>
-
-    <button type="button" class="btn btn-outline-info details-button btn-sm float-right" (click)="txList.toggleDetails()" i18n="transaction.details|Transaction Details">Details</button>
-
-    <div class="clearfix"></div>
 
     <app-transactions-list #txList [transactions]="[tx]" [errorUnblinded]="errorUnblinded" [outputIndex]="outputIndex" [transactionPage]="true"></app-transactions-list>
 
@@ -309,35 +325,37 @@
 
     <br>
 
-    <div class="title">
-      <h2 i18n="transaction.diagram|Transaction diagram">Diagram</h2>
-    </div>
+    <ng-container *ngIf="showFlow">
+      <div class="title">
+        <h2 i18n="transaction.flow|Transaction flow">Flow</h2>
+      </div>
 
-    <div class="box">
-      <div class="graph-container" #graphContainer style="visibility: hidden;"></div>
-      <div class="row">
-        <div class="col-sm">
-          <table class="table table-borderless table-striped">
-            <tbody>
-              <tr>
-                <td><span class="skeleton-loader"></span></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="col-sm">
-          <table class="table table-borderless table-striped">
-            <tbody>
-              <tr>
-                <td><span class="skeleton-loader"></span></td>
-              </tr>
-            </tbody>
-          </table>
+      <div class="box">
+        <div class="graph-container" #graphContainer style="visibility: hidden;"></div>
+        <div class="row">
+          <div class="col-sm">
+            <table class="table table-borderless table-striped">
+              <tbody>
+                <tr>
+                  <td><span class="skeleton-loader"></span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="col-sm">
+            <table class="table table-borderless table-striped">
+              <tbody>
+                <tr>
+                  <td><span class="skeleton-loader"></span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
-    </div>
 
-    <br>
+      <br>
+    </ng-container>
 
     <div class="title">
       <h2 i18n="transaction.inputs-and-outputs|Transaction inputs and outputs">Inputs & Outputs</h2>

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -73,6 +73,15 @@
 	}
 }
 
+.box.hidden {
+  visibility: hidden;
+  height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .graph-container {
   position: relative;
   width: 100%;
@@ -150,10 +159,33 @@
 	}
 }
 
-.details-button {
+.details-button, .flow-toggle {
   margin-top: -5px;
+  margin-left: 10px;
 	@media (min-width: 768px){
 		display: inline-block;
     margin-top: 0px;
+    margin-bottom: 0px;
 	}
+}
+
+.subtitle-block {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+
+  .title {
+    flex-shrink: 0;
+  }
+
+  .title-buttons {
+    flex-shrink: 1;
+    text-align: right;
+    .btn {
+      margin-top: 0;
+      margin-bottom: 8px;
+      margin-left: 8px;
+    }
+  }
 }


### PR DESCRIPTION
This PR adds toggle buttons to completely hide/show the new flow diagram on the transaction page, and enables a new url query parameter `showFlow` to provide control over this in links.

The flow diagram is shown by default. Adding `?showFlow=false` to a transaction url will make the diagram hidden.

![flow-shown](https://user-images.githubusercontent.com/83316221/193077543-e24461c0-0f81-43e7-90ac-c74993938b65.png)

![flow-hidden](https://user-images.githubusercontent.com/83316221/193077563-b49b879e-7982-466c-b9b1-2e39b80612b3.png)
