### PR TITLE
Fix mined rbf conflict prevention

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -86,18 +86,18 @@ export class Common {
         const match = spendMap.get(`${vin.txid}:${vin.vout}`);
         if (match && match.txid !== tx.txid) {
           replaced.add(match);
+          // remove this tx from the spendMap
+          // prevents the same tx being replaced more than once
+          for (const replacedVin of match.vin) {
+            const key = `${replacedVin.txid}:${replacedVin.vout}`;
+            spendMap.delete(key);
+          }
         }
+        const key = `${vin.txid}:${vin.vout}`;
+        spendMap.delete(key);
       }
       if (replaced.size) {
         matches[tx.txid] = { replaced: Array.from(replaced), replacedBy: tx };
-      }
-      // remove this tx from the spendMap
-      // prevents the same tx being replaced more than once
-      for (const vin of tx.vin) {
-        const key = `${vin.txid}:${vin.vout}`;
-        if (spendMap.get(key)?.txid === tx.txid) {
-          spendMap.delete(key);
-        }
       }
     }
     return matches;


### PR DESCRIPTION
Fixes a bug where a mempool transaction could be identified as replaced by multiple different mined transactions, producing nonsensical RBF trees, e.g:

<img width="1146" alt="Screenshot 2023-07-11 at 11 45 13 AM" src="https://github.com/mempool/mempool/assets/83316221/1c289e4e-42ae-4ff6-a572-4d50d77c3aaa">

This PR properly deletes all txos of replaced transactions from the `spendMap`, to guarantee that each transaction can only be replaced once.