### PR TITLE
Fix mempool block gradients

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -35,16 +35,25 @@ export class Common {
   }
 
   static getFeesInRange(transactions: TransactionExtended[], rangeLength: number) {
-    const arr = [transactions[transactions.length - 1].effectiveFeePerVsize];
+    const filtered: TransactionExtended[] = [];
+    let lastValidRate = Infinity;
+    // filter out anomalous fee rates to ensure monotonic range
+    for (const tx of transactions) {
+      if (tx.effectiveFeePerVsize <= lastValidRate) {
+        filtered.push(tx);
+        lastValidRate = tx.effectiveFeePerVsize;
+      }
+    }
+    const arr = [filtered[filtered.length - 1].effectiveFeePerVsize];
     const chunk = 1 / (rangeLength - 1);
     let itemsToAdd = rangeLength - 2;
 
     while (itemsToAdd > 0) {
-      arr.push(transactions[Math.floor(transactions.length * chunk * itemsToAdd)].effectiveFeePerVsize);
+      arr.push(filtered[Math.floor(filtered.length * chunk * itemsToAdd)].effectiveFeePerVsize);
       itemsToAdd--;
     }
 
-    arr.push(transactions[0].effectiveFeePerVsize);
+    arr.push(filtered[0].effectiveFeePerVsize);
     return arr;
   }
 


### PR DESCRIPTION
Fixes #2938.

Transactions in mempool blocks projected by the advanced GBT algorithm are not necessarily included precisely in order of decreasing effective fee rate, due to topological ordering constraints and varying transaction sizes.

However, our fee range calculations for the mempool block gradients assume that block transaction effective fee rates are monotonically decreasing.

As a result, sometimes the block gradients have random bands of the "wrong" color, where we've inadvertently sampled a transaction with a much higher or lower effective fee rate than the surrounding neighborhood.

This PR filters out transactions with anomalous fee rates before calculating fee ranges, to ensure that the mempool block gradients are always smooth and continuous.