### PR TITLE
Clear querlist in component destructor to prevent memory leaks

### DIFF
--- a/contributors/Arooba-git.txt
+++ b/contributors/Arooba-git.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of January 25, 2022.
+
+Signed: Arooba-git

--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -103,6 +103,7 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
 
   ngOnDestroy(): void {
     window.removeEventListener('scroll', this.onDocScroll);
+    this.faqTemplates?.destroy();
   }
 
   onDocScroll() {


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of mempool, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some uncleared querylists causing the memory to leak (screenshots below).

[before]
<img width="597" alt="before collec Screen Shot 2023-02-07 at 5 30 41 AM" src="https://user-images.githubusercontent.com/56495631/217083783-8c4a6736-e42b-4a8b-8b22-2208b86ef78e.png">


Hence we added the fix by clearing the querlist on **api-docs** component unload, and you can see the # of leaks reducing noticeably:
 <br />

<img width="676" alt="after collec Screen Shot 2023-02-07 at 5 37 10 AM" src="https://user-images.githubusercontent.com/56495631/217083809-643d947b-35ef-402a-9e49-a2d37016af58.png">


You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in txt form):
[mempool-scenario-memlab.txt](https://github.com/mempool/mempool/files/10669066/mempool-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.