### PR TITLE
ops: Add missing /api/address-prefix nginx route for bisq

### DIFF
--- a/production/nginx/server-bisq.conf
+++ b/production/nginx/server-bisq.conf
@@ -9,6 +9,10 @@ location /api/tx/ {
 	rewrite ^/api/(.*) /$1 break;
 	try_files /dev/null @esplora-api-cache-disabled;
 }
+location /api/address-prefix/ {
+	rewrite ^/api/(.*) /$1 break;
+	try_files /dev/null @esplora-api-cache-disabled;
+}
 
 # rewrite APIs to match what backend expects
 location /api/currencies {


### PR DESCRIPTION
Fixes bisq.markets address search autocomplete issue