### PR TITLE
backend: enable esplora address lookups

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -12,7 +12,7 @@ export interface AbstractBitcoinApi {
   $getRawBlock(hash: string): Promise<string>;
   $getAddress(address: string): Promise<IEsploraApi.Address>;
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
-  $getAddressPrefix(prefix: string): string[];
+  $getAddressPrefix(prefix: string): Promise<string[]>;
   $sendRawTransaction(rawTransaction: string): Promise<string>;
   $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend>;
   $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -111,7 +111,7 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.getRawMemPool();
   }
 
-  $getAddressPrefix(prefix: string): string[] {
+  $getAddressPrefix(prefix: string): Promise<string[]> {
     const found: { [address: string]: string } = {};
     const mp = mempool.getMempool();
     for (const tx in mp) {
@@ -119,12 +119,12 @@ class BitcoinApi implements AbstractBitcoinApi {
         if (vout.scriptpubkey_address.indexOf(prefix) === 0) {
           found[vout.scriptpubkey_address] = '';
           if (Object.keys(found).length >= 10) {
-            return Object.keys(found);
+            return Promise.resolve(Object.keys(found));
           }
         }
       }
     }
-    return Object.keys(found);
+    return Promise.resolve(Object.keys(found));
   }
 
   $sendRawTransaction(rawTransaction: string): Promise<string> {

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -90,7 +90,7 @@ class BitcoinRoutes {
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/summary', this.getStrippedBlockTransactions);
       ;
 
-      if (config.MEMPOOL.BACKEND !== 'esplora') {
+      if (config.MEMPOOL.BACKEND !== 'none') {
         app
           .get(config.MEMPOOL.API_URL_PREFIX + 'mempool', this.getMempool)
           .get(config.MEMPOOL.API_URL_PREFIX + 'mempool/txids', this.getMempoolTxIds)

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -56,15 +56,18 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   $getAddress(address: string): Promise<IEsploraApi.Address> {
-    throw new Error('Method getAddress not implemented.');
+    return axios.get<IEsploraApi.Address>(config.ESPLORA.REST_API_URL + '/address/' + address, this.axiosConfig)
+      .then((response) => response.data);
   }
 
   $getAddressTransactions(address: string, txId?: string): Promise<IEsploraApi.Transaction[]> {
-    throw new Error('Method getAddressTransactions not implemented.');
+    return axios.get<IEsploraApi.Transaction[]>(config.ESPLORA.REST_API_URL + '/address/' + address + "/txs", this.axiosConfig)
+      .then((response) => response.data);
   }
 
-  $getAddressPrefix(prefix: string): string[] {
-    throw new Error('Method not implemented.');
+  $getAddressPrefix(prefix: string): Promise<string[]> {
+    return axios.get<string[]>(config.ESPLORA.REST_API_URL + '/address-prefix/' + prefix, this.axiosConfig)
+      .then((response) => response.data);
   }
 
   $sendRawTransaction(rawTransaction: string): Promise<string> {


### PR DESCRIPTION
Enable `esplora` lookups; (works with the blockstream/electrs branch?)

Maybe not suitable for all esploras? idk.