### PR TITLE
Fix bugs related to advanced GBT transaction selection

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -468,7 +468,7 @@ class WebsocketHandler {
     }
 
     if (config.MEMPOOL.ADVANCED_GBT_MEMPOOL) {
-      await mempoolBlocks.makeBlockTemplates(_memPool, 2);
+      await mempoolBlocks.makeBlockTemplates(_memPool, 8, null, true);
     } else {
       mempoolBlocks.updateMempoolBlocks(_memPool);
     }


### PR DESCRIPTION
This PR fixes some bugs in the advanced transaction selection implementation & usage:
 - a regression causing descendants not to be updated properly after selecting a transaction cluster, which could cause underfilled blocks and incorrect CPFP calculations.
 - wrong parameters passed to makeBlockTemplates immediately after calculating the block audit.