### PR TITLE
Change RBF status badges

### DIFF
--- a/frontend/cypress/e2e/mainnet/mainnet.spec.ts
+++ b/frontend/cypress/e2e/mainnet/mainnet.spec.ts
@@ -537,7 +537,7 @@ describe('Mainnet', () => {
           cy.get('.container-xl > :nth-child(3)').invoke('css', 'width').should('equal', alertWidth);
         });
 
-        cy.get('.btn-danger').then(getRectangle).then((rectA) => {
+        cy.get('.btn-warning').then(getRectangle).then((rectA) => {
           cy.get('.alert').then(getRectangle).then((rectB) => {
             expect(areOverlapping(rectA, rectB), 'Confirmations box and RBF alert are overlapping').to.be.false;
           });
@@ -582,7 +582,7 @@ describe('Mainnet', () => {
           cy.get(alertLocator).invoke('css', 'width').should('equal', firstWidth);
         });
 
-        cy.get('.btn-danger').then(getRectangle).then((rectA) => {
+        cy.get('.btn-warning').then(getRectangle).then((rectA) => {
           cy.get('.alert').then(getRectangle).then((rectB) => {
             expect(areOverlapping(rectA, rectB), 'Confirmations box and RBF alert are overlapping').to.be.false;
           });

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -18,7 +18,12 @@
       </span>
 
       <div class="container-buttons">
-        <app-confirmations [chainTip]="latestBlock?.height" [height]="tx?.status?.block_height" [replaced]="replaced"></app-confirmations>
+        <app-confirmations
+          [chainTip]="latestBlock?.height"
+          [height]="tx?.status?.block_height"
+          [replaced]="replaced"
+          [removed]="this.rbfInfo?.mined && !this.tx?.status?.confirmed"
+        ></app-confirmations>
       </div>
     </ng-container>
   </div>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.html
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.html
@@ -8,6 +8,9 @@
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && replaced">
   <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Replaced</button>
 </ng-template>
-<ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced">
+<ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && removed">
+  <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.audit.removed|Transaction removed state">Removed</button>
+</ng-template>
+<ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && !removed">
   <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Unconfirmed</button>
 </ng-template>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.html
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.html
@@ -6,7 +6,7 @@
   </button>
 </ng-template>
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && replaced">
-  <button type="button" class="btn btn-sm btn-warning {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Replaced</button>
+  <button type="button" class="btn btn-sm btn-warning {{buttonClass}}" i18n="transaction.replaced|Transaction replaced state">Replaced</button>
 </ng-template>
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && removed">
   <button type="button" class="btn btn-sm btn-warning {{buttonClass}}" i18n="transaction.audit.removed|Transaction removed state">Removed</button>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.html
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.html
@@ -6,10 +6,10 @@
   </button>
 </ng-template>
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && replaced">
-  <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Replaced</button>
+  <button type="button" class="btn btn-sm btn-warning {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Replaced</button>
 </ng-template>
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && removed">
-  <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.audit.removed|Transaction removed state">Removed</button>
+  <button type="button" class="btn btn-sm btn-warning {{buttonClass}}" i18n="transaction.audit.removed|Transaction removed state">Removed</button>
 </ng-template>
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && !removed">
   <button type="button" class="btn btn-sm btn-danger {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Unconfirmed</button>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.ts
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.ts
@@ -11,6 +11,7 @@ export class ConfirmationsComponent implements OnChanges {
   @Input() chainTip: number;
   @Input() height: number;
   @Input() replaced: boolean = false;
+  @Input() removed: boolean = false;
   @Input() hideUnconfirmed: boolean = false;
   @Input() buttonClass: string = '';
 


### PR DESCRIPTION
Fixes #3866 

Label cached RBF transactions as "Removed" if a prior version gets mined, and change the color classes of both the "Replaced" and "Removed" badges from `btn-danger` to `btn-warning`:

<img width="852" alt="Screenshot 2023-06-16 at 5 34 40 PM" src="https://github.com/mempool/mempool/assets/83316221/2697d155-37c4-427e-bf98-b1d2f1433ddb">
<img width="852" alt="Screenshot 2023-06-16 at 5 34 32 PM" src="https://github.com/mempool/mempool/assets/83316221/77f4238a-1b65-4610-a39b-f59a9b321939">

