### PR TITLE
Improve backend logging

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,6 +1,25 @@
-const configFromFile = require(
-    process.env.MEMPOOL_CONFIG_FILE ? process.env.MEMPOOL_CONFIG_FILE : '../mempool-config.json'
-);
+import * as fs from 'fs';
+import logger from './logger';
+
+let configContent;
+let configFromFile = {};
+let configPath = process.env.MEMPOOL_CONFIG_FILE ? process.env.MEMPOOL_CONFIG_FILE : '../mempool-config.json';
+
+try {
+  configContent = fs.readFileSync(configPath, 'utf-8');
+  configFromFile = JSON.parse(configContent);
+
+} catch (e: any) {
+  if (e instanceof SyntaxError) {
+    logger.err(`${e.name} while parsing the config file: ${configContent}`);
+    process.exit(-1);
+  } else if (e.message.indexOf('ENOENT') === 0) {
+    logger.warn(`${configPath} not found, using default configuration`);
+  } else {
+    logger.err(e.message);
+  }
+
+}
 
 interface IConfig {
   MEMPOOL: {

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -35,7 +35,7 @@ class Logger {
   public tags = {
     mining: 'Mining',
     ln: 'Lightning',
-  };  
+  };
 
   // @ts-ignore
   public emerg: ((msg: string, tag?: string) => void);
@@ -70,22 +70,22 @@ class Logger {
   }
 
   private addprio(prio): void {
-    this[prio] = (function(_this) {
-      return function(msg, tag?: string) {
+    this[prio] = (function (_this) {
+      return function (msg, tag?: string) {
         return _this.msg(prio, msg, tag);
       };
     })(this);
   }
 
   private getNetwork(): string {
-    if (config.LIGHTNING.ENABLED) {
-      return config.MEMPOOL.NETWORK === 'mainnet' ? 'lightning' : `${config.MEMPOOL.NETWORK}-lightning`; 
+    if (config?.LIGHTNING?.ENABLED) {
+      return config?.MEMPOOL.NETWORK === 'mainnet' ? 'lightning' : `${config?.MEMPOOL?.NETWORK}-lightning`;
     }
-    if (config.BISQ.ENABLED) {
+    if (config?.BISQ?.ENABLED) {
       return 'bisq';
     }
-    if (config.MEMPOOL.NETWORK && config.MEMPOOL.NETWORK !== 'mainnet') {
-      return config.MEMPOOL.NETWORK;
+    if (config?.MEMPOOL?.NETWORK && config?.MEMPOOL?.NETWORK !== 'mainnet') {
+      return config?.MEMPOOL?.NETWORK;
     }
     return '';
   }
@@ -101,11 +101,11 @@ class Logger {
     prionum = Logger.priorities[priority] || Logger.priorities.info;
     consolemsg = `${this.ts()} [${process.pid}] ${priority.toUpperCase()}:${network} ${tag ? '[' + tag + '] ' : ''}${msg}`;
 
-    if (config.SYSLOG.ENABLED && Logger.priorities[priority] <= Logger.priorities[config.SYSLOG.MIN_PRIORITY]) {
-      syslogmsg = `<${(Logger.facilities[config.SYSLOG.FACILITY] * 8 + prionum)}> ${this.name}[${process.pid}]: ${priority.toUpperCase()}${network} ${tag ? '[' + tag + '] ' : ''}${msg}`;
+    if (config?.SYSLOG?.ENABLED && Logger.priorities[priority] <= Logger.priorities[config?.SYSLOG?.MIN_PRIORITY]) {
+      syslogmsg = `<${(Logger.facilities[config?.SYSLOG?.FACILITY] * 8 + prionum)}> ${this.name}[${process.pid}]: ${priority.toUpperCase()}${network} ${tag ? '[' + tag + '] ' : ''}${msg}`;
       this.syslog(syslogmsg);
     }
-    if (Logger.priorities[priority] > Logger.priorities[config.MEMPOOL.STDOUT_LOG_MIN_PRIORITY]) {
+    if (Logger.priorities[priority] > Logger.priorities[config?.MEMPOOL?.STDOUT_LOG_MIN_PRIORITY]) {
       return;
     }
     if (priority === 'warning') {
@@ -123,7 +123,7 @@ class Logger {
   private syslog(msg) {
     let msgbuf;
     msgbuf = Buffer.from(msg);
-    this.client.send(msgbuf, 0, msgbuf.length, config.SYSLOG.PORT, config.SYSLOG.HOST, function(err, bytes) {
+    this.client.send(msgbuf, 0, msgbuf.length, config?.SYSLOG?.PORT, config?.SYSLOG?.HOST, function (err, bytes) {
       if (err) {
         console.log(err);
       }


### PR DESCRIPTION
- Show the actual config file contents when the backend fails to parse the file, making it easier to debug missing Docker overrides.
- Update the `Logger`  utility to be used when the config file is missing a few keys.

It was crashing with:

```
/dist/logger.js:123
        if (config_1.default.SYSLOG.ENABLED && Logger.priorities[priority] <= Logger.priorities[config_1.default.SYSLOG.MIN_PRIORITY]) {
                             ^

TypeError: Cannot read properties of undefined (reading 'SYSLOG')
``` 

and 

```
/backend/dist/logger.js:102
        if (config_1.default.LIGHTNING.ENABLED) {
                             ^

TypeError: Cannot read properties of undefined (reading 'LIGHTNING')
``` 
