### PR TITLE
Reinstate the mempool loop time limit

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -186,6 +186,12 @@ class Mempool {
         loadingIndicators.setProgress('mempool', progress);
         loggerTimer = new Date().getTime() / 1000;
       }
+      // Break and restart mempool loop if we spend too much time processing
+      // new transactions that may lead to falling behind on block height
+      if (this.inSync && (new Date().getTime()) - start > 10_000) {
+        logger.debug('Breaking mempool loop because the 10s time limit exceeded.');
+        break;
+      }
     }
 
     // Reset esplora 404 counter and log a warning if needed


### PR DESCRIPTION
If we get hundreds/thousands of new transactions, the mempool loop might take time to process causing the backend to fall behind on block height.

Reinstating the 10 second timeout before we break and continue next loop. Only when the mempool is in sync.