### PR TITLE
Handle missing price (show 0)

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -1,8 +1,8 @@
 import logger from '../logger';
 import * as WebSocket from 'ws';
 import {
-  BlockExtended, TransactionExtended, WebsocketResponse, MempoolBlock, MempoolBlockDelta,
-  OptimizedStatistic, ILoadingIndicators, IConversionRates
+  BlockExtended, TransactionExtended, WebsocketResponse,
+  OptimizedStatistic, ILoadingIndicators
 } from '../mempool.interfaces';
 import blocks from './blocks';
 import memPool from './mempool';
@@ -20,6 +20,7 @@ import BlocksSummariesRepository from '../repositories/BlocksSummariesRepository
 import Audit from './audit';
 import { deepClone } from '../utils/clone';
 import priceUpdater from '../tasks/price-updater';
+import { ApiPrice } from '../repositories/PricesRepository';
 
 class WebsocketHandler {
   private wss: WebSocket.Server | undefined;
@@ -193,7 +194,7 @@ class WebsocketHandler {
     });
   }
 
-  handleNewConversionRates(conversionRates: IConversionRates) {
+  handleNewConversionRates(conversionRates: ApiPrice) {
     if (!this.wss) {
       throw new Error('WebSocket.Server is not set');
     }
@@ -214,7 +215,7 @@ class WebsocketHandler {
       'mempoolInfo': memPool.getMempoolInfo(),
       'vBytesPerSecond': memPool.getVBytesPerSecond(),
       'blocks': _blocks,
-      'conversions': priceUpdater.latestPrices,
+      'conversions': priceUpdater.getLatestPrices(),
       'mempool-blocks': mempoolBlocks.getMempoolBlocks(),
       'transactions': memPool.getLatestTransactions(),
       'backendInfo': backendInfo.getBackendInfo(),

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -293,7 +293,6 @@ interface RequiredParams {
 }
 
 export interface ILoadingIndicators { [name: string]: number; }
-export interface IConversionRates { [currency: string]: number; }
 
 export interface IBackendInfo {
   hostname: string;

--- a/backend/src/tasks/price-feeds/bitfinex-api.ts
+++ b/backend/src/tasks/price-feeds/bitfinex-api.ts
@@ -8,9 +8,6 @@ class BitfinexApi implements PriceFeed {
   public url: string = 'https://api.bitfinex.com/v1/pubticker/BTC';
   public urlHist: string = 'https://api-pub.bitfinex.com/v2/candles/trade:{GRANULARITY}:tBTC{CURRENCY}/hist';
 
-  constructor() {
-  }
-
   public async $fetchPrice(currency): Promise<number> {
     const response = await query(this.url + currency);
     if (response && response['last_price']) {

--- a/frontend/src/app/components/amount/amount.component.html
+++ b/frontend/src/app/components/amount/amount.component.html
@@ -3,13 +3,15 @@
     {{ addPlus && satoshis >= 0 ? '+' : '' }}
     {{
       (
-        (blockConversion.price[currency] >= 0 ? blockConversion.price[currency] : null) ??
-        (blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency]) ?? 0
+        (blockConversion.price[currency] > -1 ? blockConversion.price[currency] : null) ??
+        (blockConversion.price['USD']    > -1 ? blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency] : null) ?? 0
       ) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency
     }}
   </span>
   <ng-template #noblockconversion>
-    <span class="fiat">{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ (conversions ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}</span>
+    <span class="fiat">{{ addPlus && satoshis >= 0 ? '+' : '' }}
+      {{ (conversions[currency] > -1 ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}
+    </span>
   </ng-template>
 </ng-container>
 

--- a/frontend/src/app/fiat/fiat.component.html
+++ b/frontend/src/app/fiat/fiat.component.html
@@ -1,14 +1,14 @@
 <span class="green-color" *ngIf="blockConversion; else noblockconversion">
   {{
     (
-      (blockConversion.price[currency] >= 0 ? blockConversion.price[currency] : null) ??
-      (blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency]) ?? 0
+      (blockConversion.price[currency] > -1 ? blockConversion.price[currency] : null) ??
+      (blockConversion.price['USD']    > -1 ? blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency] : null) ?? 0
     ) * value / 100000000 | fiatCurrency : digitsInfo : currency
   }}
 </span>
 
 <ng-template #noblockconversion>
   <span class="green-color" *ngIf="(conversions$ | async) as conversions">
-    {{ (conversions[currency] ?? conversions['USD'] ?? 0) * value / 100000000 | fiatCurrency : digitsInfo : currency }}
+    {{ (conversions[currency] > -1 ? conversions[currency] : 0) * value / 100000000 | fiatCurrency : digitsInfo : currency }}
   </span>
 </ng-template>

--- a/frontend/src/app/services/price.service.ts
+++ b/frontend/src/app/services/price.service.ts
@@ -89,7 +89,7 @@ export class PriceService {
       return this.singlePriceObservable$.pipe(
         map((conversion) => {
           if (conversion.prices.length <= 0) {
-            return this.getEmptyPrice();
+            return undefined;
           }
           return {
             price: {
@@ -113,7 +113,7 @@ export class PriceService {
 
       return this.priceObservable$.pipe(
         map((conversion) => {
-          if (!blockTimestamp) {
+          if (!blockTimestamp || !conversion) {
             return undefined;
           }
 


### PR DESCRIPTION
This PR fixes https://github.com/mempool/mempool/issues/3205

### Testing

When you test, make sure to open the debugging console and toggle "Disable cache" in the network tab. Leave the debugging tool open while testing to make sure you don't get cached result.

- Disconnect from the internet (or emulate a network failure if you're an ops @wiz'ard)
- Truncate `prices` table
- Build the backend `npm run build`
- Delete mt-gox static price feed `rm -i ./dist/tasks/mtgox-weekly.json`
- Run the nodejs backend
- Confirm your `prices` table is empty
- Select `USD` currency in the price dropdown in the main dashboard
- [CHECK] Confirm price always show `0` (pending transaction, confirmed transaction, fees estimation, latest transactions widget, recent block, recent block transaction list, old block, old block transaction list, mempool block preview, mined block preview, old block preview, audit preview, transaction flow chart..., genesis block and anything else you can dream about)
- Switch to another currency, repeat the previous step
- Stop the nodejs backend
- Rebuild `npm run build` (to copy back the mtgox-weekly.json file into dist)
- Run the nodejs backend again
- Confirm you have some old prices in your `prices` table, USD only
- Confirm price show a (very outdated but) valid number for USD (you're going to look for transaction with high BTC value since the BTCUSD price will be 143. You wanna go through the list again from the `[CHECK]` step
- Confirm it shows 0 for all other currency. You wanna go through the list again from the `[CHECK]` step
- Reconnect to the internet
- Restart your nodejs backend, wait a few seconds
- Confirm the `prices` table has been updated
- You wanna go through the list again from the `[CHECK]` step and confirm prices are correct for USD and other currencies