### PR TITLE
Remove hardcoded mining pools colors as it's not relevant

### DIFF
--- a/frontend/src/app/app.constants.ts
+++ b/frontend/src/app/app.constants.ts
@@ -72,22 +72,10 @@ export const chartColors = [
 ];
 
 export const poolsColor = {
-   'foundryusa': '#D81B60',
-   'antpool': '#8E24AA',
-   'f2pool': '#5E35B1',
-   'poolin': '#3949AB',
-   'binancepool': '#1E88E5',
-   'viabtc': '#039BE5',
-   'btccom': '#00897B',
-   'braiinspool': '#00ACC1',
-   'sbicrypto': '#43A047',
-   'marapool': '#7CB342',
-   'luxor': '#C0CA33',
-   'unknown': '#FDD835',
-   'okkong': '#FFB300',
-}
+  'unknown': '#9C9C9C',
+};
 
- export const feeLevels = [1, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200,
+export const feeLevels = [1, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 175, 200,
   250, 300, 350, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000];
 
 export interface Language {

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -176,7 +176,7 @@ export class PoolRankingComponent implements OnInit {
     // 'Other'
     data.push({
       itemStyle: {
-        color: 'grey',
+        color: '#6b6b6b',
       },
       value: totalShareOther,
       name: 'Other' + (isMobile() ? `` : ` (${totalShareOther.toFixed(2)}%)`),


### PR DESCRIPTION
The only hardcoded colors left are `unknown` and `other` with two different shade of grey

### All

<img width="700" alt="Screenshot 2023-02-19 at 17 15 20" src="https://user-images.githubusercontent.com/9780671/219936845-a8d73339-7738-4101-9af9-f8bf83dcc925.png">

### 3y

<img width="697" alt="image" src="https://user-images.githubusercontent.com/9780671/219936855-cc74283c-5f9b-4d49-9632-a72934529257.png">

### Dashboard

Like @wiz mentioned it also matches the lightning dashboard now since we don't have hardcoded colors in there

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/9780671/219936892-e8383b16-4c78-4d0c-9857-8eb1a61992c1.png">
