### PR TITLE
Fix effective fee rates for non-cpfp dependents

### DIFF
--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -104,6 +104,7 @@ export interface AuditTransaction {
   used: boolean;
   modified: boolean;
   modifiedNode: HeapNode<AuditTransaction>;
+  dependencyRate?: number;
 }
 
 export interface CompactThreadTransaction {

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -481,7 +481,7 @@
           </ng-template>
         </td>
       </tr>
-      <tr *ngIf="cpfpInfo && (cpfpInfo?.bestDescendant || cpfpInfo?.descendants?.length || cpfpInfo?.ancestors?.length)">
+      <tr *ngIf="cpfpInfo && (cpfpInfo.effectiveFeePerVsize || cpfpInfo.bestDescendant || cpfpInfo.descendants?.length || cpfpInfo.ancestors?.length)">
         <td i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>
         <td>
           <div class="effective-fee-container">
@@ -490,7 +490,7 @@
               <app-tx-fee-rating class="ml-2 mr-2" *ngIf="tx.fee || tx.effectiveFeePerVsize" [tx]="tx"></app-tx-fee-rating>
             </ng-template>
           </div>
-          <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-right" (click)="showCpfpDetails = !showCpfpDetails">CPFP <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></button>
+          <button *ngIf="cpfpInfo.bestDescendant || cpfpInfo.descendants?.length || cpfpInfo.ancestors?.length" type="button" class="btn btn-outline-info btn-sm btn-small-height float-right" (click)="showCpfpDetails = !showCpfpDetails">CPFP <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></button>
         </td>
       </tr>
     </tbody>

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -477,7 +477,7 @@
           {{ tx.feePerVsize | feeRounding }} <span class="symbol" i18n="shared.sat-vbyte|sat/vB">sat/vB</span>
           <ng-template [ngIf]="tx?.status?.confirmed">
             &nbsp;
-            <app-tx-fee-rating *ngIf="tx.fee && ((cpfpInfo && !cpfpInfo?.descendants?.length && !cpfpInfo?.bestDescendant && !cpfpInfo?.ancestors?.length) || !cpfpInfo)" [tx]="tx"></app-tx-fee-rating>
+            <app-tx-fee-rating *ngIf="tx.fee && (!cpfpInfo || (!cpfpInfo.effectiveFeePerVsize && !cpfpInfo?.descendants?.length && !cpfpInfo?.bestDescendant && !cpfpInfo?.ancestors?.length))" [tx]="tx"></app-tx-fee-rating>
           </ng-template>
         </td>
       </tr>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -164,14 +164,17 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         if (cpfpInfo.bestDescendant && !cpfpInfo.descendants?.length) {
           relatives.push(cpfpInfo.bestDescendant);
         }
-        let totalWeight =
-          this.tx.weight +
-          relatives.reduce((prev, val) => prev + val.weight, 0);
-        let totalFees =
-          this.tx.fee +
-          relatives.reduce((prev, val) => prev + val.fee, 0);
-
-        this.tx.effectiveFeePerVsize = totalFees / (totalWeight / 4);
+        if (!cpfpInfo.effectiveFeePerVsize) {
+          let totalWeight =
+            this.tx.weight +
+            relatives.reduce((prev, val) => prev + val.weight, 0);
+          let totalFees =
+            this.tx.fee +
+            relatives.reduce((prev, val) => prev + val.fee, 0);
+          this.tx.effectiveFeePerVsize = totalFees / (totalWeight / 4);
+        } else {
+          this.tx.effectiveFeePerVsize = cpfpInfo.effectiveFeePerVsize;
+        }
 
         this.cpfpInfo = cpfpInfo;
       });

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -24,6 +24,7 @@ export interface CpfpInfo {
   ancestors: Ancestor[];
   descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
+  effectiveFeePerVsize?: number;
 }
 
 export interface RbfInfo {


### PR DESCRIPTION
Resolves #3674

This PR implements the solution proposed in #3674, by adjusting the effective fee rate calculation to consider non-CPFP dependencies.

This new dependency-based effective fee rate is the minimum of the calculated CPFP rate, and the lowest effective fee rate of any unconfirmed ancestors.

This brings the effective fee rate variable in line with the actual mining priority of the transaction.

For example, this transaction depends on an unconfirmed ancestor with an effective fee rate of 78.6 s/vb:
<img width="854" alt="Screenshot 2023-05-18 at 2 01 23 PM" src="https://github.com/mempool/mempool/assets/83316221/c8f15e36-43d6-4160-9e7f-e94533dab200">
Previously we would show only the basic fee rate of 102 s/vb, since this transaction doesn't belong to any CPFP clusters. This was misleading, because the transaction can't confirm before its lower effective fee rate ancestors which only pay 78.6 s/vb.

---

Fixing these effective fee rate outliers also improves the fee ranges of the projected blocks:

Before:
<img width="825" alt="Screenshot 2023-05-18 at 2 28 51 PM" src="https://github.com/mempool/mempool/assets/83316221/5790bd14-054b-4668-af77-96fe4c3cf592">

After:
<img width="825" alt="Screenshot 2023-05-18 at 2 28 26 PM" src="https://github.com/mempool/mempool/assets/83316221/270cb2ac-2ea3-4b0c-960a-53c08bfefdfc">

---

We probably also need to add specific handling in the UI for non-CPFP effective fee rates, to explain how the rate was obtained.