### PR TITLE
Fix transaction ETA calculation

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -59,7 +59,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   fetchRbfHistory$ = new Subject<string>();
   fetchCachedTx$ = new Subject<string>();
   isCached: boolean = false;
-  now = new Date().getTime();
+  now = Date.now();
   timeAvg$: Observable<number>;
   liquidUnblinding = new LiquidUnblinding();
   inputIndex: number;
@@ -412,6 +412,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       if (!this.tx) {
         return;
       }
+
+      this.now = Date.now();
 
       const txFeePerVSize =
         this.tx.effectiveFeePerVsize || this.tx.fee / (this.tx.weight / 4);

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -416,13 +416,15 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       const txFeePerVSize =
         this.tx.effectiveFeePerVsize || this.tx.fee / (this.tx.weight / 4);
 
+      let found = false;
       for (const block of mempoolBlocks) {
-        for (let i = 0; i < block.feeRange.length - 1; i++) {
+        for (let i = 0; i < block.feeRange.length - 1 && !found; i++) {
           if (
             txFeePerVSize <= block.feeRange[i + 1] &&
             txFeePerVSize >= block.feeRange[i]
           ) {
             this.txInBlockIndex = mempoolBlocks.indexOf(block);
+            found = true;
           }
         }
       }


### PR DESCRIPTION
_resolves #3695 and resolves #2871_

The current ETA calculation chooses the *last* projected block in which the fee span includes the transaction's effective rate.

Because of the issues discussed in #3566, when the mempool is extremely large that means it almost always chooses the final "overflow" mempool block (since the very high number of transactions ensures the fee span is very wide):

<img width="189" alt="Screenshot 2023-05-03 at 10 08 13 AM" src="https://user-images.githubusercontent.com/83316221/235975389-f0d24888-a697-4bb9-b36b-c40a316dbb5a.png">

This PR switches the ETA calculation to choose the *first* matching projected block, which should be correct for the majority of transactions.

However there are still a few edge cases from #3566 where this will underestimate the ETA, so we still need PR #3673 to completely fix the calculation.