### PR TITLE
More precise relative block times

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -41,7 +41,7 @@
               <tr>
                 <td i18n="block.timestamp">Timestamp</td>
                 <td>
-                  <app-timestamp [unixTime]="block.timestamp"></app-timestamp>
+                  <app-timestamp [unixTime]="block.timestamp" [precision]="1" minUnit="minute"></app-timestamp>
                 </td>
               </tr>
               <tr>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -53,7 +53,7 @@
               <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
             </div>
             <div [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-time'" class="time-difference">
-              <app-time kind="since" [time]="block.timestamp" [fastRender]="true"></app-time></div>
+              <app-time kind="since" [time]="block.timestamp" [fastRender]="true" [precision]="1" minUnit="minute"></app-time></div>
           </ng-container>
         </div>
         <div class="animated" [class]="showMiningInfo ? 'show' : 'hide'" *ngIf="block.extras?.pool != undefined">

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -29,10 +29,10 @@
               </div>
               <div [attr.data-cy]="'mempool-block-' + i + '-time'" class="time-difference" *ngIf="projectedBlock.blockVSize <= stateService.blockVSize; else mergedBlock">
                 <ng-template [ngIf]="network === 'liquid' || network === 'liquidtestnet'" [ngIfElse]="timeDiffMainnet">
-                  <app-time kind="until" [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true"></app-time>
+                  <app-time kind="until" [time]="(1 * i) + now + 61000" [fastRender]="false" [fixedRender]="true" [precision]="1" minUnit="minute"></app-time>
                 </ng-template>
                 <ng-template #timeDiffMainnet>
-                  <app-time kind="until" [time]="da.timeAvg * (i + 1) + now + da.timeOffset" [fastRender]="false" [fixedRender]="true"></app-time>
+                  <app-time kind="until" [time]="da.timeAvg * (i + 1) + now + da.timeOffset" [fastRender]="false" [fixedRender]="true" [precision]="1" minUnit="minute"></app-time>
                 </ng-template>
               </div>
               <ng-template #mergedBlock>

--- a/frontend/src/app/components/time/time.component.ts
+++ b/frontend/src/app/components/time/time.component.ts
@@ -29,6 +29,7 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
   @Input() fixedRender = false;
   @Input() relative = false;
   @Input() precision: number = 0;
+  @Input() minUnit: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' = 'second';
   @Input() fractionDigits: number = 0;
 
   constructor(
@@ -96,9 +97,12 @@ export class TimeComponent implements OnInit, OnChanges, OnDestroy {
     for (const [index, unit] of this.units.entries()) {
       let precisionUnit = this.units[Math.min(this.units.length - 1, index + this.precision)];
       counter = Math.floor(seconds / this.intervals[unit]);
-      const precisionCounter = Math.floor(seconds / this.intervals[precisionUnit]);
+      const precisionCounter = Math.round(seconds / this.intervals[precisionUnit]);
       if (precisionCounter > this.precisionThresholds[precisionUnit]) {
         precisionUnit = unit;
+      }
+      if (this.units.indexOf(precisionUnit) === this.units.indexOf(this.minUnit)) {
+        counter = Math.max(1, counter);
       }
       if (counter > 0) {
         let rounded = Math.round(seconds / this.intervals[precisionUnit]);

--- a/frontend/src/app/shared/components/timestamp/timestamp.component.html
+++ b/frontend/src/app/shared/components/timestamp/timestamp.component.html
@@ -2,6 +2,6 @@
 <span *ngIf="seconds !== undefined">
   &lrm;{{ seconds * 1000 | date: customFormat ?? 'yyyy-MM-dd HH:mm' }}
   <div class="lg-inline" *ngIf="!hideTimeSince">
-    <i class="symbol">(<app-time kind="since" [time]="seconds" [fastRender]="true"></app-time>)</i>
+    <i class="symbol">(<app-time kind="since" [time]="seconds" [fastRender]="true" [precision]="precision" [minUnit]="minUnit"></app-time>)</i>
   </div>
 </span>

--- a/frontend/src/app/shared/components/timestamp/timestamp.component.ts
+++ b/frontend/src/app/shared/components/timestamp/timestamp.component.ts
@@ -11,6 +11,8 @@ export class TimestampComponent implements OnChanges {
   @Input() dateString: string;
   @Input() customFormat: string;
   @Input() hideTimeSince: boolean = false;
+  @Input() precision: number = 0;
+  @Input() minUnit: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' = 'second';
 
   seconds: number | undefined = undefined;
 


### PR DESCRIPTION
This PR partially addresses #3911 by increasing the precision of the relative times displayed on blocks, using the `precision` property of the `time` component.

minutes are now displayed up to 90 minutes (maybe 120 minutes would be better?),
hours up to 48 hours,
days up to 31 days,
weeks up to 12 weeks,
and months up to 18 months.

| Before | After |
|-|-|
| <img width="779" alt="Screenshot 2023-06-29 at 10 17 11 AM" src="https://github.com/mempool/mempool/assets/83316221/173b5a32-0a45-4397-845e-52a335babf42"> | <img width="779" alt="Screenshot 2023-06-29 at 10 12 05 AM" src="https://github.com/mempool/mempool/assets/83316221/61950e4c-77f6-432e-b5d6-ed65623aa951"> |
| <img width="779" alt="Screenshot 2023-06-29 at 10 16 46 AM" src="https://github.com/mempool/mempool/assets/83316221/c458aa7e-6db6-4262-9336-67ef5a03afaa"> | <img width="779" alt="Screenshot 2023-06-29 at 10 12 32 AM" src="https://github.com/mempool/mempool/assets/83316221/0d3a68af-618c-4fcd-aa54-a80ab3efc4a3"> |
| <img width="779" alt="Screenshot 2023-06-29 at 10 16 14 AM" src="https://github.com/mempool/mempool/assets/83316221/0220ddb4-0451-4945-8880-0c6dbae1d267"> | <img width="779" alt="Screenshot 2023-06-29 at 10 13 49 AM" src="https://github.com/mempool/mempool/assets/83316221/1e6387bb-d78b-4dd8-89bf-0a70af78f314"> |

