### PR TITLE
Difficulty adjustment lock in

### DIFF
--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -34,11 +34,12 @@ export function calcDifficultyAdjustment(
   const remainingBlocks = EPOCH_BLOCK_LENGTH - blocksInEpoch;
   const nextRetargetHeight = (blockHeight >= 0) ? blockHeight + remainingBlocks : 0;
   const expectedBlocks = diffSeconds / BLOCK_SECONDS_TARGET;
+  const actualTimespan = (blocksInEpoch === 2015 ? latestBlockTimestamp : nowSeconds) - DATime;
 
   let difficultyChange = 0;
   let timeAvgSecs = blocksInEpoch ? diffSeconds / blocksInEpoch : BLOCK_SECONDS_TARGET;
 
-  difficultyChange = (BLOCK_SECONDS_TARGET / timeAvgSecs - 1) * 100;
+  difficultyChange = (BLOCK_SECONDS_TARGET / (actualTimespan / (blocksInEpoch + 1)) - 1) * 100;
   // Max increase is x4 (+300%)
   if (difficultyChange > 300) {
     difficultyChange = 300;

--- a/frontend/src/app/components/difficulty/difficulty.component.html
+++ b/frontend/src/app/components/difficulty/difficulty.component.html
@@ -33,6 +33,7 @@
                 repeatCount="indefinite"/>
             </rect>
           </svg>
+          <span *ngIf="lockedIn" class="lock-in-msg" i18n="difficulty-box.adjustment-locked-in">Difficulty adjustment locked in</span>
         </div>
         <div class="difficulty-stats">
           <div class="item">

--- a/frontend/src/app/components/difficulty/difficulty.component.scss
+++ b/frontend/src/app/components/difficulty/difficulty.component.scss
@@ -172,6 +172,18 @@
   width: 100%;
   height: 22px;
   margin-bottom: 12px;
+  position: relative;
+
+  .lock-in-msg {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    font-size: 12px;
+    line-height: 22px;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .epoch-blocks {

--- a/frontend/src/app/components/difficulty/difficulty.component.ts
+++ b/frontend/src/app/components/difficulty/difficulty.component.ts
@@ -54,6 +54,7 @@ export class DifficultyComponent implements OnInit {
   expectedHeight: number;
   expectedIndex: number;
   difference: number;
+  lockedIn: boolean = false;
   shapes: DiffShape[];
 
   tooltipPosition = { x: 0, y: 0 };
@@ -104,6 +105,7 @@ export class DifficultyComponent implements OnInit {
           this.currentIndex = this.currentHeight - this.epochStart;
           this.expectedIndex = Math.min(this.expectedHeight - this.epochStart, 2016) - 1;
           this.difference = this.currentIndex - this.expectedIndex;
+          this.lockedIn = this.currentIndex === 2015;
 
           this.shapes = [];
           this.shapes = this.shapes.concat(this.blocksToShapes(


### PR DESCRIPTION
_(builds on PR #3753)_

Display a message to show that the difficulty adjustment is confirmed after the last block in an epoch.

<img width="587" alt="Screenshot 2023-05-11 at 1 17 31 PM" src="https://github.com/mempool/mempool/assets/83316221/27844fd6-f4f3-44a6-876f-028e5c3b4b07">
