### PR TITLE
Display LN capacity on mobile

### DIFF
--- a/frontend/src/app/lightning/node-statistics/node-statistics.component.scss
+++ b/frontend/src/app/lightning/node-statistics/node-statistics.component.scss
@@ -37,8 +37,9 @@
     }
     &.more-padding {
       padding-top: 10px;
-    }  
-    &:first-child{
+    }
+    &:last-child {
+      margin-bottom: 0;
       display: none;
       @media (min-width: 485px) {
         display: block;
@@ -48,10 +49,7 @@
       }    
       @media (min-width: 992px) {
         display: block;
-      }    
-    }
-    &:last-child {
-      margin-bottom: 0;
+      }  
     }
     .card-text span {
       color: #ffffff66;


### PR DESCRIPTION
fixes #2610

Before
<img width="278" alt="Screen Shot 2022-10-06 at 21 13 35" src="https://user-images.githubusercontent.com/8561090/194376826-95a67dd9-ed3b-4b28-a807-cd022cfd8a84.png">

After
<img width="283" alt="Screen Shot 2022-10-06 at 21 13 53" src="https://user-images.githubusercontent.com/8561090/194376927-a6900877-8d57-451f-a06e-d33e276ffc0f.png">
