### PR TITLE
Truncate `coinbase_signature` and `coinbase_signature_ascii` before insertion if needed

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,7 +36,6 @@ import bitcoinRoutes from './api/bitcoin/bitcoin.routes';
 import fundingTxFetcher from './tasks/lightning/sync-tasks/funding-tx-fetcher';
 import forensicsService from './tasks/lightning/forensics.service';
 import priceUpdater from './tasks/price-updater';
-import mining from './api/mining/mining';
 import chainTips from './api/chain-tips';
 import { AxiosError } from 'axios';
 

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -16,6 +16,9 @@ class BlocksRepository {
    * Save indexed block data in the database
    */
   public async $saveBlockInDatabase(block: BlockExtended) {
+    const truncatedCoinbaseSignature = block?.extras?.coinbaseSignature?.substring(0, 500);
+    const truncatedCoinbaseSignatureAscii = block?.extras?.coinbaseSignatureAscii?.substring(0, 500);
+
     try {
       const query = `INSERT INTO blocks(
         height,             hash,                blockTimestamp,    size,
@@ -65,7 +68,7 @@ class BlocksRepository {
         block.extras.medianTimestamp,
         block.extras.header,
         block.extras.coinbaseAddress,
-        block.extras.coinbaseSignature,
+        truncatedCoinbaseSignature,
         block.extras.utxoSetSize,
         block.extras.utxoSetChange,
         block.extras.avgTxSize,
@@ -78,7 +81,7 @@ class BlocksRepository {
         block.extras.segwitTotalSize,
         block.extras.segwitTotalWeight,
         block.extras.medianFeeAmt,
-        block.extras.coinbaseSignatureAscii,
+        truncatedCoinbaseSignatureAscii,
       ];
 
       await DB.query(query, params);


### PR DESCRIPTION
Testnet block 000000007652b10d91fcf118ed315a57e5491a2514e6e0101950185e0b42b679 contains a coinbase transaction script of nearly 1MB.

This breaks the blocks indexing because the data does not fit the `varchar(500)`.

Since we probably don't want to store up to 1MB of that junk in the `coinbase_signature` and `coinbase_signature_ascii` fields so we just truncate them before insertion if needed.

This does not make sense economically for a miner to do those transactions on mainnet so IMO it's fine to have this hardcoded fix for now to testnet/signet indexing won't break.
