### PR TITLE
Fix DB migration 54 breaking liquid

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -86,7 +86,7 @@ class DatabaseMigration {
       try {
         await this.$migrateTableSchemaFromVersion(databaseSchemaVersion);
         if (databaseSchemaVersion === 0) {
-          logger.notice(`MIGRATIONS: OK. Database schema has been properly initialized to version ${DatabaseMigration.currentVersion} (latest version)`);          
+          logger.notice(`MIGRATIONS: OK. Database schema has been properly initialized to version ${DatabaseMigration.currentVersion} (latest version)`);
         } else {
           logger.notice(`MIGRATIONS: OK. Database schema have been migrated from version ${databaseSchemaVersion} to ${DatabaseMigration.currentVersion} (latest version)`);
         }
@@ -300,7 +300,7 @@ class DatabaseMigration {
       await this.$executeQuery('ALTER TABLE `lightning_stats` ADD med_base_fee_mtokens bigint(20) unsigned NOT NULL DEFAULT "0"');
       await this.updateToSchemaVersion(27);
     }
-    
+
     if (databaseSchemaVersion < 28 && isBitcoin === true) {
       if (config.LIGHTNING.ENABLED) {
         this.uniqueLog(logger.notice, `'lightning_stats' and 'node_stats' tables have been truncated.`);
@@ -464,7 +464,7 @@ class DatabaseMigration {
         await this.$executeQuery('DROP TABLE IF EXISTS `transactions`');
         await this.$executeQuery('DROP TABLE IF EXISTS `cpfp_clusters`');
         await this.updateToSchemaVersion(52);
-      } catch(e) {
+      } catch (e) {
         logger.warn('' + (e instanceof Error ? e.message : e));
       }
     }
@@ -476,9 +476,11 @@ class DatabaseMigration {
 
     if (databaseSchemaVersion < 54) {
       this.uniqueLog(logger.notice, `'prices' table has been truncated`);
-      this.uniqueLog(logger.notice, `'blocks_prices' table has been truncated`);
       await this.$executeQuery(`TRUNCATE prices`);
-      await this.$executeQuery(`TRUNCATE blocks_prices`);
+      if (isBitcoin === true) {
+        this.uniqueLog(logger.notice, `'blocks_prices' table has been truncated`);
+        await this.$executeQuery(`TRUNCATE blocks_prices`);
+      }
       await this.updateToSchemaVersion(54);
     }
   }
@@ -604,7 +606,7 @@ class DatabaseMigration {
       queries.push(`INSERT INTO state(name, number, string) VALUES ('last_hashrates_indexing', 0, NULL)`);
     }
 
-    if (version < 9  && isBitcoin === true) {
+    if (version < 9 && isBitcoin === true) {
       queries.push(`INSERT INTO state(name, number, string) VALUES ('last_weekly_hashrates_indexing', 0, NULL)`);
     }
 


### PR DESCRIPTION
```
Feb 23 13:39:20 [25277] NOTICE: <liquid> Starting Mempool Server... (273770a)
Feb 23 13:39:20 [25277] INFO: <liquid> Database connection established.
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Running migrations
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Database engine version '10.5.17-MariaDB'
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Current state.schema_version 53
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Latest DatabaseMigration.version is 54
Feb 23 13:39:20 [25277] NOTICE: <liquid> 'prices' table has been truncated
Feb 23 13:39:20 [25277] NOTICE: <liquid> 'blocks_prices' table has been truncated
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Execute query:
TRUNCATE prices
Feb 23 13:39:20 [25277] DEBUG: <liquid> MIGRATIONS: Execute query:
TRUNCATE blocks_prices
Feb 23 13:39:20 [25277] ERR: <liquid> MIGRATIONS: Unable to create required tables, aborting in 10 seconds. Error: Table 'mempool_liquid.blocks_prices' doesn't exist
```