### PR TITLE
Lowering mempool loop break limit

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -156,6 +156,7 @@ class Mempool {
       }
     };
 
+    let intervalTimer = Date.now();
     for (const txid of transactions) {
       if (!this.mempoolCache[txid]) {
         try {

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -180,9 +180,7 @@ class Mempool {
         }
       }
 
-      if (new Date().getTime() - start > 5_000) {
-        const progress = (currentMempoolSize + newTransactions.length) / transactions.length * 100;
-        logger.debug(`Mempool is synchronizing. Processed ${newTransactions.length}/${diff} txs (${Math.round(progress)}%)`);
+      if (Date.now() - intervalTimer > 5_000) {
         
         if (this.inSync) {
           // Break and restart mempool loop if we spend too much time processing

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -188,7 +188,10 @@ class Mempool {
           logger.debug('Breaking mempool loop because the 5s time limit exceeded.');
           break;
         } else {
+          const progress = (currentMempoolSize + newTransactions.length) / transactions.length * 100;
+          logger.debug(`Mempool is synchronizing. Processed ${newTransactions.length}/${diff} txs (${Math.round(progress)}%)`);
           loadingIndicators.setProgress('mempool', progress);
+          intervalTimer = Date.now()
         }
       }
     }


### PR DESCRIPTION
This PR changes 2 things:

* Lowering the break limit from 10s to 5s that the mempool loop is allowed to run before it breaks and continues
* Don't output any mempool loop progress when the mempool "in sync" status is true.

This hopefully fixes slowness in the mempool loop when a lot of new transactions comes in. But also not sending 99% progress to the frontend causing the frontend to go into "loading spinner" mode, because we are not out of sync!

