### PR TITLE
Updating time toggle size

### DIFF
--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -84,9 +84,9 @@
 
 .time-toggle {
   color: white;
-  font-size: 1rem;
+  font-size: 0.8rem;
   position: absolute;
-  bottom: -1.5em;
+  bottom: -1.8em;
   left: 1px;
   transform: translateX(-50%);
   background: none;


### PR DESCRIPTION
Reducing the size of the blockchain flip toggle to make it little less prominent.

Before
<img width="53" alt="Screen Shot 2022-10-06 at 20 33 03" src="https://user-images.githubusercontent.com/8561090/194369078-e037b0e2-08a3-4977-931e-b33245d94cb9.png">

After
<img width="52" alt="Screen Shot 2022-10-06 at 20 33 06" src="https://user-images.githubusercontent.com/8561090/194369100-d5bd67d3-8de0-46c7-9c67-ac0bd9a0c544.png">
