### PR TITLE
always show latest difficulty on hashrate chart

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -109,6 +109,14 @@ export class HashrateChartComponent implements OnInit {
         tap((response: any) => {
           const data = response.body;
 
+          // always include the latest difficulty
+          if (data.difficulty.length && data.difficulty[data.difficulty.length - 1].difficulty !== data.currentDifficulty) {
+            data.difficulty.push({
+              timestamp: Date.now() / 1000,
+              difficulty: data.currentDifficulty
+            });
+          }
+
           // We generate duplicated data point so the tooltip works nicely
           const diffFixed = [];
           let diffIndex = 1;
@@ -135,6 +143,14 @@ export class HashrateChartComponent implements OnInit {
               ++hashIndex;
             }
             ++diffIndex;
+          }
+
+          while (diffIndex <= data.difficulty.length) {
+            diffFixed.push({
+              timestamp: data.difficulty[diffIndex - 1].time,
+              difficulty: data.difficulty[diffIndex - 1].difficulty
+            });
+            diffIndex++;
           }
 
           let maResolution = 15;


### PR DESCRIPTION
We currently skip difficulty datapoints on the hashrate and difficulty chart when there isn't a corresponding hashrate datapoint.

This means the chart doesn't show the latest difficulty until the hashrate is next indexed.

This PR includes trailing difficulty points so that the latest difficulty is always visible.

Before:
<img width="1254" alt="Screenshot 2023-07-12 at 12 59 41 PM" src="https://github.com/mempool/mempool/assets/83316221/89fb3f45-28a8-451d-95c7-38a9ea435684">

After:
<img width="1254" alt="Screenshot 2023-07-12 at 12 59 18 PM" src="https://github.com/mempool/mempool/assets/83316221/afb2f7d7-8a5e-4dd3-aba6-7c444ac8f6dc">

