### PR TITLE
Docker digest GHA

### DIFF
--- a/.github/workflows/get_image_digest.yml
+++ b/.github/workflows/get_image_digest.yml
@@ -1,0 +1,27 @@
+name: 'Print images digest'
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image Version'
+        required: false
+        default: 'latest'
+        type: string 
+jobs:
+  print-images-sha:
+    runs-on: 'ubuntu-latest'
+    name: Print digest for images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: digest
+
+      - name: Run script
+        working-directory: digest
+        run: |
+          sh ./docker/scripts/get_image_digest.sh $VERSION
+        env: 
+          VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/get_image_digest.yml
+++ b/.github/workflows/get_image_digest.yml
@@ -1,7 +1,6 @@
 name: 'Print images digest'
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This PR adds a new manual workflow that can be triggered to print the Docker images digests to be used on Docker compose. It should add a new option under the Actions section where someone on the team can specify a build or fetch the latest.

In the future we could use the output of this action to automate the Umbrel docker-compose updates.

Example run at https://github.com/knorrium/mempool/actions/runs/4433971473/jobs/7779539768 using the push trigger because forked repos can't run `dispatch_workflow` actions until they are merged into the main branch.

![Screenshot from 2023-03-16 11-06-36](https://user-images.githubusercontent.com/100320/225712450-b316dce0-c48d-4eda-a96b-44b7fe8ce8c6.png)
