### PR TITLE
Fix hexadecimal conversion to show leading zeros

### DIFF
--- a/frontend/src/app/shared/pipes/decimal2hex/decimal2hex.pipe.ts
+++ b/frontend/src/app/shared/pipes/decimal2hex/decimal2hex.pipe.ts
@@ -5,6 +5,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class Decimal2HexPipe implements PipeTransform {
   transform(decimal: number): string {
-    return `0x` + decimal.toString(16);
+    return `0x` + ( decimal.toString(16) ).padStart(8, '0');
   }
 }


### PR DESCRIPTION
Fixes #2805.

Example using block 749970:

![mempool-nonce-2](https://user-images.githubusercontent.com/93150691/206093826-fe38207f-aa16-4775-989f-b2d77956b1ac.png)