### PR TITLE
Hotfix for undefined cpfp cluster bug

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -224,7 +224,12 @@ class BitcoinRoutes {
     } else {
       let cpfpInfo;
       if (config.DATABASE.ENABLED) {
-        cpfpInfo = await transactionRepository.$getCpfpInfo(req.params.txId);
+        try {
+          cpfpInfo = await transactionRepository.$getCpfpInfo(req.params.txId);
+        } catch (e) {
+          res.status(500).send('failed to get CPFP info');
+          return;
+        }
       }
       if (cpfpInfo) {
         res.json(cpfpInfo);

--- a/backend/src/repositories/CpfpRepository.ts
+++ b/backend/src/repositories/CpfpRepository.ts
@@ -78,14 +78,6 @@ class CpfpRepository {
 
       const maxChunk = 100;
       let chunkIndex = 0;
-      // insert transactions in batches of up to 100 rows
-      while (chunkIndex < txs.length) {
-        const chunk = txs.slice(chunkIndex, chunkIndex + maxChunk);
-        await transactionRepository.$batchSetCluster(chunk);
-        chunkIndex += maxChunk;
-      }
-
-      chunkIndex = 0;
       // insert clusters in batches of up to 100 rows
       while (chunkIndex < clusterValues.length) {
         const chunk = clusterValues.slice(chunkIndex, chunkIndex + maxChunk);
@@ -103,6 +95,15 @@ class CpfpRepository {
         );
         chunkIndex += maxChunk;
       }
+
+      chunkIndex = 0;
+      // insert transactions in batches of up to 100 rows
+      while (chunkIndex < txs.length) {
+        const chunk = txs.slice(chunkIndex, chunkIndex + maxChunk);
+        await transactionRepository.$batchSetCluster(chunk);
+        chunkIndex += maxChunk;
+      }
+
       return true;
     } catch (e: any) {
       logger.err(`Cannot save cpfp clusters into db. Reason: ` + (e instanceof Error ? e.message : e));

--- a/backend/src/repositories/CpfpRepository.ts
+++ b/backend/src/repositories/CpfpRepository.ts
@@ -120,8 +120,8 @@ class CpfpRepository {
       [clusterRoot]
     );
     const cluster = clusterRows[0];
-    cluster.effectiveFeePerVsize = cluster.fee_rate;
     if (cluster?.txs) {
+      cluster.effectiveFeePerVsize = cluster.fee_rate;
       cluster.txs = this.unpack(cluster.txs);
       return cluster;
     }


### PR DESCRIPTION
The bug is triggered by a stray property access without a null check introduced in #3838:

https://github.com/mempool/mempool/blob/ca9b48283dbd07ff622b5d878e83ebc3aa937a45/backend/src/repositories/CpfpRepository.ts#L113-L129

In theory that db query should never return an empty result, since the cluster id is obtained from a corresponding `compact_cpfp_transaction` record, and we always add transaction and cluster records together (so the cluster should always exist)

In practice, saving cpfp info is not an atomic operation, and transaction records are saved before their corresponding cluster record, so there's a brief moment in which someone could make a `getCpfpInfo` request, or an unrelated crash could occur and leave the db in an inconsistent state.

This hotfix:
 - adds the missing null check.
 - wraps the function call in a try/catch.
 - changes the order of operations so that cluster records are saved before their corresponding transaction records.
 
I'll look into making the database operations in `CpfpRepository.$batchSaveClusters` actually atomic in a separate PR.