### PR TITLE
Fix infinite scroll transaction list component

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -1,3 +1,5 @@
+<div infiniteScroll [alwaysCallback]="true" [infiniteScrollDistance]="2" [infiniteScrollUpDistance]="1.5" [infiniteScrollThrottle]="50" (scrolled)="onScroll()">
+
 <ng-container *ngFor="let tx of transactions; let i = index; trackBy: trackByFn">
   <div *ngIf="!transactionPage" class="header-bg box tx-page-container">
     <a class="tx-link" [routerLink]="['/tx/' | relativeUrl, tx.txid]">
@@ -11,7 +13,7 @@
     </div>
   </div>
 
-  <div class="header-bg box" infiniteScroll [alwaysCallback]="true" [infiniteScrollDistance]="2" [infiniteScrollUpDistance]="1.5" [infiniteScrollThrottle]="50" (scrolled)="onScroll()" [attr.data-cy]="'tx-' + i">
+  <div class="header-bg box">
 
     <div *ngIf="errorUnblinded" class="error-unblinded">{{ errorUnblinded }}</div>
     <div class="row">
@@ -320,6 +322,8 @@
   <br />
 
 </ng-container>
+
+</div>
 
 <ng-template #assetBox let-item>
   {{ item.value / pow(10, assetsMinimal[item.asset][3]) | number: '1.' + assetsMinimal[item.asset][3] + '-' + assetsMinimal[item.asset][3] }} {{ assetsMinimal[item.asset][1] }}

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -182,14 +182,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   }
 
   onScroll(): void {
-    const scrollHeight = document.body.scrollHeight;
-    const scrollTop = document.documentElement.scrollTop;
-    if (scrollHeight > 0) {
-      const percentageScrolled = scrollTop * 100 / scrollHeight;
-      if (percentageScrolled > 50) {
-        this.loadMore.emit();
-      }
-    }
+    this.loadMore.emit();
   }
 
   haveBlindedOutputValues(tx: Transaction): boolean {


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/3556

I think it was never actually working (and we got around related issues with some hacks) because the infinite scroll [was added inside the transaction list loop](https://github.com/mempool/mempool/commit/90c05ccb51e3b58296e410b234593c9be9b2c43e#diff-be42597e4ce09d3849630e9ce81069487e1b6f6e4fd4a52e15788bd4d60d8bce), basically triggering one event per transaction.