### PR TITLE
Use mempool chart color palette on hashrate history

### DIFF
--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -5,7 +5,7 @@ import { delay, map, retryWhen, share, startWith, switchMap, tap } from 'rxjs/op
 import { ApiService } from '../../services/api.service';
 import { SeoService } from '../../services/seo.service';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
-import { poolsColor } from '../../app.constants';
+import { chartColors, poolsColor } from '../../app.constants';
 import { StorageService } from '../../services/storage.service';
 import { MiningService } from '../../services/mining.service';
 import { download } from '../../shared/graphs.utils';
@@ -173,6 +173,7 @@ export class HashrateChartPoolsComponent implements OnInit {
     this.chartOptions = {
       title: title,
       animation: false,
+      color: chartColors,
       grid: {
         right: this.right,
         left: this.left,


### PR DESCRIPTION
Fix the following regression

### Before

<img width="2024" alt="image" src="https://user-images.githubusercontent.com/9780671/220309919-2dc9ac90-c328-4837-8b71-611d58a5c36f.png">

### New

<img width="2025" alt="image" src="https://user-images.githubusercontent.com/9780671/220310429-7a0ffa5e-86a5-49bf-819d-cf8b02681d09.png">
