### PR TITLE
show "loading" message while checking for cached txs

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -454,7 +454,7 @@
   <ng-template [ngIf]="error">
 
     <div class="text-center" *ngIf="loadingCachedTx; else waitingTemplate">
-      <h3 i18n="transaction.error.transaction-not-found">Loading transaction</h3>
+      <h3 i18n="transaction.error.loading-transaction">Loading transaction</h3>
       <div class="spinner-border text-light mt-2"></div>
     </div>
 

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -306,7 +306,7 @@
 
   </ng-template>
 
-  <ng-template [ngIf]="isLoadingTx && !error">
+  <ng-template [ngIf]="(isLoadingTx && !error) || loadingCachedTx">
 
     <div class="box">
       <div class="row">
@@ -451,20 +451,13 @@
 
   </ng-template>
 
-  <ng-template [ngIf]="error">
+  <ng-template [ngIf]="error && !loadingCachedTx">
 
-    <div class="text-center" *ngIf="loadingCachedTx; else waitingTemplate">
-      <h3 i18n="transaction.error.loading-transaction">Loading transaction</h3>
+    <div class="text-center" *ngIf="waitingForTransaction; else errorTemplate">
+      <h3 i18n="transaction.error.transaction-not-found">Transaction not found.</h3>
+      <h5 i18n="transaction.error.waiting-for-it-to-appear">Waiting for it to appear in the mempool...</h5>
       <div class="spinner-border text-light mt-2"></div>
     </div>
-
-    <ng-template #waitingTemplate>
-      <div class="text-center" *ngIf="waitingForTransaction; else errorTemplate">
-        <h3 i18n="transaction.error.transaction-not-found">Transaction not found.</h3>
-        <h5 i18n="transaction.error.waiting-for-it-to-appear">Waiting for it to appear in the mempool...</h5>
-        <div class="spinner-border text-light mt-2"></div>
-      </div>
-    </ng-template>
 
     <ng-template #errorTemplate>
       <div class="text-center">

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -453,11 +453,18 @@
 
   <ng-template [ngIf]="error">
 
-    <div class="text-center" *ngIf="waitingForTransaction; else errorTemplate">
-      <h3 i18n="transaction.error.transaction-not-found">Transaction not found.</h3>
-      <h5 i18n="transaction.error.waiting-for-it-to-appear">Waiting for it to appear in the mempool...</h5>
+    <div class="text-center" *ngIf="loadingCachedTx; else waitingTemplate">
+      <h3 i18n="transaction.error.transaction-not-found">Loading transaction</h3>
       <div class="spinner-border text-light mt-2"></div>
     </div>
+
+    <ng-template #waitingTemplate>
+      <div class="text-center" *ngIf="waitingForTransaction; else errorTemplate">
+        <h3 i18n="transaction.error.transaction-not-found">Transaction not found.</h3>
+        <h5 i18n="transaction.error.waiting-for-it-to-appear">Waiting for it to appear in the mempool...</h5>
+        <div class="spinner-border text-light mt-2"></div>
+      </div>
+    </ng-template>
 
     <ng-template #errorTemplate>
       <div class="text-center">

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -226,7 +226,6 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         this.tx.feePerVsize = tx.fee / (tx.weight / 4);
         this.isLoadingTx = false;
         this.error = undefined;
-        this.loadingCachedTx = false;
         this.waitingForTransaction = false;
         this.graphExpanded = false;
         this.transactionTime = tx.firstSeen || 0;

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -39,6 +39,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   isLoadingTx = true;
   error: any = undefined;
   errorUnblinded: any = undefined;
+  loadingCachedTx = false;
   waitingForTransaction = false;
   latestBlock: BlockExtended;
   transactionTime = -1;
@@ -199,6 +200,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.fetchCachedTxSubscription = this.fetchCachedTx$
     .pipe(
+      tap(() => {
+        this.loadingCachedTx = true;
+      }),
       switchMap((txId) =>
         this.apiService
           .getRbfCachedTx$(txId)
@@ -207,6 +211,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         return of(null);
       })
     ).subscribe((tx) => {
+      this.loadingCachedTx = false;
       if (!tx) {
         return;
       }
@@ -221,6 +226,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         this.tx.feePerVsize = tx.fee / (tx.weight / 4);
         this.isLoadingTx = false;
         this.error = undefined;
+        this.loadingCachedTx = false;
         this.waitingForTransaction = false;
         this.graphExpanded = false;
         this.transactionTime = tx.firstSeen || 0;
@@ -338,6 +344,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           this.tx.feePerVsize = tx.fee / (tx.weight / 4);
           this.isLoadingTx = false;
           this.error = undefined;
+          this.loadingCachedTx = false;
           this.waitingForTransaction = false;
           this.websocketService.startTrackTransaction(tx.txid);
           this.graphExpanded = false;
@@ -409,6 +416,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.txReplacedSubscription = this.stateService.txReplaced$.subscribe((rbfTransaction) => {
       if (!this.tx) {
         this.error = new Error();
+        this.loadingCachedTx = false;
         this.waitingForTransaction = false;
       }
       this.rbfTransaction = rbfTransaction;


### PR DESCRIPTION
On slow network connections, or when the servers are running slowly, it takes a while to check for replaced transactions in the backend cache.

Currently we show the "Transaction not found. Waiting for it to appear in the mempool..." message during this time, which can be confusing.

This PR displays "Loading transaction" while checking the backend cache, and then reverts to "Transaction not found..." only if the transaction is missing from both the mempool and the cache:

<img width="1275" alt="Screenshot 2023-07-11 at 4 08 01 PM" src="https://github.com/mempool/mempool/assets/83316221/41b50f70-0331-4220-b0c7-dfc457cae5b8">
<img width="1275" alt="Screenshot 2023-07-11 at 4 08 33 PM" src="https://github.com/mempool/mempool/assets/83316221/207c7a90-e98b-406a-9409-de2668d64161">
