### PR TITLE
Optimize websocket updates

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -130,8 +130,9 @@ class BitcoinRoutes {
 
   private getInitData(req: Request, res: Response) {
     try {
-      const result = websocketHandler.getInitData();
-      res.json(result);
+      const result = websocketHandler.getSerializedInitData();
+      res.set('Content-Type', 'application/json');
+      res.send(result);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
     }


### PR DESCRIPTION
### Summary

This PR improves the way we send websocket updates to connected clients.

The optimizations are relatively modest, but can add up quickly when there are a lot of websocket connections.

The general theme is pre-computing and caching results to avoid repeating common work for every websocket message.

The PR applies this in three main areas:

---

### 1) Caching commonly serialized data in batch websocket updates

The `$handleMempoolChange` and `$handleNewBlock` functions send batches of updates to every connected client.

Most of the data in the updates is the same for every client, except where clients have specific additional subscriptions, but currently we compute and `JSON.stringify()` the whole response separately for each client.

This PR instead pre-computes and caches the expensive JSON serializations for each bit of shared data, and then cheaply stitches together the right combinations of these (plus any individual subscriptions) for each client.

---

### 2) Pre-computing outspend updates

Currently we check for changes in outspends separately for each transaction subscription, which involves iterating over every input of every new transaction for every subscription.

This PR instead pre-computes all relevant outspend changes in a single pass.

---

### 3) Pre-serializing websocket init data

Every time a client connects (or reconnects) via websocket, we send a packet of data with initial state for the dashboard, mempool, recent blocks etc.

That data generally only changes once or twice per main loop, but it's calculated and serialized on-demand for every new connection.

This PR computes and caches the serialized init data whenever it does change, so it's always ready to send, which significantly reduces the overhead of handling new connections.

Most of the cached data is also used in the regular batch updates, so there isn't an additional cost even when new connections are infrequent.