### PR TITLE
Fix error 500 when querying /blocks using `"INDEXING_BLOCKS_AMOUNT": 0`

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -677,7 +677,7 @@ class Blocks {
   }
 
   public async $getBlocks(fromHeight?: number, limit: number = 15): Promise<BlockExtended[]> {
-    let currentHeight = fromHeight !== undefined ? fromHeight : await blocksRepository.$mostRecentBlockHeight();
+    let currentHeight = fromHeight !== undefined ? fromHeight : this.currentBlockHeight;
     const returnBlocks: BlockExtended[] = [];
 
     if (currentHeight < 0) {


### PR DESCRIPTION
### How to reproduce

Using `master` branch

- Use a completely empty database (fresh install)
- Set `"INDEXING_BLOCKS_AMOUNT": 0` in your nodejs backend config
- Set `"MINING_DASHBOARD": false` in your frontend config
- Run mempool and open `/blocks`
- Confirm there is an error 500

Using this PR

- Follow the same steps
- Confirm blocks are properly displayed without any error