### PR TITLE
Fix block summaries indexing with restored template data

### DIFF
--- a/backend/src/repositories/BlocksSummariesRepository.ts
+++ b/backend/src/repositories/BlocksSummariesRepository.ts
@@ -53,8 +53,9 @@ class BlocksSummariesRepository {
 
   public async $getIndexedSummariesId(): Promise<string[]> {
     try {
-      const [rows]: any[] = await DB.query(`SELECT id from blocks_summaries`);
-      return rows.map(row => row.id);
+      const [rows]: any[] = await DB.query(`SELECT id, length(transactions) as tlen from blocks_summaries`);
+      // filter out rows that are missing the block summary (transactions column)
+      return rows.filter(row => row.tlen > 2).map(row => row.id);
     } catch (e) {
       logger.err(`Cannot get block summaries id list. Reason: ` + (e instanceof Error ? e.message : e));
     }


### PR DESCRIPTION
Fixes an issue where block summaries would not be indexed where audit template data already exists (e.g., after restoring template data from a backup).