### PR TITLE
Difficulty mining css updates

### DIFF
--- a/frontend/src/app/components/difficulty-mining/difficulty-mining.component.scss
+++ b/frontend/src/app/components/difficulty-mining/difficulty-mining.component.scss
@@ -156,4 +156,5 @@
 
 .symbol {
   font-size: 13px;
+  white-space: nowrap;
 }

--- a/frontend/src/app/components/difficulty/difficulty.component.scss
+++ b/frontend/src/app/components/difficulty/difficulty.component.scss
@@ -30,7 +30,7 @@
     }
   }
   .card-text {
-    font-size: 20px;
+    font-size: 18px;
     margin: auto;
     position: relative;
   }
@@ -160,6 +160,7 @@
 
 .symbol {
   font-size: 13px;
+  white-space: nowrap;
 }
 
 .epoch-progress {


### PR DESCRIPTION
Reduced font-size from 20 to 18.

<img width="566" alt="Screenshot 2023-03-21 at 21 25 10" src="https://user-images.githubusercontent.com/8561090/226605490-04a535d1-e0cc-444f-be26-2c644fdb5635.png">

Preventing word wrapping at the "Previous" as shown in some languages
<img width="554" alt="Screenshot 2023-03-21 at 21 25 03" src="https://user-images.githubusercontent.com/8561090/226605462-60dddbd2-508d-4c4c-8ab2-8708d8b9f024.png">
