### PR TITLE
Don't run CI on "review_requested" event

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    types: [opened, review_requested, synchronize]
+    types: [opened, synchronize]
 
 jobs:
   cypress:


### PR DESCRIPTION
I've recently assign myself to review an open PR, and it triggered the test again (which were already all green). Does not seem necessary.