### PR TITLE
Fix difficulty adjustment bugs

### DIFF
--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -29,7 +29,7 @@ export function calcDifficultyAdjustment(
   const BLOCK_SECONDS_TARGET = 600; // Bitcoin mainnet
   const TESTNET_MAX_BLOCK_SECONDS = 1200; // Bitcoin testnet
 
-  const diffSeconds = nowSeconds - DATime;
+  const diffSeconds = Math.max(0, nowSeconds - DATime);
   const blocksInEpoch = (blockHeight >= 0) ? blockHeight % EPOCH_BLOCK_LENGTH : 0;
   const progressPercent = (blockHeight >= 0) ? blocksInEpoch / EPOCH_BLOCK_LENGTH * 100 : 100;
   const remainingBlocks = EPOCH_BLOCK_LENGTH - blocksInEpoch;
@@ -37,7 +37,7 @@ export function calcDifficultyAdjustment(
   const expectedBlocks = diffSeconds / BLOCK_SECONDS_TARGET;
 
   let difficultyChange = 0;
-  let timeAvgSecs = diffSeconds / blocksInEpoch;
+  let timeAvgSecs = blocksInEpoch ? diffSeconds / blocksInEpoch : BLOCK_SECONDS_TARGET;
   // Only calculate the estimate once we have 7.2% of blocks in current epoch
   if (blocksInEpoch >= ESTIMATE_LAG_BLOCKS) {
     difficultyChange = (BLOCK_SECONDS_TARGET / timeAvgSecs - 1) * 100;

--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -24,7 +24,6 @@ export function calcDifficultyAdjustment(
   network: string,
   latestBlockTimestamp: number,
 ): DifficultyAdjustment {
-  const ESTIMATE_LAG_BLOCKS = 146; // For first 7.2% of epoch, don't estimate.
   const EPOCH_BLOCK_LENGTH = 2016; // Bitcoin mainnet
   const BLOCK_SECONDS_TARGET = 600; // Bitcoin mainnet
   const TESTNET_MAX_BLOCK_SECONDS = 1200; // Bitcoin testnet
@@ -38,17 +37,15 @@ export function calcDifficultyAdjustment(
 
   let difficultyChange = 0;
   let timeAvgSecs = blocksInEpoch ? diffSeconds / blocksInEpoch : BLOCK_SECONDS_TARGET;
-  // Only calculate the estimate once we have 7.2% of blocks in current epoch
-  if (blocksInEpoch >= ESTIMATE_LAG_BLOCKS) {
-    difficultyChange = (BLOCK_SECONDS_TARGET / timeAvgSecs - 1) * 100;
-    // Max increase is x4 (+300%)
-    if (difficultyChange > 300) {
-      difficultyChange = 300;
-    }
-    // Max decrease is /4 (-75%)
-    if (difficultyChange < -75) {
-      difficultyChange = -75;
-    }
+
+  difficultyChange = (BLOCK_SECONDS_TARGET / timeAvgSecs - 1) * 100;
+  // Max increase is x4 (+300%)
+  if (difficultyChange > 300) {
+    difficultyChange = 300;
+  }
+  // Max decrease is /4 (-75%)
+  if (difficultyChange < -75) {
+    difficultyChange = -75;
   }
 
   // Testnet difficulty is set to 1 after 20 minutes of no blocks,

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -211,6 +211,7 @@ class WebsocketHandler {
     if (!_blocks) {
       _blocks = blocks.getBlocks().slice(-config.MEMPOOL.INITIAL_BLOCKS_AMOUNT);
     }
+    const da = difficultyAdjustment.getDifficultyAdjustment();
     return {
       'mempoolInfo': memPool.getMempoolInfo(),
       'vBytesPerSecond': memPool.getVBytesPerSecond(),
@@ -220,7 +221,7 @@ class WebsocketHandler {
       'transactions': memPool.getLatestTransactions(),
       'backendInfo': backendInfo.getBackendInfo(),
       'loadingIndicators': loadingIndicators.getLoadingIndicators(),
-      'da': difficultyAdjustment.getDifficultyAdjustment(),
+      'da': da?.previousTime ? da : undefined,
       'fees': feeApi.getRecommendedFee(),
       ...this.extraInitProperties
     };
@@ -278,7 +279,9 @@ class WebsocketHandler {
         response['mempoolInfo'] = mempoolInfo;
         response['vBytesPerSecond'] = vBytesPerSecond;
         response['transactions'] = newTransactions.slice(0, 6).map((tx) => Common.stripTransaction(tx));
-        response['da'] = da;
+        if (da?.previousTime) {
+          response['da'] = da;
+        }
         response['fees'] = recommendedFees;
       }
 
@@ -505,7 +508,7 @@ class WebsocketHandler {
       const response = {
         'block': block,
         'mempoolInfo': memPool.getMempoolInfo(),
-        'da': da,
+        'da': da?.previousTime ? da : undefined,
         'fees': fees,
       };
 

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -309,9 +309,11 @@ export interface IDifficultyAdjustment {
   remainingBlocks: number;
   remainingTime: number;
   previousRetarget: number;
+  previousTime: number;
   nextRetargetHeight: number;
   timeAvg: number;
   timeOffset: number;
+  expectedBlocks: number;
 }
 
 export interface IndexedDifficultyAdjustment {


### PR DESCRIPTION
Fixes #3414 and #3569

This PR fixes various bugs related to the difficulty adjustment:
 - A divide-by-zero error at the start of each epoch.
 - The time elapsed in the current epoch could be negative in some circumstances, which produced confusing results.
 - The difficulty adjustment calculation relies on `blocks.lastDifficultyAdjustmentTime`, which is not set until `blocks.updateBlocks()` is run. Until that time, the last difficulty adjustment time is set to zero, which resulted in an extremely large elapsed epoch time and garbage difficulty adjustment data.
 
Now, we don't send difficulty adjustment updates over the websocket until `blocks.lastDifficultyAdjustmentTime` is set and useful data is available.