### PR TITLE
Fix: napi macro breaks rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.tabSize": 2,
   "typescript.preferences.importModuleSpecifier": "relative",
-  "typescript.tsdk": "./backend/node_modules/typescript/lib"
+  "typescript.tsdk": "./backend/node_modules/typescript/lib",
+  "rust-analyzer.procMacro.ignored": { "napi-derive": ["napi"] }
 }


### PR DESCRIPTION
See issue: https://github.com/napi-rs/napi-rs/issues/944#issuecomment-1013002760

This will ignore expanding the napi macro for rust-analyzer, letting auto-complete work inside the napi impl blocks.