### PR TITLE
Monitor heap memory usage

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,12 +38,19 @@ import forensicsService from './tasks/lightning/forensics.service';
 import priceUpdater from './tasks/price-updater';
 import chainTips from './api/chain-tips';
 import { AxiosError } from 'axios';
+import v8 from 'v8';
+import { formatBytes, getBytesUnit } from './utils/format';
 
 class Server {
   private wss: WebSocket.Server | undefined;
   private server: http.Server | undefined;
   private app: Application;
   private currentBackendRetryInterval = 5;
+
+  private maxHeapSize: number = 0;
+  private heapLogInterval: number = 60;
+  private warnedHeapCritical: boolean = false;
+  private lastHeapLogTime: number | null = null;
 
   constructor() {
     this.app = express();
@@ -136,6 +143,8 @@ class Server {
     if (config.MEMPOOL.ENABLED) {
       this.runMainUpdateLoop();
     }
+
+    setInterval(() => { this.healthCheck(); }, 2500);
 
     if (config.BISQ.ENABLED) {
       bisq.startBisqService();
@@ -253,6 +262,26 @@ class Server {
       generalLightningRoutes.initRoutes(this.app);
       nodesRoutes.initRoutes(this.app);
       channelsRoutes.initRoutes(this.app);
+    }
+  }
+
+  healthCheck(): void {
+    const now = Date.now();
+    const stats = v8.getHeapStatistics();
+    this.maxHeapSize = Math.max(stats.used_heap_size, this.maxHeapSize);
+    const warnThreshold = 0.95 * stats.heap_size_limit;
+
+    const byteUnits = getBytesUnit(Math.max(this.maxHeapSize, stats.heap_size_limit));
+
+    if (!this.warnedHeapCritical && this.maxHeapSize > warnThreshold) {
+      this.warnedHeapCritical = true;
+      logger.warn(`Used ${(this.maxHeapSize / stats.heap_size_limit).toFixed(2)}% of heap limit (${formatBytes(this.maxHeapSize, byteUnits, true)} / ${formatBytes(stats.heap_size_limit, byteUnits)})!`);
+    }
+    if (this.lastHeapLogTime === null || (now - this.lastHeapLogTime) > (this.heapLogInterval * 1000)) {
+      logger.debug(`Memory usage: ${formatBytes(this.maxHeapSize, byteUnits)} / ${formatBytes(stats.heap_size_limit, byteUnits)}`);
+      this.warnedHeapCritical = false;
+      this.maxHeapSize = 0;
+      this.lastHeapLogTime = now;
     }
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -269,7 +269,7 @@ class Server {
     const now = Date.now();
     const stats = v8.getHeapStatistics();
     this.maxHeapSize = Math.max(stats.used_heap_size, this.maxHeapSize);
-    const warnThreshold = 0.95 * stats.heap_size_limit;
+    const warnThreshold = 0.8 * stats.heap_size_limit;
 
     const byteUnits = getBytesUnit(Math.max(this.maxHeapSize, stats.heap_size_limit));
 

--- a/backend/src/utils/format.ts
+++ b/backend/src/utils/format.ts
@@ -1,0 +1,29 @@
+const byteUnits = ['B', 'kB', 'MB', 'GB', 'TB'];
+
+export function getBytesUnit(bytes: number): string {
+  if (isNaN(bytes) || !isFinite(bytes)) {
+    return 'B';
+  }
+  
+  let unitIndex = 0;
+  while (unitIndex < byteUnits.length && bytes > 1024) {
+    unitIndex++;
+    bytes /= 1024;
+  }
+
+  return byteUnits[unitIndex];
+}
+
+export function formatBytes(bytes: number, toUnit: string, skipUnit = false): string {
+  if (isNaN(bytes) || !isFinite(bytes)) {
+    return `${bytes}`;
+  }
+  
+  let unitIndex = 0;
+  while (unitIndex < byteUnits.length && (toUnit && byteUnits[unitIndex] !== toUnit || (!toUnit && bytes > 1024))) {
+    unitIndex++;
+    bytes /= 1024;
+  }
+
+  return `${bytes.toFixed(2)}${skipUnit ? '' : ' ' + byteUnits[unitIndex]}`;
+}


### PR DESCRIPTION
Implements basic monitoring and logging of v8 heap memory usage.

The heap is checked with `v8.getHeapStatistics()` every few seconds, and the maximum usage each minute is printed to `logger.debug`.

As soon as usage exceeds 95% of the heap limit, we log a separate warning (at most once per minute).