### PR TITLE
ops: Fix lightning mysql credentials usage

### DIFF
--- a/production/install
+++ b/production/install
@@ -48,9 +48,9 @@ BITCOIN_MAINNET_ENABLE=ON
 BITCOIN_MAINNET_MINFEE_ENABLE=ON
 BITCOIN_TESTNET_ENABLE=ON
 BITCOIN_SIGNET_ENABLE=ON
-LN_BITCOIN_MAINNET_ENABLE=ON
-LN_BITCOIN_TESTNET_ENABLE=ON
-LN_BITCOIN_SIGNET_ENABLE=ON
+BITCOIN_MAINNET_LIGHTNING_ENABLE=ON
+BITCOIN_TESTNET_LIGHTNING_ENABLE=ON
+BITCOIN_SIGNET_LIGHTNING_ENABLE=ON
 BISQ_MAINNET_ENABLE=ON
 ELEMENTS_LIQUID_ENABLE=ON
 ELEMENTS_LIQUIDTESTNET_ENABLE=ON
@@ -230,9 +230,9 @@ MYSQL_GROUP=mysql
 MEMPOOL_MAINNET_USER='mempool'
 MEMPOOL_TESTNET_USER='mempool_testnet'
 MEMPOOL_SIGNET_USER='mempool_signet'
-LN_MEMPOOL_MAINNET_USER='mempool_mainnet_lightning'
-LN_MEMPOOL_TESTNET_USER='mempool_testnet_lightning'
-LN_MEMPOOL_SIGNET_USER='mempool_signet_lightning'
+MEMPOOL_MAINNET_LIGHTNING_USER='mempool_mainnet_lightning'
+MEMPOOL_TESTNET_LIGHTNING_USER='mempool_testnet_lightning'
+MEMPOOL_SIGNET_LIGHTNING_USER='mempool_signet_lightning'
 MEMPOOL_LIQUID_USER='mempool_liquid'
 MEMPOOL_LIQUIDTESTNET_USER='mempool_liquidtestnet'
 MEMPOOL_BISQ_USER='mempool_bisq'
@@ -240,9 +240,9 @@ MEMPOOL_BISQ_USER='mempool_bisq'
 MEMPOOL_MAINNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
 MEMPOOL_TESTNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
 MEMPOOL_SIGNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
-LN_MEMPOOL_MAINNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
-LN_MEMPOOL_TESTNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
-LN_MEMPOOL_SIGNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
+MEMPOOL_MAINNET_LIGHTNING_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
+MEMPOOL_TESTNET_LIGHTNING_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
+MEMPOOL_SIGNET_LIGHTNING_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
 MEMPOOL_LIQUID_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
 MEMPOOL_LIQUIDTESTNET_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
 MEMPOOL_BISQ_PASS=$(head -150 /dev/urandom | ${MD5} | awk '{print $1}')
@@ -827,21 +827,21 @@ else
 fi
 
 if grep LN-Mainnet $tempfile >/dev/null 2>&1;then
-    LN_BITCOIN_MAINNET_ENABLE=ON
+    BITCOIN_MAINNET_LIGHTNING_ENABLE=ON
 else
-    LN_BITCOIN_MAINNET_ENABLE=OFF
+    BITCOIN_MAINNET_LIGHTNING_ENABLE=OFF
 fi
 
 if grep LN-Testnet $tempfile >/dev/null 2>&1;then
-    LN_BITCOIN_TESTNET_ENABLE=ON
+    BITCOIN_TESTNET_LIGHTNING_ENABLE=ON
 else
-    LN_BITCOIN_TESTNET_ENABLE=OFF
+    BITCOIN_TESTNET_LIGHTNING_ENABLE=OFF
 fi
 
 if grep LN-Signet $tempfile >/dev/null 2>&1;then
-    LN_BITCOIN_SIGNET_ENABLE=ON
+    BITCOIN_SIGNET_LIGHTNING_ENABLE=ON
 else
-    LN_BITCOIN_SIGNET_ENABLE=OFF
+    BITCOIN_SIGNET_LIGHTNING_ENABLE=OFF
 fi
 
 if grep Liquid $tempfile >/dev/null 2>&1;then
