### PR TITLE
db migration to clear obsolete block audit data

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 43;
+  private static currentVersion = 44;
   private queryTimeout = 120000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -359,6 +359,11 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 43 && isBitcoin === true) {
       await this.$executeQuery(this.getCreateLNNodeRecordsTableQuery(), await this.$checkIfTableExists('nodes_records'));
+    }
+
+    if (databaseSchemaVersion < 44 && isBitcoin === true) {
+      await this.$executeQuery('TRUNCATE TABLE `blocks_audits`');
+      await this.$executeQuery('UPDATE blocks_summaries SET template = NULL');
     }
   }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -5,7 +5,7 @@ import { Common } from './common';
 
 class DatabaseMigration {
   private static currentVersion = 44;
-  private queryTimeout = 120000;
+  private queryTimeout = 900_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
 

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -416,7 +416,7 @@ class WebsocketHandler {
     let matchRate;
     const _memPool = memPool.getMempool();
 
-    if (Common.indexingEnabled()) {
+    if (Common.indexingEnabled() && memPool.isInSync()) {
       const mempoolCopy = cloneMempool(_memPool);
       const projectedBlocks = mempoolBlocks.makeBlockTemplates(mempoolCopy, 2);
 


### PR DESCRIPTION
Adds a database migration to delete old block audit data generated using getsimontemplate.

Also adds a guard to avoid saving bad audit data while the mempool isn't fully loaded.