### PR TITLE
Show `Avg fees per block` instead of `Reward Per Tx`

### DIFF
--- a/frontend/src/app/components/reward-stats/reward-stats.component.html
+++ b/frontend/src/app/components/reward-stats/reward-stats.component.html
@@ -13,21 +13,21 @@
       </div>
     </div>
     <div class="item">
-      <h5 class="card-title" i18n="mining.rewards-per-tx" i18n-ngbTooltip="mining.rewards-per-tx"
-      ngbTooltip="Reward Per Tx" placement="bottom" #rewardspertx [disableTooltip]="!isEllipsisActive(rewardspertx)">Reward Per Tx</h5>
-      <div class="card-text" i18n-ngbTooltip="mining.rewards-per-tx-desc" ngbTooltip="Average miners' reward per transaction in the past 144 blocks" placement="bottom">
+      <h5 class="card-title" i18n="mining.fees-per-block" i18n-ngbTooltip="mining.fees-per-block"
+      ngbTooltip="Avg block Fees" placement="bottom" #rewardsperblock [disableTooltip]="!isEllipsisActive(rewardsperblock)">Avg Block Fees</h5>
+      <div class="card-text" i18n-ngbTooltip="mining.fees-per-block-desc" ngbTooltip="Average fees per block in the past 144 blocks" placement="bottom">
         <div class="fee-text">
-          {{ rewardStats.rewardPerTx | amountShortener: 2 }}
-          <span i18n="shared.sat-vbyte|sat/vB">sats/tx</span>
+          {{ (rewardStats.feePerBlock / 100000000) | amountShortener: 4 }}
+          <span i18n="shared.btc-block|BTC/block">BTC/block</span>
         </div>
         <span class="fiat">
-          <app-fiat [value]="rewardStats.rewardPerTx"></app-fiat>
+          <app-fiat [value]="rewardStats.feePerBlock"></app-fiat>
         </span>
       </div>
     </div>
     <div class="item">
       <h5 class="card-title" i18n="mining.average-fee" i18n-ngbTooltip="mining.average-fee"
-      ngbTooltip="Average Fee" placement="bottom" #averagefee [disableTooltip]="!isEllipsisActive(averagefee)">Average Fee</h5>
+      ngbTooltip="Avg Tx Fee" placement="bottom" #averagefee [disableTooltip]="!isEllipsisActive(averagefee)">Avg Tx Fee</h5>
       <div class="card-text" i18n-ngbTooltip="mining.average-fee" ngbTooltip="Fee paid on average for each transaction in the past 144 blocks" placement="bottom">
         <div class="fee-text">{{ rewardStats.feePerTx | amountShortener: 2 }}
           <span i18n="shared.sat-vbyte|sat/vB">sats/tx</span>

--- a/frontend/src/app/components/reward-stats/reward-stats.component.ts
+++ b/frontend/src/app/components/reward-stats/reward-stats.component.ts
@@ -42,8 +42,8 @@ export class RewardStatsComponent implements OnInit {
         map((stats) => {
           return {
             totalReward: stats.totalReward,
-            rewardPerTx: stats.totalReward / stats.totalTx,
             feePerTx: stats.totalFee / stats.totalTx,
+            feePerBlock: stats.totalFee / 144,
           };
         })
       );


### PR DESCRIPTION
Currently we are showing the average `Reward Per Tx` for the past 144 blocks. I don't think this metric gives any useful information and I've put it there months ago due to the lack of better ideas.

One of the oldest debate around Bitcoin is about miner's subsidies over the long term, so I though it would be useful to show the average fees per block instead. It does not require any backend change since we already have the data in the frontend.

### Currently

<img width="551" alt="image" src="https://user-images.githubusercontent.com/9780671/211168347-83f0b1d3-6bee-4fd7-9253-1da17814f6c5.png">

### Updated

<img width="551" alt="image" src="https://user-images.githubusercontent.com/9780671/211168356-2bd46c64-48aa-447a-8ff7-c24d13655650.png">
