### PR TITLE
Mining pool update / re-indexer improvment

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -1039,7 +1039,7 @@ class DatabaseMigration {
   }
 
   public async $blocksReindexingTruncate(): Promise<void> {
-    logger.warn(`Truncating pools, blocks and hashrates for re-indexing (using '--reindex-blocks'). You can cancel this command within 5 seconds`);
+    logger.warn(`Truncating pools, blocks, hashrates and difficulty_adjustments tables for re-indexing (using '--reindex-blocks'). You can cancel this command within 5 seconds`);
     await Common.sleep$(5000);
 
     await this.$executeQuery(`TRUNCATE blocks`);

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -80,8 +80,6 @@ class PoolsParser {
         }
       }
     }
-
-    logger.info('Mining pools-v2.json import completed');
   }
 
   /**

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -71,7 +71,7 @@ class PoolsUpdater {
       poolsParser.setMiningPools(poolsJson);
 
       if (config.DATABASE.ENABLED === false) { // Don't run db operations
-        logger.info('Mining pools-v2.json import completed (no database)');
+        logger.info(`Mining pools-v2.json (${githubSha}) import completed (no database)`);
         return;
       }
 
@@ -84,7 +84,7 @@ class PoolsUpdater {
         logger.err(`Could not migrate mining pools, rolling back. Exception: ${JSON.stringify(e)}`, logger.tags.mining);
         await DB.query('ROLLBACK;');
       }
-      logger.info('PoolsUpdater completed');
+      logger.info(`Mining pools-v2.json (${githubSha}) import completed`);
 
     } catch (e) {
       this.lastRun = now - (oneWeek - oneDay); // Try again in 24h instead of waiting next week

--- a/frontend/src/app/components/start/start.component.html
+++ b/frontend/src/app/components/start/start.component.html
@@ -1,3 +1,5 @@
+<app-indexing-progress *ngIf="showLoadingIndicator"></app-indexing-progress>
+
 <ng-container *ngIf="specialEvent">
   <div class="pyro">
     <div class="before"></div>

--- a/frontend/src/app/components/start/start.component.ts
+++ b/frontend/src/app/components/start/start.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, OnInit, OnDestroy, ViewChild, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { StateService } from '../../services/state.service';
 import { specialBlocks } from '../../app.constants';
@@ -9,6 +9,8 @@ import { specialBlocks } from '../../app.constants';
   styleUrls: ['./start.component.scss'],
 })
 export class StartComponent implements OnInit, OnDestroy {
+  @Input() showLoadingIndicator = false;
+
   interval = 60;
   colors = ['#5E35B1', '#ffffff'];
 

--- a/frontend/src/app/components/status-view/status-view.component.html
+++ b/frontend/src/app/components/status-view/status-view.component.html
@@ -1,2 +1,2 @@
-<app-start></app-start>
+<app-start [showLoadingIndicator]="true"></app-start>
 <app-footer></app-footer>


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/3802

- If blocks are deleted from the table when we update mining pool coinbase address or tag, those two tables will be truncated and re-indexed automatically once block re-indexing is completed.

```
May 30 10:12:20 [8006] NOTICE: <lightning> difficulty_adjustments will now be re-indexed
May 30 10:12:23 [8006] NOTICE: <lightning> hashrates will now be re-indexed
```

- testnet oldest known block mined by a pool is 21106, signet is 0

```
May 30 10:29:44 [14007] NOTICE: <testnet> Deleting blocks with unknown mining pool from height 21106 for re-indexing
```

- show pools-v2.json sha upon successful mining pool update

```
May 30 10:39:13 [16915] INFO: <testnet> Mining pools-v2.json (24f3c4c67a7812d955449bdda280daf799bae1c5) import completed
```

- show indexing indicator in the /status page
<img width="1727" alt="Screenshot 2023-05-30 at 10 13 22" src="https://github.com/mempool/mempool/assets/9780671/d314276b-bd9c-4822-b100-fd674cb66de2">
