### PR TITLE
Add support for db schema rollback down to version 40

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,8 @@
     "test": "./node_modules/.bin/jest --coverage",
     "lint": "./node_modules/.bin/eslint . --ext .ts",
     "lint:fix": "./node_modules/.bin/eslint . --ext .ts --fix",
-    "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{js,ts}\""
+    "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{js,ts}\"",
+    "rollback": "node dist/api/database-migration-rollback.js"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/backend/src/api/database-migration-rollback.ts
+++ b/backend/src/api/database-migration-rollback.ts
@@ -1,0 +1,123 @@
+import config from '../config';
+import logger from '../logger';
+import { Common } from './common';
+import databaseMigration from './database-migration';
+
+const isBitcoin = ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK);
+
+/**
+ * Rollback the database schema to versionTarget
+ * !!! NON PERMANENT DATA WILL BE LOST !!!
+ * 
+ * @param versionTarget 
+ */
+export async function rollbackDbToVersion(versionTarget: number): Promise<void> {
+  if (versionTarget < 40) {
+    return logger.err(`We currently do no support rolling back db schema to a version lower than 40`);
+  }
+
+  logger.debug(`MIGRATIONS: Rolling back db schema to version ${versionTarget}`);
+  await databaseMigration.$printDatabaseVersion();
+
+  // If the `state` table does not exist, abort
+  if (!await databaseMigration.$checkIfTableExists('state')) {
+    return logger.debug(`MIGRATIONS: 'state' table does not exist. Cannot rollback because we don't know the current db schema version`);
+  }
+
+  let databaseSchemaVersion = 0;
+  try {
+    databaseSchemaVersion = await databaseMigration.$getSchemaVersionFromDatabase();
+  } catch (e) {
+    return logger.err(`MIGRATIONS: Unable to get current database migration version, aborting. Reason: ${e instanceof Error ? e.message : e}`);
+  }
+
+  if (databaseSchemaVersion === versionTarget) {
+    return logger.info(`Current database schema is already on version ${databaseSchemaVersion}. Nothing to rollback`);
+  }
+
+  logger.warn(`Your database is currently on schema version ${databaseSchemaVersion} and will be rolled back to version ${versionTarget}`);
+  logger.warn(`!!! ALL NON PERMANENT DATA WILL BE LOST !!! You can safely abort by killing this script within 10 seconds from now`);
+  await Common.sleep$(10000);
+
+  logger.warn(`Now rolling back database to version ${versionTarget}`);
+
+  let currentVersion = databaseSchemaVersion;
+  while (currentVersion > versionTarget) {
+    const methodName = `rollback${currentVersion}`;
+    if (methods[methodName] === undefined) {
+      logger.info(`There is no rollback function for version ${currentVersion}`);
+    } else {
+      logger.info(`Rolling back db migration ${currentVersion}`);
+      await methods[`rollback${currentVersion}`]();
+    }
+    --currentVersion;
+  }
+}
+
+const methods = [];
+
+methods['rollback49'] = async function (): Promise<void> {
+  // Nothing to do
+  await databaseMigration.updateToSchemaVersion(48);
+};
+
+methods['rollback48'] = async function rollback48(): Promise<void> {
+  if (isBitcoin === true) {
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS source_checked');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS closing_fee');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS node1_funding_balance');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS node2_funding_balance');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS node1_closing_balance');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS node2_closing_balance');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS funding_ratio');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS closed_by');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS single_funded');
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS outputs');
+  }
+  await databaseMigration.updateToSchemaVersion(47);
+};
+
+methods['rollback47'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery('DROP TABLE IF EXISTS transactions');
+  await databaseMigration.$executeQuery('DROP TABLE IF EXISTS cpfp_clusters');
+  await databaseMigration.$executeQuery('ALTER TABLE `blocks` DROP COLUMN IF EXISTS cpfp_indexed');
+  await databaseMigration.updateToSchemaVersion(46);
+};
+
+methods['rollback46'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery('ALTER TABLE blocks MODIFY blockTimestamp timestamp NOT NULL');
+  await databaseMigration.updateToSchemaVersion(45);
+};
+
+methods['rollback45'] = async function (): Promise<void> {
+  if (isBitcoin === true) {
+    await databaseMigration.$executeQuery('ALTER TABLE `blocks_audits` DROP COLUMN IF EXISTS fresh_txs');
+  }
+  await databaseMigration.updateToSchemaVersion(44);
+};
+
+methods['rollback44'] = async function (): Promise<void> {
+  // Nothing to do
+  await databaseMigration.updateToSchemaVersion(43);
+};
+
+methods['rollback43'] = async function (): Promise<void> {
+  if (isBitcoin === true) {
+    await databaseMigration.$executeQuery(`DROP TABLE IF EXISTS nodes_records`);
+  }
+  await databaseMigration.updateToSchemaVersion(42);
+};
+
+methods['rollback42'] = async function (): Promise<void> {
+  if (isBitcoin === true) {
+    await databaseMigration.$executeQuery('ALTER TABLE `channels` DROP COLUMN IF EXISTS closing_resolved');
+  }
+  await databaseMigration.updateToSchemaVersion(41);
+};
+
+methods['rollback41'] = async function (): Promise<void> {
+  // Nothing to do
+  await databaseMigration.updateToSchemaVersion(40);
+};
+
+rollbackDbToVersion(parseInt(process.argv[2], 10)).then(() => process.exit());

