### PR TITLE
Remove colon from block overview table

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -143,7 +143,7 @@
           </ng-template>
         </tr>
         <tr *ngIf="network !== 'liquid' && network !== 'liquidtestnet'">
-          <td i18n="block.subsidy-and-fees|Total subsidy and fees in a block">Subsidy + fees:</td>
+          <td i18n="block.subsidy-and-fees|Total subsidy and fees in a block">Subsidy + fees</td>
           <td>
             <app-amount [satoshis]="block.extras.reward" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
             <span class="fiat">
@@ -158,7 +158,7 @@
           <td style="width: 75%;"><span class="skeleton-loader"></span></td>
         </tr>
         <tr *ngIf="network !== 'liquid' && network !== 'liquidtestnet'">
-          <td i18n="block.subsidy-and-fees|Total subsidy and fees in a block">Subsidy + fees:</td>
+          <td i18n="block.subsidy-and-fees|Total subsidy and fees in a block">Subsidy + fees</td>
           <td><span class="skeleton-loader"></span></td>
         </tr>
       </ng-template>


### PR DESCRIPTION
Tiny adjustment to make the subsidy field more consistent with the other fields.

## Before

![remove-colon-2](https://user-images.githubusercontent.com/93150691/218947179-f2de4646-49a1-4f7c-8037-bd6021d17a84.png)

## After

![remove-colon-1](https://user-images.githubusercontent.com/93150691/218947202-b69442fb-f54c-40a9-9f6e-e812b3e3ee30.png)
