### PR TITLE
Fit translator avatars neatly on 2 lines

### DIFF
--- a/frontend/src/app/components/about/about.component.scss
+++ b/frontend/src/app/components/about/about.component.scss
@@ -145,6 +145,13 @@
     }
   }
 
+  .project-translators .wrapper {
+    a img {
+      width: 72px;
+      height: 72px;
+    }
+  }
+
   .copyright {
     text-align: left;
     max-width: 620px;


### PR DESCRIPTION
## Before

![Screenshot from 2023-02-23 07-50-38](https://user-images.githubusercontent.com/93150691/220911474-6ae1531b-0f95-41ee-bf2d-2e7244010f84.png)

## After

![Screenshot from 2023-02-23 07-50-14](https://user-images.githubusercontent.com/93150691/220911452-7b65c0c4-0a09-4118-97c9-3b4844342ce0.png)