### PR TITLE
Fix difficulty chart off-by-one bug

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -130,6 +130,7 @@ export class HashrateChartComponent implements OnInit {
                 });
                 ++hashIndex;
               }
+              diffIndex++;
               break;
             }
 


### PR DESCRIPTION
Fixes a bug in #3953 which could cause the last datapoint in the chart to use the wrong timestamp.

Before:
<img width="1273" alt="Screenshot 2023-07-14 at 11 05 47 AM" src="https://github.com/mempool/mempool/assets/83316221/c84686b6-28db-43cb-a262-9d93cc1a9a40">

After:

<img width="1273" alt="Screenshot 2023-07-14 at 11 05 37 AM" src="https://github.com/mempool/mempool/assets/83316221/0935adb6-75cb-4b71-8495-94b0efb2488d">
