### PR TITLE
Run Cypress tests on master after merging

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,6 +3,9 @@ name: Cypress Tests
 on:
   pull_request:
     types: [opened, review_requested, synchronize]
+  push:
+    branches:
+      - master
 jobs:
   cypress:
     if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,11 +1,11 @@
 name: Cypress Tests
 
 on:
+  push:
+    branches: [master]
   pull_request:
     types: [opened, review_requested, synchronize]
-  push:
-    branches:
-      - master
+
 jobs:
   cypress:
     if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"


### PR DESCRIPTION
When we updated the triggers to skip the `ops` PRs on #1923, the push trigger was removed completely, which caused the tests not to run once PRs are merged.

This adds the trigger back, and should fix the test status badge on the README.