### PR TITLE
Fix subscription memory leak

### DIFF
--- a/contributors/Arooba-git.txt
+++ b/contributors/Arooba-git.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of January 25, 2022.
+
+Signed: Arooba-git

--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, QueryList, AfterViewInit, ViewChildren } from '@angular/core';
 import { Env, StateService } from '../../services/state.service';
-import { Observable, merge, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { Observable, merge, of, Subject } from 'rxjs';
+import { tap, takeUntil } from 'rxjs/operators';
 import { ActivatedRoute } from "@angular/router";
 import { faqData, restApiDocsData, wsApiDocsData } from './api-docs-data';
 import { FaqTemplateDirective } from '../faq-template/faq-template.component';
@@ -12,6 +12,7 @@ import { FaqTemplateDirective } from '../faq-template/faq-template.component';
   styleUrls: ['./api-docs.component.scss']
 })
 export class ApiDocsComponent implements OnInit, AfterViewInit {
+  private destroy$: Subject<any> = new Subject<any>();
   plainHostname = document.location.hostname;
   electrsPort = 0;
   hostname = document.location.hostname;
@@ -82,7 +83,7 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
     this.restDocs = restApiDocsData;
     this.wsDocs = wsApiDocsData;
 
-    this.network$.subscribe((network) => {
+    this.network$.pipe(takeUntil(this.destroy$)).subscribe((network) => {
       this.active = (network === 'liquid' || network === 'liquidtestnet') ? 2 : 0;
       switch( network ) {
         case "":
@@ -102,6 +103,8 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
   }
 
   ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
     window.removeEventListener('scroll', this.onDocScroll);
   }
 


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of mempool, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found unsubscribed subscriptions causing the memory to leak (screenshots below).

[before]
<img width="1229" alt="before subscrip Screen Shot 2023-02-07 at 4 49 34 AM" src="https://user-images.githubusercontent.com/56495631/217083027-85f7c526-7093-4af8-8017-e8660f788c54.png">

Hence we added the fix by unsubscribing the subscription on **api-docs** component unload, and you can see the heap size and # of leaks reducing noticeably:
 <br />

<img width="1230" alt="after subscrip Screen Shot 2023-02-07 at 4 48 49 AM" src="https://user-images.githubusercontent.com/56495631/217083057-3aace957-d6c6-4b5c-9497-084a3d6a6e00.png">

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in txt form):
[mempool-scenario-memlab.txt](https://github.com/mempool/mempool/files/10669066/mempool-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.