### PR TITLE
Don't try to import LN historical stats if no topology folder is set

### DIFF
--- a/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
+++ b/backend/src/tasks/lightning/sync-tasks/stats-importer.ts
@@ -310,6 +310,11 @@ class LightningStatsImporter {
    * Import topology files LN historical data into the database
    */
   async $importHistoricalLightningStats(): Promise<void> {
+    if (!config.LIGHTNING.TOPOLOGY_FOLDER) {
+      logger.info(`Lightning topology folder is not set. Not importing historical LN stats`);
+      return;
+    }
+
     logger.debug('Run the historical importer');
     try {
       let fileList: string[] = [];


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/2877

```
Dec 28 12:11:58 [82601] INFO: <lightning> Lightning topology folder is not set. Not importing historical LN stats
```