### PR TITLE
don't cache tx data for rbf replacements

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -362,7 +362,6 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         this.waitingForTransaction = false;
       }
       this.rbfTransaction = rbfTransaction;
-      this.cacheService.setTxCache([this.rbfTransaction]);
       this.replaced = true;
       if (rbfTransaction && !this.tx) {
         this.fetchCachedTx$.next(this.txId);


### PR DESCRIPTION
Fixes a crash bug after navigating to a newly arrived RBF replacement transaction, caused by saving bad transaction data to the `cacheService` transaction cache.

Before:

https://user-images.githubusercontent.com/83316221/223038227-c5c514b2-9fec-42b2-9fe6-1e0d4a1f0bde.mp4

After:

https://user-images.githubusercontent.com/83316221/223037917-49e12137-5ab2-4828-b523-8e10c84d3a01.mp4




