### PR TITLE
Add missing sanity check when fetching single price datapoint

### DIFF
--- a/backend/src/repositories/PricesRepository.ts
+++ b/backend/src/repositories/PricesRepository.ts
@@ -160,7 +160,7 @@ class PricesRepository {
 
       // Compute fiat exchange rates
       let latestPrice = rates[0] as ApiPrice;
-      if (latestPrice.USD === -1) {
+      if (!latestPrice || latestPrice.USD === -1) {
         latestPrice = priceUpdater.getEmptyPricesObj();
       }
 


### PR DESCRIPTION
Fixes

```
Mar 27 10:53:51 [25180] ERR: Cannot fetch single historical prices from the db. Reason Cannot read properties of undefined (reading 'USD')
```