### PR TITLE
Add luminex as enterprise sponsor

### DIFF
--- a/frontend/src/app/components/about/about.component.html
+++ b/frontend/src/app/components/about/about.component.html
@@ -173,6 +173,21 @@
         </svg>
         <span>Exodus</span>
       </a>
+      <a href="https://www.luminex.io" target="_blank" title="Luminex">
+        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="66.95" height="80" viewBox="0 0 300.43 385" style="padding-top: 10px;">
+          <defs>
+            <style>
+              .cls-1 {
+                fill: #f2ea25;
+              }
+            </style>
+          </defs>
+          <path class="cls-1" d="m309.02,90.04c0,49.65-38.73,90.04-95.34,90.04s-95.34-40.39-95.34-90.04S153.77,0,213.69,0c56.28,0,95.34,40.39,95.34,90.04Zm-63.56,0c0-20.52-14.23-37.07-31.78-37.07s-31.78,16.55-31.78,37.07,14.23,37.07,31.78,37.07,31.78-16.55,31.78-37.07Z"/>
+          <path class="cls-1" d="m311.87,372.67h-66.34l-31.84-47.76-31.84,47.76h-66.34l58.38-90.22-53.07-79.61h66.34l26.54,42.46,26.53-42.46h66.34l-53.07,79.61,58.38,90.22Z"/>
+          <rect class="cls-1" width="60.69" height="372.67"/>
+        </svg>
+        <span>Luminex</span>
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
It's intentionally _not_ aligned with existing icons because it is not circular and taller than it is wide...looks too large when it is the same height as the other icons.

![Screenshot from 2023-06-14 19-00-02](https://github.com/mempool/mempool/assets/93150691/a32149f7-9b38-4a8a-b5b9-737085118dff)
