### PR TITLE
Limit special blocks by network, add future halvings

### DIFF
--- a/frontend/src/app/app.constants.ts
+++ b/frontend/src/app/app.constants.ts
@@ -139,26 +139,87 @@ export const specialBlocks = {
   '0': {
     labelEvent: 'Genesis',
     labelEventCompleted: 'The Genesis of Bitcoin',
+    networks: ['mainnet', 'testnet'],
   },
   '210000': {
     labelEvent: 'Bitcoin\'s 1st Halving',
     labelEventCompleted: 'Block Subsidy has halved to 25 BTC per block',
+    networks: ['mainnet', 'testnet'],
   },
   '420000': {
     labelEvent: 'Bitcoin\'s 2nd Halving',
     labelEventCompleted: 'Block Subsidy has halved to 12.5 BTC per block',
+    networks: ['mainnet', 'testnet'],
   },
   '630000': {
     labelEvent: 'Bitcoin\'s 3rd Halving',
     labelEventCompleted: 'Block Subsidy has halved to 6.25 BTC per block',
+    networks: ['mainnet', 'testnet'],
   },
   '709632': {
     labelEvent: 'Taproot 🌱 activation',
     labelEventCompleted: 'Taproot 🌱 has been activated!',
+    networks: ['mainnet'],
   },
   '840000': {
     labelEvent: 'Bitcoin\'s 4th Halving',
     labelEventCompleted: 'Block Subsidy has halved to 3.125 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '1050000': {
+    labelEvent: 'Bitcoin\'s 5th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 1.5625 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '1260000': {
+    labelEvent: 'Bitcoin\'s 6th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.78125 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '1470000': {
+    labelEvent: 'Bitcoin\'s 7th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.390625 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '1680000': {
+    labelEvent: 'Bitcoin\'s 8th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.1953125 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '1890000': {
+    labelEvent: 'Bitcoin\'s 9th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.09765625 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '2100000': {
+    labelEvent: 'Bitcoin\'s 10th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.04882812 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '2310000': {
+    labelEvent: 'Bitcoin\'s 11th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.02441406 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '2520000': {
+    labelEvent: 'Bitcoin\'s 12th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.01220703 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '2730000': {
+    labelEvent: 'Bitcoin\'s 13th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.00610351 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '2940000': {
+    labelEvent: 'Bitcoin\'s 14th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.00305175 BTC per block',
+    networks: ['mainnet', 'testnet'],
+  },
+  '3150000': {
+    labelEvent: 'Bitcoin\'s 15th Halving',
+    labelEventCompleted: 'Block Subsidy has halved to 0.00152587 BTC per block',
+    networks: ['mainnet', 'testnet'],
   }
 };
 

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -6,7 +6,7 @@
       <div [attr.data-cy]="'bitcoin-block-offset-' + offset + '-index-' + i"
         class="text-center bitcoin-block mined-block blockchain-blocks-offset-{{ offset }}-index-{{ i }}"
         id="bitcoin-block-{{ block.height }}" [ngStyle]="blockStyles[i]"
-        [class.blink-bg]="(specialBlocks[block.height] !== undefined)">
+        [class.blink-bg]="isSpecial(block.height)">
         <a draggable="false" [routerLink]="['/block/' | relativeUrl, block.id]" [state]="{ data: { block: block } }"
           class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">&nbsp;</a>
         <div [attr.data-cy]="'bitcoin-block-' + i + '-height'" class="block-height">

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -269,6 +269,10 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
     this.cd.markForCheck();
   }
 
+  isSpecial(height: number): boolean {
+    return this.specialBlocks[height]?.networks.includes(this.stateService.network || 'mainnet') ? true : false;
+  }
+
   getStyleForBlock(block: BlockchainBlock, index: number, animateEnterFrom: number = 0) {
     if (!block || block.placeholder) {
       return this.getStyleForPlaceholderBlock(index, animateEnterFrom);

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -116,9 +116,7 @@ export class MempoolBlocksComponent implements OnInit, OnDestroy {
           mempoolBlocks.forEach((block, i) => {
             block.index = this.blockIndex + i;
             block.height = lastBlock.height + i + 1;
-            if (this.stateService.network === '') {
-              block.blink = specialBlocks[block.height] ? true : false;
-            }
+            block.blink = specialBlocks[block.height]?.networks.includes(this.stateService.network || 'mainnet') ? true : false;
           });
 
           const stringifiedBlocks = JSON.stringify(mempoolBlocks);

--- a/frontend/src/app/components/start/start.component.ts
+++ b/frontend/src/app/components/start/start.component.ts
@@ -85,21 +85,20 @@ export class StartComponent implements OnInit, OnDestroy {
     });
     this.stateService.blocks$
       .subscribe((blocks: any) => {
-        if (this.stateService.network !== '') {
-          return;
-        }
         this.countdown = 0;
         const block = blocks[0];
 
         for (const sb in specialBlocks) {
-          const height = parseInt(sb, 10);
-          const diff = height - block.height;
-          if (diff > 0 && diff <= 1008) {
-            this.countdown = diff;
-            this.eventName = specialBlocks[sb].labelEvent;
+          if (specialBlocks[sb].networks.includes(this.stateService.network || 'mainnet')) {
+            const height = parseInt(sb, 10);
+            const diff = height - block.height;
+            if (diff > 0 && diff <= 1008) {
+              this.countdown = diff;
+              this.eventName = specialBlocks[sb].labelEvent;
+            }
           }
         }
-        if (specialBlocks[block.height]) {
+        if (specialBlocks[block.height] && specialBlocks[block.height].networks.includes(this.stateService.network || 'mainnet')) {
           this.specialEvent = true;
           this.eventName = specialBlocks[block.height].labelEventCompleted;
           setTimeout(() => {


### PR DESCRIPTION
This PR makes special blocks events configurable by network, instead of showing the blinking yellow block animation on every network.

Now, genesis and halving events show only on Bitcoin mainnet and testnet, and the taproot activation event only shows on Bitcoin mainnet.

There are currently no special blocks configured for signet, Liquid, or Liquid testnet.

This PR also adds new special block events up to the 15th halving.