### PR TITLE
Fix missing fees in liquid block tooltips

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -143,7 +143,10 @@ class Blocks {
    * @returns BlockSummary
    */
   public summarizeBlock(block: IBitcoinApi.VerboseBlock): BlockSummary {
-    const stripped = block.tx.map((tx) => {
+    if (Common.isLiquid()) {
+      block = this.convertLiquidFees(block);
+    }
+    const stripped = block.tx.map((tx: IBitcoinApi.VerboseTransaction) => {
       return {
         txid: tx.txid,
         vsize: tx.weight / 4,
@@ -156,6 +159,13 @@ class Blocks {
       id: block.hash,
       transactions: stripped
     };
+  }
+
+  private convertLiquidFees(block: IBitcoinApi.VerboseBlock): IBitcoinApi.VerboseBlock {
+    block.tx.forEach(tx => {
+      tx.fee = Object.values(tx.fee || {}).reduce((total, output) => total + output, 0);
+    });
+    return block;
   }
 
   /**


### PR DESCRIPTION
Fixes missing fee data in the mined block visualization on Liquid, due to a difference in `getblock` response format between Bitcoin and Elements Core RPC APIs.

| Before | After |
|-|-|
| <img width="513" alt="before-liquid-fees" src="https://user-images.githubusercontent.com/83316221/220521752-5375c9dc-8068-4d92-80e1-9240917dcdc7.png"> | <img width="513" alt="after-liquid-fees" src="https://user-images.githubusercontent.com/83316221/220521766-553144dc-9cea-4eab-99c0-b753289ba171.png"> |
