### PR TITLE
Update fiat shortener and use in the fiat component

### DIFF
--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -133,7 +133,7 @@
                   </a>
                 </td>
                 <td class="table-cell-satoshis"><app-amount *ngIf="(network$ | async) !== 'liquid' && (network$ | async) !== 'liquidtestnet'; else liquidAmount" [satoshis]="transaction.value" digitsInfo="1.2-4" [noFiat]="true"></app-amount><ng-template #liquidAmount i18n="shared.confidential">Confidential</ng-template></td>
-                <td class="table-cell-fiat" *ngIf="(network$ | async) === ''" ><app-fiat [value]="transaction.value" digitsInfo="1.0-0"></app-fiat></td>
+                <td class="table-cell-fiat" *ngIf="(network$ | async) === ''" ><app-fiat [value]="transaction.value" digitsInfo="1.0-0" pipe="fiatShortener"></app-fiat></td>
                 <td class="table-cell-fees">{{ transaction.fee / transaction.vsize | feeRounding }} <span class="symbol" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></td>
               </tr>
             </tbody>

--- a/frontend/src/app/fiat/fiat.component.html
+++ b/frontend/src/app/fiat/fiat.component.html
@@ -1,14 +1,34 @@
-<span [class]="colorClass" *ngIf="blockConversion; else noblockconversion">
-  {{
-    (
-      (blockConversion.price[currency] > -1 ? blockConversion.price[currency] : null) ??
-      (blockConversion.price['USD']    > -1 ? blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency] : null) ?? 0
-    ) * value / 100000000 | fiatCurrency : digitsInfo : currency
-  }}
-</span>
-
-<ng-template #noblockconversion>
-  <span [class]="colorClass" *ngIf="(conversions$ | async) as conversions">
-    {{ (conversions[currency] > -1 ? conversions[currency] : 0) * value / 100000000 | fiatCurrency : digitsInfo : currency }}
+<ng-container *ngIf="pipe === 'fiatCurrency'">
+  <span [class]="colorClass" *ngIf="blockConversion; else noblockconversion">
+    {{
+      (
+        (blockConversion.price[currency] > -1 ? blockConversion.price[currency] : null) ??
+        (blockConversion.price['USD']    > -1 ? blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency] : null) ?? 0
+      ) * value / 100000000 | fiatCurrency : digitsInfo : currency
+    }}
   </span>
-</ng-template>
+
+  <ng-template #noblockconversion>
+    <span [class]="colorClass" *ngIf="(conversions$ | async) as conversions">
+      {{ (conversions[currency] > -1 ? conversions[currency] : 0) * value / 100000000 | fiatCurrency : digitsInfo : currency }}
+    </span>
+  </ng-template>
+</ng-container>
+
+<ng-container *ngIf="pipe === 'fiatShortener'">
+  <span [class]="colorClass" *ngIf="blockConversion; else noblockconversion">
+    {{
+      (
+        (blockConversion.price[currency] > -1 ? blockConversion.price[currency] : null) ??
+        (blockConversion.price['USD']    > -1 ? blockConversion.price['USD'] * blockConversion.exchangeRates['USD' + currency] : null) ?? 0
+      ) * value / 100000000 | fiatShortener
+    }}
+  </span>
+
+  <ng-template #noblockconversion>
+    <span [class]="colorClass" *ngIf="(conversions$ | async) as conversions">
+      {{ (conversions[currency] > -1 ? conversions[currency] : 0) * value / 100000000 | fiatShortener }}
+    </span>
+  </ng-template>
+</ng-container>
+

