### PR TITLE
Display empty witness items

### DIFF
--- a/contributors/vostrnad.txt
+++ b/contributors/vostrnad.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of January 25, 2022.
+
+Signed: vostrnad

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -114,7 +114,12 @@
                           <ng-container *ngFor="let witness of vin.witness; index as i">
                             <input type="checkbox" [id]="'tx' + vindex + 'witness' + i" style="display: none;">
                             <p class="witness-item" [class.accordioned]="witness.length > 1000">
-                              {{ witness }}
+                              <ng-template [ngIf]="witness" [ngIfElse]="emptyWitnessItem">
+                                {{ witness }}
+                              </ng-template>
+                              <ng-template #emptyWitnessItem>
+                                &lt;empty&gt;
+                              </ng-template>
                             </p>
                             <div class="witness-toggle" *ngIf="witness.length > 1000">
                               <span  class="ellipsis">...</span>


### PR DESCRIPTION
Fixes #1089

Empty witness stack elements are now displayed as `<empty>` instead of not being displayed at all.