### PR TITLE
Stale blocks

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -29,6 +29,7 @@ class BitcoinApi implements AbstractBitcoinApi {
       weight: block.weight,
       previousblockhash: block.previousblockhash,
       mediantime: block.mediantime,
+      stale: block.confirmations === -1,
     };
   }
 

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -89,6 +89,7 @@ export namespace IEsploraApi {
     weight: number;
     previousblockhash: string;
     mediantime: number;
+    stale: boolean;
   }
 
   export interface Address {

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -227,6 +227,7 @@ export interface BlockExtension {
  */
 export interface BlockExtended extends IEsploraApi.Block {
   extras: BlockExtension;
+  canonical?: string;
 }
 
 export interface BlockSummary {

--- a/backend/src/repositories/BlocksAuditsRepository.ts
+++ b/backend/src/repositories/BlocksAuditsRepository.ts
@@ -62,8 +62,7 @@ class BlocksAuditRepositories {
   public async $getBlockAudit(hash: string): Promise<any> {
     try {
       const [rows]: any[] = await DB.query(
-        `SELECT blocks.height, blocks.hash as id, UNIX_TIMESTAMP(blocks.blockTimestamp) as timestamp, blocks.size,
-        blocks.weight, blocks.tx_count,
+        `SELECT blocks_audits.height, blocks_audits.hash as id, UNIX_TIMESTAMP(blocks_audits.time) as timestamp,
         template,
         missing_txs as missingTxs,
         added_txs as addedTxs,
@@ -73,7 +72,6 @@ class BlocksAuditRepositories {
         expected_fees as expectedFees,
         expected_weight as expectedWeight
         FROM blocks_audits
-        JOIN blocks ON blocks.hash = blocks_audits.hash
         JOIN blocks_templates ON blocks_templates.id = blocks_audits.hash
         WHERE blocks_audits.hash = "${hash}"
       `);

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -1,6 +1,10 @@
 <div class="container-xl" (window:resize)="onResize($event)">
 
   <div class="title-block" [class.time-ltr]="timeLtr" id="block">
+    <div *ngIf="block?.stale" class="alert alert-mempool" role="alert">
+      <span i18n="block.reorged|Block reorg" class="alert-text">This block does not belong to the main chain, it has been replaced by:</span>
+      <app-truncate [text]="block.canonical" [lastChars]="12" [link]="['/block/' | relativeUrl, block.canonical]" [maxWidth]="480"></app-truncate>
+    </div>
     <h1>
       <ng-container *ngIf="blockHeight == null || blockHeight > 0; else genesis" i18n="shared.block-title">Block</ng-container>
       <ng-template #genesis i18n="@@2303359202781425764">Genesis</ng-template>
@@ -22,6 +26,8 @@
     </h1>
 
     <div class="grow"></div>
+
+    <button *ngIf="block?.stale" type="button" class="btn btn-sm btn-danger container-button" i18n="block.stale|Stale block state">Stale</button>
 
     <button [routerLink]="['/' | relativeUrl]" class="btn btn-sm">&#10005;</button>
   </div>

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -1,3 +1,26 @@
+.title-block {
+  flex-wrap: wrap;
+  align-items: baseline;
+  @media (min-width: 650px) {
+    flex-direction: row;
+  }
+  h1 {
+    margin: 0rem;
+    margin-right: 15px;
+    line-height: 1;
+  }
+
+  .alert-mempool {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .container-button {
+    align-self: center;
+    margin-right: 1em;
+  }
+}
+
 .qr-wrapper {
   background-color: #FFF;
   padding: 10px;

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -121,6 +121,7 @@ export interface Block {
   weight: number;
   previousblockhash: string;
   stale?: boolean;
+  canonical?: string;
 }
 
 export interface Address {

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -120,6 +120,7 @@ export interface Block {
   size: number;
   weight: number;
   previousblockhash: string;
+  stale?: boolean;
 }
 
 export interface Address {


### PR DESCRIPTION
Fixes #3559. Partially addresses #1515.

This PR fixes some issues related to stale blocks and reorgs:
  1. After a reorg, the backend block cache is now updated to the canonical chain, so that we serve the correct list of recent blocks to new clients.
  2. Serve the correct block
      - Previously, requests for stale blocks would silently return the canonical block at the same height without changing the url etc.
      - Now, we always return the actual requested block for a given block hash.
  3. Now that it's possible to view stale blocks, we display an alert banner to make it clear that the block is not part of the main chain:
  
<img width="1142" alt="Screenshot 2023-07-08 at 12 36 20 AM" src="https://github.com/mempool/mempool/assets/83316221/88622ec3-8111-4c6d-abbf-8259a283ffef">

---

For future PRs:
 - [x] Replace client-side cached blocks after a reorg
 - [ ] Link to known stale blocks from main chain
 - [ ] Visualize difference between stale + canonical blocks
