### PR TITLE
Use window.location object instead of angular router for default graph window preference setting

### DIFF
--- a/frontend/src/app/services/storage.service.ts
+++ b/frontend/src/app/services/storage.service.ts
@@ -12,20 +12,22 @@ export class StorageService {
 
   setDefaultValueIfNeeded(key: string, defaultValue: string) {
     const graphWindowPreference: string = this.getValue(key);
+    const fragment = window.location.hash.replace('#', '');
+
     if (graphWindowPreference === null) { // First visit to mempool.space
-      if (this.router.url.includes('graphs') && key === 'graphWindowPreference' ||
-        this.router.url.includes('pools') && key === 'miningWindowPreference'
+      if (window.location.pathname.includes('graphs') && key === 'graphWindowPreference' ||
+        window.location.pathname.includes('pools') && key === 'miningWindowPreference'
       ) {
-        this.setValue(key, this.route.snapshot.fragment ? this.route.snapshot.fragment : defaultValue);
+        this.setValue(key, fragment ? fragment : defaultValue);
       } else {
         this.setValue(key, defaultValue);
       }
-    } else if (this.router.url.includes('graphs') && key === 'graphWindowPreference' ||
-      this.router.url.includes('pools') && key === 'miningWindowPreference'
+    } else if (window.location.pathname.includes('graphs') && key === 'graphWindowPreference' ||
+      window.location.pathname.includes('pools') && key === 'miningWindowPreference'
     ) {
       // Visit a different graphs#fragment from last visit
-      if (this.route.snapshot.fragment !== null && graphWindowPreference !== this.route.snapshot.fragment) {
-        this.setValue(key, this.route.snapshot.fragment);
+      if (fragment !== null && graphWindowPreference !== fragment) {
+        this.setValue(key, fragment);
       }
     }
   }


### PR DESCRIPTION
Angular router does not seem to be ready when we run this code (_router.url is `/` instead of `/graphs/mempool#3y`_), so we can just use window.location object directly for setting default window preference timespan in local storage.

Fixes https://github.com/mempool/mempool/issues/3605