### PR TITLE
Fee widget gradient

### DIFF
--- a/frontend/src/app/app.constants.ts
+++ b/frontend/src/app/app.constants.ts
@@ -29,6 +29,14 @@ export const mempoolFeeColors = [
   'ba3243',
   'b92b48',
   'b9254b',
+  'b8214d',
+  'b71d4f',
+  'b61951',
+  'b41453',
+  'b30e55',
+  'b10857',
+  'b00259',
+  'ae005b',
 ];
 
 export const chartColors = [
@@ -69,6 +77,7 @@ export const chartColors = [
   "#3E2723",
   "#212121",
   "#263238",
+  "#801313",
 ];
 
 export const poolsColor = {

--- a/frontend/src/app/components/fees-box/fees-box.component.ts
+++ b/frontend/src/app/components/fees-box/fees-box.component.ts
@@ -26,15 +26,23 @@ export class FeesBoxComponent implements OnInit {
     this.recommendedFees$ = this.stateService.recommendedFees$
       .pipe(
         tap((fees) => {
-          let feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.minimumFee >= feeLvl);
+          let feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.economyFee >= feeLvl);
           feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
           const startColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
 
+          feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.hourFee >= feeLvl);
+          feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
+          const lowColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+
+          feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.halfHourFee >= feeLvl);
+          feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
+          const medColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+
           feeLevelIndex = feeLevels.slice().reverse().findIndex((feeLvl) => fees.fastestFee >= feeLvl);
           feeLevelIndex = feeLevelIndex >= 0 ? feeLevels.length - feeLevelIndex : feeLevelIndex;
-          const endColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
+          const highColor = '#' + (mempoolFeeColors[feeLevelIndex - 1] || mempoolFeeColors[mempoolFeeColors.length - 1]);
 
-          this.gradient = `linear-gradient(to right, ${startColor}, ${endColor})`;
+          this.gradient = `linear-gradient(to right, ${lowColor} 0%, ${medColor} 50%, ${highColor} 100%)`;
           this.noPriority = startColor;
         }
       )

--- a/frontend/src/app/components/statistics/statistics.component.html
+++ b/frontend/src/app/components/statistics/statistics.component.html
@@ -84,8 +84,7 @@
         </div>
         <div class="card-body">
           <div class="incoming-transactions-graph">
-            <app-mempool-graph #mempoolgraph dir="ltr" [template]="'advanced'" [limitFee]="500"
-              [limitFilterFee]="filterFeeIndex" [height]="500" [left]="65" [right]="10"
+            <app-mempool-graph #mempoolgraph dir="ltr" [template]="'advanced'" [height]="500" [left]="65" [right]="10"
               [data]="mempoolStats && mempoolStats.length ? mempoolStats : null"></app-mempool-graph>
           </div>
         </div>

--- a/frontend/src/app/components/television/television.component.html
+++ b/frontend/src/app/components/television/television.component.html
@@ -3,7 +3,6 @@
     <div class="chart-holder">
       <app-mempool-graph
         [template]="'advanced'"
-        [limitFee]="500"
         [height]="600"
         [left]="60"
         [right]="10"

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -26,8 +26,7 @@
               <div class="mempool-graph">
                 <app-mempool-graph
                 [template]="'widget'"
-                [limitFee]="150"
-                [limitFilterFee]="1"
+                [filterSize]="1000000"
                 [data]="mempoolStats.value?.mempool"
                 [windowPreferenceOverride]="'2h'"
                 ></app-mempool-graph>


### PR DESCRIPTION
This PR fixes the colors & gradient in the recommended fee widget.

Before, we used a single linear gradient from the `minimumFee` color to the `fastestFee` color (even though the gradient runs from "Low Priority" to "High Priority".

After, we start from the correct color for "Low Priority", and add a halfway stop in the gradient at the "Medium Priority" color. 

It also correctly uses the `economyFee` color for the "No Priority" section (instead of `minimumFee`)

| Before | After |
|-|-|
| <img width="580" alt="Screenshot 2023-05-08 at 1 06 38 PM" src="https://user-images.githubusercontent.com/83316221/236915981-8be253f3-b1a9-4370-bf70-b360e7923147.png"> | <img width="580" alt="Screenshot 2023-05-08 at 1 06 24 PM" src="https://user-images.githubusercontent.com/83316221/236916007-40556234-7d0c-4a9f-a36e-d7ea9db33f95.png"> |
| <img width="580" alt="Screenshot 2023-05-08 at 1 00 47 PM" src="https://user-images.githubusercontent.com/83316221/236916494-848b11c9-66e4-460b-ab94-7b30d66cdfe3.png"> | <img width="580" alt="Screenshot 2023-05-08 at 1 00 56 PM" src="https://user-images.githubusercontent.com/83316221/236916534-503b46cf-4b94-4acf-9637-efcd517b2fc0.png"> |

