### PR TITLE
fix missing cpfp fee ratings on mobile

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -488,7 +488,7 @@
           <div class="effective-fee-container">
             {{ tx.effectiveFeePerVsize | feeRounding }} <span class="symbol" i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
             <ng-template [ngIf]="tx.status.confirmed">
-              <app-tx-fee-rating class="d-none d-lg-inline ml-2" *ngIf="tx.fee" [tx]="tx"></app-tx-fee-rating>
+              <app-tx-fee-rating class="ml-2 mr-2" *ngIf="tx.fee || tx.effectiveFeePerVsize" [tx]="tx"></app-tx-fee-rating>
             </ng-template>
           </div>
           <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-right" (click)="showCpfpDetails = !showCpfpDetails">CPFP <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></button>


### PR DESCRIPTION
The optimal/overpaid fee rating badge for recently mined CPFP transactions was missing on mobile.

| Before | After |
|-|-|
| ![localhost_4200_tx_628bcc05c86e075a0e1ed0b44b96d3fab3e8b37fbbe55e628c705a3ae8924dbf(iPhone SE)](https://user-images.githubusercontent.com/83316221/224200662-7a41e761-6020-4c57-ab2c-ac5d65d531ca.png) | ![localhost_4200_(iPhone SE)](https://user-images.githubusercontent.com/83316221/224200693-29aa6ece-d4a1-443a-b237-ea613ab7b92f.png) |
