### PR TITLE
Fix thread inconsistency / lazy deletion race condition bugs

### DIFF
--- a/backend/src/api/audit.ts
+++ b/backend/src/api/audit.ts
@@ -1,4 +1,5 @@
 import config from '../config';
+import logger from '../logger';
 import { TransactionExtended, MempoolBlockWithTransactions } from '../mempool.interfaces';
 
 const PROPAGATION_MARGIN = 180; // in seconds, time since a transaction is first seen after which it is assumed to have propagated to all miners
@@ -77,6 +78,8 @@ class Audit {
         } else {
           failures++;
         }
+      } else {
+        logger.warn('projected transaction missing from mempool cache');
       }
       index++;
     }
@@ -129,6 +132,8 @@ class Audit {
           }
         }
         overflowWeightRemaining -= (mempool[txid]?.weight || 0);
+      } else {
+        logger.warn('projected transaction missing from mempool cache');
       }
       index--;
     }

--- a/backend/src/api/disk-cache.ts
+++ b/backend/src/api/disk-cache.ts
@@ -43,7 +43,9 @@ class DiskCache {
       const mempool = memPool.getMempool();
       const mempoolArray: TransactionExtended[] = [];
       for (const tx in mempool) {
-        mempoolArray.push(mempool[tx]);
+        if (mempool[tx] && !mempool[tx].deleteAfter) {
+          mempoolArray.push(mempool[tx]);
+        }
       }
 
       Common.shuffleArray(mempoolArray);

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -151,7 +151,7 @@ class MempoolBlocks {
     // prepare a stripped down version of the mempool with only the minimum necessary data
     // to reduce the overhead of passing this data to the worker thread
     const strippedMempool: { [txid: string]: ThreadTransaction } = {};
-    Object.values(newMempool).forEach(entry => {
+    Object.values(newMempool).filter(tx => !tx.deleteAfter).forEach(entry => {
       strippedMempool[entry.txid] = {
         txid: entry.txid,
         fee: entry.fee,
@@ -186,7 +186,9 @@ class MempoolBlocks {
         this.txSelectionWorker?.once('error', reject);
       });
       this.txSelectionWorker.postMessage({ type: 'set', mempool: strippedMempool });
-      const { blocks, clusters } = await workerResultPromise;
+      let { blocks, clusters } = await workerResultPromise;
+      // filter out stale transactions
+      blocks = blocks.map(block => block.filter(tx => (tx.txid && tx.txid in newMempool)));
 
       // clean up thread error listener
       this.txSelectionWorker?.removeListener('error', threadErrorListener);
@@ -228,7 +230,9 @@ class MempoolBlocks {
         this.txSelectionWorker?.once('error', reject);
       });
       this.txSelectionWorker.postMessage({ type: 'update', added: addedStripped, removed });
-      const { blocks, clusters } = await workerResultPromise;
+      let { blocks, clusters } = await workerResultPromise;
+      // filter out stale transactions
+      blocks = blocks.map(block => block.filter(tx => (tx.txid && tx.txid in newMempool)));
 
       // clean up thread error listener
       this.txSelectionWorker?.removeListener('error', threadErrorListener);
@@ -243,7 +247,7 @@ class MempoolBlocks {
     // update this thread's mempool with the results
     blocks.forEach(block => {
       block.forEach(tx => {
-        if (tx.txid in mempool) {
+        if (tx.txid && tx.txid in mempool) {
           if (tx.effectiveFeePerVsize != null) {
             mempool[tx.txid].effectiveFeePerVsize = tx.effectiveFeePerVsize;
           }
@@ -253,6 +257,9 @@ class MempoolBlocks {
             const cluster = clusters[tx.cpfpRoot];
             let matched = false;
             cluster.forEach(txid => {
+              if (!txid || !mempool[txid]) {
+                return;
+              }
               if (txid === tx.txid) {
                 matched = true;
               } else {

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -38,7 +38,6 @@ class Mempool {
 
   constructor() {
     setInterval(this.updateTxPerSecond.bind(this), 1000);
-    setInterval(this.deleteExpiredTransactions.bind(this), 20000);
   }
 
   /**
@@ -256,7 +255,7 @@ class Mempool {
     }
   }
 
-  private deleteExpiredTransactions() {
+  public deleteExpiredTransactions() {
     const now = new Date().getTime();
     for (const tx in this.mempoolCache) {
       const lazyDeleteAt = this.mempoolCache[tx].deleteAfter;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -178,6 +178,7 @@ class Server {
           logger.debug(msg);
         }
       }
+      memPool.deleteExpiredTransactions();
       await blocks.$updateBlocks();
       await memPool.$updateMempool();
       indexer.$run();


### PR DESCRIPTION
Hopefully resolves #3558 and #3453

### Problem:

On startup (and on new blocks), we initialize the tx worker thread by copying across the whole mempool, and then keep the worker's copy in sync using diffs of added and removed transactions.

However, transactions are removed from the worker thread when they are *marked* for deletion, not when they are *actually* deleted.

This means any transactions in the mempool cache already marked for deletion when `makeBlockTemplates` is called will be added to the worker mempool, but not removed when they are later lazily deleted from the main thread mempool.

When such a transaction gets included in a projected block, it can cause errors in various places where we assume the transaction must exists in the main thread mempool, e.g:
```
ERR: updateBlockTemplates failed. Cannot read properties of undefined (reading 'fee')
```
or
```
TypeError: Cannot read properties of undefined (reading 'weight')
```

### Solution:
1) don't save lazily deleted transactions to the disk cache.
2) invoke the lazy deletion function from the main loop, instead of `setInterval`, to avoid race conditions.
3) strip out lazily deleted transactions before copying the mempool into the `tx-selection-worker` thread.
4) strip out any stale transactions returned by the worker thread.
5) sanity check that mempool entries actually still exist before trying to access their properties.
