### PR TITLE
More precise durations in difficulty components

### DIFF
--- a/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.component.html
+++ b/frontend/src/app/components/difficulty-adjustments-table/difficulty-adjustments-table.component.html
@@ -14,7 +14,7 @@
           <a [routerLink]="['/block' | relativeUrl, diffChange.height]">{{ diffChange.height }}</a>
         </td>
         <td class="date text-left">
-          <app-time kind="since" [time]="diffChange.timestamp" [fastRender]="true"></app-time>
+          <app-time kind="since" [time]="diffChange.timestamp" [fastRender]="true" [precision]="1"></app-time>
         </td>
         <td class="text-right">{{ diffChange.difficultyShorten }}</td>
         <td class="text-right" [style]="diffChange.change >= 0 ? 'color: #42B747' : 'color: #B74242'">

--- a/frontend/src/app/components/difficulty-mining/difficulty-mining.component.html
+++ b/frontend/src/app/components/difficulty-mining/difficulty-mining.component.html
@@ -10,7 +10,7 @@
             <ng-template #blocksPlural let-i i18n="shared.blocks">{{ i }} <span class="shared-block">blocks</span></ng-template>
             <ng-template #blocksSingular let-i i18n="shared.block">{{ i }} <span class="shared-block">block</span></ng-template>
           </div>
-          <div class="symbol"><app-time kind="until" [time]="epochData.estimatedRetargetDate" [fastRender]="true"></app-time></div>
+          <div class="symbol"><app-time kind="until" [time]="epochData.estimatedRetargetDate" [fastRender]="true" [precision]="1"></app-time></div>
         </div>
         <div class="item">
           <h5 class="card-title" i18n="difficulty-box.estimate">Estimate</h5>
@@ -54,7 +54,7 @@
             <ng-template #blocksPlural let-i i18n="shared.blocks">{{ i }} <span class="shared-block">blocks</span></ng-template>
             <ng-template #blocksSingular let-i i18n="shared.block">{{ i }} <span class="shared-block">block</span></ng-template>
           </div>
-          <div class="symbol"><app-time kind="until" [time]="epochData.timeUntilHalving" [fastRender]="true"></app-time></div>
+          <div class="symbol"><app-time kind="until" [time]="epochData.timeUntilHalving" [fastRender]="true" [precision]="1"></app-time></div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/difficulty/difficulty.component.html
+++ b/frontend/src/app/components/difficulty/difficulty.component.html
@@ -68,7 +68,7 @@
             </div>
           </div>
           <div class="item">
-            <div class="card-text"><app-time kind="until" [time]="epochData.estimatedRetargetDate" [fastRender]="true"></app-time></div>
+            <div class="card-text"><app-time kind="until" [time]="epochData.estimatedRetargetDate" [fastRender]="true" [precision]="1"></app-time></div>
             <div class="symbol">
               {{ epochData.retargetDateString }}
             </div>

