### PR TITLE
Ignore BTC prices that are out of wack

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -544,7 +544,7 @@ class Blocks {
               priceId: lastestPriceId,
             }]);
           } else {
-            logger.info(`Cannot save block price for ${blockExtended.height} because the price updater hasnt completed yet. Trying again in 10 seconds.`, logger.tags.mining);
+            logger.debug(`Cannot save block price for ${blockExtended.height} because the price updater hasnt completed yet. Trying again in 10 seconds.`, logger.tags.mining);
             setTimeout(() => {
               indexer.runSingleTask('blocksPrices');
             }, 10000);

--- a/backend/src/repositories/PricesRepository.ts
+++ b/backend/src/repositories/PricesRepository.ts
@@ -28,12 +28,30 @@ export interface Conversion {
   exchangeRates: ExchangeRates;
 }
 
+export const MAX_PRICES = {
+  USD: 100000000,
+  EUR: 100000000,
+  GBP: 100000000,
+  CAD: 100000000,
+  CHF: 100000000,
+  AUD: 100000000,
+  JPY: 10000000000,
+};
+
 class PricesRepository {
   public async $savePrices(time: number, prices: IConversionRates): Promise<void> {
     if (prices.USD === 0) {
       // Some historical price entries have no USD prices, so we just ignore them to avoid future UX issues
-      // As of today there are only 4 (on 2013-09-05, 2013-0909, 2013-09-12 and 2013-09-26) so that's fine
+      // since we use USD as default/fallback when we don't have a price for another currency
       return;
+    }
+
+    // Sanity check
+    for (const currency of Object.keys(prices)) {
+      if (prices[currency] < 0 || prices[currency] > MAX_PRICES[currency]) {
+        logger.info(`Ignore BTC${currency} price of ${prices[currency]}`);
+        prices[currency] = 0;
+      }
     }
 
     try {


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/3095

Tested with hardcoded insane values from the Coinbase price feed.
Example output that may happen if a price API sends us a price that does not make sense.

```
Feb 22 12:31:22 [59810] INFO: [Mining] Ignored Coinbase BTC/USD price: 100000000000000
Feb 22 12:31:34 [59810] INFO: [Mining] Ignored Coinbase BTC/GBP price: 100000000000000
Feb 22 12:32:15 [59810] INFO: [Mining] Ignored historical BTC/USD price: 100000000000
Feb 22 12:32:15 [59810] INFO: [Mining] Ignored historical BTC/GBP price: 100000000000
```