@@ -1756,7 +1756,7 @@ if [ "${BITCOIN_MAINNET_ENABLE}" = ON -o "${BITCOIN_TESTNET_ENABLE}" = ON -o "${
     osSudo "${MEMPOOL_USER}" sh -c "cd ${MEMPOOL_HOME}/mainnet && git checkout ${MEMPOOL_LATEST_RELEASE}"
 fi
 
-if [ "${LN_BITCOIN_MAINNET_ENABLE}" = ON ];then
+if [ "${BITCOIN_MAINNET_LIGHTNING_ENABLE}" = ON ];then
     echo "[*] Creating Mempool instance for Lightning Network on Bitcoin Mainnet"
     osSudo "${MEMPOOL_USER}" git config --global advice.detachedHead false
     osSudo "${MEMPOOL_USER}" git clone --branch "${MEMPOOL_REPO_BRANCH}" "${MEMPOOL_REPO_URL}" "${MEMPOOL_HOME}/mainnet-lightning"
@@ -1774,7 +1774,7 @@ if [ "${BITCOIN_TESTNET_ENABLE}" = ON ];then
     osSudo "${MEMPOOL_USER}" sh -c "cd ${MEMPOOL_HOME}/testnet && git checkout ${MEMPOOL_LATEST_RELEASE}"
 fi
 
-if [ "${LN_BITCOIN_TESTNET_ENABLE}" = ON ];then
+if [ "${BITCOIN_TESTNET_LIGHTNING_ENABLE}" = ON ];then
     echo "[*] Creating Mempool instance for Lightning Network on Bitcoin Testnet"
     osSudo "${MEMPOOL_USER}" git config --global advice.detachedHead false
     osSudo "${MEMPOOL_USER}" git clone --branch "${MEMPOOL_REPO_BRANCH}" "${MEMPOOL_REPO_URL}" "${MEMPOOL_HOME}/testnet-lightning"
@@ -1792,7 +1792,7 @@ if [ "${BITCOIN_SIGNET_ENABLE}" = ON ];then
     osSudo "${MEMPOOL_USER}" sh -c "cd ${MEMPOOL_HOME}/signet && git checkout ${MEMPOOL_LATEST_RELEASE}"
 fi
 
-if [ "${LN_BITCOIN_SIGNET_ENABLE}" = ON ];then
+if [ "${BITCOIN_SIGNET_LIGHTNING_ENABLE}" = ON ];then
     echo "[*] Creating Mempool instance for Lightning Network on Bitcoin Signet"
     osSudo "${MEMPOOL_USER}" git config --global advice.detachedHead false
     osSudo "${MEMPOOL_USER}" git clone --branch "${MEMPOOL_REPO_BRANCH}" "${MEMPOOL_REPO_URL}" "${MEMPOOL_HOME}/signet-lightning"
@@ -1852,13 +1852,13 @@ create database mempool_signet;
 grant all on mempool_signet.* to '${MEMPOOL_SIGNET_USER}'@'localhost' identified by '${MEMPOOL_SIGNET_PASS}';
 
 create database mempool_mainnet_lightning;
-grant all on mempool_mainnet_lightning.* to '${LN_MEMPOOL_MAINNET_USER}'@'localhost' identified by '${LN_MEMPOOL_MAINNET_PASS}';
+grant all on mempool_mainnet_lightning.* to '${MEMPOOL_MAINNET_LIGHTNING_USER}'@'localhost' identified by '${MEMPOOL_MAINNET_LIGHTNING_PASS}';
 
 create database mempool_testnet_lightning;
-grant all on mempool_testnet_lightning.* to '${LN_MEMPOOL_TESTNET_USER}'@'localhost' identified by '${LN_MEMPOOL_TESTNET_PASS}';
+grant all on mempool_testnet_lightning.* to '${MEMPOOL_TESTNET_LIGHTNING_USER}'@'localhost' identified by '${MEMPOOL_TESTNET_LIGHTNING_PASS}';
 
 create database mempool_signet_lightning;
-grant all on mempool_signet_lightning.* to '${LN_MEMPOOL_SIGNET_USER}'@'localhost' identified by '${LN_MEMPOOL_SIGNET_PASS}';
+grant all on mempool_signet_lightning.* to '${MEMPOOL_SIGNET_LIGHTNING_USER}'@'localhost' identified by '${MEMPOOL_SIGNET_LIGHTNING_PASS}';
 
 create database mempool_liquid;
 grant all on mempool_liquid.* to '${MEMPOOL_LIQUID_USER}'@'localhost' identified by '${MEMPOOL_LIQUID_PASS}';
@@ -1878,12 +1878,12 @@ declare -x MEMPOOL_TESTNET_USER="${MEMPOOL_TESTNET_USER}"
 declare -x MEMPOOL_TESTNET_PASS="${MEMPOOL_TESTNET_PASS}"
 declare -x MEMPOOL_SIGNET_USER="${MEMPOOL_SIGNET_USER}"
 declare -x MEMPOOL_SIGNET_PASS="${MEMPOOL_SIGNET_PASS}"
-declare -x LN_MEMPOOL_MAINNET_USER="${LN_MEMPOOL_MAINNET_USER}"
-declare -x LN_MEMPOOL_MAINNET_PASS="${LN_MEMPOOL_MAINNET_PASS}"
-declare -x LN_MEMPOOL_TESTNET_USER="${LN_MEMPOOL_TESTNET_USER}"
-declare -x LN_MEMPOOL_TESTNET_PASS="${LN_MEMPOOL_TESTNET_PASS}"
-declare -x LN_MEMPOOL_SIGNET_USER="${LN_MEMPOOL_SIGNET_USER}"
-declare -x LN_MEMPOOL_SIGNET_PASS="${LN_MEMPOOL_SIGNET_PASS}"
+declare -x MEMPOOL_MAINNET_LIGHTNING_USER="${MEMPOOL_MAINNET_LIGHTNING_USER}"
+declare -x MEMPOOL_MAINNET_LIGHTNING_PASS="${MEMPOOL_MAINNET_LIGHTNING_PASS}"
+declare -x MEMPOOL_TESTNET_LIGHTNING_USER="${MEMPOOL_TESTNET_LIGHTNING_USER}"
+declare -x MEMPOOL_TESTNET_LIGHTNING_PASS="${MEMPOOL_TESTNET_LIGHTNING_PASS}"
+declare -x MEMPOOL_SIGNET_LIGHTNING_USER="${MEMPOOL_SIGNET_LIGHTNING_USER}"
+declare -x MEMPOOL_SIGNET_LIGHTNING_PASS="${MEMPOOL_SIGNET_LIGHTNING_PASS}"
 declare -x MEMPOOL_LIQUID_USER="${MEMPOOL_LIQUID_USER}"
 declare -x MEMPOOL_LIQUID_PASS="${MEMPOOL_LIQUID_PASS}"
 declare -x MEMPOOL_LIQUIDTESTNET_USER="${MEMPOOL_LIQUIDTESTNET_USER}"

--- a/production/mempool-config.mainnet-lightning.json
+++ b/production/mempool-config.mainnet-lightning.json
@@ -43,8 +43,8 @@
     "ENABLED": true,
     "HOST": "127.0.0.1",
     "PORT": 3306,
-    "DATABASE": "mempool_mainnet_lightning",
-    "USERNAME": "mempool_mainnet_lightning",
+    "USERNAME": "__MEMPOOL_MAINNET_LIGHTNING_USER__",
+    "PASSWORD": "__MEMPOOL_MAINNET_LIGHTNING_PASS__",
     "PASSWORD": "mempool_mainnet_lightning"
   }
 }

