### PR TITLE
Improve unit selection for duration formatting

### DIFF
--- a/frontend/src/app/components/difficulty/difficulty.component.html
+++ b/frontend/src/app/components/difficulty/difficulty.component.html
@@ -37,7 +37,7 @@
         <div class="difficulty-stats">
           <div class="item">
             <div class="card-text">
-              ~<app-time [time]="epochData.timeAvg / 1000" [forceFloorOnTimeIntervals]="['minute']" [fractionDigits]="1"></app-time>
+              ~<app-time [time]="epochData.timeAvg / 1000" [fractionDigits]="1"></app-time>
             </div>
             <div class="symbol" i18n="difficulty-box.average-block-time">Average block time</div>
           </div>

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -26,7 +26,7 @@
                 <app-time kind="until" [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time>
               </ng-template>
               <ng-template #timeDiffMainnet>
-                <app-time kind="until" [time]="da.timeAvg * (i + 1) + now + da.timeOffset" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time>
+                <app-time kind="until" [time]="da.timeAvg * (i + 1) + now + da.timeOffset" [fastRender]="false" [fixedRender]="true"></app-time>
               </ng-template>
             </div>
             <ng-template #mergedBlock>

--- a/frontend/src/app/components/time/time.component.ts
+++ b/frontend/src/app/components/time/time.component.ts
@@ -18,7 +18,6 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
   @Input() fastRender = false;
   @Input() fixedRender = false;
   @Input() relative = false;
-  @Input() forceFloorOnTimeIntervals: string[];
   @Input() fractionDigits: number = 0;
 
   constructor(
@@ -84,21 +83,17 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
 
     let counter: number;
     for (const i in this.intervals) {
-      if (this.kind !== 'until' || this.forceFloorOnTimeIntervals && this.forceFloorOnTimeIntervals.indexOf(i) > -1) {
-        counter = Math.floor(seconds / this.intervals[i]);
-      } else {
-        counter = Math.round(seconds / this.intervals[i]);
-      }
-      let rounded = counter;
-      if (this.fractionDigits) {
-        const roundFactor = Math.pow(10,this.fractionDigits);
-        rounded = Math.round((seconds / this.intervals[i]) * roundFactor) / roundFactor;
-      }
-      const dateStrings = dates(rounded);
+      counter = Math.floor(seconds / this.intervals[i]);
       if (counter > 0) {
+        let rounded = Math.round(seconds / this.intervals[i]);
+        if (this.fractionDigits) {
+          const roundFactor = Math.pow(10,this.fractionDigits);
+          rounded = Math.round((seconds / this.intervals[i]) * roundFactor) / roundFactor;
+        }
+        const dateStrings = dates(rounded);
         switch (this.kind) {
           case 'since':
-            if (counter === 1) {
+            if (rounded === 1) {
               switch (i) { // singular (1 day)
                 case 'year': return $localize`:@@time-since:${dateStrings.i18nYear}:DATE: ago`; break;
                 case 'month': return $localize`:@@time-since:${dateStrings.i18nMonth}:DATE: ago`; break;
@@ -121,7 +116,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             }
             break;
           case 'until':
-            if (counter === 1) {
+            if (rounded === 1) {
               switch (i) { // singular (In ~1 day)
                 case 'year': return $localize`:@@time-until:In ~${dateStrings.i18nYear}:DATE:`; break;
                 case 'month': return $localize`:@@time-until:In ~${dateStrings.i18nMonth}:DATE:`; break;
@@ -144,7 +139,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             }
             break;
           case 'span':
-            if (counter === 1) {
+            if (rounded === 1) {
               switch (i) { // singular (1 day)
                 case 'year': return $localize`:@@time-span:After ${dateStrings.i18nYear}:DATE:`; break;
                 case 'month': return $localize`:@@time-span:After ${dateStrings.i18nMonth}:DATE:`; break;
@@ -167,7 +162,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             }
             break;
           default:
-            if (counter === 1) {
+            if (rounded === 1) {
               switch (i) { // singular (1 day)
                 case 'year': return dateStrings.i18nYear; break;
                 case 'month': return dateStrings.i18nMonth; break;

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -109,10 +109,10 @@
                       </ng-template>
                       <ng-template #belowBlockLimit>
                         <ng-template [ngIf]="network === 'liquid' || network === 'liquidtestnet'" [ngIfElse]="timeEstimateDefault">
-                          <app-time kind="until" [time]="(60 * 1000 * this.mempoolPosition.block) + now" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time>
+                          <app-time kind="until" [time]="(60 * 1000 * this.mempoolPosition.block) + now" [fastRender]="false" [fixedRender]="true"></app-time>
                         </ng-template>
                         <ng-template #timeEstimateDefault>
-                          <app-time kind="until" *ngIf="(timeAvg$ | async) as timeAvg;" [time]="(timeAvg * this.mempoolPosition.block) + now + timeAvg" [fastRender]="false" [fixedRender]="true" [forceFloorOnTimeIntervals]="['hour']"></app-time>
+                          <app-time kind="until" *ngIf="(timeAvg$ | async) as timeAvg;" [time]="(timeAvg * this.mempoolPosition.block) + now + timeAvg" [fastRender]="false" [fixedRender]="true"></app-time>
                         </ng-template>
                       </ng-template>
                     </ng-template>


### PR DESCRIPTION
This PR brings `<app-time kind="until">` behavior in line with other time formatting modes.

Before, the `until` mode formatted durations using the largest unit that rounded to a positive integer, unless explicitly overridden.

This produced bad results in the difficulty adjustment widgets in particular, e.g. displaying an expected time until the next adjustment of 15 days as "In ~1 month"

Now, all durations are formatted using the largest unit such that `floor(time-in-units) >= 1`, which produces more natural results.

| Seconds | Duration | Formatted result before | Formatted result after |
|-|-|-|-|
| 86400 | 1 day | In ~1 day | In ~1 day |
| 172800 | 2 days | In ~2 days | In ~2 days |
| 259200 | 3 days | In ~3 days | In ~3 days |
| 345600 | 4 days | In ~1 week | In ~4 days |
| 432000 | 5 days | In ~1 week| In ~5 days |
| 518400 | 6 days | In ~1 week | In ~6 days |
| 604800 | 7 days | In ~1 week | In ~1 week |
| 691200 | 8 days | In ~1 week | In ~1 week |
| 1123200 | 13 days | In ~2 weeks | In ~2 weeks |
| 1209600 | 14 days | In ~2 weeks | In ~2 weeks |
| 1296000 | 15 days | In ~1 month | In ~2 weeks |
| 2505600 | 29 days | In ~1 month | In ~4 weeks |
| 2592000 | 30 days | In ~1 month | In ~1 month |