### PR TITLE
increase size of mempool_byte_weight db column

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 52;
+  private static currentVersion = 53;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -467,6 +467,11 @@ class DatabaseMigration {
       } catch(e) {
         logger.warn('' + (e instanceof Error ? e.message : e));
       }
+    }
+
+    if (databaseSchemaVersion < 53) {
+      await this.$executeQuery('ALTER TABLE statistics MODIFY mempool_byte_weight bigint(20) UNSIGNED NOT NULL');
+      await this.updateToSchemaVersion(53);
     }
   }
 


### PR DESCRIPTION
Fixes an error encountered while testing #3068 with an extremely large simulated mempool:

```
ERR: $create() errorOut of range value for column 'mempool_byte_weight' at row 1
```

The `mempool_byte_weight` column in the `statistics` table is a normal sized MySQL integer, with a maximum value of 4294967295. The mempool doesn't seem likely to reach this weight any time soon, but in theory could exceed it within production `maxmempool` limits.

This PR expands the `mempool_byte_weight` column to a `bigint` type, raising the maximum supported weight to 2<sup>64</sup>-1