### PR TITLE
Reset pools sha db state

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -497,6 +497,7 @@ class DatabaseMigration {
       this.uniqueLog(logger.notice, this.blocksTruncatedMessage);
       await this.$executeQuery('DELETE FROM `pools`');
       await this.$executeQuery('ALTER TABLE pools AUTO_INCREMENT = 1');
+      await this.$executeQuery(`UPDATE state SET string = NULL WHERE name = 'pools_json_sha'`);
       this.uniqueLog(logger.notice, '`pools` table has been truncated`');
       await this.updateToSchemaVersion(56);
     }


### PR DESCRIPTION
Add missing pools sha state reset in db migration.

# Testing

- `git reset --hard v2.4.0`
- `npm install`
- `npm run build && npm run start-production`
- Wait for a few blocks to be indexed with the old mining pools.json
- `stop nodejs backend`
- `git pull`
- `npm install`
- `npm run build && npm run start-production`
- Confirm you see
```
Mar 27 19:46:55 [65589] NOTICE: <lightning> MIGRATIONS: OK. Database schema have been migrated from version 19 to 59 (latest version)
Mar 27 19:46:56 [65589] DEBUG: <lightning> pools-v2.json sha | Current: null | Github: 71cd80eae5ce6de28f227ddec28bef18cc62b62d
Mar 27 19:46:56 [65589] INFO: <lightning> [Mining] Downloading pools-v2.json for the first time from https://raw.githubusercontent.com/mempool/mining-pools/master/pools-v2.json over clearnet
```
- Wait for a few blocks to be indexed with the new mining pools-v2.json
