### PR TITLE
Node AS table overflow fix

### DIFF
--- a/frontend/src/app/lightning/node/node.component.html
+++ b/frontend/src/app/lightning/node/node.component.html
@@ -83,17 +83,19 @@
             </tr>
             <tr>
               <td i18n="isp" class="text-truncate label">ISP</td>
-              <td *ngIf="node.as_number">
+              <td *ngIf="node.as_number else unknownAS">
                 <a class="d-block text-wrap" [routerLink]="['/lightning/nodes/isp' | relativeUrl, node.as_number]">
                   {{ node.as_organization }} [ASN {{node.as_number}}]
                 </a>                
               </td>
-              <td *ngIf="clearnetSocketCount === 0 && torSocketCount > 0">
-                <span class="badge badge-success" placement="bottom" i18n="tor">Exclusively on Tor</span>
-              </td>
-              <td *ngIf="node.sockets.length === 0">
-                <span i18n="unknown">Unknown</span>
-              </td>
+              <ng-template #unknownAS>
+                <td *ngIf="clearnetSocketCount === 0 && torSocketCount > 0">
+                  <span class="badge badge-success" placement="bottom" i18n="tor">Exclusively on Tor</span>
+                </td>
+                <td *ngIf="node.sockets.length === 0">
+                  <span i18n="unknown">Unknown</span>
+                </td>
+              </ng-template>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/app/lightning/node/node.component.ts
+++ b/frontend/src/app/lightning/node/node.component.ts
@@ -58,6 +58,8 @@ export class NodeComponent implements OnInit {
         }),
         map((node) => {
           this.seoService.setTitle($localize`Node: ${node.alias}`);
+          this.clearnetSocketCount = 0;
+          this.torSocketCount = 0;
 
           const socketsObject = [];
           for (const socket of node.sockets.split(',')) {


### PR DESCRIPTION
Fixes the following overflow that happens on Node [ 023b3ec101c9ab4e060b345d7d6b1728f5ca2db1e21bda9a88f2b9f6b1a3825ef9 ] when AS is present but no Sockets.

<img width="512" alt="Screenshot 2023-01-12 at 20 48 34" src="https://user-images.githubusercontent.com/8561090/212129060-d4a342de-3042-4232-99c9-272aa9da397b.png">
