### PR TITLE
Fix block summaries repo upsert race condition

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -439,7 +439,7 @@ class WebsocketHandler {
         };
       }) : [];
 
-      BlocksSummariesRepository.$saveSummary({
+      BlocksSummariesRepository.$saveTemplate({
         height: block.height,
         template: {
           id: block.id,

--- a/backend/src/repositories/BlocksSummariesRepository.ts
+++ b/backend/src/repositories/BlocksSummariesRepository.ts
@@ -17,24 +17,41 @@ class BlocksSummariesRepository {
     return undefined;
   }
 
-  public async $saveSummary(params: { height: number, mined?: BlockSummary, template?: BlockSummary}) {
-    const blockId = params.mined?.id ?? params.template?.id;
+  public async $saveSummary(params: { height: number, mined?: BlockSummary}) {
+    const blockId = params.mined?.id;
     try {
-      const [dbSummary]: any[] = await DB.query(`SELECT * FROM blocks_summaries WHERE id = "${blockId}"`);
-      if (dbSummary.length === 0) { // First insertion
-        await DB.query(`INSERT INTO blocks_summaries VALUE (?, ?, ?, ?)`, [
-          params.height, blockId, JSON.stringify(params.mined?.transactions ?? []), JSON.stringify(params.template?.transactions ?? [])
-        ]);
-      } else if (params.mined !== undefined) { // Update mined block summary
-        await DB.query(`UPDATE blocks_summaries SET transactions = ? WHERE id = "${params.mined.id}"`, [JSON.stringify(params.mined.transactions)]);
-      } else if (params.template !== undefined) { // Update template block summary
-        await DB.query(`UPDATE blocks_summaries SET template = ? WHERE id = "${params.template.id}"`, [JSON.stringify(params.template?.transactions)]);
-      }
+      const transactions = JSON.stringify(params.mined?.transactions || []);
+      await DB.query(`
+        INSERT INTO blocks_summaries (height, id, transactions, template)
+        VALUE (?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+          transactions = ?
+      `, [params.height, blockId, transactions, '[]', transactions]);
     } catch (e: any) {
       if (e.errno === 1062) { // ER_DUP_ENTRY - This scenario is possible upon node backend restart
         logger.debug(`Cannot save block summary for ${blockId} because it has already been indexed, ignoring`);
       } else {
         logger.debug(`Cannot save block summary for ${blockId}. Reason: ${e instanceof Error ? e.message : e}`);
+        throw e;
+      }
+    }
+  }
+
+  public async $saveTemplate(params: { height: number, template: BlockSummary}) {
+    const blockId = params.template?.id;
+    try {
+      const transactions = JSON.stringify(params.template?.transactions || []);
+      await DB.query(`
+        INSERT INTO blocks_summaries (height, id, transactions, template)
+        VALUE (?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+          template = ?
+      `, [params.height, blockId, '[]', transactions, transactions]);
+    } catch (e: any) {
+      if (e.errno === 1062) { // ER_DUP_ENTRY - This scenario is possible upon node backend restart
+        logger.debug(`Cannot save block template for ${blockId} because it has already been indexed, ignoring`);
+      } else {
+        logger.debug(`Cannot save block template for ${blockId}. Reason: ${e instanceof Error ? e.message : e}`);
         throw e;
       }
     }


### PR DESCRIPTION
Hopefully fixes the root cause of the possible race condition mentioned in PR #2772.

`BlocksSummariesRepository.$saveSummary` asynchronously checks whether a database row exists, before either inserting a new summary or updating the row. These two DB operations could potentially become interleaved when `$saveSummary` is called multiple times in quick succession, causing failed attempts to insert duplicate entries and loss of data.

This PR replaces `BlocksSummariesRepository.$saveSummary` with two separate functions `$saveSummary` and `$saveTemplate` which use `ON DUPLICATE KEY UPDATE` syntax to save block summary and template data atomically.