### PR TITLE
Restore liquid max block weight to defaults

### DIFF
--- a/production/mempool-frontend-config.liquid.json
+++ b/production/mempool-frontend-config.liquid.json
@@ -11,7 +11,6 @@
   "LIQUID_WEBSITE_URL": "https://liquid.network",
   "BISQ_WEBSITE_URL": "https://bisq.markets",
   "ITEMS_PER_PAGE": 25,
-  "BLOCK_WEIGHT_UNITS": 300000,
   "MEMPOOL_BLOCKS_AMOUNT": 2,
   "KEEP_BLOCKS_AMOUNT": 16
 }


### PR DESCRIPTION
Removes the artificially low 300kWU block weight cap in the production liquid frontend, which fixes some UI issues when liquid blocks are full.

Before:

<img width="1362" alt="Screenshot 2023-05-24 at 3 52 40 PM" src="https://github.com/mempool/mempool/assets/83316221/347c843d-07c4-4202-9935-86bb726e6a4e">

After:

<img width="1362" alt="Screenshot 2023-05-24 at 3 53 55 PM" src="https://github.com/mempool/mempool/assets/83316221/be2022a2-cef1-4c3b-9bf4-2fd3a67827ce">
