### PR TITLE
Block audit feature

### DIFF
--- a/backend/src/api/mining/mining-routes.ts
+++ b/backend/src/api/mining/mining-routes.ts
@@ -238,6 +238,12 @@ class MiningRoutes {
   public async $getBlockAudit(req: Request, res: Response) {
     try {
       const audit = await BlocksAuditsRepository.$getBlockAudit(req.params.hash);
+
+      if (!audit) {
+        res.status(404).send(`This block has not been audited.`);
+        return;
+      }
+
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 3600 * 24).toUTCString());

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -413,7 +413,7 @@ class WebsocketHandler {
 
     let mBlocks: undefined | MempoolBlock[];
     let mBlockDeltas: undefined | MempoolBlockDelta[];
-    let matchRate = 0;
+    let matchRate;
     const _memPool = memPool.getMempool();
 
     if (Common.indexingEnabled()) {

--- a/backend/src/repositories/BlocksAuditsRepository.ts
+++ b/backend/src/repositories/BlocksAuditsRepository.ts
@@ -58,10 +58,12 @@ class BlocksAuditRepositories {
         WHERE blocks_audits.hash = "${hash}"
       `);
       
-      rows[0].missingTxs = JSON.parse(rows[0].missingTxs);
-      rows[0].addedTxs = JSON.parse(rows[0].addedTxs);
-      rows[0].transactions = JSON.parse(rows[0].transactions);
-      rows[0].template = JSON.parse(rows[0].template);
+      if (rows.length) {
+        rows[0].missingTxs = JSON.parse(rows[0].missingTxs);
+        rows[0].addedTxs = JSON.parse(rows[0].addedTxs);
+        rows[0].transactions = JSON.parse(rows[0].transactions);
+        rows[0].template = JSON.parse(rows[0].template);
+      }
             
       return rows[0];
     } catch (e: any) {

--- a/backend/src/repositories/BlocksAuditsRepository.ts
+++ b/backend/src/repositories/BlocksAuditsRepository.ts
@@ -71,6 +71,20 @@ class BlocksAuditRepositories {
       throw e;
     }
   }
+
+  public async $getShortBlockAudit(hash: string): Promise<any> {
+    try {
+      const [rows]: any[] = await DB.query(
+        `SELECT hash as id, match_rate as matchRate
+        FROM blocks_audits
+        WHERE blocks_audits.hash = "${hash}"
+      `);
+      return rows[0];
+    } catch (e: any) {
+      logger.err(`Cannot fetch block audit from db. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
 }
 
 export default new BlocksAuditRepositories();

--- a/frontend/src/app/components/block-audit/block-audit.component.html
+++ b/frontend/src/app/components/block-audit/block-audit.component.html
@@ -1,21 +1,22 @@
 <div class="container-xl" (window:resize)="onResize($event)">
 
-  <div *ngIf="(auditObservable$ | async) as blockAudit; else skeleton">
-    <div class="title-block" id="block">
-      <h1>
-        <span class="next-previous-blocks">
-          <span i18n="shared.block-title">Block </span>
-          &nbsp;
-          <a [routerLink]="['/block/' | relativeUrl, blockAudit.id]">{{ blockAudit.height }}</a>
-          &nbsp;
-          <span i18n="shared.template-vs-mined">Template vs Mined</span>
-        </span>
-      </h1>
+  <div class="title-block" id="block">
+    <h1>
+      <span class="next-previous-blocks">
+        <span i18n="shared.block-audit-title">Block Audit</span>
+        &nbsp;
+        <a *ngIf="blockAudit" [routerLink]="['/block/' | relativeUrl, blockHash]">{{ blockAudit.height }}</a>
+        &nbsp;
+      </span>
+    </h1>
 
-      <div class="grow"></div>
+    <div class="grow"></div>
 
-      <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
-    </div>
+    <button [routerLink]="['/block/' | relativeUrl, blockHash]" class="btn btn-sm">&#10005;</button>
+  </div>
+
+  <div *ngIf="!error && !isLoading">
+    
 
     <!-- OVERVIEW -->
     <div class="box mb-3">
@@ -26,8 +27,8 @@
             <tbody>
               <tr>
                 <td class="td-width" i18n="block.hash">Hash</td>
-                <td><a [routerLink]="['/block/' | relativeUrl, blockAudit.id]" title="{{ blockAudit.id }}">{{ blockAudit.id | shortenString : 13 }}</a>
-                  <app-clipboard class="d-none d-sm-inline-block" [text]="blockAudit.id"></app-clipboard>
+                <td><a [routerLink]="['/block/' | relativeUrl, blockHash]" title="{{ blockHash }}">{{ blockHash | shortenString : 13 }}</a>
+                  <app-clipboard class="d-none d-sm-inline-block" [text]="blockHash"></app-clipboard>
                 </td>
               </tr>
               <tr>
@@ -39,6 +40,10 @@
                       </app-time-since>)</i>
                   </div>
                 </td>
+              </tr>
+              <tr>
+                <td class="td-width" i18n="shared.transaction-count">Transactions</td>
+                <td>{{ blockAudit.tx_count }}</td>
               </tr>
               <tr>
                 <td i18n="blockAudit.size">Size</td>
@@ -57,20 +62,24 @@
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
-                <td class="td-width" i18n="shared.transaction-count">Transactions</td>
-                <td>{{ blockAudit.tx_count }}</td>
-              </tr>
-              <tr>
-                <td i18n="block.match-rate">Match rate</td>
+                <td i18n="block.health">Block health</td>
                 <td>{{ blockAudit.matchRate }}%</td>
               </tr>
               <tr>
-                <td i18n="block.missing-txs">Missing txs</td>
+                <td i18n="block.missing-txs">Removed txs</td>
                 <td>{{ blockAudit.missingTxs.length }}</td>
+              </tr>
+              <tr>
+                <td i18n="block.missing-txs">Omitted txs</td>
+                <td>{{ numMissing }}</td>
               </tr>
               <tr>
                 <td i18n="block.added-txs">Added txs</td>
                 <td>{{ blockAudit.addedTxs.length }}</td>
+              </tr>
+              <tr>
+                <td i18n="block.missing-txs">Included txs</td>
+                <td>{{ numUnexpected }}</td>
               </tr>
             </tbody>
           </table>
@@ -79,33 +88,110 @@
     </div> <!-- box -->
 
     <!-- ADDED vs MISSING button -->
-    <div class="d-flex justify-content-center menu mt-3" *ngIf="isMobile">
-      <a routerLinkActive="active" class="btn btn-primary w-50 mr-1 ml-1 menu-button" i18n="block.missing-txs"
-        fragment="missing" (click)="changeMode('missing')">Missing</a>
-      <a routerLinkActive="active" class="btn btn-primary w-50 mr-1 ml-1 menu-button" i18n="block.added-txs"
-        fragment="added" (click)="changeMode('added')">Added</a>
+    <div class="d-flex justify-content-center menu mt-3 mb-3" *ngIf="isMobile">
+      <a class="btn btn-primary w-50 mr-1 ml-1 menu-button" [class.active]="mode === 'projected'" i18n="block.projected"
+        fragment="projected" (click)="changeMode('projected')">Projected</a>
+      <a class="btn btn-primary w-50 mr-1 ml-1 menu-button" [class.active]="mode === 'actual'" i18n="block.actual"
+        fragment="actual" (click)="changeMode('actual')">Actual</a>
     </div>
   </div>
 
+  <ng-template [ngIf]="!error && isLoading">
+    <div class="title-block" id="block">
+      <h1>
+        <span class="next-previous-blocks">
+          <span i18n="shared.block-audit-title">Block Audit</span>
+          &nbsp;
+          <a *ngIf="blockAudit" [routerLink]="['/block/' | relativeUrl, blockHash]">{{ blockAudit.height }}</a>
+          &nbsp;
+        </span>
+      </h1>
+
+      <div class="grow"></div>
+
+      <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
+    </div>
+
+    <!-- OVERVIEW -->
+    <div class="box mb-3">
+      <div class="row">
+        <!-- LEFT COLUMN -->
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- RIGHT COLUMN -->
+        <div class="col-sm">
+          <table class="table table-borderless table-striped">
+            <tbody>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div> <!-- row -->
+    </div> <!-- box -->
+
+    <!-- ADDED vs MISSING button -->
+    <div class="d-flex justify-content-center menu mt-3 mb-3" *ngIf="isMobile">
+      <a class="btn btn-primary w-50 mr-1 ml-1 menu-button" [class.active]="mode === 'projected'" i18n="block.projected"
+        fragment="projected" (click)="changeMode('projected')">Projected</a>
+      <a class="btn btn-primary w-50 mr-1 ml-1 menu-button" [class.active]="mode === 'actual'" i18n="block.actual"
+        fragment="actual" (click)="changeMode('actual')">Actual</a>
+    </div>
+  </ng-template>
+
+  <ng-template [ngIf]="error">
+    <div *ngIf="error && error.status === 404; else generalError" class="text-center">
+      <br>
+      <b i18n="error.audit-unavailable">audit unavailable</b>
+      <br><br>
+      <i>{{ error.error }}</i>
+      <br>
+      <br>
+    </div>
+    <ng-template #generalError>
+      <div class="text-center">
+        <br>
+        <span i18n="error.general-loading-data">Error loading data.</span>
+        <br><br>
+        <i>{{ error }}</i>
+        <br>
+        <br>
+      </div>
+    </ng-template>
+  </ng-template>
+
   <!-- VISUALIZATIONS -->
-  <div class="box">
+  <div class="box" *ngIf="!error">
     <div class="row">
       <!-- MISSING TX RENDERING -->
       <div class="col-sm" *ngIf="webGlEnabled">
-        <app-block-overview-graph #blockGraphTemplate [isLoading]="isLoading" [resolution]="75"
+        <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.projected-block">Projected Block</h3>
+        <app-block-overview-graph #blockGraphProjected [isLoading]="isLoading" [resolution]="75"
           [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false"
           (txClickEvent)="onTxClick($event)"></app-block-overview-graph>
       </div>
 
       <!-- ADDED TX RENDERING -->
       <div class="col-sm" *ngIf="webGlEnabled && !isMobile">
-        <app-block-overview-graph #blockGraphMined [isLoading]="isLoading" [resolution]="75"
+        <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.actual-block">Actual Block</h3>
+        <app-block-overview-graph #blockGraphActual [isLoading]="isLoading" [resolution]="75"
           [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false"
           (txClickEvent)="onTxClick($event)"></app-block-overview-graph>
       </div>
     </div> <!-- row -->
   </div> <!-- box -->
-
-  <ng-template #skeleton></ng-template>
 
 </div>

--- a/frontend/src/app/components/block-audit/block-audit.component.scss
+++ b/frontend/src/app/components/block-audit/block-audit.component.scss
@@ -38,3 +38,7 @@
     max-width: 150px;
   }
 }
+
+.block-subtitle {
+  text-align: center;
+}

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -7,6 +7,15 @@ import { feeLevels, mempoolFeeColors } from '../../app.constants';
 const hoverTransitionTime = 300;
 const defaultHoverColor = hexToColor('1bd8f4');
 
+const feeColors = mempoolFeeColors.map(hexToColor);
+const auditFeeColors = feeColors.map((color) => desaturate(color, 0.3));
+const auditColors = {
+  censored: hexToColor('f344df'),
+  missing: darken(desaturate(hexToColor('f344df'), 0.3), 0.7),
+  added: hexToColor('03E1E5'),
+  selected: darken(desaturate(hexToColor('039BE5'), 0.3), 0.7),
+}
+
 // convert from this class's update format to TxSprite's update format
 function toSpriteUpdate(params: ViewUpdateParams): SpriteUpdateParams {
   return {
@@ -143,17 +152,19 @@ export default class TxView implements TransactionStripped {
 
   getColor(): Color {
     const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, this.feerate) < feeLvl) - 1;
-    const feeLevelColor = hexToColor(mempoolFeeColors[feeLevelIndex] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+    const feeLevelColor = feeColors[feeLevelIndex] || feeColors[mempoolFeeColors.length - 1];
     // Block audit
     switch(this.status) {
       case 'censored':
-        return hexToColor('D81BC2');
+        return auditColors.censored;
       case 'missing':
-        return hexToColor('8C1BD8');
+        return auditColors.missing;
       case 'added':
-        return hexToColor('03E1E5');
+        return auditColors.added;
       case 'selected':
-        return hexToColor('039BE5');
+        return auditColors.selected;
+      case 'found':
+        return auditFeeColors[feeLevelIndex] || auditFeeColors[mempoolFeeColors.length - 1];
       default:
         return feeLevelColor;
     }
@@ -167,4 +178,23 @@ function hexToColor(hex: string): Color {
     b: parseInt(hex.slice(4, 6), 16) / 255,
     a: 1
   };
+}
+
+function desaturate(color: Color, amount: number): Color {
+  const gray = (color.r + color.g + color.b) / 6;
+  return {
+    r: color.r + ((gray - color.r) * amount),
+    g: color.g + ((gray - color.g) * amount),
+    b: color.b + ((gray - color.b) * amount),
+    a: color.a,
+  };
+}
+
+function darken(color: Color, amount: number): Color {
+  return {
+    r: color.r * amount,
+    g: color.g * amount,
+    b: color.b * amount,
+    a: color.a,
+  }
 }

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -25,7 +25,7 @@ export default class TxView implements TransactionStripped {
   vsize: number;
   value: number;
   feerate: number;
-  status?: 'found' | 'missing' | 'added';
+  status?: 'found' | 'missing' | 'added' | 'censored' | 'selected';
 
   initialised: boolean;
   vertexArray: FastVertexArray;
@@ -142,16 +142,21 @@ export default class TxView implements TransactionStripped {
   }
 
   getColor(): Color {
-    // Block audit
-    if (this.status === 'missing') {
-      return hexToColor('039BE5');
-    } else if (this.status === 'added') {
-      return hexToColor('D81B60');
-    }
-
-    // Block component
     const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, this.feerate) < feeLvl) - 1;
-    return hexToColor(mempoolFeeColors[feeLevelIndex] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+    const feeLevelColor = hexToColor(mempoolFeeColors[feeLevelIndex] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+    // Block audit
+    switch(this.status) {
+      case 'censored':
+        return hexToColor('D81BC2');
+      case 'missing':
+        return hexToColor('8C1BD8');
+      case 'added':
+        return hexToColor('03E1E5');
+      case 'selected':
+        return hexToColor('039BE5');
+      default:
+        return feeLevelColor;
+    }
   }
 }
 

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -36,10 +36,10 @@
         <td class="td-width" i18n="transaction.audit-status">Audit status</td>
         <ng-container [ngSwitch]="tx?.status">
           <td *ngSwitchCase="'found'" i18n="transaction.audit.match">match</td>
-          <td *ngSwitchCase="'censored'" i18n="transaction.audit.censored">censored</td>
+          <td *ngSwitchCase="'censored'" i18n="transaction.audit.removed">removed</td>
           <td *ngSwitchCase="'missing'" i18n="transaction.audit.missing">missing</td>
-          <td *ngSwitchCase="'added'" i18n="transaction.audit.prioritized">prioritized</td>
-          <td *ngSwitchCase="'selected'" i18n="transaction.audit.unexpected">unexpected</td>
+          <td *ngSwitchCase="'added'" i18n="transaction.audit.added">added</td>
+          <td *ngSwitchCase="'selected'" i18n="transaction.audit.included">included</td>
         </ng-container>
       </tr>
     </tbody>

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -32,6 +32,16 @@
         <td class="td-width" i18n="transaction.vsize|Transaction Virtual Size">Virtual size</td>
         <td [innerHTML]="'&lrm;' + (vsize | vbytes: 2)"></td>
       </tr>
+      <tr *ngIf="tx && tx.status && tx.status.length">
+        <td class="td-width" i18n="transaction.audit-status">Audit status</td>
+        <ng-container [ngSwitch]="tx?.status">
+          <td *ngSwitchCase="'found'" i18n="transaction.audit.match">match</td>
+          <td *ngSwitchCase="'censored'" i18n="transaction.audit.censored">censored</td>
+          <td *ngSwitchCase="'missing'" i18n="transaction.audit.missing">missing</td>
+          <td *ngSwitchCase="'added'" i18n="transaction.audit.prioritized">prioritized</td>
+          <td *ngSwitchCase="'selected'" i18n="transaction.audit.unexpected">unexpected</td>
+        </ng-container>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -110,6 +110,13 @@
                   </span>
                   </td>
                 </tr>
+                <tr *ngIf="indexingAvailable">
+                  <td i18n="block.health">Block health</td>
+                  <td>
+                    <a *ngIf="block.extras?.matchRate != null" [routerLink]="['/block-audit/' | relativeUrl, blockHash]">{{ block.extras.matchRate }}%</a>
+                    <span *ngIf="block.extras?.matchRate == null" i18n="unknown">Unknown</span>
+                  </td>
+                </tr>
               </ng-template>
             </tbody>
           </table>

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -47,6 +47,7 @@ export class BlockComponent implements OnInit, OnDestroy {
   transactionsError: any = null;
   overviewError: any = null;
   webGlEnabled = true;
+  indexingAvailable = false;
 
   transactionSubscription: Subscription;
   overviewSubscription: Subscription;
@@ -85,6 +86,9 @@ export class BlockComponent implements OnInit, OnDestroy {
     this.timeLtrSubscription = this.stateService.timeLtr.subscribe((ltr) => {
       this.timeLtr = !!ltr;
     });
+
+    this.indexingAvailable = (this.stateService.env.BASE_MODULE === 'mempool' &&
+      this.stateService.env.MINING_DASHBOARD === true);
 
     this.txsLoadingStatus$ = this.route.paramMap
       .pipe(

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -14,6 +14,8 @@
           i18n-ngbTooltip="mining.pool-name" ngbTooltip="Pool" placement="bottom" #miningpool [disableTooltip]="!isEllipsisActive(miningpool)">Pool</th>
         <th class="timestamp" i18n="latest-blocks.timestamp" *ngIf="!widget" [class]="indexingAvailable ? '' : 'legacy'">Timestamp</th>
         <th class="mined" i18n="latest-blocks.mined" *ngIf="!widget" [class]="indexingAvailable ? '' : 'legacy'">Mined</th>
+        <th *ngIf="indexingAvailable" class="health text-left" i18n="latest-blocks.health" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}"
+          i18n-ngbTooltip="latest-blocks.health" ngbTooltip="Health" placement="bottom" #health [disableTooltip]="!isEllipsisActive(health)">Health</th>
         <th *ngIf="indexingAvailable" class="reward text-right" i18n="latest-blocks.reward" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}"
           i18n-ngbTooltip="latest-blocks.reward" ngbTooltip="Reward" placement="bottom" #reward [disableTooltip]="!isEllipsisActive(reward)">Reward</th>
         <th *ngIf="indexingAvailable && !widget" class="fees text-right" i18n="latest-blocks.fees" [class]="indexingAvailable ? '' : 'legacy'">Fees</th>
@@ -37,11 +39,29 @@
               <span *ngIf="!widget" class="tooltiptext badge badge-secondary scriptmessage">{{ block.extras.coinbaseRaw | hex2ascii }}</span>
             </div>
           </td>
-          <td class="timestamp" *ngIf="!widget">
+          <td class="timestamp" *ngIf="!widget" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
             &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
           </td>
           <td class="mined" *ngIf="!widget" [class]="indexingAvailable ? '' : 'legacy'">
             <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
+          </td>
+          <td *ngIf="indexingAvailable" class="health text-right" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
+            <a *ngIf="block.extras?.matchRate != null" class="clear-link" [routerLink]="['/block-audit/' | relativeUrl, block.id]">
+              <div class="progress progress-health">
+                <div class="progress-bar progress-bar-health" role="progressbar"
+                  [ngStyle]="{'width': (100 - (block.extras?.matchRate || 0)) + '%' }"></div>
+                <div class="progress-text">
+                  <span>{{ block.extras.matchRate }}%</span>
+                </div>
+              </div>
+            </a>
+            <div *ngIf="block.extras?.matchRate == null" class="progress progress-health">
+              <div class="progress-bar progress-bar-health" role="progressbar"
+                [ngStyle]="{'width': '100%' }"></div>
+              <div class="progress-text">
+                <span>~</span>
+              </div>
+            </div>
           </td>
           <td *ngIf="indexingAvailable" class="reward text-right" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
             <app-amount [satoshis]="block.extras.reward" [noFiat]="true" digitsInfo="1.2-2"></app-amount>
@@ -76,6 +96,9 @@
             </td>
             <td class="mined" *ngIf="!widget" [class]="indexingAvailable ? '' : 'legacy'">
               <span class="skeleton-loader" style="max-width: 125px"></span>
+            </td>
+            <td *ngIf="indexingAvailable" class="health text-left" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
+              <span class="skeleton-loader" style="max-width: 75px"></span>
             </td>
             <td *ngIf="indexingAvailable" class="reward text-right" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
               <span class="skeleton-loader" style="max-width: 75px"></span>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -63,7 +63,7 @@ tr, td, th {
 }
 
 .height {
-  width: 10%;
+  width: 8%;
 }
 .height.widget {
   width: 15%;
@@ -77,12 +77,18 @@ tr, td, th {
 
 .timestamp {
   width: 18%;
-  @media (max-width: 900px) {
+  @media (max-width: 1100px) {
     display: none;
   }
 }
 .timestamp.legacy {
   width: 20%;
+  @media (max-width: 1100px) {
+    display: table-cell;
+  }
+  @media (max-width: 850px) {
+    display: none;
+  }
 }
 
 .mined {
@@ -93,6 +99,10 @@ tr, td, th {
 }
 .mined.legacy {
   width: 15%;
+  @media (max-width: 1000px) {
+    padding-right: 20px;
+    width: 20%;
+  }
   @media (max-width: 576px) {
     display: table-cell;
   }
@@ -100,6 +110,7 @@ tr, td, th {
 
 .txs {
   padding-right: 40px;
+  width: 8%;
   @media (max-width: 1100px) {
     padding-right: 10px;
   }
@@ -113,17 +124,21 @@ tr, td, th {
 }
 .txs.widget {
   padding-right: 0;
+  display: none;
   @media (max-width: 650px) {
     display: none;
   }
 }
 .txs.legacy {
-  padding-right: 80px;
-  width: 10%;
+  width: 18%;
+  display: table-cell;
+  @media (max-width: 1000px) {
+    padding-right: 20px;
+  }
 }
 
 .fees {
-  width: 10%;
+  width: 8%;
   @media (max-width: 650px) {
     display: none;
   }
@@ -133,7 +148,7 @@ tr, td, th {
 }
 
 .reward {
-  width: 10%;
+  width: 8%;
   @media (max-width: 576px) {
     width: 7%;
     padding-right: 30px;
@@ -152,8 +167,11 @@ tr, td, th {
 }
 
 .size {
-  width: 12%;
+  width: 10%;
   @media (max-width: 1000px) {
+    width: 13%;
+  }
+  @media (max-width: 950px) {
     width: 15%;
   }
   @media (max-width: 650px) {
@@ -164,9 +182,31 @@ tr, td, th {
   }
 }
 .size.legacy {
-  width: 20%;
+  width: 30%;
   @media (max-width: 576px) {
     display: table-cell;
+  }
+}
+
+.health {
+  width: 10%;
+  @media (max-width: 1000px) {
+    width: 13%;
+  }
+  @media (max-width: 950px) {
+    display: none;
+  }
+}
+.health.widget {
+  width: 25%;
+  @media (max-width: 1000px) {
+    display: none;
+  }
+  @media (max-width: 767px) {
+    display: table-cell;
+  }
+  @media (max-width: 500px) {
+    display: none;
   }
 }
 

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -141,7 +141,7 @@ export interface TransactionStripped {
   fee: number;
   vsize: number;
   value: number;
-  status?: 'found' | 'missing' | 'added';
+  status?: 'found' | 'missing' | 'added' | 'censored' | 'selected';
 }
 
 export interface RewardStats {

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -70,7 +70,7 @@ export interface TransactionStripped {
   fee: number;
   vsize: number;
   value: number;
-  status?: 'found' | 'missing' | 'added';
+  status?: 'found' | 'missing' | 'added' | 'censored' | 'selected';
 }
 
 export interface IBackendInfo {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -668,6 +668,15 @@ h1, h2, h3 {
   background-color: #2e324e;
 }
 
+.progress.progress-health {
+  background: repeating-linear-gradient(to right, #2d3348, #2d3348 0%, #105fb0 0%, #1a9436 100%);
+  justify-content: flex-end;
+}
+
+.progress-bar.progress-bar-health {
+  background: #2d3348;
+}
+
 .mt-2-5, .my-2-5 {
   margin-top: 0.75rem !important;
 }


### PR DESCRIPTION
__(depends on PR #2621)__

This PR tidies up some unfinished parts of the Block Audit page, and exposes that feature by linking it from the block page and the /blocks and mining dashboard latest blocks lists.

### Terminology

"Match Rate" didn't seem appropriate now that the scoring is geared more towards "is a miner possibly censoring transactions?".

I've provisionally renamed the metric "Block Health", but I'm sure we can come up with something better. Maybe "Audit Score" or "Prediction Rate"?

### Block Audit page

I tweaked the styling of the audit visualizations a bit:

 - Swapped the colors around: 'missing' txs are now pink/magenta, and 'added' are blue/cyan.
 - Desaturated the colors for normal 'matching' transactions, to make highlighted txs more visible.
 - Different colors for the new categories of tx (see note below).
 - Changed the subtitles & toggle button labels to 'Projected Block' and 'Actual Block'.

The new scoring heuristics give us five categories of transaction, based on the differences between the projected and mined block, and whether those differences appear to be intentional or by chance.

| | in the projected block | in the mined block | intentional? | color |
|-|-|-|-|-|
| *match* | ✅ | ✅ | ~ | normal |
| *removed* | ✅ | ❌ | ✅ | magenta |
| *omitted* | ✅ | ❌ | ❌ | dark pink |
| *added* | ❌ | ✅ | ✅ | cyan |
| *included* | ❌ | ✅ | ❌ | dark blue |

Again, the names could be improved.

![audit-page](https://user-images.githubusercontent.com/83316221/198754340-7f0ce91b-c92d-4bbd-80e1-92d98a7c782a.png)

### Block Page

The score is added to the block details table, and links to the corresponding block audit page.

![block-page](https://user-images.githubusercontent.com/83316221/198754529-d5ba97d6-687a-4b13-80ef-394f809b3fd8.png)

### Blocks List

The score is shown in the list on the /blocks page and on the mining dashboard as a "progress bar"-style meter, and again links to the audit page.

The list on the main dashboard is unchanged.

![main-block-list](https://user-images.githubusercontent.com/83316221/198754892-07ea074e-a7e1-43e1-aae0-c010b81f1393.png)

![mining-dash](https://user-images.githubusercontent.com/83316221/198754901-7e5253d1-0cb3-434c-b2ae-c80c5f5819a1.png)