### PR TITLE
Remove search bar focus border

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.scss
+++ b/frontend/src/app/components/search-form/search-form.component.scss
@@ -53,3 +53,8 @@ form {
   margin-top: 1px;
   margin-right: 2px;
 }
+
+input:focus {
+  box-shadow: none;
+  border-color: #1b1f2c;
+}


### PR DESCRIPTION
This is needed now when the Search Bar is autofocusing.

Downside is that the blinking cursor is the only indication of focus, but fine IMO.

Before
<img width="515" alt="Screenshot 2023-03-10 at 20 18 14" src="https://user-images.githubusercontent.com/8561090/224303134-08178bd6-34bd-46af-a3f6-0093266de1ea.png">

After
<img width="527" alt="Screenshot 2023-03-10 at 20 18 07" src="https://user-images.githubusercontent.com/8561090/224303141-ada3e42c-ffce-4556-9000-2f4d99b0171a.png">

