### PR TITLE
Use effective fee rate heuristics for block fee span

### DIFF
--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -214,6 +214,16 @@ export interface MempoolStats {
   tx_count: number;
 }
 
+export interface EffectiveFeeStats {
+  medianFee: number; // median effective fee rate
+  feeRange: number[]; // 2nd, 10th, 25th, 50th, 75th, 90th, 98th percentiles
+}
+
+export interface CpfpSummary {
+  transactions: TransactionExtended[];
+  clusters: { root: string, height: number, txs: Ancestor[], effectiveFeePerVsize: number }[];
+}
+
 export interface Statistic {
   id?: number;
   added: string;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1,4 +1,4 @@
-import { BlockExtended, BlockExtension, BlockPrice } from '../mempool.interfaces';
+import { BlockExtended, BlockExtension, BlockPrice, EffectiveFeeStats } from '../mempool.interfaces';
 import DB from '../database';
 import logger from '../logger';
 import { Common } from '../api/common';
@@ -904,6 +904,25 @@ class BlocksRepository {
       );
     } catch (e) {
       logger.err(`Cannot update block fee_percentiles. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
+   * Save indexed effective fee statistics
+   * 
+   * @param id 
+   * @param feeStats 
+   */
+  public async $saveEffectiveFeeStats(id: string, feeStats: EffectiveFeeStats): Promise<void> {
+    try {
+      await DB.query(`
+        UPDATE blocks SET median_fee = ?, fee_span = ?
+        WHERE hash = ?`,
+        [feeStats.medianFee, JSON.stringify(feeStats.feeRange), id]
+      );
+    } catch (e) {
+      logger.err(`Cannot update block fee stats. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }

--- a/backend/src/repositories/CpfpRepository.ts
+++ b/backend/src/repositories/CpfpRepository.ts
@@ -48,7 +48,7 @@ class CpfpRepository {
     }
   }
 
-  public async $batchSaveClusters(clusters: { root: string, height: number, txs: any, effectiveFeePerVsize: number}[]): Promise<boolean> {
+  public async $batchSaveClusters(clusters: { root: string, height: number, txs: Ancestor[], effectiveFeePerVsize: number }[]): Promise<boolean> {
     try {
       const clusterValues: any[] = [];
       const txs: any[] = [];

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -25,7 +25,7 @@
           </ng-template>
           <div [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-fee-span'" class="fee-span"
             *ngIf="block?.extras?.feeRange; else emptyfeespan">
-            {{ block?.extras?.feeRange?.[1] | number:feeRounding }} - {{
+            {{ block?.extras?.feeRange?.[0] | number:feeRounding }} - {{
             block?.extras?.feeRange[block?.extras?.feeRange?.length - 1] | number:feeRounding }} <ng-container
               i18n="shared.sat-vbyte|sat/vB">sat/vB</ng-container>
           </div>


### PR DESCRIPTION
Resolves #3302 

This PR takes advantage of our CPFP-based effective fee rate data to improve the fee span and median fee information for mined blocks.

It uses some heuristics to skip outliers and identify the minimum effective fee required and the maximum effective rate paid to get into each block.

The “median fee” now represents the approximate fee rate paid for the *median vbyte* of each block (specifically, the average rate paid for the middle ~10000 weight units). This should be a more consistent and informative metric than the fee rate of the median *transaction*, which can be skewed significantly one way or the other by the composition of the block.

Fee spans will be calculated & indexed using the new method only for new blocks. Updating the fee info for existing blocks currently requires a full CPFP re-index. This will be improved in a future PR.

Before:
_fee span shows the raw minimum and maximum fees, ignoring CPFP relationships_
<img width="1136" alt="Screenshot 2023-03-12 at 11 36 10 AM" src="https://user-images.githubusercontent.com/83316221/224524866-f7c7cb84-1577-432a-a0d5-5b4b819bf8df.png">

After:
_fee span shows the minimum and maximum effective rates_
<img width="1136" alt="Screenshot 2023-03-12 at 1 39 15 PM" src="https://user-images.githubusercontent.com/83316221/224524869-623ae0a8-7018-4312-ab01-0c8999e9ffdc.png">
