### PR TITLE
toggle to enable/disable block audits

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -23,12 +23,19 @@
 
     <div class="grow"></div>
 
+    <div class="audit-toggle" *ngIf="webGlEnabled && auditAvailable">
+      <app-toggle
+        textLeft="audit"
+        i18n-textLeft="block.audit-mode"
+        [checked]="auditModeEnabled"
+        (toggleStatusChanged)="toggleAuditMode($event)"
+      ></app-toggle>
+    </div>
+
     <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
   </div>
 
   <div class="clearfix"></div>
-
-
 
   <div class="box" *ngIf="!error">
     <div class="row">
@@ -54,7 +61,7 @@
                 <td i18n="block.weight">Weight</td>
                 <td [innerHTML]="'&lrm;' + (block.weight | wuBytes: 2)"></td>
               </tr>
-              <tr *ngIf="!auditDataMissing && indexingAvailable">
+              <tr *ngIf="auditAvailable">
                 <td i18n="block.health">Block health</td>
                 <td>
                   <span
@@ -88,21 +95,21 @@
               <tr>
                 <td colspan="2"><span class="skeleton-loader"></span></td>
               </tr>
-              <tr *ngIf="!auditDataMissing && indexingAvailable">
+              <tr *ngIf="showAudit">
                 <td colspan="2"><span class="skeleton-loader"></span></td>
               </tr>
             </ng-template>
-            <ng-container *ngIf="isMobile || (webGlEnabled && (auditDataMissing || !indexingAvailable)); then restOfTable;"></ng-container>
+            <ng-container *ngIf="isMobile || (webGlEnabled && !showAudit); then restOfTable;"></ng-container>
           </tbody>
         </table>
       </div>
       <div class="col-sm">
-        <table class="table table-borderless table-striped" *ngIf="!isMobile && !(webGlEnabled && (auditDataMissing || !indexingAvailable))">
+        <table class="table table-borderless table-striped" *ngIf="!isMobile && !(webGlEnabled && !showAudit)">
           <tbody>
             <ng-container *ngTemplateOutlet="restOfTable"></ng-container>
           </tbody>
         </table>
-        <div class="col-sm chart-container" *ngIf="webGlEnabled && (!indexingAvailable || auditDataMissing)">
+        <div class="col-sm chart-container" *ngIf="webGlEnabled && !showAudit">
           <app-block-overview-graph
             #blockGraphActual
             [isLoading]="isLoadingOverview"
@@ -204,8 +211,8 @@
   <br>
 
   <!-- VISUALIZATIONS -->
-  <div class="box" *ngIf="!error && webGlEnabled && indexingAvailable && !auditDataMissing">
-    <div class="nav nav-tabs" *ngIf="isMobile && auditEnabled">
+  <div class="box" *ngIf="!error && webGlEnabled && showAudit">
+    <div class="nav nav-tabs" *ngIf="isMobile && showAudit">
       <a class="nav-link" [class.active]="mode === 'projected'" i18n="block.projected"
         fragment="projected" (click)="changeMode('projected')">Projected</a>
       <a class="nav-link" [class.active]="mode === 'actual'" i18n="block.actual"
@@ -217,7 +224,7 @@
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="isLoadingOverview" [resolution]="75"
             [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !auditEnabled"></app-block-overview-graph>
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit"></app-block-overview-graph>
           <ng-container *ngIf="!isMobile || mode !== 'actual'; else emptyBlockInfo"></ng-container>
         </div>
       </div>
@@ -226,7 +233,7 @@
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphActual [isLoading]="isLoadingOverview" [resolution]="75"
             [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !auditEnabled"></app-block-overview-graph>
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit"></app-block-overview-graph>
           <ng-container *ngTemplateOutlet="emptyBlockInfo"></ng-container>
         </div>
       </div>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -23,15 +23,6 @@
 
     <div class="grow"></div>
 
-    <div class="audit-toggle" *ngIf="webGlEnabled && auditAvailable">
-      <app-toggle
-        textLeft="audit"
-        i18n-textLeft="block.audit-mode"
-        [checked]="auditModeEnabled"
-        (toggleStatusChanged)="toggleAuditMode($event)"
-      ></app-toggle>
-    </div>
-
     <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
   </div>
 
@@ -288,8 +279,22 @@
       </div>
     </div>
 
-    <div class="text-right mt-3">
-      <button type="button" class="btn btn-outline-info btn-sm btn-details" (click)="toggleShowDetails()" i18n="transaction.details|Transaction Details">Details</button>
+    <div class="text-right mt-3 toggle-btns">
+      <button
+        *ngIf="webGlEnabled && auditAvailable"
+        type="button"
+        class="btn btn-outline-info btn-sm btn-audit"
+        [class.active]="auditModeEnabled"
+        (click)="toggleAuditMode()"
+        i18n="block.toggle-audit|Toggle Audit"
+      >Audit</button>
+      <button
+        type="button"
+        class="btn btn-outline-info btn-sm btn-details"
+        [class.active]="showDetails"
+        (click)="toggleShowDetails()"
+        i18n="transaction.details|Transaction Details"
+      >Details</button>
     </div>
 
     <div #blockTxTitle id="block-tx-title" class="block-tx-title">

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -206,9 +206,10 @@
     </ng-template>
   </ng-template>
 
-  <span id="overview"></span>
-
-  <br>
+  <ng-container *ngIf="showAudit">
+    <span id="overview"></span>
+    <br>
+  </ng-container>
 
   <!-- VISUALIZATIONS -->
   <div class="box" *ngIf="!error && webGlEnabled && showAudit">

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -223,3 +223,10 @@ h1 {
     margin-right: 1em;
   }
 }
+
+.audit-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-right: 1em;
+}

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -75,12 +75,17 @@ h1 {
 	}
 }
 
