### PR TITLE
It's time (Enable fullrbf)

### DIFF
--- a/production/bitcoin.conf
+++ b/production/bitcoin.conf
@@ -8,6 +8,7 @@ par=16
 dbcache=8192
 maxmempool=4096
 mempoolexpiry=999999
+mempoolfullrbf=1
 maxconnections=42
 onion=127.0.0.1:9050
 rpcallowip=127.0.0.1

--- a/production/bitcoin.minfee.conf
+++ b/production/bitcoin.minfee.conf
@@ -4,6 +4,7 @@ txindex=0
 listen=1
 daemon=1
 prune=1337
+mempoolfullrbf=1
 rpcallowip=127.0.0.1
 rpcuser=__BITCOIN_RPC_USER__
 rpcpassword=__BITCOIN_RPC_PASS__


### PR DESCRIPTION
AntPool, Binance Pool and Mara pool are among the mining pools now mining full RBF transactions just by looking for a while.

We catch these transactions when they get mined, but they show up as "added" skewing the audit template.

There are mostly benefits in enabling fullrbf to get the full picture of the mempool and not just throw "transaction not found".

<img width="1206" alt="Screenshot 2023-06-15 at 21 04 17" src="https://github.com/mempool/mempool/assets/8561090/4dbacc0e-1c5e-4716-a0fb-5ea871f3225a">

<img width="403" alt="Screenshot 2023-06-15 at 21 04 56" src="https://github.com/mempool/mempool/assets/8561090/37ee4295-94a5-456f-a4c8-12dfcb42d72e">
