### PR TITLE
Expose whether Lightning is enabled on the backend

### DIFF
--- a/backend/src/api/backend-info.ts
+++ b/backend/src/api/backend-info.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { IBackendInfo } from '../mempool.interfaces';
+import config from '../config';
 
 class BackendInfo {
   private backendInfo: IBackendInfo;
@@ -22,7 +23,8 @@ class BackendInfo {
     this.backendInfo = {
       hostname: os.hostname(),
       version: versionInfo.version,
-      gitCommit: versionInfo.gitCommit
+      gitCommit: versionInfo.gitCommit,
+      lightning: config.LIGHTNING.ENABLED
     };
   }
 

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -274,6 +274,7 @@ export interface IBackendInfo {
   hostname: string;
   gitCommit: string;
   version: string;
+  lightning: boolean;
 }
 
 export interface IDifficultyAdjustment {


### PR DESCRIPTION
Adds the `lightning` field to the `/backend-info` response, in preparation for the "one-frontend-multiple-backends" Docker configuration.