### PR TITLE
Chunked worker thread messaging

### DIFF
--- a/backend/src/api/tx-selection-worker.ts
+++ b/backend/src/api/tx-selection-worker.ts
@@ -8,22 +8,24 @@ let mempool: Map<number, CompactThreadTransaction> = new Map();
 
 if (parentPort) {
   parentPort.on('message', (params) => {
-    if (params.type === 'set') {
-      mempool = params.mempool;
-    } else if (params.type === 'update') {
-      params.added.forEach(tx => {
+    if (params.type === 'clear') {
+      mempool = new Map();
+    } else {
+      params.added?.forEach(tx => {
         mempool.set(tx.uid, tx);
       });
-      params.removed.forEach(uid => {
+      params.removed?.forEach(uid => {
         mempool.delete(uid);
       });
     }
-    
-    const { blocks, rates, clusters } = makeBlockTemplates(mempool);
 
-    // return the result to main thread.
-    if (parentPort) {
-      parentPort.postMessage({ blocks, rates, clusters });
+    if (params.type === 'execute') {
+      const { blocks, rates, clusters } = makeBlockTemplates(mempool);
+
+      // return the result to main thread.
+      if (parentPort) {
+        parentPort.postMessage({ blocks, rates, clusters });
+      }
     }
   });
 }


### PR DESCRIPTION
This draft PR aims to minimize the amount of time the main thread can be blocked by inter-thread communication for the GBT worker.

Sending mempool data to the worker thread is synchronous and slow. When the mempool is very full, it can block the main thread and delay other time-sensitive backend tasks like responding to API requests.

This PR splits some particularly large worker messages into multiple chunks, and yields to the javascript event loop between sending each chunk so that other tasks can continue to make progress.

Keeping in draft for now while I test more thoroughly and figure out optimal chunk sizes etc.