### PR TITLE
smarter time duration unit selection

### DIFF
--- a/frontend/src/app/components/time/time.component.ts
+++ b/frontend/src/app/components/time/time.component.ts
@@ -11,6 +11,15 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
   interval: number;
   text: string;
   units: string[] = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second'];
+  precisionThresholds = {
+    year: 100,
+    month: 18,
+    week: 12,
+    day: 31,
+    hour: 48,
+    minute: 90,
+    second: 90
+  };
   intervals = {};
 
   @Input() time: number;
@@ -85,8 +94,12 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
 
     let counter: number;
     for (const [index, unit] of this.units.entries()) {
-      const precisionUnit = this.units[Math.min(this.units.length - 1), index + this.precision];
+      let precisionUnit = this.units[Math.min(this.units.length - 1, index + this.precision)];
       counter = Math.floor(seconds / this.intervals[unit]);
+      const precisionCounter = Math.floor(seconds / this.intervals[precisionUnit]);
+      if (precisionCounter > this.precisionThresholds[precisionUnit]) {
+        precisionUnit = unit;
+      }
       if (counter > 0) {
         let rounded = Math.round(seconds / this.intervals[precisionUnit]);
         if (this.fractionDigits) {


### PR DESCRIPTION
PR #3677 added an option to the time rendering component to display some durations with more precision.

In some cases, the extra precision is excessive:

<img width="587" alt="Screenshot 2023-05-11 at 1 32 25 PM" src="https://github.com/mempool/mempool/assets/83316221/a0d8d0cd-e367-4757-b221-5eddc22be2fa">

This PR improves unit selection for higher precisions to display durations more naturally:

<img width="587" alt="Screenshot 2023-05-11 at 1 32 36 PM" src="https://github.com/mempool/mempool/assets/83316221/31404c19-892b-421f-96a7-9523d0a59b67">