### PR TITLE
Auto disable LN on macaroon fail

### DIFF
--- a/backend/src/api/lightning/lnd/lnd-api.ts
+++ b/backend/src/api/lightning/lnd/lnd-api.ts
@@ -4,21 +4,28 @@ import * as fs from 'fs';
 import { AbstractLightningApi } from '../lightning-api-abstract-factory';
 import { ILightningApi } from '../lightning-api.interface';
 import config from '../../../config';
+import logger from '../../../logger';
 
 class LndApi implements AbstractLightningApi {
   axiosConfig: AxiosRequestConfig = {};
 
   constructor() {
     if (config.LIGHTNING.ENABLED) {
-      this.axiosConfig = {
-        headers: {
-          'Grpc-Metadata-macaroon': fs.readFileSync(config.LND.MACAROON_PATH).toString('hex')
-        },
-        httpsAgent: new Agent({
-          ca: fs.readFileSync(config.LND.TLS_CERT_PATH)
-        }),
-        timeout: config.LND.TIMEOUT
-      };
+      try {
+        const macaroon = fs.readFileSync(config.LND.MACAROON_PATH).toString('hex');
+        this.axiosConfig = {
+          headers: {
+            'Grpc-Metadata-macaroon': macaroon
+          },
+          httpsAgent: new Agent({
+            ca: fs.readFileSync(config.LND.TLS_CERT_PATH)
+          }),
+          timeout: config.LND.TIMEOUT
+        };
+      } catch (e) {
+        logger.err(`Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING. ` + (e instanceof Error ? e.message : e));
+        config.LIGHTNING.ENABLED = false;
+      }
     }
   }
 

--- a/backend/src/api/lightning/lnd/lnd-api.ts
+++ b/backend/src/api/lightning/lnd/lnd-api.ts
@@ -24,8 +24,9 @@ class LndApi implements AbstractLightningApi {
         timeout: config.LND.TIMEOUT
       };
     } catch (e) {
-      logger.err(`Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING. ` + (e instanceof Error ? e.message : e));
       config.LIGHTNING.ENABLED = false;
+      logger.updateNetwork();
+      logger.err(`Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING. ` + (e instanceof Error ? e.message : e));
     }
   }
 

--- a/backend/src/api/lightning/lnd/lnd-api.ts
+++ b/backend/src/api/lightning/lnd/lnd-api.ts
@@ -10,22 +10,22 @@ class LndApi implements AbstractLightningApi {
   axiosConfig: AxiosRequestConfig = {};
 
   constructor() {
-    if (config.LIGHTNING.ENABLED) {
-      try {
-        const macaroon = fs.readFileSync(config.LND.MACAROON_PATH).toString('hex');
-        this.axiosConfig = {
-          headers: {
-            'Grpc-Metadata-macaroon': macaroon
-          },
-          httpsAgent: new Agent({
-            ca: fs.readFileSync(config.LND.TLS_CERT_PATH)
-          }),
-          timeout: config.LND.TIMEOUT
-        };
-      } catch (e) {
-        logger.err(`Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING. ` + (e instanceof Error ? e.message : e));
-        config.LIGHTNING.ENABLED = false;
-      }
+    if (!config.LIGHTNING.ENABLED) {
+      return;
+    }
+    try {
+      this.axiosConfig = {
+        headers: {
+          'Grpc-Metadata-macaroon': fs.readFileSync(config.LND.MACAROON_PATH).toString('hex'),
+        },
+        httpsAgent: new Agent({
+          ca: fs.readFileSync(config.LND.TLS_CERT_PATH)
+        }),
+        timeout: config.LND.TIMEOUT
+      };
+    } catch (e) {
+      logger.err(`Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING. ` + (e instanceof Error ? e.message : e));
+      config.LIGHTNING.ENABLED = false;
     }
   }
 

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -69,6 +69,10 @@ class Logger {
     this.network = this.getNetwork();
   }
 
+  public updateNetwork(): void {
+    this.network = this.getNetwork();
+  }
+
   private addprio(prio): void {
     this[prio] = (function(_this) {
       return function(msg, tag?: string) {

--- a/docker/frontend/entrypoint.sh
+++ b/docker/frontend/entrypoint.sh
@@ -10,6 +10,8 @@ cp /etc/nginx/nginx.conf /patch/nginx.conf
 sed -i "s/__MEMPOOL_FRONTEND_HTTP_PORT__/${__MEMPOOL_FRONTEND_HTTP_PORT__}/g" /patch/nginx.conf
 cat /patch/nginx.conf > /etc/nginx/nginx.conf
 
+[ "${APP_LIGHTNING_NODE_PORT}" = "9735" ] && LIGHTNING=true
+
 # Runtime overrides - read env vars defined in docker compose
 
 __TESTNET_ENABLED__=${TESTNET_ENABLED:=false}


### PR DESCRIPTION
Upon startup and LND is enabled, automatically disable LIGHTNING if no macaroon file was found.

It will look like this.

```
Mar 21 15:47:50 [60293] ERR: <lightning> Could not initialize LND Macaroon and TLS Cert. Disabling LIGHTNING. ENOENT: no such file or directory, open
Mar 21 15:47:50 [60293] NOTICE: <lightning> Starting Mempool Server... (cd2bda4)
```