### PR TITLE
Network-specific activation heights for transaction feature badges

### DIFF
--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -254,3 +254,30 @@ export function selectPowerOfTen(val: number): { divider: number, unit: string }
 
   return selectedPowerOfTen;
 }
+
+const featureActivation = {
+  mainnet: {
+    rbf: 399701,
+    segwit: 477120,
+    taproot: 709632,
+  },
+  testnet: {
+    rbf: 720255,
+    segwit: 872730,
+    taproot: 2032291,
+  },
+  signet: {
+    rbf: 0,
+    segwit: 0,
+    taproot: 0,
+  },
+};
+
+export function isFeatureActive(network: string, height: number, feature: 'rbf' | 'segwit' | 'taproot'): boolean {
+  const activationHeight = featureActivation[network || 'mainnet']?.[feature];
+  if (activationHeight != null) {
+    return height >= activationHeight;
+  } else {
+    return false;
+  }
+}

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -23,6 +23,7 @@ import { BlockExtended, CpfpInfo } from '../../interfaces/node-api.interface';
 import { LiquidUnblinding } from './liquid-ublinding';
 import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
 import { Price, PriceService } from '../../services/price.service';
+import { isFeatureActive } from '../../bitcoin.utils';
 
 @Component({
   selector: 'app-transaction',
@@ -438,9 +439,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
 
   setFeatures(): void {
     if (this.tx) {
-      this.segwitEnabled = !this.tx.status.confirmed || this.tx.status.block_height >= 477120;
-      this.taprootEnabled = !this.tx.status.confirmed || this.tx.status.block_height >= 709632;
-      this.rbfEnabled = !this.tx.status.confirmed || this.tx.status.block_height > 399700;
+      this.segwitEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'segwit');
+      this.taprootEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'taproot');
+      this.rbfEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'rbf');
     } else {
       this.segwitEnabled = false;
       this.taprootEnabled = false;


### PR DESCRIPTION
_(builds on PR #3345)_

Previously, we incorrectly reused mainnet feature activation heights to decide when to display transaction feature badges.

This PR switches to network-specific activation height logic, set to the following heights:

Mainnet
```
rbf: 399701,
segwit: 477120,
taproot: 709632,
```

Testnet
```
rbf: 720255,
segwit: 872730,
taproot: 2032291,
```

Signet
```
rbf: 0,
segwit: 0,
taproot: 0,
```

Before:
(all feature badges hidden because signet block height is much lower than the mainnet activation height of RBF, taproot and segwit features.)
<img width="1144" alt="Screenshot 2023-03-14 at 1 07 26 PM" src="https://user-images.githubusercontent.com/83316221/224891360-ef02d0e3-fe5c-427d-9a9b-1cf20b934c08.png">

After:
Signet transactions show feature badges
<img width="1144" alt="Screenshot 2023-03-14 at 1 06 57 PM" src="https://user-images.githubusercontent.com/83316221/224891373-eb73731e-ef6b-4f2c-8645-9025d2d8c5a2.png">
