### PR TITLE
Match the bytes pipe with the vbyte pipe

### DIFF
--- a/contributors/danger89.txt
+++ b/contributors/danger89.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of November 24, 2022.
+
+Signed: danger89

--- a/frontend/src/app/shared/pipes/bytes-pipe/bytes.pipe.ts
+++ b/frontend/src/app/shared/pipes/bytes-pipe/bytes.pipe.ts
@@ -17,7 +17,7 @@ export class BytesPipe implements PipeTransform {
         'TB': {max: Number.MAX_SAFE_INTEGER, prev: 'GB'}
     };
 
-    transform(input: any, decimal: number = 0, from: ByteUnit = 'B', to?: ByteUnit): any {
+    transform(input: any, decimal: number = 0, from: ByteUnit = 'B', to?: ByteUnit, plainText?: boolean): any {
 
         if (!(isNumberFinite(input) &&
                 isNumberFinite(decimal) &&
@@ -38,7 +38,7 @@ export class BytesPipe implements PipeTransform {
 
             const result = toDecimal(BytesPipe.calculateResult(format, bytes), decimal);
 
-            return BytesPipe.formatResult(result, to);
+            return BytesPipe.formatResult(result, to, plainText);
         }
 
         for (const key in BytesPipe.formats) {
@@ -47,12 +47,15 @@ export class BytesPipe implements PipeTransform {
 
                 const result = toDecimal(BytesPipe.calculateResult(format, bytes), decimal);
 
-                return BytesPipe.formatResult(result, key);
+                return BytesPipe.formatResult(result, key, plainText);
             }
         }
     }
 
-    static formatResult(result: number, unit: string): string {
+    static formatResult(result: number, unit: string, plainText: boolean): string {
+        if(plainText){
+            return `${result} ${unit}`;
+        }
         return `${result} <span class="symbol">${unit}</span>`;
     }
 


### PR DESCRIPTION
For people who want to use the bytes pipe (like me), it's missing the `plainText` option for displaying in the graph.

So match the bytes pipe again with the vbyte angular pipe.

Thanks.

Regards,
Melroy van den Berg
