### PR TITLE
Fix new block mempool eviction race condition

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -529,13 +529,14 @@ class Blocks {
     return await BlocksRepository.$validateChain();
   }
 
-  public async $updateBlocks() {
+  public async $updateBlocks(): Promise<number> {
     // warn if this run stalls the main loop for more than 2 minutes
     const timer = this.startTimer();
 
     diskCache.lock();
 
     let fastForwarded = false;
+    let handledBlocks = 0;
     const blockHeightTip = await bitcoinApi.$getBlockHeightTip();
     this.updateTimerProgress(timer, 'got block height tip');
 
@@ -697,11 +698,15 @@ class Blocks {
       this.updateTimerProgress(timer, `waiting for async callbacks to complete for ${this.currentBlockHeight}`);
       await Promise.all(callbackPromises);
       this.updateTimerProgress(timer, `async callbacks completed for ${this.currentBlockHeight}`);
+
+      handledBlocks++;
     }
 
     diskCache.unlock();
 
     this.clearTimer(timer);
+
+    return handledBlocks;
   }
 
   private startTimer() {

--- a/backend/src/api/disk-cache.ts
+++ b/backend/src/api/disk-cache.ts
@@ -52,7 +52,7 @@ class DiskCache {
       const mempool = memPool.getMempool();
       const mempoolArray: TransactionExtended[] = [];
       for (const tx in mempool) {
-        if (mempool[tx] && !mempool[tx].deleteAfter) {
+        if (mempool[tx]) {
           mempoolArray.push(mempool[tx]);
         }
       }

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -178,7 +178,7 @@ class MempoolBlocks {
     // prepare a stripped down version of the mempool with only the minimum necessary data
     // to reduce the overhead of passing this data to the worker thread
     const strippedMempool: { [txid: string]: ThreadTransaction } = {};
-    Object.values(newMempool).filter(tx => !tx.deleteAfter).forEach(entry => {
+    Object.values(newMempool).forEach(entry => {
       strippedMempool[entry.txid] = {
         txid: entry.txid,
         fee: entry.fee,

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -163,7 +163,7 @@ class RbfCache {
   }
 
   // flag a transaction as removed from the mempool
-  public evict(txid, fast: boolean = false): void {
+  public evict(txid: string, fast: boolean = false): void {
     if (this.txs.has(txid) && (fast || !this.expiring.has(txid))) {
       this.expiring.set(txid, fast ? Date.now() + (1000 * 60 * 10) : Date.now() + (1000 * 86400)); // 24 hours
     }

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -301,6 +301,9 @@ class WebsocketHandler {
       rbfReplacements = rbfCache.getRbfTrees(false);
       fullRbfReplacements = rbfCache.getRbfTrees(true);
     }
+    for (const deletedTx of deletedTransactions) {
+      rbfCache.evict(deletedTx.txid);
+    }
     const recommendedFees = feeApi.getRecommendedFee();
 
     this.wss.clients.forEach(async (client) => {

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -80,7 +80,6 @@ export interface TransactionExtended extends IEsploraApi.Transaction {
   descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
   cpfpChecked?: boolean;
-  deleteAfter?: number;
   position?: {
     block: number,
     vsize: number,


### PR DESCRIPTION
This PR attempts to fix #3650, and another more general case that can cause incorrect templates and 0% audit scores due prematurely marking transactions as deleted.

---

### Problem

I believe the underlying cause is a new block arriving after we started updating blocks, but before we update the mempool in the main update loop:
https://github.com/mempool/mempool/blob/d18ebdfc5902b47a0afd869c59e3c8d92d3c90fd/backend/src/index.ts#L183-L184

When this happens, `mempool.$updateMempool` gets the new state of the mempool *after* transactions have been removed for inclusion in the new block, marks those transactions as deleted, and applies the change to the projected mempool templates.

On the next run of the main update loop, `blocks.$updateBlocks` discovers the new block and runs the audit against the post-block mempool state.

This is essentially the same bug as #400, which was addressed by adding a 30 second delay before deleting transactions from the mempool cache. Unfortunately that solution doesn't play nicely with mempool projections and audits, which need more immediate consistency.

---

### Solution

Instead of mitigating the effects of the race condition, this PR aims to eliminate it by changing the sequence of the main update loop as follows:

https://github.com/mempool/mempool/blob/3a6205ad00c515b6ca584f35d67e0bb7295e91ab/backend/src/index.ts#L183-L191

1. Fetch the current state of the mempool.
2. Check & process new blocks.
3. If there were no new blocks, update the mempool using that state.
   - since we found no new blocks after fetching the mempool, we know that this mempool update doesn't remove any transactions due to block inclusion.
4. Otherwise skip the mempool update and run the loop again asap.
   - the new blocks could have arrived between steps 1 and 2, so skipping the mempool update here ensures don't try to apply a stale mempool state.

The PR also removes the now-obsolete lazy deletion code.