### PR TITLE
Fix initial pool update when db is empty

### DIFF
--- a/backend/src/api/disk-cache.ts
+++ b/backend/src/api/disk-cache.ts
@@ -62,7 +62,7 @@ class DiskCache {
   }
 
   wipeCache() {
-    logger.notice(`Wipping nodejs backend cache/cache*.json files`);
+    logger.notice(`Wiping nodejs backend cache/cache*.json files`);
     try {
       fs.unlinkSync(DiskCache.FILE_NAME);
     } catch (e: any) {

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -12,7 +12,7 @@ import * as https from 'https';
  */
 class PoolsUpdater {
   lastRun: number = 0;
-  currentSha: string | undefined = undefined;
+  currentSha: string | null = null;
   poolsUrl: string = config.MEMPOOL.POOLS_JSON_URL;
   treeUrl: string = config.MEMPOOL.POOLS_JSON_TREE_URL;
 
@@ -33,7 +33,7 @@ class PoolsUpdater {
 
     try {
       const githubSha = await this.fetchPoolsSha(); // Fetch pools-v2.json sha from github
-      if (githubSha === undefined) {
+      if (githubSha === null) {
         return;
       }
 
@@ -42,12 +42,12 @@ class PoolsUpdater {
       }
 
       logger.debug(`pools-v2.json sha | Current: ${this.currentSha} | Github: ${githubSha}`);
-      if (this.currentSha !== undefined && this.currentSha === githubSha) {
+      if (this.currentSha !== null && this.currentSha === githubSha) {
         return;
       }
 
       // See backend README for more details about the mining pools update process
-      if (this.currentSha !== undefined && // If we don't have any mining pool, download it at least once
+      if (this.currentSha !== null && // If we don't have any mining pool, download it at least once
         config.MEMPOOL.AUTOMATIC_BLOCK_REINDEXING !== true && // Automatic pools update is disabled
         !process.env.npm_config_update_pools // We're not manually updating mining pool
       ) {
@@ -57,7 +57,7 @@ class PoolsUpdater {
       }
 
       const network = config.SOCKS5PROXY.ENABLED ? 'tor' : 'clearnet';
-      if (this.currentSha === undefined) {
+      if (this.currentSha === null) {
         logger.info(`Downloading pools-v2.json for the first time from ${this.poolsUrl} over ${network}`, logger.tags.mining);
       } else {
         logger.warn(`pools-v2.json is outdated, fetch latest from ${this.poolsUrl} over ${network}`, logger.tags.mining);
@@ -108,20 +108,20 @@ class PoolsUpdater {
   /**
    * Fetch our latest pools-v2.json sha from the db
    */
-  private async getShaFromDb(): Promise<string | undefined> {
+  private async getShaFromDb(): Promise<string | null> {
     try {
       const [rows]: any[] = await DB.query('SELECT string FROM state WHERE name="pools_json_sha"');
-      return (rows.length > 0 ? rows[0].string : undefined);
+      return (rows.length > 0 ? rows[0].string : null);
     } catch (e) {
       logger.err('Cannot fetch pools-v2.json sha from db. Reason: ' + (e instanceof Error ? e.message : e), logger.tags.mining);
-      return undefined;
+      return null;
     }
   }
 
   /**
    * Fetch our latest pools-v2.json sha from github
    */
-  private async fetchPoolsSha(): Promise<string | undefined> {
+  private async fetchPoolsSha(): Promise<string | null> {
     const response = await this.query(this.treeUrl);
 
     if (response !== undefined) {
@@ -133,7 +133,7 @@ class PoolsUpdater {
     }
 
     logger.err(`Cannot find "pools-v2.json" in git tree (${this.treeUrl})`, logger.tags.mining);
-    return undefined;
+    return null;
   }
 
   /**


### PR DESCRIPTION
When `pools_json_sha` is not initialized in the db, always download the mining pool even if `AUTOMATIC_BLOCK_REINDEXING: false`

### Testing

- Run `npm run start --reindex-blocks` and confirm you don't need the additional `--update-pools` for the pools table to be populated