### PR TITLE
Add note about enterprise support to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Mempool can be conveniently installed on the following full-node distros:
 
 Mempool can be installed in other ways too, but we only recommend doing so if you're a developer, have experience managing servers, or otherwise know what you're doing.
 
+**We only provide support for advanced installation methods to <a href="https://mempool.space/enterprise">Enterprise sponsors</a>.**
+
 - See the [`docker/`](./docker/) directory for instructions on deploying Mempool with Docker.
 - See the [`backend/`](./backend/) and [`frontend/`](./frontend/) directories for manual install instructions oriented for developers.
 - See the [`production/`](./production/) directory for guidance on setting up a more serious Mempool instance designed for high performance at scale.

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,9 @@
 
 These instructions are mostly intended for developers. 
 
-If you choose to use these instructions for a production setup, be aware that you will still probably need to do additional configuration for your specific OS, environment, use-case, etc. We do our best here to provide a good starting point, but only proceed if you know what you're doing. Mempool does not provide support for custom setups.
+If you choose to use these instructions for a production setup, be aware that you will still probably need to do additional configuration for your specific OS, environment, use-case, etc. We do our best here to provide a good starting point, but only proceed if you know what you're doing.
+
+**We only provide support for this installation method to <a href="https://mempool.space/enterprise">Enterprise sponsors</a>.**
 
 See other ways to set up Mempool on [the main README](/../../#installation-methods).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,8 @@ If you are looking to use these Docker images to deploy your own instance of Mem
 
 See a video guide of this installation method by k3tan [on BitcoinTV.com](https://bitcointv.com/w/8fpAx6rf5CQ16mMhospwjg).
 
+**We only provide support for this installation method to <a href="https://mempool.space/enterprise">Enterprise sponsors</a>.**
+
 Jump to a section in this doc:
 - [Configure with Bitcoin Core Only](#configure-with-bitcoin-core-only)
 - [Configure with Bitcoin Core + Electrum Server](#configure-with-bitcoin-core--electrum-server)

--- a/production/README.md
+++ b/production/README.md
@@ -2,7 +2,7 @@
 
 These instructions are for setting up a serious production Mempool website for Bitcoin (mainnet, testnet, signet), Liquid (mainnet, testnet), and Bisq.
 
-Again, this setup is no joke—home users should use [one of the other installation methods](../#installation-methods).
+This setup is no joke—home users should use [one of the other installation methods](../#installation-methods). We only provide support for this installation method to <a href="https://mempool.space/enterprise">Enterprise sponsors</a>.
 
 ### Server Hardware
 


### PR DESCRIPTION
Added notes on the main README as well as Docker, manual, and production install READMEs.

All the notes go something like this:

> **We only provide support for advanced installation methods to <a href="https://mempool.space/enterprise">Enterprise sponsors</a>.**