### PR TITLE
Mononaut/optimize gbt data

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -282,7 +282,7 @@ class WebsocketHandler {
     this.printLogs();
 
     if (config.MEMPOOL.ADVANCED_GBT_MEMPOOL) {
-      await mempoolBlocks.$updateBlockTemplates(newMempool, newTransactions, deletedTransactions.map(tx => tx.txid), true);
+      await mempoolBlocks.$updateBlockTemplates(newMempool, newTransactions, deletedTransactions, true);
     } else {
       mempoolBlocks.updateMempoolBlocks(newMempool, true);
     }

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -84,17 +84,18 @@ export interface TransactionExtended extends IEsploraApi.Transaction {
     block: number,
     vsize: number,
   };
+  uid?: number;
 }
 
 export interface AuditTransaction {
-  txid: string;
+  uid: number;
   fee: number;
   weight: number;
   feePerVsize: number;
   effectiveFeePerVsize: number;
-  vin: string[];
+  inputs: number[];
   relativesSet: boolean;
-  ancestorMap: Map<string, AuditTransaction>;
+  ancestorMap: Map<number, AuditTransaction>;
   children: Set<AuditTransaction>;
   ancestorFee: number;
   ancestorWeight: number;
@@ -104,13 +105,24 @@ export interface AuditTransaction {
   modifiedNode: HeapNode<AuditTransaction>;
 }
 
+export interface CompactThreadTransaction {
+  uid: number;
+  fee: number;
+  weight: number;
+  feePerVsize: number;
+  effectiveFeePerVsize?: number;
+  inputs: number[];
+  cpfpRoot?: string;
+  cpfpChecked?: boolean;
+}
+
 export interface ThreadTransaction {
   txid: string;
   fee: number;
   weight: number;
   feePerVsize: number;
   effectiveFeePerVsize?: number;
-  vin: string[];
+  inputs: number[];
   cpfpRoot?: string;
   cpfpChecked?: boolean;
 }


### PR DESCRIPTION
_(builds on PR #3709)_

This PR optimizes some of the data structures used in the advanced GBT implementation with the aim of speeding up mempool updates.

The main change is switching from txid strings to short numerical ids to identify transactions in the GBT thread worker.

ids are assigned sequentially, and tracked by a Map in the `MempoolBlocks` module. Some helper functions convert between numeric ids and txids when communicating with the worker thread.

This significantly reduces the amount of data copied back and forth from the thread worker, since now we only need a single javascript number to identify each transaction instead of a 128-byte txid string, and the majority of the GBT data consists of transaction identifiers.

In order to work with numerical ids, a few structures in the GBT implementation have been converted from simple Objects to ES6 Maps. Setting and accessing Map elements by numeric key seems to be more efficient than the equivalent operations with txid-keyed Objects, and the GBT algorithm runs noticeably faster.

The whole concept is a bit gross, but it does speed up mempool updates by 20-40% on my machine in current conditions, and significantly reduces the time spent on blocking cross-thread communication.