### PR TITLE
Removing Lightning Beta tag

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -205,14 +205,14 @@
   <!-- VISUALIZATIONS -->
   <div class="box" *ngIf="!error && webGlEnabled && showAudit">
     <div class="nav nav-tabs" *ngIf="isMobile && showAudit">
-      <a class="nav-link" [class.active]="mode === 'projected'" i18n="block.projected"
-        fragment="projected" (click)="changeMode('projected')">Projected</a>
+      <a class="nav-link" [class.active]="mode === 'projected'"
+        fragment="projected" (click)="changeMode('projected')"><ng-container i18n="block.projected">Projected</ng-container>&nbsp;&nbsp;<span class="badge badge-pill badge-warning" i18n="beta">beta</span></a>
       <a class="nav-link" [class.active]="mode === 'actual'" i18n="block.actual"
         fragment="actual" (click)="changeMode('actual')">Actual</a>
     </div>
     <div class="row">
       <div class="col-sm">
-        <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.projected-block">Projected Block</h3>
+        <h3 class="block-subtitle" *ngIf="!isMobile"><ng-container i18n="block.projected-block">Projected Block</ng-container> <span class="badge badge-pill badge-warning beta" i18n="beta">beta</span></h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="isLoadingOverview" [resolution]="75"
             [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" [auditHighlighting]="showAudit"

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -228,3 +228,12 @@ h1 {
     margin-right: 1em;
   }
 }
+
+.beta {
+  font-size: 10px;
+  margin: 5p;
+  padding: 5p;
+  position: absolute;
+  top: 11px;
+  margin-left: 10px;
+}

--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -42,7 +42,6 @@
       </li>
       <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" id="btn-pools" *ngIf="stateService.env.LIGHTNING">
         <a class="nav-link" [routerLink]="['/lightning' | relativeUrl]" (click)="collapse()"><fa-icon [icon]="['fas', 'bolt']" [fixedWidth]="true" i18n-title="master-page.lightning" title="Lightning Explorer"></fa-icon>
-          <span class="badge badge-pill badge-warning beta" i18n="beta">beta</span>
         </a>
       </li>
       <li class="nav-item" routerLinkActive="active" id="btn-blocks" *ngIf="!stateService.env.MINING_DASHBOARD">


### PR DESCRIPTION
EDITED:

Moving beta tag from Lightning to Block Audit

Desktop
<img width="367" alt="Screenshot 2023-01-31 at 15 49 31" src="https://user-images.githubusercontent.com/8561090/215712946-07101ca7-458f-4b1a-9931-e00070942750.png">


Mobile

<img width="276" alt="Screenshot 2023-01-31 at 15 50 45" src="https://user-images.githubusercontent.com/8561090/215713231-95db7cb2-0061-4e21-8898-f476d44764d3.png">

