### PR TITLE
Fix for pool output address matching

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -306,7 +306,7 @@ class Blocks {
     }
 
     const asciiScriptSig = transactionUtils.hex2ascii(txMinerInfo.vin[0].scriptsig);
-    const address = txMinerInfo.vout[0].scriptpubkey_address;
+    const addresses = txMinerInfo.vout.map((vout) => vout.scriptpubkey_address).filter((address) => address);
 
     let pools: PoolTag[] = [];
     if (config.DATABASE.ENABLED === true) {
@@ -316,11 +316,13 @@ class Blocks {
     }
 
     for (let i = 0; i < pools.length; ++i) {
-      if (address !== undefined) {
-        const addresses: string[] = typeof pools[i].addresses === 'string' ?
+      if (addresses.length) {
+        const poolAddresses: string[] = typeof pools[i].addresses === 'string' ?
           JSON.parse(pools[i].addresses) : pools[i].addresses;
-        if (addresses.indexOf(address) !== -1) {
-          return pools[i];
+        for (let y = 0; y < poolAddresses.length; y++) {
+          if (addresses.indexOf(poolAddresses[y]) !== -1) {
+            return pools[i];
+          }
         }
       }
 


### PR DESCRIPTION
fixes #3782

Testing:

Remove block (791074) [00000000000000000001aadcd2ac42e0fabcc46b9a2d2150963d4c594f22e294] from your database and reload it, it should now match it as F2Pool because we match with all output addresses.

This PR doesn't trigger a rescan of unknown pools that we might have missed because this will be fixed after this is merged and we update the miningpool repo next time? (we should add the /F2pool/ tag to the repo to not just rely on output addresses in this case)