### PR TITLE
Fix difficulty estimate

### DIFF
--- a/backend/src/__tests__/api/difficulty-adjustment.test.ts
+++ b/backend/src/__tests__/api/difficulty-adjustment.test.ts
@@ -14,11 +14,11 @@ describe('Mempool Difficulty Adjustment', () => {
           750134,                         // Current block height
           0.6280047707459726,             // Previous retarget % (Passed through)
           'mainnet',                      // Network (if testnet, next value is non-zero)
-          0,                              // If not testnet, not used
+          0,                              // Latest block timestamp in seconds (only used if difficulty already locked in)
         ],
         { // Expected Result
           progressPercent: 9.027777777777777,
-          difficultyChange: 12.562233927411782,
+          difficultyChange: 13.180707740199772,
           estimatedRetargetDate: 1661895424692,
           remainingBlocks: 1834,
           remainingTime: 977591692,
@@ -41,7 +41,7 @@ describe('Mempool Difficulty Adjustment', () => {
         ],
         { // Expected Result is same other than timeOffset
           progressPercent: 9.027777777777777,
-          difficultyChange: 12.562233927411782,
+          difficultyChange: 13.180707740199772,
           estimatedRetargetDate: 1661895424692,
           remainingBlocks: 1834,
           remainingTime: 977591692,
@@ -52,6 +52,29 @@ describe('Mempool Difficulty Adjustment', () => {
           timeOffset: -667000, // 11 min 7 seconds since last block (testnet only)
           // If we add time avg to abs(timeOffset) it makes exactly 1200000 ms, or 20 minutes
           expectedBlocks: 161.68833333333333,
+        },
+      ],
+      [ // Vector 3 (mainnet lock-in (epoch ending 788255))
+        [ // Inputs
+          dt('2023-04-20T09:57:33.000Z'), // Last DA time (in seconds)
+          dt('2023-05-04T14:54:09.000Z'), // Current time (now) (in seconds)
+          788255,                         // Current block height
+          1.7220298879531821,             // Previous retarget % (Passed through)
+          'mainnet',                      // Network (if testnet, next value is non-zero)
+          dt('2023-05-04T14:54:26.000Z'), // Latest block timestamp in seconds
+        ],
+        { // Expected Result
+          progressPercent: 99.95039682539682,
+          difficultyChange: -1.4512637555574193,
+          estimatedRetargetDate: 1683212658129,
+          remainingBlocks: 1,
+          remainingTime: 609129,
+          previousRetarget: 1.7220298879531821,
+          previousTime: 1681984653,
+          nextRetargetHeight: 788256,
+          timeAvg: 609129,
+          timeOffset: 0,
+          expectedBlocks: 2045.66,
         },
       ],
     ] as [[number, number, number, number, string, number], DifficultyAdjustment][];

--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -34,11 +34,12 @@ export function calcDifficultyAdjustment(
   const remainingBlocks = EPOCH_BLOCK_LENGTH - blocksInEpoch;
   const nextRetargetHeight = (blockHeight >= 0) ? blockHeight + remainingBlocks : 0;
   const expectedBlocks = diffSeconds / BLOCK_SECONDS_TARGET;
+  const actualTimespan = (blocksInEpoch === 2015 ? latestBlockTimestamp : nowSeconds) - DATime;
 
   let difficultyChange = 0;
   let timeAvgSecs = blocksInEpoch ? diffSeconds / blocksInEpoch : BLOCK_SECONDS_TARGET;
 
-  difficultyChange = (BLOCK_SECONDS_TARGET / timeAvgSecs - 1) * 100;
+  difficultyChange = (BLOCK_SECONDS_TARGET / (actualTimespan / (blocksInEpoch + 1)) - 1) * 100;
   // Max increase is x4 (+300%)
   if (difficultyChange > 300) {
     difficultyChange = 300;


### PR DESCRIPTION
The current difficulty adjustment estimation is subtly wrong at the very end of each epoch.

### Problem

Actual difficulty adjustments are determined by
```
difficultyChange = ((targetEpochDuration / actualEpochDuration) - 1) * 100
```
where the `targetEpochDuration` is 20160 minutes, and the `actualEpochDuration` is the time taken to mine the previous 2015 blocks (not 2016, due to a well documented off-by-one error in Bitcoin Core).

This means the next difficulty adjustment is "locked in" as soon as the last block in an epoch is mined, since by that point the `actualEpochDuration` is known (equal to the difference in timestamps between the 1st and 2016th blocks in the epoch).

---

Our estimates were made with
```
difficultyChange = ((BLOCK_SECONDS_TARGET / (diffSeconds / blocksInEpoch)) - 1) * 100;
```
where `diffSeconds` is the time since the 1st block of the epoch, and `blocksInEpoch` is the number of blocks mined so far.

`diffSeconds` continues to increase after the last block in the epoch is mined, which has the effect of gradually lowering the estimate below the correct value while we wait for the next epoch to begin.

---

For example, in the most recent epoch, the next difficulty adjustment was guaranteed to be -1.45% as soon as block 788255 was received. However, we continued to lower the estimate while waiting for block 788256 (the first of the next epoch):

<img width="587" alt="Screenshot 2023-05-11 at 11 16 05 AM" src="https://github.com/mempool/mempool/assets/83316221/77493ac4-6678-4b2c-b500-27b3db0be483">

<img width="587" alt="Screenshot 2023-05-11 at 11 06 42 AM" src="https://github.com/mempool/mempool/assets/83316221/9b8b62b4-c18a-41ef-beda-5f7bd5beb291">

### Fix

This PR freezes the predicted adjustment at the known correct value as soon as the last block in an epoch is mined:

<img width="587" alt="Screenshot 2023-05-11 at 12 44 48 PM" src="https://github.com/mempool/mempool/assets/83316221/5928fd6f-a4b6-4d7f-84f3-fe483aec955c">


It also adjusts the estimate calculation to include the expected next block in the `blocksInEpoch` count. i.e. the estimate asks "what would the average block time be if the next block arrived right now?".

That doesn't make a huge difference to ongoing estimates, but produces a nicer transition from estimate to confirmed adjustment on the arrival of the last block.