### PR TITLE
Fix navigation-breaking JS error on liquid block page

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -439,17 +439,17 @@ export class BlockComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.stateService.markBlock$.next({});
-    this.transactionSubscription.unsubscribe();
+    this.transactionSubscription?.unsubscribe();
     this.overviewSubscription?.unsubscribe();
     this.auditSubscription?.unsubscribe();
-    this.keyNavigationSubscription.unsubscribe();
-    this.blocksSubscription.unsubscribe();
-    this.networkChangedSubscription.unsubscribe();
-    this.queryParamsSubscription.unsubscribe();
-    this.timeLtrSubscription.unsubscribe();
-    this.auditSubscription.unsubscribe();
+    this.keyNavigationSubscription?.unsubscribe();
+    this.blocksSubscription?.unsubscribe();
+    this.networkChangedSubscription?.unsubscribe();
+    this.queryParamsSubscription?.unsubscribe();
+    this.timeLtrSubscription?.unsubscribe();
+    this.auditSubscription?.unsubscribe();
     this.unsubscribeNextBlockSubscriptions();
-    this.childChangeSubscription.unsubscribe();
+    this.childChangeSubscription?.unsubscribe();
   }
 
   unsubscribeNextBlockSubscriptions() {


### PR DESCRIPTION
Fixes an bug in the `ngOnDestroy` hook on the block component in Liquid, which interrupts navigating away from that page.

To reproduce the bug: Running in Liquid mode, open any block page, then try to navigate away to a different (non-block) page. Navigation fails with an error in the console.