### PR TITLE
better representation of zero-value outputs in flow diagram

### DIFF
--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
@@ -21,13 +21,13 @@
           markerWidth="1.5" markerHeight="1"
           orient="auto">
       </marker>
-      <radialGradient id="gradient0" x1="0%" y1="0%" x2="100%" y2="100%">
+      <radialGradient id="gradient0" x1="0%" y1="0%" x2="100%" y2="100%" gradientUnits="userSpaceOnUse">
         <stop [attr.stop-color]="gradient[0]" />
       </radialGradient>
-      <radialGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <radialGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="100%" gradientUnits="userSpaceOnUse">
         <stop [attr.stop-color]="gradient[1]" />
       </radialGradient>
-      <radialGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <radialGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="100%" gradientUnits="userSpaceOnUse">
         <stop [attr.stop-color]="gradient[2]" />
       </radialGradient>
       <linearGradient id="input-gradient" x1="0%" y1="0%" x2="100%" y2="0%">

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.html
@@ -21,6 +21,15 @@
           markerWidth="1.5" markerHeight="1"
           orient="auto">
       </marker>
+      <radialGradient id="gradient0" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop [attr.stop-color]="gradient[0]" />
+      </radialGradient>
+      <radialGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop [attr.stop-color]="gradient[1]" />
+      </radialGradient>
+      <radialGradient id="gradient2" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop [attr.stop-color]="gradient[2]" />
+      </radialGradient>
       <linearGradient id="input-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
         <stop offset="0%" [attr.stop-color]="gradient[0]" />
         <stop offset="100%" [attr.stop-color]="gradient[1]" />
@@ -117,7 +126,7 @@
         (pointerout)="onBlur($event, 'output-connector', i);"
         (click)="onClick($event, 'output-connector', outputData[i].index);"
       />
-      <path
+      <path *ngIf="!output.zeroValue"
         [attr.d]="output.markerPath"
         class="output marker-target {{output.class}}"
         [class.highlight]="outputData[i].index === outputIndex"
@@ -125,12 +134,22 @@
         (pointerout)="onBlur($event, 'output', i);"
         (click)="onClick($event, 'output', outputData[i].index);"
       />
-      <path
+      <path *ngIf="!output.zeroValue"
         [attr.d]="output.path"
         class="line {{output.class}}"
         [class.highlight]="outputIndex != null && outputData[i].index === outputIndex"
         [style]="output.style"
         attr.marker-start="url(#{{output.class}}-arrow)"
+        (pointerover)="onHover($event, 'output', i);"
+        (pointerout)="onBlur($event, 'output', i);"
+        (click)="onClick($event, 'output', outputData[i].index);"
+      />
+      <path *ngIf="output.zeroValue"
+        [attr.d]="output.path"
+        class="line {{output.class}} zerovalue"
+        [class.highlight]="outputIndex != null && outputData[i].index === outputIndex"
+        [class.zerovalue]="output.zeroValue"
+        [style]="output.style"
         (pointerover)="onHover($event, 'output', i);"
         (pointerout)="onBlur($event, 'output', i);"
         (click)="onClick($event, 'output', outputData[i].index);"

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.scss
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.scss
@@ -11,6 +11,10 @@
     &.fee {
       stroke: url(#fee-gradient);
     }
+    &.zerovalue {
+      stroke: url(#gradient0);
+      stroke-linecap: round;
+    }
 
     &.highlight {
       z-index: 8;
@@ -20,6 +24,9 @@
       }
       &.output {
         stroke: url(#output-highlight-gradient);
+      }
+      &.zerovalue {
+        stroke: #1bd8f4;
       }
     }
   }
@@ -35,6 +42,9 @@
     }
     &.fee {
       stroke: url(#fee-hover-gradient);
+    }
+    &.zerovalue {
+      stroke: white;
     }
   }
 

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -260,7 +260,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
     let lastOuter = 0;
     let lastInner = innerTop;
     // gap between strands
-    const spacing = (this.height - visibleWeight) / gaps;
+    const spacing = Math.max(4, (this.height - visibleWeight) / gaps);
 
     // curve adjustments to prevent overlaps
     let offset = 0;
@@ -270,7 +270,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
     let pad = 0;
     lineParams.forEach((line, i) => {
       if (xputs[i].value === 0) {
-        line.outerY = lastOuter + this.zeroValueThickness / 2;
+        line.outerY = lastOuter + (this.zeroValueThickness / 2);
         lastOuter += this.zeroValueThickness + spacing;
         return;
       }
@@ -349,7 +349,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
 
   makePath(side: 'in' | 'out', outer: number, inner: number, weight: number, offset: number, pad: number): string {
     const start = (weight * 0.5) + this.connectorWidth;
-    const curveStart = Math.max(start + 1, pad - offset);
+    const curveStart = Math.max(start + 5, pad - offset);
     const end =  this.width / 2 - (this.midWidth * 0.9) + 1;
     const curveEnd = end - offset - 10;
     const midpoint = (curveStart + curveEnd) / 2;
@@ -368,11 +368,11 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
 
   makeZeroValuePath(side: 'in' | 'out', y: number): string {
     const offset = this.zeroValueThickness / 2;
-    const start = this.connectorWidth + 10;
+    const start = (this.connectorWidth / 2) + 10;
     if (side === 'in') {
-      return `M ${start + offset} ${y} L ${start + this.zeroValueWidth + offset} ${y + 1}`;
+      return `M ${start + offset} ${y} L ${start + this.zeroValueWidth + offset} ${y}`;
     } else { // mirrored in y-axis for the right hand side
-      return `M ${this.width - start - offset} ${y} L ${this.width - start - this.zeroValueWidth - offset} ${y + 1}`;
+      return `M ${this.width - start - offset} ${y} L ${this.width - start - this.zeroValueWidth - offset} ${y}`;
     }
   }
 


### PR DESCRIPTION
_(merge PR #2649 first)_

change the shape of zero-valued outputs in the transaction diagram to make OP_RETURNs more visible and the 'flow' of coins more intuitive, as discussed in #2604.

Before:
<img width="1145" alt="zero-value-before" src="https://user-images.githubusercontent.com/83316221/202847743-d408e81a-5672-4f67-9334-a113222ff73d.png">

After:
<img width="1145" alt="zero-value-after" src="https://user-images.githubusercontent.com/83316221/202847754-c3838adc-3c7d-4b88-843b-c584822b7546.png">

