### PR TITLE
Fix multiple mined RBF replacements of the same tx

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -91,6 +91,14 @@ export class Common {
       if (replaced.size) {
         matches[tx.txid] = { replaced: Array.from(replaced), replacedBy: tx };
       }
+      // remove this tx from the spendMap
+      // prevents the same tx being replaced more than once
+      for (const vin of tx.vin) {
+        const key = `${vin.txid}:${vin.vout}`;
+        if (spendMap.get(key)?.txid === tx.txid) {
+          spendMap.delete(key);
+        }
+      }
     }
     return matches;
   }


### PR DESCRIPTION
Fixes an edge case where a transaction could be marked as replaced-by-fee by multiple mined transactions.

In conventional RBF, a transaction is evicted from the mempool by the first replacement, so it's impossible for one transaction to belong to multiple RBF events even if their inputs are eventually spent by several different transactions.

The RBF feature depends on that assumption, and produces nonsensical results & RBF trees if a transaction is replaced multiple times (since the replacement graph would no longer be a tree).

With this PR, each mempool transaction may only be marked as replaced-by-fee by the *first* mined transaction which spends the same inputs.