### PR TITLE
Log warning when pools are out of date

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -219,6 +219,16 @@ Generate block at regular interval (every 10 seconds in this example):
    watch -n 10 "./src/bitcoin-cli -regtest -rpcport=8332 generatetoaddress 1 $address"
    ```
 
+### Mining pools update
+
+By default, mining pools will be not automatically updated regularly (`config.MEMPOOL.AUTOMATIC_BLOCK_REINDEXING` is set to `false`). 
+
+To manually update your mining pools, you can use the `--update-pools` command line flag when you run the nodejs backend. For example `npm run start --update-pools`. This will trigger the mining pools update and automatically re-index appropriate blocks.
+
+You can enabled the automatic mining pools update by settings `config.MEMPOOL.AUTOMATIC_BLOCK_REINDEXING` to `true` in your `mempool-config.json`.
+
+When a `coinbase tag` or `coinbase address` change is detected, all blocks tagged to the `unknown` mining pools (starting from height 130635) will be deleted from the `blocks` table. Additionaly, all blocks which were tagged to the pool which has been updated will also be deleted from the `blocks` table. Of course, those blocks will be automatically reindexed.
+
 ### Re-index tables
 
 You can manually force the nodejs backend to drop all data from a specified set of tables for future re-index. This is mostly useful for the mining dashboard and the lightning explorer.


### PR DESCRIPTION
### UPDATED DESC

Most of the changes of this PR have been merged already in https://github.com/mempool/mempool/pull/2869. The only extra thing left from this PR is the updated README and one additional log from the new `--update-pools` command line.

### _ORIGINAL PR_

_Currently in our production servers, we have `config.MEMPOOL.AUTOMATIC_BLOCK_REINDEXING` set to `false`. This means that when mining pools are updated, we are not automatically re-indexing the corresponding blocks table. This leads to inconsistent result where older blocks are tagged using the older pool definition, while new blocks are tagged using the latest pool definition._

_This PR disable the mining pools automatic update if `config.MEMPOOL.AUTOMATIC_BLOCK_REINDEXING` is set to `false`. A new nodejs command line option is provided to manually trigger the mining pools update `--update-pools`, which will both update the mining pools and re-index appropriate blocks at the same time. See updated backend README for more details._