### PR TITLE
Bisq markets search bar fix

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -107,7 +107,13 @@ export class SearchFormComponent implements OnInit {
           }))),
         );
       }),
-      tap((result: any[]) => {
+      map((result: any[]) => {
+        if (this.network === 'bisq') {
+          result[0] = result[0].map((address: string) => 'B' + address);
+        }
+        return result;
+      }),
+      tap(() => {
         this.isTypeaheading$.next(false);
       })
     );
@@ -126,7 +132,7 @@ export class SearchFormComponent implements OnInit {
       ]
       ).pipe(
         map((latestData) => {
-          const searchText = latestData[0];
+          let searchText = latestData[0];
           if (!searchText.length) {
             return {
               searchText: '',
@@ -144,14 +150,14 @@ export class SearchFormComponent implements OnInit {
           const addressPrefixSearchResults = result[0];
           const lightningResults = result[1];
 
-          if (this.network === 'bisq') {
-            return searchText.map((address: string) => 'B' + address);
-          }
-
           const matchesBlockHeight = this.regexBlockheight.test(searchText);
           const matchesTxId = this.regexTransaction.test(searchText) && !this.regexBlockhash.test(searchText);
           const matchesBlockHash = this.regexBlockhash.test(searchText);
           const matchesAddress = this.regexAddress.test(searchText);
+
+          if (matchesAddress && this.network === 'bisq') {
+            searchText = 'B' + searchText;
+          }
 
           return {
             searchText: searchText,


### PR DESCRIPTION
fixes #2986

The search should handle the following address cases. 

The search should fill in the "B" prefix when missing and display addresses with "B" prefix always.

```
B15GQ6ZjX5jNxhosF6
B15GQ6ZjX5jNxhosF64VkGQD8eSDsGRqF39
15GQ6ZjX5jNxhosF6
15GQ6ZjX5jNxhosF64VkGQD8eSDsGRqF39
```