### PR TITLE
Fix txids interpreted as addresses in search bar

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -153,7 +153,7 @@ export class SearchFormComponent implements OnInit {
           const matchesBlockHeight = this.regexBlockheight.test(searchText);
           const matchesTxId = this.regexTransaction.test(searchText) && !this.regexBlockhash.test(searchText);
           const matchesBlockHash = this.regexBlockhash.test(searchText);
-          const matchesAddress = this.regexAddress.test(searchText);
+          const matchesAddress = !matchesTxId && this.regexAddress.test(searchText);
 
           if (matchesAddress && this.network === 'bisq') {
             searchText = 'B' + searchText;
@@ -198,7 +198,7 @@ export class SearchFormComponent implements OnInit {
     const searchText = result || this.searchForm.value.searchText.trim();
     if (searchText) {
       this.isSearching = true;
-      if (this.regexAddress.test(searchText)) {
+      if (!this.regexTransaction.test(searchText) && this.regexAddress.test(searchText)) {
         this.navigate('/address/', searchText);
       } else if (this.regexBlockhash.test(searchText) || this.regexBlockheight.test(searchText)) {
         this.navigate('/block/', searchText);


### PR DESCRIPTION
The search form currently detects addresses using the regex:
```javascript
/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[A-z]{2,5}1[a-zA-HJ-NP-Z0-9]{39,59})$/
```

However, the bech32 part of the regex also matches some txids like
`beef1148f71f2361f927f79de502251afeebfbdc3feb67ec164084576103ba2e`
or
`eddcf1b57634c7348d969e3a49f06026d70537bd2ad84aa475fce45bb98bb239`
where the first few characters are all letters, and the 5th or 6th character is '1'.

Because the search form gives priority to addresses, it's impossible to access one of these transactions from the search bar.

https://github.com/mempool/mempool/assets/83316221/e192b45a-4414-4b91-b1d4-e5cfef00f411

This PR implements a short term workaround, by preventing the search form from interpreting a query as an address if it also matches the txid regex:

<img width="524" alt="Screenshot 2023-05-10 at 8 12 20 PM" src="https://github.com/mempool/mempool/assets/83316221/b502168a-c6ce-472e-9df9-ed356ec4c12d">

---

The long term solution is to validate bech32 addresses more rigorously to ensure that they match known formats for the networks we support.

It would also be nice to parse the human readable part of a bech32 address, and automatically redirect to signet/testnet/liquid/bisq as appropriate.

