### PR TITLE
Fix rounded vsize in block summaries

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -130,7 +130,7 @@ class Blocks {
     const stripped = block.tx.map((tx) => {
       return {
         txid: tx.txid,
-        vsize: tx.vsize,
+        vsize: tx.weight / 4,
         fee: tx.fee ? Math.round(tx.fee * 100000000) : 0,
         value: Math.round(tx.vout.reduce((acc, vout) => acc + (vout.value ? vout.value : 0), 0) * 100000000)
       };


### PR DESCRIPTION
Fixes #2668

Apparently Bitcoin Core rounds vsize up to the next integer in all of its RPC responses.

In most places we calculate a more precise vsize ourselves as `weight / 4`, but for the block summaries used in the mined blocks visualization we were using Core's rounded figures directly.

Old blocks have already been indexed with rounded vsize, but this PR will switch to the unrounded `weight / 4` for new blocks going forward.