### PR TITLE
Block audit tweaks

### DIFF
--- a/backend/src/api/audit.ts
+++ b/backend/src/api/audit.ts
@@ -1,5 +1,10 @@
 import config from '../config';
-import { BlockExtended, TransactionExtended, MempoolBlockWithTransactions } from '../mempool.interfaces';
+import bitcoinApi from './bitcoin/bitcoin-api-factory';
+import { Common } from './common';
+import { TransactionExtended, MempoolBlockWithTransactions, AuditScore } from '../mempool.interfaces';
+import blocksRepository from '../repositories/BlocksRepository';
+import blocksAuditsRepository from '../repositories/BlocksAuditsRepository';
+import blocks from '../api/blocks';
 
 const PROPAGATION_MARGIN = 180; // in seconds, time since a transaction is first seen after which it is assumed to have propagated to all miners
 
@@ -81,7 +86,7 @@ class Audit {
         }
         overflowWeight += tx.weight;
       }
-      totalWeight += tx.weight
+      totalWeight += tx.weight;
     }
 
     // transactions missing from near the end of our template are probably not being censored
@@ -97,7 +102,7 @@ class Audit {
         }
         if (mempool[txid].effectiveFeePerVsize > maxOverflowRate) {
           maxOverflowRate = mempool[txid].effectiveFeePerVsize;
-          rateThreshold = (Math.ceil(maxOverflowRate * 100) / 100) + 0.005
+          rateThreshold = (Math.ceil(maxOverflowRate * 100) / 100) + 0.005;
         }
       } else if (mempool[txid].effectiveFeePerVsize <= rateThreshold) { // tolerance of 0.01 sat/vb + rounding
         if (isCensored[txid]) {
@@ -116,6 +121,45 @@ class Audit {
       added,
       score
     };
+  }
+
+  public async $getBlockAuditScores(fromHeight?: number, limit: number = 15): Promise<AuditScore[]> {
+    let currentHeight = fromHeight !== undefined ? fromHeight : await blocksRepository.$mostRecentBlockHeight();
+    const returnScores: AuditScore[] = [];
+
+    if (currentHeight < 0) {
+      return returnScores;
+    }
+
+    for (let i = 0; i < limit && currentHeight >= 0; i++) {
+      const block = blocks.getBlocks().find((b) => b.height === currentHeight);
+      if (block?.extras?.matchRate != null) {
+        returnScores.push({
+          hash: block.id,
+          matchRate: block.extras.matchRate
+        });
+      } else {
+        let currentHash;
+        if (!currentHash && Common.indexingEnabled()) {
+          const dbBlock = await blocksRepository.$getBlockByHeight(currentHeight);
+          if (dbBlock && dbBlock['id']) {
+            currentHash = dbBlock['id'];
+          }
+        }
+        if (!currentHash) {
+          currentHash = await bitcoinApi.$getBlockHash(currentHeight);
+        }
+        if (currentHash) {
+          const auditScore = await blocksAuditsRepository.$getBlockAuditScore(currentHash);
+          returnScores.push({
+            hash: currentHash,
+            matchRate: auditScore?.matchRate
+          });
+        }
+      }
+      currentHeight--;
+    }
+    return returnScores;
   }
 }
 

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -195,9 +195,9 @@ class Blocks {
         };
       }
 
-      const auditSummary = await BlocksAuditsRepository.$getShortBlockAudit(block.id);
-      if (auditSummary) {
-        blockExtended.extras.matchRate = auditSummary.matchRate;
+      const auditScore = await BlocksAuditsRepository.$getBlockAuditScore(block.id);
+      if (auditScore != null) {
+        blockExtended.extras.matchRate = auditScore.matchRate;
       }
     }
 

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -32,6 +32,11 @@ export interface BlockAudit {
   matchRate: number,
 }
 