-.btn-details {
+.toggle-btns {
   position: relative;
+  z-index: 2;
   top: 7px;
   @media (min-width: 550px) {
     top: 0px;
   }
+}
+
+.btn-audit {
+  margin-right: .5em;
 }
 
 .block-tx-title {
@@ -222,11 +227,4 @@ h1 {
   .ng-fa-icon {
     margin-right: 1em;
   }
-}
-
-.audit-toggle {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-right: 1em;
 }

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -608,8 +608,8 @@ export class BlockComponent implements OnInit, OnDestroy {
     this.showAudit = this.auditAvailable && this.auditModeEnabled;
   }
 
-  toggleAuditMode(event): void {
-    this.stateService.hideAudit.next(!event);
+  toggleAuditMode(): void {
+    this.stateService.hideAudit.next(this.auditModeEnabled);
   }
 
   updateAuditAvailableFromBlockHeight(blockHeight: number): void {

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -118,6 +118,7 @@ export class StateService {
   blockScrolling$: Subject<boolean> = new Subject<boolean>();
   timeLtr: BehaviorSubject<boolean>;
   hideFlow: BehaviorSubject<boolean>;
+  hideAudit: BehaviorSubject<boolean>;
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
@@ -176,6 +177,12 @@ export class StateService {
       } else {
         this.storageService.removeItem('flow-preference');
       }
+    });
+
+    const savedAuditPreference = this.storageService.getValue('audit-preference');
+    this.hideAudit = new BehaviorSubject<boolean>(savedAuditPreference === 'hide');
+    this.hideAudit.subscribe((hide) => {
+      this.storageService.setValue('audit-preference', hide ? 'hide' : 'show');
     });
   }
 

--- a/frontend/src/app/shared/components/toggle/toggle.component.html
+++ b/frontend/src/app/shared/components/toggle/toggle.component.html
@@ -1,8 +1,8 @@
 <div class="d-flex align-items-center">
-  <span style="margin-bottom: 0.5rem">{{ textLeft }}</span>&nbsp;
-  <label class="switch">
+  <span>{{ textLeft }}</span>&nbsp;
+  <label class="switch" style="margin-bottom: 0;">
     <input type="checkbox" [checked]="checked" (change)="onToggleStatusChanged($event)">
-    <span class="slider round"></span>
+    <span class="slider round" [class.animate]="animate"></span>
   </label>
-  &nbsp;<span style="margin-bottom: 0.5rem">{{ textRight }}</span>
+  &nbsp;<span>{{ textRight }}</span>
 </div>

--- a/frontend/src/app/shared/components/toggle/toggle.component.scss
+++ b/frontend/src/app/shared/components/toggle/toggle.component.scss
@@ -22,8 +22,6 @@
   right: 0;
   bottom: 0;
   background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
 }
 
 .slider:before {
@@ -34,6 +32,9 @@
   left: 2px;
   bottom: 2px;
   background-color: white;
+}
+
+.slider.animate, .slider.animate:before {
   -webkit-transition: .4s;
   transition: .4s;
 }

--- a/frontend/src/app/shared/components/toggle/toggle.component.ts
+++ b/frontend/src/app/shared/components/toggle/toggle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, ChangeDetectionStrategy, EventEmitter, AfterViewInit } from '@angular/core';
+import { Component, Input, Output, ChangeDetectionStrategy, EventEmitter, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 
 @Component({
   selector: 'app-toggle',
@@ -11,9 +11,15 @@ export class ToggleComponent implements AfterViewInit {
   @Input() textLeft: string;
   @Input() textRight: string;
   @Input() checked: boolean = false;
+  animate: boolean = false;
+
+  constructor(
+    private cd: ChangeDetectorRef,
+  ) { }
 
   ngAfterViewInit(): void {
-    this.toggleStatusChanged.emit(false);
+    this.animate = true;
+    setTimeout(() => { this.cd.markForCheck()});
   }
 
   onToggleStatusChanged(e): void {


### PR DESCRIPTION
Adds a toggle button to the block page to show/hide block audits (if available).

Audits are shown by default, and user's preference is cached to localStorage.

![audit-toggle](https://user-images.githubusercontent.com/83316221/210346352-feea90e8-88aa-4d3d-8a36-a269a40bee00.png)
