### PR TITLE
Track and display purged transaction status

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -20,6 +20,7 @@ import BlocksAuditsRepository from '../repositories/BlocksAuditsRepository';
 import BlocksSummariesRepository from '../repositories/BlocksSummariesRepository';
 import Audit from './audit';
 import { deepClone } from '../utils/clone';
+import mempool from './mempool';
 
 class WebsocketHandler {
   private wss: WebSocket.Server | undefined;
@@ -90,6 +91,9 @@ class WebsocketHandler {
                     }
                   }
                 }
+              }
+              if (config.MEMPOOL.USE_SECOND_NODE_FOR_MINFEE && memPool.getMempool()[client['track-tx']]) {
+                response['txPurged'] = memPool.isTxPurged(client['track-tx']);
               }
             } else {
               client['track-tx'] = null;
@@ -393,6 +397,11 @@ class WebsocketHandler {
               break;
             }
           }
+        }
+
+        // update purge status of unconfirmed tracked txs
+        if (config.MEMPOOL.USE_SECOND_NODE_FOR_MINFEE && newMempool[client['track-tx']]) {
+          response['txPurged'] = memPool.isTxPurged(client['track-tx']);
         }
       }
 

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -1,6 +1,10 @@
 <div class="container-xl">
 
   <div class="title-block">
+    <div *ngIf="isPurged" class="alert alert-mempool" role="alert">
+      <span i18n="transaction.purged|Purged from mempool">This transaction has been purged from our default sized 300MB mempool</span>
+    </div>
+
     <div *ngIf="rbfTransaction" class="alert alert-mempool" role="alert">
       <span i18n="transaction.rbf.replacement|RBF replacement">This transaction has been replaced by:</span>
       <app-truncate [text]="rbfTransaction.txid" [lastChars]="12" [link]="['/tx/' | relativeUrl, rbfTransaction.txid]"></app-truncate>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -43,6 +43,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   fetchRbfSubscription: Subscription;
   fetchCachedTxSubscription: Subscription;
   txReplacedSubscription: Subscription;
+  txPurgedSubscription: Subscription;
   blocksSubscription: Subscription;
   queryParamsSubscription: Subscription;
   urlFragmentSubscription: Subscription;
@@ -55,6 +56,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   fetchCpfp$ = new Subject<string>();
   fetchRbfHistory$ = new Subject<string>();
   fetchCachedTx$ = new Subject<string>();
+  isPurged: boolean = false;
   now = new Date().getTime();
   timeAvg$: Observable<number>;
   liquidUnblinding = new LiquidUnblinding();
@@ -359,6 +361,10 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     });
 
+    this.txPurgedSubscription = this.stateService.txPurged$.subscribe((isPurged) => {
+      this.isPurged = isPurged;
+    });
+
     this.queryParamsSubscription = this.route.queryParams.subscribe((params) => {
       if (params.showFlow === 'false') {
         this.overrideFlowPreference = false;
@@ -494,6 +500,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.fetchRbfSubscription.unsubscribe();
     this.fetchCachedTxSubscription.unsubscribe();
     this.txReplacedSubscription.unsubscribe();
+    this.txPurgedSubscription.unsubscribe();
     this.blocksSubscription.unsubscribe();
     this.queryParamsSubscription.unsubscribe();
     this.flowPrefSubscription.unsubscribe();

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -16,6 +16,7 @@ export interface WebsocketResponse {
   tx?: Transaction;
   rbfTransaction?: ReplacedTransaction;
   txReplaced?: ReplacedTransaction;
+  txPurged?: boolean;
   utxoSpent?: object;
   transactions?: TransactionStripped[];
   loadingIndicators?: ILoadingIndicators;

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -94,6 +94,7 @@ export class StateService {
   mempoolBlockTransactions$ = new Subject<TransactionStripped[]>();
   mempoolBlockDelta$ = new Subject<MempoolBlockDelta>();
   txReplaced$ = new Subject<ReplacedTransaction>();
+  txPurged$ = new Subject<boolean>();
   utxoSpent$ = new Subject<object>();
   difficultyAdjustment$ = new ReplaySubject<DifficultyAdjustment>(1);
   mempoolTransactions$ = new Subject<Transaction>();

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -261,6 +261,10 @@ export class WebsocketService {
       this.stateService.txReplaced$.next(response.txReplaced);
     }
 
+    if (response.txPurged != null) {
+      this.stateService.txPurged$.next(response.txPurged);
+    }
+
     if (response['mempool-blocks']) {
       this.stateService.mempoolBlocks$.next(response['mempool-blocks']);
     }


### PR DESCRIPTION
This PR tracks the contents of the second "minfee" node's mempool (if one is configured) to detect which transactions are evicted from a default-sized mempool during periods of congestion.

The status of these transactions is sent to any clients subscribed to the corresponding `track-tx` websocket updates.

<img width="1145" alt="Screenshot 2023-02-12 at 8 57 02 PM" src="https://user-images.githubusercontent.com/83316221/218363136-e6cb9f48-e108-4d86-a390-0f271b9f5512.png">

### Issues

#### Compatibility
This approach may not be compatible with PR #2845, since it isn't trivial to tell which transactions have been purged due to low fee rate, and which have been excluded due to differing mempool policies.

#### Consistency
This relies on the main and minfee nodes having consistent mempools.

Ideally the two nodes would be directly peered.

### Alternatives
We could simply label all transactions with effective fee rates below the current minimum. However, there are various edge cases where this would be inaccurate - for example, when a low-fee transaction is evicted from the default mempool, but then has its effective rate boosted by CPFP in the main mempool.