### PR TITLE
blockchain momentum scrolling

### DIFF
--- a/frontend/src/app/components/start/start.component.ts
+++ b/frontend/src/app/components/start/start.component.ts
@@ -196,11 +196,13 @@ export class StartComponent implements OnInit, OnDestroy {
 
   updateVelocity(x: number) {
     const now = performance.now();
-    const dt = now - this.lastUpdate;
-    this.lastUpdate = now;
-    const velocity = (x - this.lastMouseX) / dt;
-    this.velocity = (0.8 * this.velocity) + (0.2 * velocity);
-    this.lastMouseX = x;
+    let dt = now - this.lastUpdate;
+    if (dt > 0) {
+      this.lastUpdate = now;
+      const velocity = (x - this.lastMouseX) / dt;
+      this.velocity = (0.8 * this.velocity) + (0.2 * velocity);
+      this.lastMouseX = x;
+    }
   }
 
   animateMomentum() {


### PR DESCRIPTION
Extension to #3211 to simulate momentum scrolling on iOS, or when scrolling the blockchain manually with the mouse on desktop:

*Before*:

https://user-images.githubusercontent.com/83316221/222876486-f6507100-1cdc-4f19-8318-f03c8b24653b.mov

*After*:

https://user-images.githubusercontent.com/83316221/222876495-d11f971b-652d-4641-907b-f901a1ee0d9c.mov


