### PR TITLE
Save effective rates to templates & summaries

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -113,6 +113,10 @@ export class Common {
     };
   }
 
+  static stripTransactions(txs: TransactionExtended[]): TransactionStripped[] {
+    return txs.map(this.stripTransaction);
+  }
+
   static sleep$(ms: number): Promise<void> {
     return new Promise((resolve) => {
        setTimeout(() => {

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -562,14 +562,7 @@ class WebsocketHandler {
         const { censored, added, fresh, sigop, score, similarity } = Audit.auditBlock(transactions, projectedBlocks, auditMempool);
         const matchRate = Math.round(score * 100 * 100) / 100;
 
-        const stripped = projectedBlocks[0]?.transactions ? projectedBlocks[0].transactions.map((tx) => {
-          return {
-            txid: tx.txid,
-            vsize: tx.vsize,
-            fee: tx.fee ? Math.round(tx.fee) : 0,
-            value: tx.value,
-          };
-        }) : [];
+        const stripped = projectedBlocks[0]?.transactions ? projectedBlocks[0].transactions : [];
 
         let totalFees = 0;
         let totalWeight = 0;


### PR DESCRIPTION
_(builds on PR #3881)_

This PR adds effective fee rates to the audit templates and block summaries saved to the database for new blocks, and displays those rates in the block audit view when available:

| <img width="552" alt="Screenshot 2023-06-29 at 7 22 25 PM" src="https://github.com/mempool/mempool/assets/83316221/d1aa300b-1f0c-4f5c-9088-7038707cf906"> | <img width="552" alt="Screenshot 2023-06-29 at 7 22 41 PM" src="https://github.com/mempool/mempool/assets/83316221/259957d3-f0d3-4827-a627-cc6a83ef2063"> |
|-|-|

Existing templates & block summaries are unaffected.