### PR TITLE
Lightning dashboard overflow titles fixes

### DIFF
--- a/frontend/src/app/lightning/channels-statistics/channels-statistics.component.scss
+++ b/frontend/src/app/lightning/channels-statistics/channels-statistics.component.scss
@@ -2,7 +2,10 @@
   color: #4a68b9;
   font-size: 10px;
   margin-bottom: 4px;  
-  font-size: 1rem;
+  font-size: 1rem;      
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card-text {

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.html
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.html
@@ -3,21 +3,21 @@
   <div *ngIf="widget">
     <div class="pool-distribution" *ngIf="(nodesPerAsObservable$ | async) as stats; else loadingReward">
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.clearnet-capacity">Clearnet Capacity</h5>
+        <h5 class="card-title" i18n="lightning.clearnet-capacity">Clearnet Capacity</h5>
         <p class="card-text" i18n-ngbTooltip="lightning.clearnet-capacity-desc"
           ngbTooltip="How much liquidity is running on nodes advertising at least one clearnet IP address" placement="bottom">
           <app-amount [satoshis]="stats.clearnetCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.unknown-capacity">Unknown Capacity</h5>
+        <h5 class="card-title" i18n="lightning.unknown-capacity">Unknown Capacity</h5>
         <p class="card-text" i18n-ngbTooltip="lightning.unknown-capacity-desc"
         ngbTooltip="How much liquidity is running on nodes which ISP was not identifiable" placement="bottom">
           <app-amount [satoshis]="stats.unknownCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
         </p>
       </div>
       <div class="item">
-        <h5 class="card-title d-inline-block" i18n="lightning.tor-capacity">Tor Capacity</h5>
+        <h5 class="card-title" i18n="lightning.tor-capacity">Tor Capacity</h5>
         <p class="card-text" i18n-ngbTooltip="lightning.tor-capacity-desc"
         ngbTooltip="How much liquidity is running on nodes advertising only Tor addresses" placement="bottom">
           <app-amount [satoshis]="stats.torCapacity" [digitsInfo]="'1.2-2'" [noFiat]="true"></app-amount>
@@ -80,19 +80,19 @@
 <ng-template #loadingReward>
   <div class="pool-distribution">
     <div class="item">
-      <h5 class="card-title d-inline-block" i18n="lightning.clearnet-capacity">Clearnet Capacity</h5>
+      <h5 class="card-title" i18n="lightning.clearnet-capacity">Clearnet Capacity</h5>
       <p class="card-text">
         <span class="skeleton-loader skeleton-loader-big"></span>
       </p>
     </div>
     <div class="item">
-      <h5 class="card-title d-inline-block" i18n="lightning.unknown-capacity">Unknown Capacity</h5>
+      <h5 class="card-title" i18n="lightning.unknown-capacity">Unknown Capacity</h5>
       <p class="card-text">
         <span class="skeleton-loader skeleton-loader-big"></span>
       </p>
     </div>
     <div class="item">
-      <h5 class="card-title d-inline-block" i18n="lightning.tor-capacity">Tor Capacity</h5>
+      <h5 class="card-title" i18n="lightning.tor-capacity">Tor Capacity</h5>
       <p class="card-text">
         <span class="skeleton-loader skeleton-loader-big"></span>
       </p>

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.scss
@@ -68,10 +68,13 @@
     margin-bottom: 5px;
   }
   .item {
-    max-width: 160px;
+    max-width: 150px;
     width: 50%;
     display: inline-block;
     margin: 0px auto 20px;
+    @media (min-width: 485px) {
+      max-width: 160px;
+    }
     &:nth-child(2) {
       order: 2;
       @media (min-width: 485px) {


### PR DESCRIPTION
fixes #3127

Added ellipsis when overflowing on the Lightning dashboard.

Portugese after:

<img width="578" alt="Screenshot 2023-03-11 at 19 22 42" src="https://user-images.githubusercontent.com/8561090/224479389-2197e1ff-23f8-4b92-a927-84a63d8a8345.png">

Georgian before and after
<img width="566" alt="Screenshot 2023-03-11 at 19 32 00" src="https://user-images.githubusercontent.com/8561090/224479404-1a64eb17-9ff2-4180-babf-68becd8a82f8.png">
<img width="565" alt="Screenshot 2023-03-11 at 19 31 29" src="https://user-images.githubusercontent.com/8561090/224479408-67c37fba-d165-45a2-a8b0-5c936569eb94.png">



