### PR TITLE
Add spacer for missing fiat values

### DIFF
--- a/frontend/src/app/fiat/fiat.component.html
+++ b/frontend/src/app/fiat/fiat.component.html
@@ -8,7 +8,10 @@
 </span>
 
 <ng-template #noblockconversion>
-  <span [class]="colorClass" *ngIf="(conversions$ | async) as conversions">
+  <span [class]="colorClass" *ngIf="(conversions$ | async) as conversions; else noconversion">
     {{ (conversions[currency] > -1 ? conversions[currency] : 0) * value / 100000000 | fiatCurrency : digitsInfo : currency }}
   </span>
+  <ng-template #noconversion>
+    <span>&nbsp;</span>
+  </ng-template>
 </ng-template>


### PR DESCRIPTION
Fixes an issue where dashboard widgets would be misaligned if fiat data was missing for any reason.

| Before | After |
|-|-|
| <img width="863" alt="Screenshot 2023-07-11 at 11 20 03 AM" src="https://github.com/mempool/mempool/assets/83316221/7e151b1c-33a4-4d3d-9f4c-cb7417c1f916"> | <img width="863" alt="Screenshot 2023-07-11 at 11 19 52 AM" src="https://github.com/mempool/mempool/assets/83316221/e14885ab-3635-40f9-b2a2-2c29d592d030"> |
