### PR TITLE
Log a warn if there are lot of 404 from esplora tx api while updating nodejs backend mempool

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -31,6 +31,11 @@ class Mempool {
   private mempoolProtection = 0;
   private latestTransactions: any[] = [];
 
+  private ESPLORA_MISSING_TX_WARNING_THRESHOLD = 100; 
+  private SAMPLE_TIME = 10000; // In ms
+  private timer = new Date().getTime();
+  private missingTxCount = 0;
+
   constructor() {
     setInterval(this.updateTxPerSecond.bind(this), 1000);
     setInterval(this.deleteExpiredTransactions.bind(this), 20000);
@@ -128,6 +133,16 @@ class Mempool {
       loadingIndicators.setProgress('mempool', Object.keys(this.mempoolCache).length / transactions.length * 100);
     }
 
+    // https://github.com/mempool/mempool/issues/3283
+    const logEsplora404 = (missingTxCount, threshold, time) => {
+      const log = `In the past ${time / 1000} seconds, esplora tx API replied ${missingTxCount} times with a 404 error code while updating nodejs backend mempool`;
+      if (missingTxCount >= threshold) {
+        logger.warn(log);
+      } else if (missingTxCount > 0) {
+        logger.debug(log);
+      }
+    };
+
     for (const txid of transactions) {
       if (!this.mempoolCache[txid]) {
         try {
@@ -142,7 +157,10 @@ class Mempool {
           }
           hasChange = true;
           newTransactions.push(transaction);
-        } catch (e) {
+        } catch (e: any) {
+          if (config.MEMPOOL.BACKEND === 'esplora' && e.response?.status === 404) {
+            this.missingTxCount++;
+          }
           logger.debug(`Error finding transaction '${txid}' in the mempool: ` + (e instanceof Error ? e.message : e));
         }
       }
@@ -150,6 +168,14 @@ class Mempool {
       if ((new Date().getTime()) - start > Mempool.WEBSOCKET_REFRESH_RATE_MS) {
         break;
       }
+    }
+
+    // Reset esplora 404 counter and log a warning if needed
+    const elapsedTime = new Date().getTime() - this.timer;
+    if (elapsedTime > this.SAMPLE_TIME) {
+      logEsplora404(this.missingTxCount, this.ESPLORA_MISSING_TX_WARNING_THRESHOLD, elapsedTime);
+      this.timer = new Date().getTime();
+      this.missingTxCount = 0;
     }
 
     // Prevent mempool from clear on bitcoind restart by delaying the deletion


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/3283

- A permanent timer is initialized when we start the nodejsbackend.
- When we update the nodejs mempool backend, every 404 will increment a counter.
- At the end of each nodejs backend mempool update
  - If the timer passed the 10 seconds mark
    - If we got more than 100 times a 404 error from esplora while querying the tx api, we log a warn, otherwise we log a debug.
    - We reset the counter and the timer

Sample output

```
Mar  9 14:46:48 [46601] DEBUG: <lightning> Error finding transaction 'b31f9804ff5bdd08dd617be738e6448f4aaa390371f04c2ac2abcec326c08a3d' in the mempool:
Mar  9 14:46:48 [46601] DEBUG: <lightning> Error finding transaction 'bec254287b99d070fc03e60b0ae26da24a32d57385fe87d128f089c05aab4b9f' in the mempool:
Mar  9 14:46:48 [46601] WARN: <lightning> In the past 4.982 seconds, esplora tx API replied 41 times with a 404 error code
Mar  9 14:46:48 [46601] DEBUG: <lightning> Mempool templates calculated in 0.051 seconds
Mar  9 14:46:48 [46601] DEBUG: <lightning> Mempool updated in 10.132 seconds. New size: 7838 (+27696)
Mar  9 14:46:49 [46601] DEBUG: <lightning> Updating mempool...
Mar  9 14:46:49 [46601] DEBUG: <lightning> Error finding transaction 'a704710ef6676030de5390e51cc5bb95a1477302485822e9443a3868e38fc0f5' in the mempool:
Mar  9 14:46:49 [46601] DEBUG: <lightning> Error finding transaction '8cb2aed3f1b9f7808a726469effab7dc801e87f04cc2b7c3af35d0a4a8ac7036' in the mempool:
... same message lot of times
Mar  9 14:46:54 [46601] DEBUG: <lightning> Error finding transaction 'e9fddc4ce98d77e63a72049275ac85e882c89442b13f2345b962cfb91af69405' in the mempool:
Mar  9 14:46:54 [46601] DEBUG: <lightning> Error finding transaction '95d477c8bb4e183106eb6f44251109bba894d00d563806b46adc9c2ba70e9fc7' in the mempool:
Mar  9 14:46:54 [46601] WARN: <lightning> In the past 5.001 seconds, esplora tx API replied 41 times with a 404 error code
Mar  9 14:46:55 [46601] DEBUG: <lightning> Error finding transaction 'c1830e812c09bcf83f72a57619985dfd1cd5fc8d7e3043c3013cb99261713061' in the mempool:
Mar  9 14:46:55 [46601] DEBUG: <lightning> Error finding transaction 'db8cfd1bb92731eb0e5f17887f09ee68278f811997b963c97dafb6ccd92df086' in the mempool:
... same message lot of times
Mar  9 14:46:59 [46601] DEBUG: <lightning> Error finding transaction 'cbd0f8bb6f8e5121c218173834604f7e99c59b7afa51eee2e7db4c6fb39895ac' in the mempool:
Mar  9 14:46:59 [46601] DEBUG: <lightning> Error finding transaction 'ad878c8e944a713900c2792c7e1364daa3277f9bc37d27bb04957309e4bd22a7' in the mempool:
Mar  9 14:46:59 [46601] WARN: <lightning> In the past 4.981 seconds, esplora tx API replied 31 times with a 404 error code
Mar  9 14:46:59 [46601] DEBUG: <lightning> Mempool templates calculated in 0.121 seconds
Mar  9 14:47:00 [46601] DEBUG: <lightning> Mempool updated in 10.249 seconds. New size: 15862 (+19893)
```