### PR TITLE
More prominent audit status badges

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -35,12 +35,12 @@
       <tr *ngIf="auditEnabled && tx && tx.status && tx.status.length">
         <td class="td-width" i18n="transaction.audit-status">Audit status</td>
         <ng-container [ngSwitch]="tx?.status">
-          <td *ngSwitchCase="'found'" i18n="transaction.audit.match">Match</td>
-          <td *ngSwitchCase="'censored'" i18n="transaction.audit.removed">Removed</td>
-          <td *ngSwitchCase="'missing'" i18n="transaction.audit.marginal">Marginal fee rate</td>
-          <td *ngSwitchCase="'fresh'" i18n="transaction.audit.recently-broadcasted">Recently broadcasted</td>
-          <td *ngSwitchCase="'added'" i18n="transaction.audit.added">Added</td>
-          <td *ngSwitchCase="'selected'" i18n="transaction.audit.marginal">Marginal fee rate</td>
+          <td *ngSwitchCase="'found'"><span class="badge badge-success" i18n="transaction.audit.match">Match</span></td>
+          <td *ngSwitchCase="'censored'"><span class="badge badge-danger" i18n="transaction.audit.removed">Removed</span></td>
+          <td *ngSwitchCase="'missing'"><span class="badge badge-warning" i18n="transaction.audit.marginal">Marginal fee rate</span></td>
+          <td *ngSwitchCase="'fresh'"><span class="badge badge-warning" i18n="transaction.audit.recently-broadcasted">Recently broadcasted</span></td>
+          <td *ngSwitchCase="'added'"><span class="badge badge-warning" i18n="transaction.audit.added">Added</span></td>
+          <td *ngSwitchCase="'selected'"><span class="badge badge-warning" i18n="transaction.audit.marginal">Marginal fee rate</span></td>
         </ng-container>
       </tr>
     </tbody>


### PR DESCRIPTION
<img width="402" alt="Screenshot 2023-01-29 at 13 09 27" src="https://user-images.githubusercontent.com/8561090/215316522-3ee8a297-db45-4622-abaa-e3ce8c8a3f5d.png">

<img width="371" alt="Screenshot 2023-01-29 at 13 09 34" src="https://user-images.githubusercontent.com/8561090/215316532-308a5e14-09c8-4635-a8a8-51e4a1d17564.png">

<img width="379" alt="Screenshot 2023-01-29 at 13 09 51" src="https://user-images.githubusercontent.com/8561090/215316547-e2c8c8ff-cc3d-493d-ab33-e205027aeaff.png">
