### PR TITLE
CPFP Optimizations

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -350,7 +350,7 @@ class Blocks {
       let countThisRun = 0;
       let timer = new Date().getTime() / 1000;
       const startedAt = new Date().getTime() / 1000;
-
+      let lastHeight;
       for (const block of unindexedBlocks) {
         // Logging
         const elapsedSeconds = Math.max(1, new Date().getTime() / 1000 - timer);
@@ -365,11 +365,13 @@ class Blocks {
 
         await this.$indexCPFP(block.hash, block.height); // Calculate and save CPFP data for transactions in this block
 
+        lastHeight = block.height;
         // Logging
         count++;
         countThisRun++;
       }
       if (count > 0) {
+        await cpfpRepository.$insertProgressMarker(lastHeight);
         logger.notice(`CPFP indexing completed: indexed ${count} blocks`);
       } else {
         logger.debug(`CPFP indexing completed: indexed ${count} blocks`);

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -341,6 +341,7 @@ class Blocks {
     try {
       // Get all indexed block hash
       const unindexedBlocks = await blocksRepository.$getCPFPUnindexedBlocks();
+      logger.info(`Indexing cpfp data for ${unindexedBlocks.length} blocks`);
 
       if (!unindexedBlocks?.length) {
         return;
@@ -357,7 +358,7 @@ class Blocks {
         const elapsedSeconds = Math.max(1, new Date().getTime() / 1000 - timer);
         if (elapsedSeconds > 5) {
           const runningFor = Math.max(1, Math.round((new Date().getTime() / 1000) - startedAt));
-          const blockPerSeconds = Math.max(1, countThisRun / elapsedSeconds);
+          const blockPerSeconds = (countThisRun / elapsedSeconds);
           const progress = Math.round(count / unindexedBlocks.length * 10000) / 100;
           logger.debug(`Indexing cpfp clusters for #${block.height} | ~${blockPerSeconds.toFixed(2)} blocks/sec | total: ${count}/${unindexedBlocks.length} (${progress}%) | elapsed: ${runningFor} seconds`);
           timer = new Date().getTime() / 1000;

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -753,33 +753,14 @@ class Blocks {
 
   public async $indexCPFP(hash: string, height: number): Promise<void> {
     let transactions;
-    if (Common.blocksSummariesIndexingEnabled()) {
-      transactions = await this.$getStrippedBlockTransactions(hash);
-      const rawBlock = await bitcoinApi.$getRawBlock(hash);
-      const block = Block.fromBuffer(rawBlock);
-      const txMap = {};
-      for (const tx of block.transactions || []) {
-        txMap[tx.getId()] = tx;
-      }
-      for (const tx of transactions) {
-        // convert from bitcoinjs to esplora vin format
-        if (txMap[tx.txid]?.ins) {
-          tx.vin = txMap[tx.txid].ins.map(vin => {
-            return {
-              txid: vin.hash.slice().reverse().toString('hex')
-            };
-          });
-        }
-      }
-    } else {
-      const block = await bitcoinClient.getBlock(hash, 2);
-      transactions = block.tx.map(tx => {
-        tx.vsize = tx.weight / 4;
-        tx.fee *= 100_000_000;
-        return tx;
-      });
-    }
  
+    const block = await bitcoinClient.getBlock(hash, 2);
+    transactions = block.tx.map(tx => {
+      tx.vsize = tx.weight / 4;
+      tx.fee *= 100_000_000;
+      return tx;
+    });
+
     let cluster: TransactionStripped[] = [];
     let ancestors: { [txid: string]: boolean } = {};
     for (let i = transactions.length - 1; i >= 0; i--) {

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -806,7 +806,6 @@ class Blocks {
         ancestors[vin.txid] = true;
       });
     }
-    await blocksRepository.$setCPFPIndexed(hash);
   }
 }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -445,6 +445,8 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 50 && isBitcoin === true) {
       await this.$executeQuery('ALTER TABLE `blocks` DROP COLUMN `cpfp_indexed`');
+      await this.$executeQuery(this.getCreateCompactCPFPTableQuery(), await this.$checkIfTableExists('compact_cpfp_clusters'));
+      await this.$executeQuery(this.getCreateCompactTransactionsTableQuery(), await this.$checkIfTableExists('compact_transactions'));
       await this.updateToSchemaVersion(50);
     }
   }
@@ -915,6 +917,25 @@ class DatabaseMigration {
       cluster varchar(65) DEFAULT NULL,
       PRIMARY KEY (txid),
       FOREIGN KEY (cluster) REFERENCES cpfp_clusters (root) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
+  }
+
+  private getCreateCompactCPFPTableQuery(): string {
+    return `CREATE TABLE IF NOT EXISTS compact_cpfp_clusters (
+      root binary(32) NOT NULL,
+      height int(10) NOT NULL,
+      txs BLOB DEFAULT NULL,
+      fee_rate float unsigned NOT NULL,
+      PRIMARY KEY (root),
+      INDEX (height)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
+  }
+
+  private getCreateCompactTransactionsTableQuery(): string {
+    return `CREATE TABLE IF NOT EXISTS compact_transactions (
+      txid binary(32) NOT NULL,
+      cluster binary(32) DEFAULT NULL,
+      PRIMARY KEY (txid)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
   }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { Common } from './common';
 
 class DatabaseMigration {
-  private static currentVersion = 49;
+  private static currentVersion = 50;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -441,6 +441,11 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 49 && isBitcoin === true) {
       await this.$executeQuery('TRUNCATE TABLE `blocks_audits`');
       await this.updateToSchemaVersion(49);
+    }
+
+    if (databaseSchemaVersion < 50 && isBitcoin === true) {
+      await this.$executeQuery('ALTER TABLE `blocks` DROP COLUMN `cpfp_indexed`');
+      await this.updateToSchemaVersion(50);
     }
   }
 

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -8,6 +8,8 @@ import HashratesRepository from './HashratesRepository';
 import { escape } from 'mysql2';
 import BlocksSummariesRepository from './BlocksSummariesRepository';
 import DifficultyAdjustmentsRepository from './DifficultyAdjustmentsRepository';
+import bitcoinClient from '../api/bitcoin/bitcoin-client';
+import config from '../config';
 
 class BlocksRepository {
   /**
@@ -667,16 +669,26 @@ class BlocksRepository {
    */
    public async $getCPFPUnindexedBlocks(): Promise<any[]> {
     try {
-      const [rows]: any = await DB.query(`SELECT height, hash FROM blocks WHERE cpfp_indexed = 0 ORDER BY height DESC`);
-      return rows;
+      const blockchainInfo = await bitcoinClient.getBlockchainInfo();
+      const currentBlockHeight = blockchainInfo.blocks;
+      const [lastHeightRows]: any = await DB.query(`SELECT MIN(height) AS minHeight from cpfp_clusters`);
+      const lastHeight = (lastHeightRows.length && lastHeightRows[0].minHeight != null) ? lastHeightRows[0].minHeight : currentBlockHeight;
+
+      let indexingBlockAmount = Math.min(config.MEMPOOL.INDEXING_BLOCKS_AMOUNT, blockchainInfo.blocks);
+      if (indexingBlockAmount <= -1) {
+        indexingBlockAmount = currentBlockHeight + 1;
+      }
+      const firstHeight = Math.max(0, currentBlockHeight - indexingBlockAmount + 1);
+
+      if (firstHeight < lastHeight) {
+        const [rows]: any = await DB.query(`SELECT height, hash FROM blocks WHERE height BETWEEN ? AND ? ORDER BY height DESC`, [firstHeight, lastHeight]);
+        return rows;
+      }
     } catch (e) {
       logger.err('Cannot fetch CPFP unindexed blocks. Reason: ' + (e instanceof Error ? e.message : e));
       throw e;
     }
-  }
-
-  public async $setCPFPIndexed(hash: string): Promise<void> {
-    await DB.query(`UPDATE blocks SET cpfp_indexed = 1 WHERE hash = ?`, [hash]);
+    return [];
   }
 
   /**

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -671,7 +671,7 @@ class BlocksRepository {
     try {
       const blockchainInfo = await bitcoinClient.getBlockchainInfo();
       const currentBlockHeight = blockchainInfo.blocks;
-      const [lastHeightRows]: any = await DB.query(`SELECT MIN(height) AS minHeight from cpfp_clusters`);
+      const [lastHeightRows]: any = await DB.query(`SELECT MIN(height) AS minHeight from compact_cpfp_clusters`);
       const lastHeight = (lastHeightRows.length && lastHeightRows[0].minHeight != null) ? lastHeightRows[0].minHeight : currentBlockHeight;
 
       let indexingBlockAmount = Math.min(config.MEMPOOL.INDEXING_BLOCKS_AMOUNT, blockchainInfo.blocks);

--- a/backend/src/repositories/CpfpRepository.ts
+++ b/backend/src/repositories/CpfpRepository.ts
@@ -1,34 +1,72 @@
+import cluster, { Cluster } from 'cluster';
+import { RowDataPacket } from 'mysql2';
 import DB from '../database';
 import logger from '../logger';
 import { Ancestor } from '../mempool.interfaces';
+import transactionRepository from '../repositories/TransactionRepository';
 
 class CpfpRepository {
-  public async $saveCluster(height: number, txs: Ancestor[], effectiveFeePerVsize: number): Promise<void> {
+  public async $saveCluster(clusterRoot: string, height: number, txs: Ancestor[], effectiveFeePerVsize: number): Promise<void> {
+    if (!txs[0]) {
+      return;
+    }
     try {
-      const txsJson = JSON.stringify(txs);
+      const packedTxs = Buffer.from(this.pack(txs));
       await DB.query(
         `
-          INSERT INTO cpfp_clusters(root, height, txs, fee_rate)
-          VALUE (?, ?, ?, ?)
+          INSERT INTO compact_cpfp_clusters(root, height, txs, fee_rate)
+          VALUE (UNHEX(?), ?, ?, ?)
           ON DUPLICATE KEY UPDATE
             height = ?,
             txs = ?,
             fee_rate = ?
         `,
-        [txs[0].txid, height, txsJson, effectiveFeePerVsize, height, txsJson, effectiveFeePerVsize, height]
+        [clusterRoot, height, packedTxs, effectiveFeePerVsize, height, packedTxs, effectiveFeePerVsize]
       );
+      for (const tx of txs) {
+        await transactionRepository.$setCluster(tx.txid, clusterRoot);
+      }
     } catch (e: any) {
       logger.err(`Cannot save cpfp cluster into db. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }
 
+  public async $getCluster(clusterRoot: string): Promise<Cluster> {
+    const [clusterRows]: any = await DB.query(
+      `
+        SELECT *
+        FROM compact_cpfp_clusters
+        WHERE root = UNHEX(?)
+      `,
+      [clusterRoot]
+    );
+    const cluster = clusterRows[0];
+    cluster.txs = this.unpack(cluster.txs);
+    return cluster;
+  }
+
   public async $deleteClustersFrom(height: number): Promise<void> {
     logger.info(`Delete newer cpfp clusters from height ${height} from the database`);
     try {
+      const [rows] = await DB.query(
+        `
+          SELECT txs, height, root from compact_cpfp_clusters
+          WHERE height >= ?
+        `,
+        [height]
+      ) as RowDataPacket[][];
+      if (rows?.length) {
+        for (let clusterToDelete of rows) {
+          const txs = this.unpack(clusterToDelete.txs);
+          for (let tx of txs) {
+            await transactionRepository.$removeTransaction(tx.txid);
+          }
+        }
+      }
       await DB.query(
         `
-          DELETE from cpfp_clusters
+          DELETE from compact_cpfp_clusters
           WHERE height >= ?
         `,
         [height]
@@ -37,6 +75,42 @@ class CpfpRepository {
       logger.err(`Cannot delete cpfp clusters from db. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
+  }
+
+  public pack(txs: Ancestor[]): ArrayBuffer {
+    const buf = new ArrayBuffer(44 * txs.length);
+    const view = new DataView(buf);
+    txs.forEach((tx, i) => {
+      const offset = i * 44;
+      for (let x = 0; x < 32; x++) {
+        // store txid in little-endian
+        view.setUint8(offset + (31 - x), parseInt(tx.txid.slice(x * 2, (x * 2) + 2), 16));
+      }
+      view.setUint32(offset + 32, tx.weight);
+      view.setBigUint64(offset + 36, BigInt(Math.round(tx.fee)));
+    });
+    return buf;
+  }
+
+  public unpack(buf: Buffer): Ancestor[] {
+    if (!buf) {
+      return [];
+    }
+
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    const txs: Ancestor[] = [];
+    const view = new DataView(arrayBuffer);
+    for (let offset = 0; offset < arrayBuffer.byteLength; offset += 44) {
+      const txid = Array.from(new Uint8Array(arrayBuffer, offset, 32)).reverse().map(b => b.toString(16).padStart(2, '0')).join('');
+      const weight = view.getUint32(offset + 32);
+      const fee = Number(view.getBigUint64(offset + 36));
+      txs.push({
+        txid,
+        weight,
+        fee
+      });
+    }
+    return txs;
   }
 }
 

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -83,7 +83,6 @@ class TransactionRepository {
     return {
       descendants,
       ancestors,
-      effectiveFeePerVsize: cpfp.fee_rate
     };
   }
 }

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -34,6 +34,30 @@ class TransactionRepository {
     }
   }
 
+  public async $batchSetCluster(txs): Promise<void> {
+    try {
+      let query = `
+          INSERT IGNORE INTO compact_transactions
+          (
+            txid,
+            cluster
+          )
+          VALUES
+      `;
+      query += txs.map(tx => {
+        return (' (UNHEX(?), UNHEX(?))');
+      }) + ';';
+      const values = txs.map(tx => [tx.txid, tx.cluster]).flat();
+      await DB.query(
+        query,
+        values
+      );
+    } catch (e: any) {
+      logger.err(`Cannot save cpfp transactions into db. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
   public async $getCpfpInfo(txid: string): Promise<CpfpInfo | void> {
     try {
       const [txRows]: any = await DB.query(

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -131,8 +131,11 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           this.cpfpInfo = null;
           return;
         }
-
-        const relatives = [...cpfpInfo.ancestors, ...cpfpInfo.descendants || [cpfpInfo.bestDescendant]];
+        // merge ancestors/descendants
+        const relatives = [...(cpfpInfo.ancestors || []), ...(cpfpInfo.descendants || [])];
+        if (cpfpInfo.bestDescendant && !cpfpInfo.descendants?.length) {
+          relatives.push(cpfpInfo.bestDescendant);
+        }
         let totalWeight =
           this.tx.weight +
           relatives.reduce((prev, val) => prev + val.weight, 0);

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -131,26 +131,17 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           this.cpfpInfo = null;
           return;
         }
-        if (cpfpInfo.effectiveFeePerVsize) {
-          this.tx.effectiveFeePerVsize = cpfpInfo.effectiveFeePerVsize;
-        } else {
-          const lowerFeeParents = cpfpInfo.ancestors.filter(
-            (parent) => parent.fee / (parent.weight / 4) < this.tx.feePerVsize
-          );
-          let totalWeight =
-            this.tx.weight +
-            lowerFeeParents.reduce((prev, val) => prev + val.weight, 0);
-          let totalFees =
-            this.tx.fee +
-            lowerFeeParents.reduce((prev, val) => prev + val.fee, 0);
 
-          if (cpfpInfo?.bestDescendant) {
-            totalWeight += cpfpInfo?.bestDescendant.weight;
-            totalFees += cpfpInfo?.bestDescendant.fee;
-          }
+        const relatives = [...cpfpInfo.ancestors, ...cpfpInfo.descendants || [cpfpInfo.bestDescendant]];
+        let totalWeight =
+          this.tx.weight +
+          relatives.reduce((prev, val) => prev + val.weight, 0);
+        let totalFees =
+          this.tx.fee +
+          relatives.reduce((prev, val) => prev + val.fee, 0);
 
-          this.tx.effectiveFeePerVsize = totalFees / (totalWeight / 4);
-        }
+        this.tx.effectiveFeePerVsize = totalFees / (totalWeight / 4);
+
         if (!this.tx.status.confirmed) {
           this.stateService.markBlock$.next({
             txFeePerVSize: this.tx.effectiveFeePerVsize,

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -24,7 +24,6 @@ export interface CpfpInfo {
   ancestors: Ancestor[];
   descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
-  effectiveFeePerVsize?: number;
 }
 
 export interface DifficultyAdjustment {


### PR DESCRIPTION
This PR optimizes various aspects of the CPFP indexing process:
 - New compact db table schemas with ~70% reduction in storage requirements.
 - Slightly faster indexing.
 - Eliminates dependence on the blocks table.
 - Skips clusters of transactions with the same fee rates.
 - Removes unnecessary foreign key constraints which should make ops tasks like truncating/exporting/importing these tables less annoying.

And
 - Replaces the slow JOIN query at the `/api/v1/cpfp` endpoint with a fast two-part lookup.

The new schemas store txids as fixed-length binary columns, and replace the JSON cluster transactions column with a compact binary blob.

CPFP data is now inserted in batches instead of individual rows.

The database migration includes a step to copy over any already-indexed CPFP data from the old tables. This could take several hours, but it's much faster than reindexing from the beginning. 
**However, it will delay the backend coming online and result in some downtime**. If that's not acceptable, I expect I could shift this step into a background process.
Old data should be preserved until the migration completes cleanly, but it might be a good idea to back up the `cpfp_clusters` and `transactions` tables before running this, just in case.