### PR TITLE
safer mempool cloning for different GBT algorithms

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -19,6 +19,7 @@ import feeApi from './fee-api';
 import BlocksAuditsRepository from '../repositories/BlocksAuditsRepository';
 import BlocksSummariesRepository from '../repositories/BlocksSummariesRepository';
 import Audit from './audit';
+import { deepClone } from '../utils/clone';
 
 class WebsocketHandler {
   private wss: WebSocket.Server | undefined;
@@ -421,7 +422,7 @@ class WebsocketHandler {
     let projectedBlocks;
     // template calculation functions have mempool side effects, so calculate audits using
     // a cloned copy of the mempool if we're running a different algorithm for mempool updates
-    const auditMempool = (config.MEMPOOL.ADVANCED_GBT_AUDIT === config.MEMPOOL.ADVANCED_GBT_MEMPOOL) ? _memPool : JSON.parse(JSON.stringify(_memPool));
+    const auditMempool = (config.MEMPOOL.ADVANCED_GBT_AUDIT === config.MEMPOOL.ADVANCED_GBT_MEMPOOL) ? _memPool : deepClone(_memPool);
     if (config.MEMPOOL.ADVANCED_GBT_AUDIT) {
       projectedBlocks = await mempoolBlocks.makeBlockTemplates(auditMempool, false);
     } else {

--- a/backend/src/utils/clone.ts
+++ b/backend/src/utils/clone.ts
@@ -1,0 +1,14 @@
+// simple recursive deep clone for literal-type objects
+// does not preserve Dates, Maps, Sets etc
+// does not support recursive objects
+// properties deeper than maxDepth will be shallow cloned
+export function deepClone(obj: any, maxDepth: number = 50, depth: number = 0): any {
+  let cloned = obj;
+  if (depth < maxDepth && typeof obj === 'object') {
+    cloned = Array.isArray(obj) ? [] : {};
+    for (const key in obj) {
+      cloned[key] = deepClone(obj[key], maxDepth, depth + 1);
+    }
+  }
+  return cloned;
+}


### PR DESCRIPTION
Short term fix for #3029 - backend crashing on new block with very large mempool, when ADVANCED_GBT_MEMPOOL and ADVANCED_GBT_AUDIT are different.

This appears to be due to the `JSON.stringify` serialization used to clone the mempool exceeding the maximum nodejs string size of 512mb.

This PR replaces `JSON.parse(JSON.stringify(...))` with a simple recursive deep cloning method. It's much slower than `JSON.parse(JSON.stringify(...))`, but should cope with significantly larger mempool sizes.

Tested on the current mainnet mempool of >285MB / ~34k transactions.