### PR TITLE
the last two docker-compose overrides need MEMPOOL_ in front

### DIFF
--- a/contributors/pfoytik.txt
+++ b/contributors/pfoytik.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of June 15, 2023.
+
+Signed pfoytik

--- a/docker/README.md
+++ b/docker/README.md
@@ -144,8 +144,8 @@ Corresponding `docker-compose.yml` overrides:
       MEMPOOL_ADVANCED_GBT_AUDIT: ""
       MEMPOOL_ADVANCED_GBT_MEMPOOL: ""
       MEMPOOL_CPFP_INDEXING: ""
-      MAX_BLOCKS_BULK_QUERY: ""
-      DISK_CACHE_BLOCK_INTERVAL: ""
+      MEMPOOL_MAX_BLOCKS_BULK_QUERY: ""
+      MEMPOOL_DISK_CACHE_BLOCK_INTERVAL: ""
       ...
 ```
 


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
Simple correction that hung me up, in the docker README.MD the last two override variables for the MEMPOOL variables were listed as shown below without "MEMPOOL_" in front
![image](https://github.com/mempool/mempool/assets/30268344/8c15b086-10a4-45b2-91af-b640ad49a5f9)

This pull request simply corrects those values to be:
![image](https://github.com/mempool/mempool/assets/30268344/f6d560f8-d779-4761-9192-b79728df0ad8)

I tested on my local instance and verified that this change is reflected in the mempool-config.json file when the containers startup.
