### PR TITLE
calculate & index ancestor-dependent effective rates

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -1,4 +1,4 @@
-import { Ancestor, CpfpInfo, CpfpSummary, EffectiveFeeStats, MempoolBlockWithTransactions, TransactionExtended, MempoolTransactionExtended, TransactionStripped, WorkingEffectiveFeeStats } from '../mempool.interfaces';
+import { Ancestor, CpfpInfo, CpfpSummary, CpfpCluster, EffectiveFeeStats, MempoolBlockWithTransactions, TransactionExtended, MempoolTransactionExtended, TransactionStripped, WorkingEffectiveFeeStats } from '../mempool.interfaces';
 import config from '../config';
 import { NodeSocket } from '../repositories/NodesSocketsRepository';
 import { isIP } from 'net';
@@ -366,39 +366,79 @@ export class Common {
   }
 
   static calculateCpfp(height: number, transactions: TransactionExtended[]): CpfpSummary {
-    const clusters: { root: string, height: number, txs: Ancestor[], effectiveFeePerVsize: number }[] = [];
-    let cluster: TransactionExtended[] = [];
-    let ancestors: { [txid: string]: boolean } = {};
+    const clusters: CpfpCluster[] = []; // list of all cpfp clusters in this block
+    const clusterMap: { [txid: string]: CpfpCluster } = {}; // map transactions to their cpfp cluster
+    let clusterTxs: TransactionExtended[] = []; // working list of elements of the current cluster
+    let ancestors: { [txid: string]: boolean } = {}; // working set of ancestors of the current cluster root
     const txMap = {};
+    // initialize the txMap
+    for (const tx of transactions) {
+      txMap[tx.txid] = tx;
+    }
+    // reverse pass to identify CPFP clusters
     for (let i = transactions.length - 1; i >= 0; i--) {
       const tx = transactions[i];
-      txMap[tx.txid] = tx;
       if (!ancestors[tx.txid]) {
         let totalFee = 0;
         let totalVSize = 0;
-        cluster.forEach(tx => {
+        clusterTxs.forEach(tx => {
           totalFee += tx?.fee || 0;
           totalVSize += (tx.weight / 4);
         });
         const effectiveFeePerVsize = totalFee / totalVSize;
-        if (cluster.length > 1) {
-          clusters.push({
-            root: cluster[0].txid,
+        let cluster: CpfpCluster;
+        if (clusterTxs.length > 1) {
+          cluster = {
+            root: clusterTxs[0].txid,
             height,
-            txs: cluster.map(tx => { return { txid: tx.txid, weight: tx.weight, fee: tx.fee || 0 }; }),
+            txs: clusterTxs.map(tx => { return { txid: tx.txid, weight: tx.weight, fee: tx.fee || 0 }; }),
             effectiveFeePerVsize,
-          });
+          };
+          clusters.push(cluster);
         }
-        cluster.forEach(tx => {
+        clusterTxs.forEach(tx => {
           txMap[tx.txid].effectiveFeePerVsize = effectiveFeePerVsize;
+          if (cluster) {
+            clusterMap[tx.txid] = cluster;
+          }
         });
-        cluster = [];
+        // reset working vars
+        clusterTxs = [];
         ancestors = {};
       }
-      cluster.push(tx);
+      clusterTxs.push(tx);
       tx.vin.forEach(vin => {
         ancestors[vin.txid] = true;
       });
+    }
+    // forward pass to enforce ancestor rate caps
+    for (const tx of transactions) {
+      let minAncestorRate = tx.effectiveFeePerVsize;
+      for (const vin of tx.vin) {
+        if (txMap[vin.txid]?.effectiveFeePerVsize) {
+          minAncestorRate = Math.min(minAncestorRate, txMap[vin.txid].effectiveFeePerVsize);
+        }
+      }
+      // check rounded values to skip cases with almost identical fees
+      const roundedMinAncestorRate = Math.ceil(minAncestorRate);
+      const roundedEffectiveFeeRate = Math.floor(tx.effectiveFeePerVsize);
+      if (roundedMinAncestorRate < roundedEffectiveFeeRate) {
+        tx.effectiveFeePerVsize = minAncestorRate;
+        if (!clusterMap[tx.txid]) {
+          // add a single-tx cluster to record the dependent rate
+          const cluster = {
+            root: tx.txid,
+            height,
+            txs: [{ txid: tx.txid, weight: tx.weight, fee: tx.fee || 0 }],
+            effectiveFeePerVsize: minAncestorRate,
+          };
+          clusterMap[tx.txid] = cluster;
+          clusters.push(cluster);
+        } else {
+          // update the existing cluster with the dependent rate
+          clusterMap[tx.txid].effectiveFeePerVsize = minAncestorRate;
+        }
+      }
     }
     return {
       transactions,

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -253,9 +253,16 @@ export interface WorkingEffectiveFeeStats extends EffectiveFeeStats {
   maxFee: number;
 }
 
+export interface CpfpCluster {
+  root: string,
+  height: number,
+  txs: Ancestor[],
+  effectiveFeePerVsize: number,
+}
+
 export interface CpfpSummary {
   transactions: TransactionExtended[];
-  clusters: { root: string, height: number, txs: Ancestor[], effectiveFeePerVsize: number }[];
+  clusters: CpfpCluster[];
 }
 
 export interface Statistic {

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -105,6 +105,7 @@ class TransactionRepository {
     return {
       descendants,
       ancestors,
+      effectiveFeePerVsize: cluster.effectiveFeePerVsize,
     };
   }
 }


### PR DESCRIPTION
This PR extends the dependency-based effective fee rate logic of #3786 to CPFP calculations for mined blocks.

The effective fee rate of each transaction in a mined block is now calculated as the minimum of the effective rate of that transaction and that of all of its ancestors in the same block.

For example, this transaction has a fee rate of 93.2 sat/vb, but depends on an ancestor in the same block with an effective rate of only 90.5 sat/vb:

<img width="853" alt="Screenshot 2023-06-06 at 6 24 30 PM" src="https://github.com/mempool/mempool/assets/83316221/c444b380-2a09-42d0-bf1a-2a04fe4a403b">

This makes rates more consistent between projected and mined blocks, and should also make it easier to compute accurate block fee ranges.