### PR TITLE
Fix lightning channel close classification logic

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 40;
+  private static currentVersion = 41;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -347,6 +347,10 @@ class DatabaseMigration {
       await this.$executeQuery('ALTER TABLE `nodes` ADD capacity bigint(20) unsigned DEFAULT NULL');
       await this.$executeQuery('ALTER TABLE `nodes` ADD channels int(11) unsigned DEFAULT NULL');
       await this.$executeQuery('ALTER TABLE `nodes` ADD INDEX `capacity` (`capacity`);');
+    }
+
+    if (databaseSchemaVersion < 41 && isBitcoin === true) {
+      await this.$executeQuery('UPDATE channels SET closing_reason = NULL WHERE closing_reason = 1');
     }
   }
 


### PR DESCRIPTION
(fixes #2637)

This PR fixes a bug in the `runClosedChannelsForensics` close classification logic.

Specifically, we were misidentifying force closes as mutual when the close had:
 - a single spent `to_remote` output
 - no `to_local` output
 - no HTLCs
 - no anchors
 
e.g. https://mempool.space/lightning/channel/745541451452710913

In that case, the two types of close can be distinguished by their sequence numbers & locktime, however this clause prematurely assumed such a close must be mutual:

https://github.com/mempool/mempool/blob/eb18625802995db26db115aa4755227a395af137/backend/src/tasks/lightning/network-sync.service.ts#L329-L332

Channels that have already been misclassified will need to be reconsidered. I'm not sure what the best approach is here - maybe add a database migration to reset `closing_reason=NULL` for force-closed channels, so they'll be picked up on the next run of `runClosedChannelsForensics`?