### PR TITLE
Fix % on heap limit warn

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -276,7 +276,7 @@ class Server {
 
     if (!this.warnedHeapCritical && this.maxHeapSize > warnThreshold) {
       this.warnedHeapCritical = true;
-      logger.warn(`Used ${(this.maxHeapSize / stats.heap_size_limit).toFixed(2)}% of heap limit (${formatBytes(this.maxHeapSize, byteUnits, true)} / ${formatBytes(stats.heap_size_limit, byteUnits)})!`);
+      logger.warn(`Used ${(this.maxHeapSize / stats.heap_size_limit * 100).toFixed(2)}% of heap limit (${formatBytes(this.maxHeapSize, byteUnits, true)} / ${formatBytes(stats.heap_size_limit, byteUnits)})!`);
     }
     if (this.lastHeapLogTime === null || (now - this.lastHeapLogTime) > (this.heapLogInterval * 1000)) {
       logger.debug(`Memory usage: ${formatBytes(this.maxHeapSize, byteUnits)} / ${formatBytes(stats.heap_size_limit, byteUnits)}`);


### PR DESCRIPTION
PR

`Mar 16 14:34:44 [49088] WARN: <lightning> Used 84.77% of heap limit (1.74 / 2.05 GB)!`

Previously

`Mar 16 14:35:57 [49862] WARN: <lightning> Used 0.84% of heap limit (1.72 / 2.05 GB)!`