### PR TITLE
Filter GBT input

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -529,13 +529,14 @@ class Blocks {
     return await BlocksRepository.$validateChain();
   }
 
-  public async $updateBlocks() {
+  public async $updateBlocks(): Promise<number> {
     // warn if this run stalls the main loop for more than 2 minutes
     const timer = this.startTimer();
 
     diskCache.lock();
 
     let fastForwarded = false;
+    let handledBlocks = 0;
     const blockHeightTip = await bitcoinApi.$getBlockHeightTip();
     this.updateTimerProgress(timer, 'got block height tip');
 
@@ -697,11 +698,15 @@ class Blocks {
       this.updateTimerProgress(timer, `waiting for async callbacks to complete for ${this.currentBlockHeight}`);
       await Promise.all(callbackPromises);
       this.updateTimerProgress(timer, `async callbacks completed for ${this.currentBlockHeight}`);
+
+      handledBlocks++;
     }
 
     diskCache.unlock();
 
     this.clearTimer(timer);
+
+    return handledBlocks;
   }
 
   private startTimer() {

--- a/backend/src/api/disk-cache.ts
+++ b/backend/src/api/disk-cache.ts
@@ -52,7 +52,7 @@ class DiskCache {
       const mempool = memPool.getMempool();
       const mempoolArray: TransactionExtended[] = [];
       for (const tx in mempool) {
-        if (mempool[tx] && !mempool[tx].deleteAfter) {
+        if (mempool[tx]) {
           mempoolArray.push(mempool[tx]);
         }
       }

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -178,7 +178,7 @@ class MempoolBlocks {
     // prepare a stripped down version of the mempool with only the minimum necessary data
     // to reduce the overhead of passing this data to the worker thread
     const strippedMempool: { [txid: string]: ThreadTransaction } = {};
-    Object.values(newMempool).filter(tx => !tx.deleteAfter).forEach(entry => {
+    Object.values(newMempool).forEach(entry => {
       strippedMempool[entry.txid] = {
         txid: entry.txid,
         fee: entry.fee,

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -163,7 +163,7 @@ class RbfCache {
   }
 
   // flag a transaction as removed from the mempool
-  public evict(txid, fast: boolean = false): void {
+  public evict(txid: string, fast: boolean = false): void {
     if (this.txs.has(txid) && (fast || !this.expiring.has(txid))) {
       this.expiring.set(txid, fast ? Date.now() + (1000 * 60 * 10) : Date.now() + (1000 * 86400)); // 24 hours
     }

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -301,6 +301,9 @@ class WebsocketHandler {
       rbfReplacements = rbfCache.getRbfTrees(false);
       fullRbfReplacements = rbfCache.getRbfTrees(true);
     }
+    for (const deletedTx of deletedTransactions) {
+      rbfCache.evict(deletedTx.txid);
+    }
     const recommendedFees = feeApi.getRecommendedFee();
 
     this.wss.clients.forEach(async (client) => {

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -80,7 +80,6 @@ export interface TransactionExtended extends IEsploraApi.Transaction {
   descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
   cpfpChecked?: boolean;
-  deleteAfter?: number;
   position?: {
     block: number,
     vsize: number,

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -80,6 +80,7 @@ export interface TransactionExtended extends IEsploraApi.Transaction {
   descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
   cpfpChecked?: boolean;
+  hasRelatives?: boolean;
   position?: {
     block: number,
     vsize: number,


### PR DESCRIPTION
### Summary

This draft PR implements a possible optimization to reduce the amount of work for the advanced GBT algorithm.

Generally, the algorithm needs to consider the entire mempool in order to accurately assemble CPFP packages, calculate effective fee rates and prioritize transactions.

However, transactions with no in-mempool relatives are guaranteed to not be part of any CPFP package, or to affect other CPFP packages, so we can safely filter these transactions out below a certain fee rate threshold without affecting the resulting GBT templates.

### Implementation

This PR implements that filtering, including tracking and accommodating changes to the set of filtered transactions as the threshold changes. After templates are calculated from the filtered set, any omitted transactions are reinserted in the last block.

The threshold is currently set as `max(purging rate, avg effective fee rate of projected blocks 8-24)`. More investigation is needed to see how aggressively the threshold can be raised without excluding any transactions which ought to be in the first 8 projected blocks.

### Results

At this threshold, in current mempool conditions, applying the filter reduces the total number of transactions to consider for the GBT algorithm from ~277k to ~213k, which results in about a **20% overall speed up** for the `$updateMempool` function on average (on my machine).

Using a more conservative threshold of just the current default mempool purging rate, the filter reduces the number transactions to consider to ~250k, for an average **10% speed up**.

In theory, I think the impact should be larger as the mempool grows, since the proportion of transactions falling below the threshold will also increase.