### PR TITLE
Detect RBF by mined transactions

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -77,6 +77,24 @@ export class Common {
     return matches;
   }
 
+  static findMinedRbfTransactions(minedTransactions: TransactionExtended[], spendMap: Map<string, TransactionExtended>): { [txid: string]: { replaced: TransactionExtended[], replacedBy: TransactionExtended }} {
+    const matches: { [txid: string]: { replaced: TransactionExtended[], replacedBy: TransactionExtended }} = {};
+    for (const tx of minedTransactions) {
+      const replaced: Set<TransactionExtended> = new Set();
+      for (let i = 0; i < tx.vin.length; i++) {
+        const vin = tx.vin[i];
+        const match = spendMap.get(`${vin.txid}:${vin.vout}`);
+        if (match && match.txid !== tx.txid) {
+          replaced.add(match);
+        }
+      }
+      if (replaced.size) {
+        matches[tx.txid] = { replaced: Array.from(replaced), replacedBy: tx };
+      }
+    }
+    return matches;
+  }
+
   static stripTransaction(tx: TransactionExtended): TransactionStripped {
     return {
       txid: tx.txid,

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -31,7 +31,7 @@ class RbfCache {
   }
 
   public add(replaced: TransactionExtended[], newTxExtended: TransactionExtended): void {
-    if (!newTxExtended || !replaced?.length) {
+    if (!newTxExtended || !replaced?.length || this.txs.has(newTxExtended.txid)) {
       return;
     }
 

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -332,6 +332,8 @@ class WebsocketHandler {
     for (const deletedTx of deletedTransactions) {
       rbfCache.evict(deletedTx.txid);
     }
+    memPool.removeFromSpendMap(deletedTransactions);
+    memPool.addToSpendMap(newTransactions);
     const recommendedFees = feeApi.getRecommendedFee();
 
     // update init data
@@ -598,6 +600,10 @@ class WebsocketHandler {
         block.extras.similarity = Common.getSimilarity(mBlocks[0], transactions);
       }
     }
+
+    const rbfTransactions = Common.findMinedRbfTransactions(transactions, memPool.getSpendMap());
+    memPool.handleMinedRbfTransactions(rbfTransactions);
+    memPool.removeFromSpendMap(transactions);
 
     // Update mempool to remove transactions included in the new block
     for (const txId of txIds) {


### PR DESCRIPTION
Resolves #3758.

This PR tracks the utxos spent by each transaction in our mempool, which allows us to efficiently detect when those are replaced by previously unseen transactions in newly mined blocks.

This means we can show the full RBF chain even when the final version of the transaction doesn't reach us before a block is mined (e.g. due to propagation delays, out-of-band submission, or use of full RBF).