### PR TITLE
Reverse time by default for RTL languages

### DIFF
--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Inject, Injectable, PLATFORM_ID, LOCALE_ID } from '@angular/core';
 import { ReplaySubject, BehaviorSubject, Subject, fromEvent, Observable } from 'rxjs';
 import { Transaction } from '../interfaces/electrs.interface';
 import { IBackendInfo, MempoolBlock, MempoolBlockWithTransactions, MempoolBlockDelta, MempoolInfo, Recommendedfees, ReplacedTransaction, TransactionStripped } from '../interfaces/websocket.interface';
@@ -113,6 +113,7 @@ export class StateService {
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
+    @Inject(LOCALE_ID) private locale: string,
     private router: Router,
     private storageService: StorageService,
   ) {
@@ -151,7 +152,10 @@ export class StateService {
 
     this.blockVSize = this.env.BLOCK_WEIGHT_UNITS / 4;
 
-    this.timeLtr = new BehaviorSubject<boolean>(this.storageService.getValue('time-preference-ltr') === 'true');
+    const savedTimePreference = this.storageService.getValue('time-preference-ltr');
+    const rtlLanguage = (this.locale.startsWith('ar') || this.locale.startsWith('fa') || this.locale.startsWith('he'));
+    // default time direction is right-to-left, unless locale is a RTL language
+    this.timeLtr = new BehaviorSubject<boolean>(savedTimePreference === 'true' || (savedTimePreference == null && rtlLanguage));
     this.timeLtr.subscribe((ltr) => {
       this.storageService.setValue('time-preference-ltr', ltr ? 'true' : 'false');
     });


### PR DESCRIPTION
Reverses the default time direction for RTL language users, so that the mempool blocks are at the 'start' of the line, like they are for other languages in the original layout.

_(remember to clear localStorage before testing, otherwise the default direction will be overridden by any cached preference)_