### PR TITLE
delay writing disk cache until block handler completes

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -533,6 +533,8 @@ class Blocks {
     // warn if this run stalls the main loop for more than 2 minutes
     const timer = this.startTimer();
 
+    diskCache.lock();
+
     let fastForwarded = false;
     const blockHeightTip = await bitcoinApi.$getBlockHeightTip();
     this.updateTimerProgress(timer, 'got block height tip');
@@ -696,6 +698,8 @@ class Blocks {
       await Promise.all(callbackPromises);
       this.updateTimerProgress(timer, `async callbacks completed for ${this.currentBlockHeight}`);
     }
+
+    diskCache.unlock();
 
     this.clearTimer(timer);
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -205,6 +205,8 @@ class Server {
         logger.debug(`AxiosError: ${e?.message}`);
       }
       setTimeout(this.runMainUpdateLoop.bind(this), 1000 * this.currentBackendRetryInterval);
+    } finally {
+      diskCache.unlock();
     }
   }
 


### PR DESCRIPTION
This PR adds a semaphore-style lock to the disk cache task to prevent it from writing cache files while new blocks are being processed.

If a new block arrives while the `$saveCacheToDisk(true)` is running, it will pause and wait for the block handler to complete before starting the next `writeFile` operation.