--- a/frontend/src/app/components/time/time.component.ts
+++ b/frontend/src/app/components/time/time.component.ts
@@ -10,6 +10,7 @@ import { dates } from '../../shared/i18n/dates';
 export class TimeComponent implements OnInit, OnChanges, OnDestroy {
   interval: number;
   text: string;
+  units: string[] = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second'];
   intervals = {};
 
   @Input() time: number;
@@ -18,6 +19,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
   @Input() fastRender = false;
   @Input() fixedRender = false;
   @Input() relative = false;
+  @Input() precision: number = 0;
   @Input() fractionDigits: number = 0;
 
   constructor(
@@ -82,19 +84,20 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     let counter: number;
-    for (const i in this.intervals) {
-      counter = Math.floor(seconds / this.intervals[i]);
+    for (const [index, unit] of this.units.entries()) {
+      const precisionUnit = this.units[Math.min(this.units.length - 1), index + this.precision];
+      counter = Math.floor(seconds / this.intervals[unit]);
       if (counter > 0) {
-        let rounded = Math.round(seconds / this.intervals[i]);
+        let rounded = Math.round(seconds / this.intervals[precisionUnit]);
         if (this.fractionDigits) {
           const roundFactor = Math.pow(10,this.fractionDigits);
-          rounded = Math.round((seconds / this.intervals[i]) * roundFactor) / roundFactor;
+          rounded = Math.round((seconds / this.intervals[precisionUnit]) * roundFactor) / roundFactor;
         }
         const dateStrings = dates(rounded);
         switch (this.kind) {
           case 'since':
             if (rounded === 1) {
-              switch (i) { // singular (1 day)
+              switch (precisionUnit) { // singular (1 day)
                 case 'year': return $localize`:@@time-since:${dateStrings.i18nYear}:DATE: ago`; break;
                 case 'month': return $localize`:@@time-since:${dateStrings.i18nMonth}:DATE: ago`; break;
                 case 'week': return $localize`:@@time-since:${dateStrings.i18nWeek}:DATE: ago`; break;
@@ -104,7 +107,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
                 case 'second': return $localize`:@@time-since:${dateStrings.i18nSecond}:DATE: ago`; break;
               }
             } else {
-              switch (i) { // plural (2 days)
+              switch (precisionUnit) { // plural (2 days)
                 case 'year': return $localize`:@@time-since:${dateStrings.i18nYears}:DATE: ago`; break;
                 case 'month': return $localize`:@@time-since:${dateStrings.i18nMonths}:DATE: ago`; break;
                 case 'week': return $localize`:@@time-since:${dateStrings.i18nWeeks}:DATE: ago`; break;
@@ -117,7 +120,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             break;
           case 'until':
             if (rounded === 1) {
-              switch (i) { // singular (In ~1 day)
+              switch (precisionUnit) { // singular (In ~1 day)
                 case 'year': return $localize`:@@time-until:In ~${dateStrings.i18nYear}:DATE:`; break;
                 case 'month': return $localize`:@@time-until:In ~${dateStrings.i18nMonth}:DATE:`; break;
                 case 'week': return $localize`:@@time-until:In ~${dateStrings.i18nWeek}:DATE:`; break;
@@ -127,7 +130,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
                 case 'second': return $localize`:@@time-until:In ~${dateStrings.i18nSecond}:DATE:`;
               }
             } else {
-              switch (i) { // plural (In ~2 days)
+              switch (precisionUnit) { // plural (In ~2 days)
                 case 'year': return $localize`:@@time-until:In ~${dateStrings.i18nYears}:DATE:`; break;
                 case 'month': return $localize`:@@time-until:In ~${dateStrings.i18nMonths}:DATE:`; break;
                 case 'week': return $localize`:@@time-until:In ~${dateStrings.i18nWeeks}:DATE:`; break;
@@ -140,7 +143,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             break;
           case 'span':
             if (rounded === 1) {
-              switch (i) { // singular (1 day)
+              switch (precisionUnit) { // singular (1 day)
                 case 'year': return $localize`:@@time-span:After ${dateStrings.i18nYear}:DATE:`; break;
                 case 'month': return $localize`:@@time-span:After ${dateStrings.i18nMonth}:DATE:`; break;
                 case 'week': return $localize`:@@time-span:After ${dateStrings.i18nWeek}:DATE:`; break;
@@ -150,7 +153,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
                 case 'second': return $localize`:@@time-span:After ${dateStrings.i18nSecond}:DATE:`; break;
               }
             } else {
-              switch (i) { // plural (2 days)
+              switch (precisionUnit) { // plural (2 days)
                 case 'year': return $localize`:@@time-span:After ${dateStrings.i18nYears}:DATE:`; break;
                 case 'month': return $localize`:@@time-span:After ${dateStrings.i18nMonths}:DATE:`; break;
                 case 'week': return $localize`:@@time-span:After ${dateStrings.i18nWeeks}:DATE:`; break;
@@ -163,7 +166,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
             break;
           default:
             if (rounded === 1) {
-              switch (i) { // singular (1 day)
+              switch (precisionUnit) { // singular (1 day)
                 case 'year': return dateStrings.i18nYear; break;
                 case 'month': return dateStrings.i18nMonth; break;
                 case 'week': return dateStrings.i18nWeek; break;
@@ -173,7 +176,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
                 case 'second': return dateStrings.i18nSecond; break;
               }
             } else {
-              switch (i) { // plural (2 days)
+              switch (precisionUnit) { // plural (2 days)
                 case 'year': return dateStrings.i18nYears; break;
                 case 'month': return dateStrings.i18nMonths; break;
                 case 'week': return dateStrings.i18nWeeks; break;


### PR DESCRIPTION
_(builds on #3676)_

In some places I think it would be more informative to display times/durations with higher precision.

This PR increases the displayed precision of:

The estimated retarget time in the difficulty adjustment widget:
| Before | After |
|-|-|
| <img width="579" alt="Screenshot 2023-04-22 at 6 23 10 AM" src="https://user-images.githubusercontent.com/83316221/233737103-43f889f6-b996-42c8-90a2-caa784623aae.png"> | <img width="579" alt="Screenshot 2023-04-22 at 6 23 05 AM" src="https://user-images.githubusercontent.com/83316221/233737133-4b4332e8-2094-4a5b-b861-f189f2d9640c.png"> |

Estimated retarget and halving times in the mining difficulty adjustment widget:
| Before | After |
|-|-|
| <img width="579" alt="Screenshot 2023-04-22 at 6 23 25 AM" src="https://user-images.githubusercontent.com/83316221/233737205-e411fa28-24c5-4411-bc4a-ac14a6b8289b.png"> | <img width="579" alt="Screenshot 2023-04-22 at 6 23 21 AM" src="https://user-images.githubusercontent.com/83316221/233737218-dc719427-c783-46a5-9cd7-71a171d83aa2.png"> |

The difficulty adjustments table:
| Before | After |
|-|-|
| <img width="571" alt="Screenshot 2023-04-22 at 6 24 15 AM" src="https://user-images.githubusercontent.com/83316221/233737308-e228ea53-16a3-43ae-a922-bccce62ef6c5.png"> | <img width="571" alt="Screenshot 2023-04-22 at 6 23 50 AM" src="https://user-images.githubusercontent.com/83316221/233737332-fe23890d-2ea9-4081-8acb-998c3b95d27e.png"> |

