### PR TITLE
Added the total number of inputs and outputs in tx details.

### DIFF
--- a/contributors/bholm.txt
+++ b/contributors/bholm.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of May 5, 2023.
+
+Signed: bholm

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -264,6 +264,10 @@
           <table class="table table-borderless table-striped">
             <tbody>
               <tr>
+                <td i18n="transaction.inputs">Inputs</td>
+                <td [innerHTML]="'&lrm;' + (tx.vin.length | number)"></td>
+              </tr>
+              <tr>
                 <td i18n="block.size">Size</td>
                 <td [innerHTML]="'&lrm;' + (tx.size | bytes: 2)"></td>
               </tr>
@@ -281,6 +285,10 @@
         <div class="col-sm">
           <table class="table table-borderless table-striped">
             <tbody>
+              <tr>
+                <td i18n="transaction.outputs">Outputs</td>
+                <td [innerHTML]="'&lrm;' + (tx.vout.length | number)"></td>
+              </tr>
               <tr>
                 <td i18n="transaction.version">Version</td>
                 <td [innerHTML]="'&lrm;' + (tx.version | number)"></td>
@@ -420,12 +428,20 @@
                 <td><span class="skeleton-loader"></span></td>
                 <td><span class="skeleton-loader"></span></td>
               </tr>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
             </tbody>
           </table>
         </div>
         <div class="col-sm">
           <table class="table table-borderless table-striped">
             <tbody>
+              <tr>
+                <td><span class="skeleton-loader"></span></td>
+                <td><span class="skeleton-loader"></span></td>
+              </tr>
               <tr>
                 <td><span class="skeleton-loader"></span></td>
                 <td><span class="skeleton-loader"></span></td>


### PR DESCRIPTION
I often find myself wanting to see at a glance the total number of inputs or outputs to a transaction but I'm currently forced to either manually count them (impractical for large transactions) or just copy the txid to another block explorer that does. I just made a front end change that adds an extra row to the Details table of the transaction component with the total inputs and outputs for that transaction.