### PR TITLE
Increased performance

### DIFF
--- a/backend/rust-gbt/src/lib.rs
+++ b/backend/rust-gbt/src/lib.rs
@@ -30,7 +30,7 @@ use u32_hasher_types::{u32hashmap_with_capacity, U32HasherState};
 /// by virtue of starting with such a large capacity.
 ///
 /// Note: This doesn't *have* to be a power of 2. (uwu)
-const STARTING_CAPACITY: usize = 2048;
+const STARTING_CAPACITY: usize = 32768;
 
 type ThreadTransactionsMap = HashMap<u32, ThreadTransaction, U32HasherState>;
 


### PR DESCRIPTION
This almost halves the time of the gbt function. (Though the gbt function itself is surprisingly a small portion of the total time including TypeScript.)

The peak memory usage was 46MB, even with this really large initial capacity for a bunch of Vecs and Queues.

I was also shocked that converting the Vec for mempool_stack twice (collecting both times and re-allocating) actually was faster.

I guess it makes sense because we moved the hashmap lookups to an O(n) operation instead of an O(n log n) (worst case) operation, and the reallocation only happens 2 times (O(1))

I was able to measure this thanks to the test case. :+1: