### PR TITLE
reduce prominence of marginal fee rate audit txs

### DIFF
--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -10,12 +10,13 @@ const defaultHoverColor = hexToColor('1bd8f4');
 
 const feeColors = mempoolFeeColors.map(hexToColor);
 const auditFeeColors = feeColors.map((color) => darken(desaturate(color, 0.3), 0.9));
+const marginalFeeColors = feeColors.map((color) => darken(desaturate(color, 0.8), 1.1));
 const auditColors = {
   censored: hexToColor('f344df'),
   missing: darken(desaturate(hexToColor('f344df'), 0.3), 0.7),
   added: hexToColor('0099ff'),
   selected: darken(desaturate(hexToColor('0099ff'), 0.3), 0.7),
-}
+};
 
 // convert from this class's update format to TxSprite's update format
 function toSpriteUpdate(params: ViewUpdateParams): SpriteUpdateParams {
@@ -161,13 +162,13 @@ export default class TxView implements TransactionStripped {
       case 'censored':
         return auditColors.censored;
       case 'missing':
-        return auditColors.missing;
+        return marginalFeeColors[feeLevelIndex] || marginalFeeColors[mempoolFeeColors.length - 1];
       case 'fresh':
         return auditColors.missing;
       case 'added':
         return auditColors.added;
       case 'selected':
-        return auditColors.selected;
+        return marginalFeeColors[feeLevelIndex] || marginalFeeColors[mempoolFeeColors.length - 1];
       case 'found':
         if (this.context === 'projected') {
           return auditFeeColors[feeLevelIndex] || auditFeeColors[mempoolFeeColors.length - 1];


### PR DESCRIPTION
Changes the coloring of 'marginal fee rate' transactions in the block audit visualizations from pink/blue to a highly desaturated version of the normal fee colors.

Hopefully this makes the block audits look less dramatic when there are lots of same-fee-rate substitutions (e.g. when an exchange dumps multiple blocks worth of identical txs into the mempool), and draw attention towards more interesting transactions.

| Before | After |
|-|-|
| <img width="1129" alt="Screenshot 2023-01-18 at 5 12 52 PM" src="https://user-images.githubusercontent.com/83316221/213316098-3f47d572-9e6c-4052-bb01-26c1e3cba5f1.png"> | <img width="1129" alt="Screenshot 2023-01-18 at 5 12 37 PM" src="https://user-images.githubusercontent.com/83316221/213316127-07dfa945-ae0a-40e3-ac42-f7215327b142.png"> |

