### PR TITLE
skip unnecessary makeBlockTemplates call

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -178,8 +178,8 @@ class Server {
           logger.debug(msg);
         }
       }
-      memPool.deleteExpiredTransactions();
       await blocks.$updateBlocks();
+      memPool.deleteExpiredTransactions();
       await memPool.$updateMempool();
       indexer.$run();
 


### PR DESCRIPTION
This PR significantly speeds up `handleNewBlock` by skipping the expensive pre-audit run of `makeBlockTemplates` when using the same GBT algorithm for both mempool updates and block audits.

This is possible because in that case the projected templates from the last run should still  be valid (since our internal copy of the mempool shouldn't have changed in that time).

---

The PR then replaces the later call to `updateBlockTemplates` in that function with `makeBlockTemplates`, so that the thread worker state is still reset every block.

This might not be strictly necessary, and adds a small amount of extra thread I/O, but it's a nice sanity check in case the thread worker ever drifts out of sync for any reason.