### PR TITLE
[mining] resolve mining pool conflict for block 00000000000000000003aff64602a1687539515d9e2c44dc1f8c31289901781a

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -370,7 +370,8 @@ class Blocks {
         logger.info(`Got conflicting mining pool match for block ${id}. Manually picking foundryusa`, logger.tags.mining);
         return pick(matchingPools, 'foundryusa');
       } else {
-        logger.warn(`Got conflicting mining pool match for block ${id} but we did not define manual conflit resolution. Block may be tagged to the wrong mining pool. Candidates were: ${matchingPools.map(p => p.slug).join(',')}`, logger.tags.mining);
+        logger.warn(`Got conflicting mining pool match for block ${id} but we did not define manual conflict resolution. Block may be tagged to the wrong mining pool. Candidates were: ${matchingPools.map(p => p.slug).join(',')}`, logger.tags.mining);
+        return matchingPools[0]; // Keep the previous behavior
       }
     }
 


### PR DESCRIPTION
This PR adds a new mining pool conflict check when we tag blocks to their pool. The new logic is:

- If we only found one matching pool, we tag the block to it
- If we found more than one matching pool, we need to hardcode how to resolve the conflict and manually pick the mining pool. In the future if there are lot of conflicts, a weighted mining pools approach could be used. I will check if we already have lot of conflict in the historical blocks.
- If we did not match anything, tag to the unknown pool

### Testing

```mysql
DELETE from block where id = '00000000000000000003aff64602a1687539515d9e2c44dc1f8c31289901781a'
```

Restart the nodejs backend and confirm you see the following message:

```
May  7 22:57:17 [52945] INFO: <lightning> [Mining] Got conflicting mining pool match for block 00000000000000000003aff64602a1687539515d9e2c44dc1f8c31289901781a. Manually picking foundryusa
```

For now, if there is a mining pool conflict and we did not defined a conflict resolution rule, we return the first match, this way we keep the existing behavior intact.

So to resume this PR only fixes the tag for block `00000000000000000003aff64602a1687539515d9e2c44dc1f8c31289901781a` but allows future manual fixes if needed