### PR TITLE
Disable pool update when running lightning only

### DIFF
--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -17,7 +17,9 @@ class PoolsUpdater {
   treeUrl: string = config.MEMPOOL.POOLS_JSON_TREE_URL;
 
   public async updatePoolsJson(): Promise<void> {
-    if (['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) === false) {
+    if (['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) === false ||
+      config.MEMPOOL.ENABLED === false
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/3348

We still need the pools.json when indexing is disabled because we index on the fly. Block(s) API return the same data regardless of indexing status 👍🏻 