--- a/frontend/src/app/fiat/fiat.component.ts
+++ b/frontend/src/app/fiat/fiat.component.ts
@@ -18,6 +18,7 @@ export class FiatComponent implements OnInit, OnDestroy {
   @Input() digitsInfo = '1.2-2';
   @Input() blockConversion: Price;
   @Input() colorClass = 'green-color';
+  @Input() pipe: 'fiatShortener' | 'fiatCurrency' = 'fiatCurrency';
 
   constructor(
     private stateService: StateService,

--- a/frontend/src/app/shared/pipes/fiat-shortener.pipe.ts
+++ b/frontend/src/app/shared/pipes/fiat-shortener.pipe.ts
@@ -31,17 +31,27 @@ export class FiatShortenerPipe implements PipeTransform {
       { value: 1, symbol: '' },
       { value: 1e3, symbol: 'k' },
       { value: 1e6, symbol: 'M' },
-      { value: 1e9, symbol: 'G' },
+      { value: 1e9, symbol: 'B' },
       { value: 1e12, symbol: 'T' },
       { value: 1e15, symbol: 'P' },
       { value: 1e18, symbol: 'E' }
     ];
-    const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
     const item = lookup.slice().reverse().find((item) => num >= item.value);
 
-    let result = item ? (num / item.value).toFixed(digits).replace(rx, '$1') : '0';
-    result = new Intl.NumberFormat(this.locale, { style: 'currency', currency, maximumFractionDigits: 0 }).format(item ? num / item.value : 0);
+    const format = new Intl.NumberFormat(this.locale, { style: 'currency', currency, maximumFractionDigits: 2 });
+    const parts = format.formatToParts(item ? num / item.value : 0);
+
+    let final = '';
+    let powerTenSymbolAdded = false;
+    for (const part of parts.reverse()) {
+      if ((part.type === 'integer' || part.type === 'fraction') && powerTenSymbolAdded === false) {
+        final = part.value + item.symbol + final;
+        powerTenSymbolAdded = true;
+      } else {
+        final = part.value + final;
+      }
+    }
     
-    return result + item.symbol;
+    return final;
   }
 }

--- a/frontend/src/app/shared/pipes/fiat-shortener.pipe.ts
+++ b/frontend/src/app/shared/pipes/fiat-shortener.pipe.ts
@@ -1,4 +1,3 @@
-import { formatCurrency, getCurrencySymbol } from '@angular/common';
 import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { StateService } from '../../services/state.service';
@@ -20,11 +19,10 @@ export class FiatShortenerPipe implements PipeTransform {
   }
 
   transform(num: number, ...args: any[]): unknown {
-    const digits = args[0] || 1;
     const currency = args[1] || this.currency || 'USD';
 
-    if (num < 1000) {
-      return new Intl.NumberFormat(this.locale, { style: 'currency', currency, maximumFractionDigits: 1 }).format(num);
+    if (num < 100000) {
+      return new Intl.NumberFormat(this.locale, { style: 'currency', currency }).format(num);
     }
 
     const lookup = [
@@ -38,7 +36,7 @@ export class FiatShortenerPipe implements PipeTransform {
     ];
     const item = lookup.slice().reverse().find((item) => num >= item.value);
 
-    const format = new Intl.NumberFormat(this.locale, { style: 'currency', currency, maximumFractionDigits: 2 });
+    const format = new Intl.NumberFormat(this.locale, { style: 'currency', currency, maximumSignificantDigits: 3 });
     const parts = format.formatToParts(item ? num / item.value : 0);
 
     let final = '';

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -85,6 +85,7 @@ import { TimestampComponent } from './components/timestamp/timestamp.component';
 import { ToggleComponent } from './components/toggle/toggle.component';
 import { GeolocationComponent } from '../shared/components/geolocation/geolocation.component';
 import { TestnetAlertComponent } from './components/testnet-alert/testnet-alert.component';
+import { FiatShortenerPipe } from './pipes/fiat-shortener.pipe';
 
 @NgModule({
   declarations: [
@@ -111,6 +112,7 @@ import { TestnetAlertComponent } from './components/testnet-alert/testnet-alert.
     Decimal2HexPipe,
     FeeRoundingPipe,
     FiatCurrencyPipe,
+    FiatShortenerPipe,
     ColoredPriceDirective,
     BlockchainComponent,
     MempoolBlocksComponent,
@@ -214,6 +216,7 @@ import { TestnetAlertComponent } from './components/testnet-alert/testnet-alert.
     VbytesPipe,
     WuBytesPipe,
     FiatCurrencyPipe,
+    FiatShortenerPipe,
     CeilPipe,
     ShortenStringPipe,
     CapAddressPipe,


### PR DESCRIPTION
Also fixes https://github.com/mempool/mempool/issues/3214

# Update desc

This PR updates the fiat amount component so that it can either show the full fiat number (as of today), or use a shorten version.

This PR only updates the latest transaction component to avoid overflow on the main dashboard when the fiat number is too wide.

<img width="565" alt="image" src="https://user-images.githubusercontent.com/9780671/226160093-439d0d5f-a048-4d1e-8dbf-0737f97db581.png">


~This changes the way we display fiat amount everywhere we use the fiat component. Fiat amount are not shown in a much shorter fashion, showing only the relevant part and using power of ten symbols.~

~I think this is nice because fiat value are only provided for UI convenience and are not relevant to bitcoin itself, so they should not take too much UI space either.~

~This will also greatly reduce UI overflow related issues.~

~Maybe we want to scope this change so let me know what you think.~