--- a/backend/src/api/database-migration-rollback.ts
+++ b/backend/src/api/database-migration-rollback.ts
@@ -56,6 +56,46 @@ export async function rollbackDbToVersion(versionTarget: number): Promise<void> 
 
 const methods = [];
 
+methods['rollback57'] = async function (): Promise<void> {
+  if (isBitcoin === true) {
+    await databaseMigration.$executeQuery(`ALTER TABLE nodes MODIFY updated_at datetime NOT NULL`);
+  }
+  await databaseMigration.updateToSchemaVersion(56);
+};
+
+methods['rollback56'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery(`ALTER TABLE pools DROP COLUMN IF EXISTS unique_id`);
+  await databaseMigration.updateToSchemaVersion(55);
+};
+
+methods['rollback55'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery(`ALTER TABLE blocks
+    DROP COLUMN IF EXISTS median_timestamp,
+    DROP COLUMN IF EXISTS coinbase_address,
+    DROP COLUMN IF EXISTS coinbase_signature,
+    DROP COLUMN IF EXISTS coinbase_signature_ascii,
+    DROP COLUMN IF EXISTS avg_tx_size,
+    DROP COLUMN IF EXISTS total_inputs,
+    DROP COLUMN IF EXISTS total_outputs,
+    DROP COLUMN IF EXISTS total_output_amt,
+    DROP COLUMN IF EXISTS fee_percentiles,
+    DROP COLUMN IF EXISTS median_fee_amt,
+    DROP COLUMN IF EXISTS segwit_total_txs,
+    DROP COLUMN IF EXISTS segwit_total_size,
+    DROP COLUMN IF EXISTS segwit_total_weight,
+    DROP COLUMN IF EXISTS header,
+    DROP COLUMN IF EXISTS utxoset_change,
+    DROP COLUMN IF EXISTS utxoset_size,
+    DROP COLUMN IF EXISTS total_input_amt
+  `);
+  await databaseMigration.updateToSchemaVersion(54);
+};
+
+methods['rollback54'] = async function (): Promise<void> {
+  // Nothing to do
+  await databaseMigration.updateToSchemaVersion(53);
+};
+
 methods['rollback53'] = async function (): Promise<void> {
   await databaseMigration.$executeQuery('ALTER TABLE statistics MODIFY mempool_byte_weight int(10) UNSIGNED NOT NULL');
   await databaseMigration.updateToSchemaVersion(52);

--- a/backend/src/api/database-migration-rollback.ts
+++ b/backend/src/api/database-migration-rollback.ts
@@ -56,6 +56,32 @@ export async function rollbackDbToVersion(versionTarget: number): Promise<void> 
 
 const methods = [];
 
+methods['rollback53'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery('ALTER TABLE statistics MODIFY mempool_byte_weight int(10) UNSIGNED NOT NULL');
+  await databaseMigration.updateToSchemaVersion(52);
+};
+
+methods['rollback52'] = async function (): Promise<void> {
+  logger.warn(`!!! CPFP data will be lost !!! You can safely abort by killing this script within 10 seconds from now`);
+  await Common.sleep$(10000);
+
+  await databaseMigration.$executeQuery(databaseMigration.getCreateCPFPTableQuery());
+  await databaseMigration.$executeQuery(databaseMigration.getCreateTransactionsTableQuery());
+  await databaseMigration.$executeQuery('DROP TABLE IF EXISTS compact_cpfp_clusters');
+  await databaseMigration.$executeQuery('DROP TABLE IF EXISTS compact_transactions');
+  await databaseMigration.updateToSchemaVersion(51);
+};
+
+methods['rollback51'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery('ALTER TABLE IF EXISTS `cpfp_clusters` DROP INDEX IF EXISTS `height`');
+  await databaseMigration.updateToSchemaVersion(50);
+};
+
+methods['rollback50'] = async function (): Promise<void> {
+  await databaseMigration.$executeQuery('ALTER TABLE `blocks` ADD cpfp_indexed tinyint(1) DEFAULT 0');
+  await databaseMigration.updateToSchemaVersion(49);
+};
+
 methods['rollback49'] = async function (): Promise<void> {
   // Nothing to do
   await databaseMigration.updateToSchemaVersion(48);

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -979,7 +979,7 @@ class DatabaseMigration {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
   }
 
-  private getCreateCPFPTableQuery(): string {
+  public getCreateCPFPTableQuery(): string {
     return `CREATE TABLE IF NOT EXISTS cpfp_clusters (
       root varchar(65) NOT NULL,
       height int(10) NOT NULL,
@@ -989,7 +989,7 @@ class DatabaseMigration {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
   }
 
-  private getCreateTransactionsTableQuery(): string {
+  public getCreateTransactionsTableQuery(): string {
     return `CREATE TABLE IF NOT EXISTS transactions (
       txid varchar(65) NOT NULL,
       cluster varchar(65) DEFAULT NULL,

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -542,7 +542,7 @@ class DatabaseMigration {
   /**
    * Small query execution wrapper to log all executed queries
    */
-  private async $executeQuery(query: string, silent = false): Promise<any> {
+  public async $executeQuery(query: string, silent = false): Promise<any> {
     if (!silent) {
       logger.debug('MIGRATIONS: Execute query:\n' + query);
     }
@@ -552,7 +552,7 @@ class DatabaseMigration {
   /**
    * Check if 'table' exists in the database
    */
-  private async $checkIfTableExists(table: string): Promise<boolean> {
+  public async $checkIfTableExists(table: string): Promise<boolean> {
     const query = `SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '${config.DATABASE.DATABASE}' AND TABLE_NAME = '${table}'`;
     const [rows] = await DB.query({ sql: query, timeout: this.queryTimeout });
     return rows[0]['COUNT(*)'] === 1;
@@ -561,7 +561,7 @@ class DatabaseMigration {
   /**
    * Get current database version
    */
-  private async $getSchemaVersionFromDatabase(): Promise<number> {
+  public async $getSchemaVersionFromDatabase(): Promise<number> {
     const query = `SELECT number FROM state WHERE name = 'schema_version';`;
     const [rows] = await this.$executeQuery(query, true);
     return rows[0]['number'];
@@ -642,14 +642,14 @@ class DatabaseMigration {
     return `UPDATE state SET number = ${DatabaseMigration.currentVersion} WHERE name = 'schema_version';`;
   }
 
-  private async updateToSchemaVersion(version): Promise<void> {
+  public async updateToSchemaVersion(version): Promise<void> {
     await this.$executeQuery(`UPDATE state SET number = ${version} WHERE name = 'schema_version';`);
   }
 
   /**
    * Print current database version
    */
-  private async $printDatabaseVersion() {
+  public async $printDatabaseVersion() {
     try {
       const [rows] = await this.$executeQuery('SELECT VERSION() as version;', true);
       logger.debug(`MIGRATIONS: Database engine version '${rows[0].version}'`);


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2754

@mononaut if this is merged, make sure to add rollback queries if you increment the db schema version in the future 👍🏻 

### Usage

Example: Rollback db schema to version 40. This is a destructive operation, all deleted data is lost forever.

`npm run build && npm run rollback 40`