### PR TITLE
tolerate trailing slash in unfurler requests

### DIFF
--- a/unfurler/src/language/lang.ts
+++ b/unfurler/src/language/lang.ts
@@ -62,15 +62,15 @@ export const languages = languageDict;
 
 // expects path to start with a leading '/'
 export function parseLanguageUrl(path) {
-  const parts = path.split('/');
+  const parts = path.split('/').filter(part => part.length);
   let lang;
   let rest;
-  if (languages[parts[1]]) {
-    lang = parts[1];
-    rest = '/' + parts.slice(2).join('/');
+  if (languages[parts[0]]) {
+    lang = parts[0];
+    rest = '/' + parts.slice(1).join('/');
   } else {
     lang = null;
-    rest = path;
+    rest = '/' + parts.join('/');
   }
   if (lang === 'en') {
     lang = null;


### PR DESCRIPTION
Fixes a bug where the unfurler would time out for requests with a trailing slash:
> ```ERR <bitcoin-unfurler> failed to render /en/preview/tx/fe968c18c62799aac5871b80e2162bbe4b796e4686df18816840a6a11fa34ff2/ for screenshot: waiting for selector `meta[property="og:preview:loading"]` failed: timeout 3000ms exceeded```

Regular navigation strips trailing slashes, but `router.navigateByUrl` used by the open graph navigation service does not, and so fails to match the route and initiate preview tasks.