### PR TITLE
Refactor advanced GBT implementation to minimize inter-thread data transfer

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -21,7 +21,7 @@ class Mempool {
   private mempoolChangedCallback: ((newMempool: {[txId: string]: TransactionExtended; }, newTransactions: TransactionExtended[],
     deletedTransactions: TransactionExtended[]) => void) | undefined;
   private asyncMempoolChangedCallback: ((newMempool: {[txId: string]: TransactionExtended; }, newTransactions: TransactionExtended[],
-    deletedTransactions: TransactionExtended[]) => void) | undefined;
+    deletedTransactions: TransactionExtended[]) => Promise<void>) | undefined;
 
   private txPerSecondArray: number[] = [];
   private txPerSecond: number = 0;

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -251,7 +251,7 @@ class WebsocketHandler {
     }
 
     if (config.MEMPOOL.ADVANCED_GBT_MEMPOOL) {
-      await mempoolBlocks.makeBlockTemplates(newMempool, 8, null, true);
+      await mempoolBlocks.updateBlockTemplates(newMempool, newTransactions, deletedTransactions.map(tx => tx.txid));
     } else {
       mempoolBlocks.updateMempoolBlocks(newMempool);
     }
@@ -419,7 +419,7 @@ class WebsocketHandler {
     const _memPool = memPool.getMempool();
 
     if (config.MEMPOOL.ADVANCED_GBT_AUDIT) {
-      await mempoolBlocks.makeBlockTemplates(_memPool, 2);
+      await mempoolBlocks.makeBlockTemplates(_memPool);
     } else {
       mempoolBlocks.updateMempoolBlocks(_memPool);
     }
@@ -462,13 +462,15 @@ class WebsocketHandler {
       }
     }
 
+    const removed: string[] = [];
     // Update mempool to remove transactions included in the new block
     for (const txId of txIds) {
       delete _memPool[txId];
+      removed.push(txId);
     }
 
     if (config.MEMPOOL.ADVANCED_GBT_MEMPOOL) {
-      await mempoolBlocks.makeBlockTemplates(_memPool, 8, null, true);
+      await mempoolBlocks.updateBlockTemplates(_memPool, [], removed);
     } else {
       mempoolBlocks.updateMempoolBlocks(_memPool);
     }

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -81,10 +81,10 @@ export interface TransactionExtended extends IEsploraApi.Transaction {
 export interface AuditTransaction {
   txid: string;
   fee: number;
-  size: number;
   weight: number;
   feePerVsize: number;
-  vin: IEsploraApi.Vin[];
+  effectiveFeePerVsize: number;
+  vin: string[];
   relativesSet: boolean;
   ancestorMap: Map<string, AuditTransaction>;
   children: Set<AuditTransaction>;
@@ -94,6 +94,17 @@ export interface AuditTransaction {
   used: boolean;
   modified: boolean;
   modifiedNode: HeapNode<AuditTransaction>;
+}
+
+export interface ThreadTransaction {
+  txid: string;
+  fee: number;
+  weight: number;
+  feePerVsize: number;
+  effectiveFeePerVsize?: number;
+  vin: string[];
+  cpfpRoot?: string;
+  cpfpChecked?: boolean;
 }
 
 export interface Ancestor {


### PR DESCRIPTION
_(depends on PR #2778)_

This PR refactors the advanced transaction selection implementation to minimize the amount of data copied back and forth from the worker thread and thereby avoid stalling the main thread.

### Implementation

Instead of sending the entire mempool to the worker thread on each update, and then copying the whole thing + the constructed blocks back into the main thread after processing, we use a single long-lived thread process and send only essential data.

When the mempool is updated, we send a very condensed summary of new transactions (only txid, vin txids, fee, and weight and feerates) and a list of removed txids.

The worker thread uses that to update its own copy of the mempool in-place, performs the transaction selection algorithm, and returns a condensed summary of the resulting blocks.

The main thread efficiently updates it's own mempool with the new effective feerate and CPFP info, and rehydrates the blocks.

Testing with an artificial 100MB+/ mempool, this does seem to significantly reduce the main thread overhead.

### Alternatives

An alternative solution to avoid copying lots of data between threads would be to store the mempool in a SharedArrayBuffer, which can be accessed from either thread (with appropriate mutex locks).

Unfortunately, SharedArrayBuffer only supports fixed-length byte arrays, so we'd need to serialize and deserialize the data from JSON or Protocol Buffers or something similar in both threads on every update.

That seems likely to come with it's own significant overhead, as well as a lot of extra complexity.