### PR TITLE
Clean up legacy CPFP calculations

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -127,14 +127,6 @@ class Blocks {
       }
     }
 
-    if (addMempoolData) {
-      transactions.forEach((tx) => {
-        if (!tx.cpfpChecked) {
-          Common.setRelativesAndGetCpfpInfo(tx as MempoolTransactionExtended, mempool); // Child Pay For Parent
-        }
-      });
-    }
-
     if (!quiet) {
       logger.debug(`${transactionsFound} of ${txIds.length} found in mempool. ${transactionsFetched} fetched through backend service.`);
     }

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -358,6 +358,9 @@ class MempoolBlocks {
             block: blockIndex,
             vsize: totalVsize + (mempoolTx.vsize / 2),
           };
+          mempoolTx.ancestors = [];
+          mempoolTx.descendants = [];
+          mempoolTx.bestDescendant = null;
           mempoolTx.cpfpChecked = true;
 
           // online calculation of stack-of-blocks fee stats


### PR DESCRIPTION
This PR removes some unnecessary legacy CPFP calculations which can cause performance issues during new block processing when the mempool is very large.

It also ensures that CPFP relatives are reset between runs of the GBT algorithm, to ensure transactions can't accumulate stale ancestors.