### PR TITLE
Rapid mempool sync

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -11,7 +11,6 @@ import bitcoinSecondClient from './bitcoin/bitcoin-second-client';
 import rbfCache from './rbf-cache';
 
 class Mempool {
-  private static WEBSOCKET_REFRESH_RATE_MS = 10000;
   private inSync: boolean = false;
   private mempoolCacheDelta: number = -1;
   private mempoolCache: { [txId: string]: TransactionExtended } = {};
@@ -34,7 +33,6 @@ class Mempool {
   private SAMPLE_TIME = 10000; // In ms
   private timer = new Date().getTime();
   private missingTxCount = 0;
-
   private mainLoopTimeout: number = 120000;
 
   constructor() {
@@ -134,7 +132,7 @@ class Mempool {
     this.mempoolCacheDelta = Math.abs(diff);
 
     if (!this.inSync) {
-      loadingIndicators.setProgress('mempool', Object.keys(this.mempoolCache).length / transactions.length * 100);
+      loadingIndicators.setProgress('mempool', currentMempoolSize / transactions.length * 100);
     }
 
     // https://github.com/mempool/mempool/issues/3283
@@ -147,6 +145,7 @@ class Mempool {
       }
     };
 
+    let loggerTimer = new Date().getTime() / 1000;
     for (const txid of transactions) {
       if (!this.mempoolCache[txid]) {
         try {
@@ -169,9 +168,12 @@ class Mempool {
           logger.debug(`Error finding transaction '${txid}' in the mempool: ` + (e instanceof Error ? e.message : e));
         }
       }
-
-      if ((new Date().getTime()) - start > Mempool.WEBSOCKET_REFRESH_RATE_MS) {
-        break;
+      const elapsedSeconds = Math.round((new Date().getTime() / 1000) - loggerTimer);
+      if (elapsedSeconds > 4) {
+        const progress = (currentMempoolSize + newTransactions.length) / transactions.length * 100;
+        logger.debug(`Mempool is synchronizing. Processed ${newTransactions.length}/${diff} txs (${Math.round(progress)}%)`);
+        loadingIndicators.setProgress('mempool', progress);
+        loggerTimer = new Date().getTime() / 1000;
       }
     }
 


### PR DESCRIPTION
Instead of pausing all the time to calculate block templates and other, we now let the mempool sync run until finished, which will speed up first runs and restarts a lot. Only downside is that we might not see something visible on the mempool blocks growing, other than the progress indicator moving up.

```
May  7 18:47:00 [85265] NOTICE: Mempool Server is running on port 8999
May  7 18:47:00 [85265] DEBUG: Updating mempool...
May  7 18:47:14 [85265] DEBUG: Mempool is synchronizing. Processed 10227/16555 txs (98%)
May  7 18:47:18 [85265] DEBUG: Mempool is synchronizing. Processed 13284/16555 txs (99%)
May  7 18:47:25 [85265] DEBUG: Mempool templates calculated in 2.473 seconds
May  7 18:47:29 [85265] DEBUG: Mempool updated in 28.971 seconds. New size: 407203 (+16555)
```