+export interface AuditScore {
+  hash: string,
+  matchRate?: number,
+}
+
 export interface MempoolBlock {
   blockSize: number;
   blockVSize: number;

--- a/backend/src/repositories/BlocksAuditsRepository.ts
+++ b/backend/src/repositories/BlocksAuditsRepository.ts
@@ -1,6 +1,6 @@
 import DB from '../database';
 import logger from '../logger';
-import { BlockAudit } from '../mempool.interfaces';
+import { BlockAudit, AuditScore } from '../mempool.interfaces';
 
 class BlocksAuditRepositories {
   public async $saveAudit(audit: BlockAudit): Promise<void> {
@@ -72,10 +72,10 @@ class BlocksAuditRepositories {
     }
   }
 
-  public async $getShortBlockAudit(hash: string): Promise<any> {
+  public async $getBlockAuditScore(hash: string): Promise<AuditScore> {
     try {
       const [rows]: any[] = await DB.query(
-        `SELECT hash as id, match_rate as matchRate
+        `SELECT hash, match_rate as matchRate
         FROM blocks_audits
         WHERE blocks_audits.hash = "${hash}"
       `);

--- a/frontend/src/app/components/block-audit/block-audit.component.html
+++ b/frontend/src/app/components/block-audit/block-audit.component.html
@@ -97,21 +97,6 @@
   </div>
 
   <ng-template [ngIf]="!error && isLoading">
-    <div class="title-block" id="block">
-      <h1>
-        <span class="next-previous-blocks">
-          <span i18n="shared.block-audit-title">Block Audit</span>
-          &nbsp;
-          <a *ngIf="blockAudit" [routerLink]="['/block/' | relativeUrl, blockHash]">{{ blockAudit.height }}</a>
-          &nbsp;
-        </span>
-      </h1>
-
-      <div class="grow"></div>
-
-      <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
-    </div>
-
     <!-- OVERVIEW -->
     <div class="box mb-3">
       <div class="row">

--- a/frontend/src/app/components/block-audit/block-audit.component.html
+++ b/frontend/src/app/components/block-audit/block-audit.component.html
@@ -42,10 +42,6 @@
                 </td>
               </tr>
               <tr>
-                <td class="td-width" i18n="shared.transaction-count">Transactions</td>
-                <td>{{ blockAudit.tx_count }}</td>
-              </tr>
-              <tr>
                 <td i18n="blockAudit.size">Size</td>
                 <td [innerHTML]="'&lrm;' + (blockAudit.size | bytes: 2)"></td>
               </tr>
@@ -62,6 +58,10 @@
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
+                <td class="td-width" i18n="shared.transaction-count">Transactions</td>
+                <td>{{ blockAudit.tx_count }}</td>
+              </tr>
+              <tr>
                 <td i18n="block.health">Block health</td>
                 <td>{{ blockAudit.matchRate }}%</td>
               </tr>
@@ -70,16 +70,8 @@
                 <td>{{ blockAudit.missingTxs.length }}</td>
               </tr>
               <tr>
-                <td i18n="block.missing-txs">Omitted txs</td>
-                <td>{{ numMissing }}</td>
-              </tr>
-              <tr>
                 <td i18n="block.added-txs">Added txs</td>
                 <td>{{ blockAudit.addedTxs.length }}</td>
-              </tr>
-              <tr>
-                <td i18n="block.missing-txs">Included txs</td>
-                <td>{{ numUnexpected }}</td>
               </tr>
             </tbody>
           </table>
@@ -108,7 +100,6 @@
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
-              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
             </tbody>
           </table>
         </div>
@@ -117,7 +108,6 @@
         <div class="col-sm">
           <table class="table table-borderless table-striped">
             <tbody>
-              <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
               <tr><td class="td-width" colspan="2"><span class="skeleton-loader"></span></td></tr>
@@ -165,16 +155,16 @@
       <div class="col-sm" *ngIf="webGlEnabled">
         <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.projected-block">Projected Block</h3>
         <app-block-overview-graph #blockGraphProjected [isLoading]="isLoading" [resolution]="75"
-          [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false"
-          (txClickEvent)="onTxClick($event)"></app-block-overview-graph>
+          [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx"
+          (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)"></app-block-overview-graph>
       </div>
 
       <!-- ADDED TX RENDERING -->
       <div class="col-sm" *ngIf="webGlEnabled && !isMobile">
         <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.actual-block">Actual Block</h3>
         <app-block-overview-graph #blockGraphActual [isLoading]="isLoading" [resolution]="75"
-          [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false"
-          (txClickEvent)="onTxClick($event)"></app-block-overview-graph>
+          [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx"
+          (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)"></app-block-overview-graph>
       </div>
     </div> <!-- row -->
   </div> <!-- box -->

--- a/frontend/src/app/components/block-audit/block-audit.component.ts
+++ b/frontend/src/app/components/block-audit/block-audit.component.ts
@@ -37,6 +37,7 @@ export class BlockAuditComponent implements OnInit, AfterViewInit, OnDestroy {
   isLoading = true;
   webGlEnabled = true;
   isMobile = window.innerWidth <= 767.98;
+  hoverTx: string;
 
   childChangeSubscription: Subscription;
 
@@ -117,9 +118,11 @@ export class BlockAuditComponent implements OnInit, AfterViewInit, OnDestroy {
                 }
               }
               for (const [index, tx] of blockAudit.transactions.entries()) {
-                if (isAdded[tx.txid]) {
+                if (index === 0) {
+                  tx.status = null;
+                } else if (isAdded[tx.txid]) {
                   tx.status = 'added';
-                } else if (index === 0 || inTemplate[tx.txid]) {
+                } else if (inTemplate[tx.txid]) {
                   tx.status = 'found';
                 } else {
                   tx.status = 'selected';
@@ -188,5 +191,13 @@ export class BlockAuditComponent implements OnInit, AfterViewInit, OnDestroy {
   onTxClick(event: TransactionStripped): void {
     const url = new RelativeUrlPipe(this.stateService).transform(`/tx/${event.txid}`);
     this.router.navigate([url]);
+  }
+
+  onTxHover(txid: string): void {
+    if (txid && txid.length) {
+      this.hoverTx = txid;
+    } else {
+      this.hoverTx = null;
+    }
   }
 }

--- a/frontend/src/app/components/block-audit/block-audit.component.ts
+++ b/frontend/src/app/components/block-audit/block-audit.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnDestroy, OnInit, AfterViewInit, ViewChildren, QueryList } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import { Subscription, combineLatest } from 'rxjs';
-import { map, switchMap, startWith, catchError } from 'rxjs/operators';
+import { Subscription, combineLatest, of } from 'rxjs';
+import { map, switchMap, startWith, catchError, filter } from 'rxjs/operators';
 import { BlockAudit, TransactionStripped } from '../../interfaces/node-api.interface';
 import { ApiService } from '../../services/api.service';
+import { ElectrsApiService } from '../../services/electrs-api.service';
 import { StateService } from '../../services/state.service';
 import { detectWebGL } from '../../shared/graphs.utils';
 import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
@@ -52,7 +53,8 @@ export class BlockAuditComponent implements OnInit, AfterViewInit, OnDestroy {
     private route: ActivatedRoute,
     public stateService: StateService,
     private router: Router,
-    private apiService: ApiService
+    private apiService: ApiService,
+    private electrsApiService: ElectrsApiService,
   ) {
     this.webGlEnabled = detectWebGL();
   }
@@ -77,71 +79,95 @@ export class BlockAuditComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.auditSubscription = this.route.paramMap.pipe(
       switchMap((params: ParamMap) => {
-        this.blockHash = params.get('id') || null;
-        if (!this.blockHash) {
+        const blockHash = params.get('id') || null;
+        if (!blockHash) {
           return null;
         }
+
+        let isBlockHeight = false;
+        if (/^[0-9]+$/.test(blockHash)) {
+          isBlockHeight = true;
+        } else {
+          this.blockHash = blockHash;
+        }
+
+        if (isBlockHeight) {
+          return this.electrsApiService.getBlockHashFromHeight$(parseInt(blockHash, 10))
+            .pipe(
+              switchMap((hash: string) => {
+                if (hash) {
+                  this.blockHash = hash;
+                  return this.apiService.getBlockAudit$(this.blockHash)
+                } else {
+                  return null;
+                }
+              }),
+              catchError((err) => {
+                this.error = err;
+                return of(null);
+              }),
+            );
+        }
         return this.apiService.getBlockAudit$(this.blockHash)
-          .pipe(
-            map((response) => {
-              const blockAudit = response.body;
-              const inTemplate = {};
-              const inBlock = {};
-              const isAdded = {};
-              const isCensored = {};
-              const isMissing = {};
-              const isSelected = {};
-              this.numMissing = 0;
-              this.numUnexpected = 0;
-              for (const tx of blockAudit.template) {
-                inTemplate[tx.txid] = true;
-              }
-              for (const tx of blockAudit.transactions) {
-                inBlock[tx.txid] = true;
-              }
-              for (const txid of blockAudit.addedTxs) {
-                isAdded[txid] = true;
-              }
-              for (const txid of blockAudit.missingTxs) {
-                isCensored[txid] = true;
-              }
-              // set transaction statuses
-              for (const tx of blockAudit.template) {
-                if (isCensored[tx.txid]) {
-                  tx.status = 'censored';
-                } else if (inBlock[tx.txid]) {
-                  tx.status = 'found';
-                } else {
-                  tx.status = 'missing';
-                  isMissing[tx.txid] = true;
-                  this.numMissing++;
-                }
-              }
-              for (const [index, tx] of blockAudit.transactions.entries()) {
-                if (index === 0) {
-                  tx.status = null;
-                } else if (isAdded[tx.txid]) {
-                  tx.status = 'added';
-                } else if (inTemplate[tx.txid]) {
-                  tx.status = 'found';
-                } else {
-                  tx.status = 'selected';
-                  isSelected[tx.txid] = true;
-                  this.numUnexpected++;
-                }
-              }
-              for (const tx of blockAudit.transactions) {
-                inBlock[tx.txid] = true;
-              }
-              return blockAudit;
-            })
-          );
+      }),
+      filter((response) => response != null),
+      map((response) => {
+        const blockAudit = response.body;
+        const inTemplate = {};
+        const inBlock = {};
+        const isAdded = {};
+        const isCensored = {};
+        const isMissing = {};
+        const isSelected = {};
+        this.numMissing = 0;
+        this.numUnexpected = 0;
+        for (const tx of blockAudit.template) {
+          inTemplate[tx.txid] = true;
+        }
+        for (const tx of blockAudit.transactions) {
+          inBlock[tx.txid] = true;
+        }
+        for (const txid of blockAudit.addedTxs) {
+          isAdded[txid] = true;
+        }
+        for (const txid of blockAudit.missingTxs) {
+          isCensored[txid] = true;
+        }
+        // set transaction statuses
+        for (const tx of blockAudit.template) {
+          if (isCensored[tx.txid]) {
+            tx.status = 'censored';
+          } else if (inBlock[tx.txid]) {
+            tx.status = 'found';
+          } else {
+            tx.status = 'missing';
+            isMissing[tx.txid] = true;
+            this.numMissing++;
+          }
+        }
+        for (const [index, tx] of blockAudit.transactions.entries()) {
+          if (index === 0) {
+            tx.status = null;
+          } else if (isAdded[tx.txid]) {
+            tx.status = 'added';
+          } else if (inTemplate[tx.txid]) {
+            tx.status = 'found';
+          } else {
+            tx.status = 'selected';
+            isSelected[tx.txid] = true;
+            this.numUnexpected++;
+          }
+        }
+        for (const tx of blockAudit.transactions) {
+          inBlock[tx.txid] = true;
+        }
+        return blockAudit;
       }),
       catchError((err) => {
         console.log(err);
         this.error = err;
         this.isLoading = false;
-        return null;
+        return of(null);
       }),
     ).subscribe((blockAudit) => {
       this.blockAudit = blockAudit;

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -12,8 +12,8 @@ const auditFeeColors = feeColors.map((color) => desaturate(color, 0.3));
 const auditColors = {
   censored: hexToColor('f344df'),
   missing: darken(desaturate(hexToColor('f344df'), 0.3), 0.7),
-  added: hexToColor('03E1E5'),
-  selected: darken(desaturate(hexToColor('039BE5'), 0.3), 0.7),
+  added: hexToColor('0099ff'),
+  selected: darken(desaturate(hexToColor('0099ff'), 0.3), 0.7),
 }
 
 // convert from this class's update format to TxSprite's update format

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -37,9 +37,9 @@
         <ng-container [ngSwitch]="tx?.status">
           <td *ngSwitchCase="'found'" i18n="transaction.audit.match">match</td>
           <td *ngSwitchCase="'censored'" i18n="transaction.audit.removed">removed</td>
-          <td *ngSwitchCase="'missing'" i18n="transaction.audit.missing">missing</td>
+          <td *ngSwitchCase="'missing'" i18n="transaction.audit.omitted">omitted</td>
           <td *ngSwitchCase="'added'" i18n="transaction.audit.added">added</td>
-          <td *ngSwitchCase="'selected'" i18n="transaction.audit.included">included</td>
+          <td *ngSwitchCase="'selected'" i18n="transaction.audit.extra">extra</td>
         </ng-container>
       </tr>
     </tbody>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -114,7 +114,7 @@
                   <td i18n="block.health">Block health</td>
                   <td>
                     <a *ngIf="block.extras?.matchRate != null" [routerLink]="['/block-audit/' | relativeUrl, blockHash]">{{ block.extras.matchRate }}%</a>
-                    <span *ngIf="block.extras?.matchRate == null" i18n="unknown">Unknown</span>
+                    <span *ngIf="block.extras?.matchRate === null" i18n="unknown">Unknown</span>
                   </td>
                 </tr>
               </ng-template>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -46,22 +46,17 @@
             <app-time-since [time]="block.timestamp" [fastRender]="true"></app-time-since>
           </td>
           <td *ngIf="indexingAvailable" class="health text-right" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
-            <a *ngIf="block.extras?.matchRate != null" class="clear-link" [routerLink]="['/block-audit/' | relativeUrl, block.id]">
+            <a class="clear-link" [routerLink]="auditScores[block.id] != null ? ['/block-audit/' | relativeUrl, block.id] : null">
               <div class="progress progress-health">
                 <div class="progress-bar progress-bar-health" role="progressbar"
-                  [ngStyle]="{'width': (100 - (block.extras?.matchRate || 0)) + '%' }"></div>
+                  [ngStyle]="{'width': (100 - (auditScores[block.id] || 0)) + '%' }"></div>
                 <div class="progress-text">
-                  <span>{{ block.extras.matchRate }}%</span>
+                  <span *ngIf="auditScores[block.id] != null;">{{ auditScores[block.id] }}%</span>
+                  <span *ngIf="auditScores[block.id] === undefined" class="skeleton-loader"></span>
+                  <span *ngIf="auditScores[block.id] === null">~</span>
                 </div>
               </div>
             </a>
-            <div *ngIf="block.extras?.matchRate == null" class="progress progress-health">
-              <div class="progress-bar progress-bar-health" role="progressbar"
-                [ngStyle]="{'width': '100%' }"></div>
-              <div class="progress-text">
-                <span>~</span>
-              </div>
-            </div>
           </td>
           <td *ngIf="indexingAvailable" class="reward text-right" [ngClass]="{'widget': widget, 'legacy': !indexingAvailable}">
             <app-amount [satoshis]="block.extras.reward" [noFiat]="true" digitsInfo="1.2-2"></app-amount>

--- a/frontend/src/app/components/blocks-list/blocks-list.component.scss
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.scss
@@ -196,6 +196,10 @@ tr, td, th {
   @media (max-width: 950px) {
     display: none;
   }
+
+  .progress-text .skeleton-loader {
+    top: -8.5px;
+  }
 }
 .health.widget {
   width: 25%;

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -152,6 +152,11 @@ export interface RewardStats {
   totalTx: number;
 }
 
+export interface AuditScore {
+  hash: string;
+  matchRate?: number;
+}
+
 export interface ITopNodesPerChannels {
   publicKey: string,
   alias: string,

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { CpfpInfo, OptimizedMempoolStats, AddressInformation, LiquidPegs, ITranslators,
-  PoolStat, BlockExtended, TransactionStripped, RewardStats } from '../interfaces/node-api.interface';
+  PoolStat, BlockExtended, TransactionStripped, RewardStats, AuditScore } from '../interfaces/node-api.interface';
 import { Observable } from 'rxjs';
 import { StateService } from './state.service';
 import { WebsocketResponse } from '../interfaces/websocket.interface';
@@ -231,6 +231,19 @@ export class ApiService {
   getBlockAudit$(hash: string) : Observable<any> {
     return this.httpClient.get<any>(
       this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/blocks/audit/` + hash, { observe: 'response' }
+    );
+  }
+
+  getBlockAuditScores$(from: number): Observable<AuditScore[]> {
+    return this.httpClient.get<AuditScore[]>(
+      this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/blocks/audit/scores` +
+      (from !== undefined ? `/${from}` : ``)
+    );
+  }
+
+  getBlockAuditScore$(hash: string) : Observable<any> {
+    return this.httpClient.get<any>(
+      this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/blocks/audit/score/` + hash
     );
   }
 


### PR DESCRIPTION
various minor improvements to the block audit feature:
- fix skeleton loaders
- small change to the audit score calculation to reduce false positives.
- remove confusing 'omitted' and 'included' counts.
- highlight the corresponding tx in the other block on mouseover.
- shift 'added' color slightly towards blue, to differentiate it from the mouseover color.
- handle `/block-audit/:height` as well as `/block-audit/:hash`.