### PR TITLE
Broadcast transaction packages

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -15,6 +15,7 @@ export interface AbstractBitcoinApi {
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
   $getAddressPrefix(prefix: string): string[];
   $sendRawTransaction(rawTransaction: string): Promise<string>;
+  $submitPackage(rawTransactions: string[]): Promise<string>;
   $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend>;
   $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]>;
   $getBatchedOutspends(txId: string[]): Promise<IEsploraApi.Outspend[][]>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -137,6 +137,10 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.sendRawTransaction(rawTransaction);
   }
 
+  $submitPackage(rawTransactions: string[]): Promise<string> {
+    return this.bitcoindClient.submitPackage(rawTransactions);
+  }
+
   async $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend> {
     const txOut = await this.bitcoindClient.getTxOut(txId, vout, false);
     return {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -118,6 +118,10 @@ class ElectrsApi implements AbstractBitcoinApi {
     throw new Error('Method not implemented.');
   }
 
+  $submitPackage(rawTransactions: string[]): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
+
   $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend> {
     return this.$queryWrapper<IEsploraApi.Outspend>(config.ESPLORA.REST_API_URL + '/tx/' + txId + '/outspend/' + vout);
   }

--- a/backend/src/rpc-api/commands.ts
+++ b/backend/src/rpc-api/commands.ts
@@ -80,6 +80,7 @@ module.exports = {
   setTxFee: 'settxfee',
   signMessage: 'signmessage',
   signRawTransaction: 'signrawtransaction', // bitcoind v0.7.0+
+  submitPackage: 'submitpackage',
   stop: 'stop',
   submitBlock: 'submitblock', // bitcoind v0.7.0+
   validateAddress: 'validateaddress',

--- a/contributors/joostjager.txt
+++ b/contributors/joostjager.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of January 25, 2022.
+
+Signed: joostjager

--- a/frontend/src/app/components/push-transaction/push-transaction.component.html
+++ b/frontend/src/app/components/push-transaction/push-transaction.component.html
@@ -3,10 +3,20 @@
 
   <form [formGroup]="pushTxForm" (submit)="pushTxForm.valid && postTx()" novalidate>
     <div class="mb-3">
-      <textarea formControlName="txHash" class="form-control" rows="5" i18n-placeholder="transaction.hex" placeholder="Transaction hex"></textarea>
+      <div formArrayName="txHash">
+        <div *ngFor="let tx of getTxs().controls; index as i">
+          <textarea [formControlName]="i" class="form-control mb-3" rows="5" i18n-placeholder="transaction.hex" placeholder="Transaction hex"></textarea>
+        </div>
+      </div>
     </div>
-    <button [disabled]="isLoading" type="submit" class="btn btn-primary mr-2" i18n="shared.broadcast-transaction|Broadcast Transaction">Broadcast Transaction</button>
-    <p class="red-color d-inline">{{ error }}</p> <a *ngIf="txId" [routerLink]="['/tx/' | relativeUrl, txId]">{{ txId }}</a>
+    <div class="d-flex justify-content-between mb-3">
+      <button [disabled]="isLoading" type="submit" class="btn btn-primary mr-2" i18n="shared.broadcast-transaction|Broadcast Transaction">Broadcast Transaction</button>
+      <button [disabled]="isLoading" class="btn btn-secondary" (click)="addTx()">Add Child Transaction</button>
+    </div>
+    <p class="red-color d-inline">{{ error }}</p> 
+    <div *ngFor="let txId of txIds">
+      <a [routerLink]="['/tx/' | relativeUrl, txId]">{{ txId }}</a>
+    </div>
   </form>
 
 </div>

--- a/frontend/src/app/components/push-transaction/push-transaction.component.ts
+++ b/frontend/src/app/components/push-transaction/push-transaction.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { UntypedFormBuilder, UntypedFormGroup, Validators, FormArray } from '@angular/forms';
 import { ApiService } from '../../services/api.service';
 
 @Component({
@@ -10,7 +10,7 @@ import { ApiService } from '../../services/api.service';
 export class PushTransactionComponent implements OnInit {
   pushTxForm: UntypedFormGroup;
   error: string = '';
-  txId: string = '';
+  txIds: string[] = [];
   isLoading = false;
 
   constructor(
@@ -20,18 +20,30 @@ export class PushTransactionComponent implements OnInit {
 
   ngOnInit(): void {
     this.pushTxForm = this.formBuilder.group({
-      txHash: ['', Validators.required],
+      txHash: this.formBuilder.array([]),
     });
+
+    this.addTx();
+  }
+
+  getTxs() {
+    return this.pushTxForm.get('txHash') as FormArray;
+  }
+
+  addTx() {
+    this.getTxs().push(this.formBuilder.control('', Validators.required))
   }
 
   postTx() {
     this.isLoading = true;
     this.error = '';
-    this.txId = '';
-    this.apiService.postTransaction$(this.pushTxForm.get('txHash').value)
+    this.txIds = [];
+    const txs = this.pushTxForm.get('txHash').value;
+    const txData = txs.join(' ');
+    this.apiService.postTransaction$(txData)
       .subscribe((result) => {
         this.isLoading = false;
-        this.txId = result;
+        this.txIds = result;
         this.pushTxForm.reset();
       },
       (error) => {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -149,7 +149,7 @@ export class ApiService {
   }
 
   postTransaction$(hexPayload: string): Observable<any> {
-    return this.httpClient.post<any>(this.apiBaseUrl + this.apiBasePath + '/api/tx', hexPayload, { responseType: 'text' as 'json'});
+    return this.httpClient.post<String[]>(this.apiBaseUrl + this.apiBasePath + '/api/tx', hexPayload);
   }
 
   listPools$(interval: string | undefined) : Observable<any> {


### PR DESCRIPTION
This PR demonstrates a possible implementation of package broadcasting. It facilitates the addition of transactions to the mempool even when their fee rate is below the minimum, as long as the total package fee rate suffices. An example of this could be a 1 sat/b lightning commitment transaction, which is time-sensitive (the parent tx), along with a high fee rate child transaction that covers the cost for the parent tx too.

According to the FAQ, mempool.space utilizes a virtually limitless mempool. In this scenario, transactions would still be accepted even if they were broadcasted individually. However, versions hosted in other locations might operate with more confined mempools. For these versions, package broadcasting might be the only technique to push a package similar to the one described above into their mempool.

To utilize this on the mainnet, it necessitates the application of this patch: https://github.com/bitcoin/bitcoin/pull/27609. The discussions around the PR suggest its usage is safe.

https://github.com/mempool/mempool/assets/4638168/670504af-a86e-4e86-9cda-a89cb09a1347