### PR TITLE
fix graph filter dropdown colors

### DIFF
--- a/frontend/src/app/components/statistics/statistics.component.ts
+++ b/frontend/src/app/components/statistics/statistics.component.ts
@@ -196,7 +196,7 @@ export class StatisticsComponent implements OnInit {
         this.feeLevelDropdownData.push({
           fee: fee,
           range,
-          color: _chartColors[i - 1],
+          color: _chartColors[i],
         });
       }
     });


### PR DESCRIPTION
Fixes an off-by-one error in assigning colors for the mempool graph fee filter dropdown.
| Before | After |
|-|-|
| <img width="229" alt="Screenshot 2023-06-05 at 2 24 30 PM" src="https://github.com/mempool/mempool/assets/83316221/3359e393-4c0b-4f3e-b052-09c3e8eab224"> | <img width="229" alt="Screenshot 2023-06-05 at 2 24 17 PM" src="https://github.com/mempool/mempool/assets/83316221/b16e7b6d-c92b-4057-ae3b-a3d0eaa4b486"> |