--- a/production/mempool-config.signet-lightning.json
+++ b/production/mempool-config.signet-lightning.json
@@ -38,8 +38,8 @@
     "ENABLED": true,
     "HOST": "127.0.0.1",
     "PORT": 3306,
-    "USERNAME": "mempool_signet_lightning",
-    "PASSWORD": "mempool_signet_lightning",
+    "USERNAME": "__MEMPOOL_SIGNET_LIGHTNING_USER__",
+    "PASSWORD": "__MEMPOOL_SIGNET_LIGHTNING_PASS__",
     "DATABASE": "mempool_signet_lightning"
   }
 }

--- a/production/mempool-config.testnet-lightning.json
+++ b/production/mempool-config.testnet-lightning.json
@@ -38,8 +38,8 @@
     "ENABLED": true,
     "HOST": "127.0.0.1",
     "PORT": 3306,
-    "USERNAME": "mempool_testnet_lightning",
-    "PASSWORD": "mempool_testnet_lightning",
+    "USERNAME": "__MEMPOOL_TESTNET_LIGHTNING_USER__",
+    "PASSWORD": "__MEMPOOL_TESTNET_LIGHTNING_PASS__",
     "DATABASE": "mempool_testnet_lightning"
   }
 }


### PR DESCRIPTION
The `mempool_mainnet_lightning` user/pass was hard-coded in backend configs, should use variables instead