### PR TITLE
Fix & reenable cpfp indexer optimized path

### DIFF
--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -44,7 +44,9 @@ class TransactionRepository {
       const [rows]: any = await DB.query(query, [txid]);
       if (rows.length) {
         rows[0].txs = JSON.parse(rows[0].txs) as Ancestor[];
-        return this.convertCpfp(rows[0]);
+        if (rows[0]?.txs?.length) {
+          return this.convertCpfp(rows[0]);
+        }
       }
     } catch (e) {
       logger.err('Cannot get transaction cpfp info from db. Reason: ' + (e instanceof Error ? e.message : e));


### PR DESCRIPTION
Resolves a lingering issue from #2737 by fixing the broken optimized code path in the CPFP indexer and reenabling it when the `blocks_summaries` table is available.

This option speeds up CPFP indexing by extracting block transactions from raw block data and augmenting with fees from the `blocks_summaries` table, to avoid the expensive verbose block RPC call.
