### PR TITLE
Disconnect websocket clients on error

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -47,7 +47,10 @@ class WebsocketHandler {
 
     this.wss.on('connection', (client: WebSocket) => {
       this.numConnected++;
-      client.on('error', logger.info);
+      client.on('error', (e) => {
+        logger.info('websocket client error: ' + (e instanceof Error ? e.message : e));
+        client.close();
+      });
       client.on('close', () => {
         this.numDisconnected++;
       });
@@ -169,6 +172,7 @@ class WebsocketHandler {
           }
         } catch (e) {
           logger.debug('Error parsing websocket message: ' + (e instanceof Error ? e.message : e));
+          client.close();
         }
       });
     });


### PR DESCRIPTION
Forcibly disconnect websocket clients if the connection throws an error, or we receive a message which can't be parsed as JSON.

also see #3706 