### PR TITLE
Fix transaction marker boundary condition

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -287,11 +287,12 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
 
     this.arrowVisible = true;
 
-    for (const block of this.mempoolBlocks) {
-      for (let i = 0; i < block.feeRange.length - 1; i++) {
+    let found = false;
+    for (let txInBlockIndex = 0; txInBlockIndex < this.mempoolBlocks.length && !found; txInBlockIndex++) {
+      const block = this.mempoolBlocks[txInBlockIndex];
+      for (let i = 0; i < block.feeRange.length - 1 && !found; i++) {
         if (this.txFeePerVSize < block.feeRange[i + 1] && this.txFeePerVSize >= block.feeRange[i]) {
-          const txInBlockIndex = this.mempoolBlocks.indexOf(block);
-          const feeRangeIndex = block.feeRange.findIndex((val, index) => this.txFeePerVSize < block.feeRange[index + 1]);
+          const feeRangeIndex = i;
           const feeRangeChunkSize = 1 / (block.feeRange.length - 1);
 
           const txFee = this.txFeePerVSize - block.feeRange[i];
@@ -306,8 +307,12 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
             + ((1 - feePosition) * blockedFilledPercentage * this.blockWidth);
 
           this.rightPosition = arrowRightPosition;
-          break;
+          found = true;
         }
+      }
+      if (this.txFeePerVSize >= block.feeRange[block.feeRange.length - 1]) {
+        this.rightPosition = txInBlockIndex * (this.blockWidth + this.blockPadding);
+        found = true;
       }
     }
   }


### PR DESCRIPTION
Fixes #2598

### Issue

Caused by a bad boundary condition when finding the position of a tx within the fee ranges of the projected blocks.

We were looking for a range where `min <= feerate < max`, but for the highest effective feerate tx in each projected block, `feerate == max` so no matching range is found, and the marker arrow defaults to the center of the selected block.

This can also happen if a transaction has an effective fee rate that lies between the maximum fee of one projected block and the minimum fee of the next. In theory this shouldn't be possible, but presumably sometimes the two sources of data (the mempool block fee ranges, and effective rates calculated from `getCPFPinfo` data) don't perfectly align.

### Steps to reproduce

Go to /mempool-block/0 and select the highest effective feerate transaction (usually the very top-right corner, unless that tx has lower rate descendants). The marker arrow incorrectly displays in the center of the block, instead of the far right hand side.