### PR TITLE
Only show block audit highlighting when audit is enabled

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -9,5 +9,6 @@
     [tx]="selectedTx || hoverTx"
     [cursorPosition]="tooltipPosition"
     [clickable]="!!selectedTx"
+    [auditEnabled]="auditHighlighting"
   ></app-block-overview-tooltip>
 </div>

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -20,6 +20,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
   @Input() disableSpinner = false;
   @Input() mirrorTxid: string | void;
   @Input() unavailable: boolean = false;
+  @Input() auditHighlighting: boolean = false;
   @Output() txClickEvent = new EventEmitter<TransactionStripped>();
   @Output() txHoverEvent = new EventEmitter<string>();
   @Output() readyEvent = new EventEmitter();
@@ -69,6 +70,9 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
     }
     if (changes.mirrorTxid) {
       this.setMirror(this.mirrorTxid);
+    }
+    if (changes.auditHighlighting) {
+      this.setHighlightingEnabled(this.auditHighlighting);
     }
   }
 
@@ -195,7 +199,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
       this.start();
     } else {
       this.scene = new BlockScene({ width: this.displayWidth, height: this.displayHeight, resolution: this.resolution,
-        blockLimit: this.blockLimit, orientation: this.orientation, flip: this.flip, vertexArray: this.vertexArray });
+        blockLimit: this.blockLimit, orientation: this.orientation, flip: this.flip, vertexArray: this.vertexArray, highlighting: this.auditHighlighting });
       this.start();
     }
   }
@@ -392,6 +396,13 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
     if (txid && this.scene.txs[txid]) {
       this.mirrorTx = this.scene.txs[txid];
       this.scene.setHover(this.mirrorTx, true);
+      this.start();
+    }
+  }
+
+  setHighlightingEnabled(enabled: boolean): void {
+    if (this.scene) {
+      this.scene.setHighlighting(enabled);
       this.start();
     }
   }

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -38,6 +38,7 @@ export default class TxView implements TransactionStripped {
   feerate: number;
   status?: 'found' | 'missing' | 'fresh' | 'added' | 'censored' | 'selected';
   context?: 'projected' | 'actual';
+  scene?: BlockScene;
 
   initialised: boolean;
   vertexArray: FastVertexArray;
@@ -50,7 +51,8 @@ export default class TxView implements TransactionStripped {
 
   dirty: boolean;
 
-  constructor(tx: TransactionStripped, vertexArray: FastVertexArray) {
+  constructor(tx: TransactionStripped, scene: BlockScene) {
+    this.scene = scene;
     this.context = tx.context;
     this.txid = tx.txid;
     this.fee = tx.fee;
@@ -59,7 +61,7 @@ export default class TxView implements TransactionStripped {
     this.feerate = tx.fee / tx.vsize;
     this.status = tx.status;
     this.initialised = false;
-    this.vertexArray = vertexArray;
+    this.vertexArray = scene.vertexArray;
 
     this.hover = false;
 
@@ -157,6 +159,10 @@ export default class TxView implements TransactionStripped {
   getColor(): Color {
     const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, this.feerate) < feeLvl) - 1;
     const feeLevelColor = feeColors[feeLevelIndex] || feeColors[mempoolFeeColors.length - 1];
+    // Normal mode
+    if (!this.scene?.highlightingEnabled) {
+      return feeLevelColor;
+    }
     // Block audit
     switch(this.status) {
       case 'censored':

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -32,7 +32,7 @@
         <td class="td-width" i18n="transaction.vsize|Transaction Virtual Size">Virtual size</td>
         <td [innerHTML]="'&lrm;' + (vsize | vbytes: 2)"></td>
       </tr>
-      <tr *ngIf="tx && tx.status && tx.status.length">
+      <tr *ngIf="auditEnabled && tx && tx.status && tx.status.length">
         <td class="td-width" i18n="transaction.audit-status">Audit status</td>
         <ng-container [ngSwitch]="tx?.status">
           <td *ngSwitchCase="'found'" i18n="transaction.audit.match">Match</td>

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -11,6 +11,7 @@ export class BlockOverviewTooltipComponent implements OnChanges {
   @Input() tx: TransactionStripped | void;
   @Input() cursorPosition: Position;
   @Input() clickable: boolean;
+  @Input() auditEnabled: boolean = false;
 
   txid = '';
   fee = 0;

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -215,7 +215,7 @@
         <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.projected-block">Projected Block</h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="isLoadingOverview" [resolution]="75"
-            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx"
+            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" [auditHighlighting]="showAudit"
             (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit"></app-block-overview-graph>
           <ng-container *ngIf="!isMobile || mode !== 'actual'; else emptyBlockInfo"></ng-container>
         </div>
@@ -224,7 +224,7 @@
         <h3 class="block-subtitle" *ngIf="!isMobile" i18n="block.actual-block">Actual Block</h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphActual [isLoading]="isLoadingOverview" [resolution]="75"
-            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"
+            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"  [auditHighlighting]="showAudit"
             (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit"></app-block-overview-graph>
           <ng-container *ngTemplateOutlet="emptyBlockInfo"></ng-container>
         </div>


### PR DESCRIPTION
_(builds on #2899, please merge that PR first)_

Fixes an issue where audit-related transaction tooltip data and highlighting/colors are shown when audit data is available but audits are disabled (either via the toggle or the `..._BLOCK_AUDIT_START_HEIGHT` frontend config setting), which could be confusing to see without the context of the rest of the audit.

Before:
<img width="1138" alt="Screenshot 2023-01-26 at 7 18 33 PM" src="https://user-images.githubusercontent.com/83316221/214987435-0e07cf65-32c8-49d9-80f2-54d49948e3d1.png">

After:
<img width="1138" alt="Screenshot 2023-01-26 at 7 19 05 PM" src="https://user-images.githubusercontent.com/83316221/214987456-303788cc-3ecd-4389-b34f-bb0d1872aa63.png">
