### PR TITLE
Liquidity > Capacity

### DIFF
--- a/frontend/src/app/lightning/nodes-ranking/top-nodes-per-channels/top-nodes-per-channels.component.html
+++ b/frontend/src/app/lightning/nodes-ranking/top-nodes-per-channels/top-nodes-per-channels.component.html
@@ -1,7 +1,7 @@
 
 
 <div class="container-xl" style="min-height: 335px" [ngClass]="{'widget': widget, 'full-height': !widget}">
-  <h1 *ngIf="!widget" class="float-left" i18n="lightning.liquidity-ranking">Liquidity Ranking</h1>
+  <h1 *ngIf="!widget" class="float-left" i18n="lightning.liquidity-ranking">Capacity Ranking</h1>
 
   <div class="clearfix"></div>
 


### PR DESCRIPTION
On the main Lightning view these two views are titled as "Liquidity Ranking" and "Connectivity Ranking":

<img width="1169" alt="Screenshot 2023-06-25 at 14 03 16" src="https://github.com/mempool/mempool/assets/2123375/4032ba7d-0ad5-4292-9957-b675b35ad260">

However on the individual pages they are both titled "Liquidity Ranking":

<img width="1439" alt="Screenshot 2023-06-25 at 14 03 28" src="https://github.com/mempool/mempool/assets/2123375/49627b22-bfee-4701-acc4-1a7f0311e2b8">

<img width="1429" alt="Screenshot 2023-06-25 at 14 03 32" src="https://github.com/mempool/mempool/assets/2123375/2446ce8d-a1be-4249-ac2d-59c2a8f02629">


This PR brings the listing view title inline with the main Lightning view.
