### PR TITLE
Revert "New button light color"

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -10,7 +10,6 @@ $nav-tabs-link-active-bg: #11131f;
 $primary: #105fb0;
 $secondary: #2d3348;
 $success: #1a9436;
-$light: #744ad1;
 $info: #1bd8f4;
 
 $h5-font-size: 1.15rem !default;


### PR DESCRIPTION
This reverts commit c79c1d9958ff52dee9acf377f136c6641c7dd138.

Adding light base color was a mistake since it affected some of the loading spinners and it looks bad, especially on the search bar.

Current master
<img width="74" alt="Screen Shot 2022-09-30 at 04 04 46" src="https://user-images.githubusercontent.com/8561090/193162773-884fa284-1987-4d55-8c44-a2eb43813126.png">

This pr (revert)
<img width="71" alt="Screen Shot 2022-09-30 at 04 04 34" src="https://user-images.githubusercontent.com/8561090/193162778-5ac7dd61-1aa8-4965-80c8-a9d033a17e16.png">
