### PR TITLE
Fixes arrow position on confirmed blocks

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -107,7 +107,7 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
           this.blocks.unshift(block);
           this.blocks = this.blocks.slice(0, this.dynamicBlocksAmount);
 
-          if (txConfirmed) {
+          if (txConfirmed && this.height === block.height) {
             this.markHeight = block.height;
             this.moveArrowToPosition(true, true);
           } else {

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -347,7 +347,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.blocksSubscription = this.stateService.blocks$.subscribe(([block, txConfirmed]) => {
       this.latestBlock = block;
 
-      if (txConfirmed && this.tx) {
+      if (txConfirmed && this.tx && !this.tx.status.confirmed) {
         this.tx.status = {
           confirmed: true,
           block_height: block.height,


### PR DESCRIPTION
fixes #3294

**How to test**

1. Start tracking a tx that will most likely be included in the next block
2. Wait for two confirmations
3. Press the back button of the web browser
4. Press the forward button of the web browser
5. There should no longer play a confirmation sound, and the arrow should not wrongly move to the first block. This should only happen at the confirmation.


