### PR TITLE
Switch "Latest blocks" to "Latest replacements"

### DIFF
--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -6,6 +6,7 @@ import { Common } from "./common";
 interface RbfTransaction extends TransactionStripped {
   rbf?: boolean;
   mined?: boolean;
+  fullRbf?: boolean;
 }
 
 interface RbfTree {
@@ -15,6 +16,16 @@ interface RbfTree {
   mined?: boolean;
   fullRbf: boolean;
   replaces: RbfTree[];
+}
+
+export interface ReplacementInfo {
+  mined: boolean;
+  fullRbf: boolean;
+  txid: string;
+  oldFee: number;
+  oldVsize: number;
+  newFee: number;
+  newVsize: number;
 }
 
 class RbfCache {
@@ -41,11 +52,15 @@ class RbfCache {
     this.txs.set(newTx.txid, newTxExtended);
 
     // maintain rbf trees
-    let fullRbf = false;
+    let txFullRbf = false;
+    let treeFullRbf = false;
     const replacedTrees: RbfTree[] = [];
     for (const replacedTxExtended of replaced) {
       const replacedTx = Common.stripTransaction(replacedTxExtended) as RbfTransaction;
       replacedTx.rbf = replacedTxExtended.vin.some((v) => v.sequence < 0xfffffffe);
+      if (!replacedTx.rbf) {
+        txFullRbf = true;
+      }
       this.replacedBy.set(replacedTx.txid, newTx.txid);
       if (this.treeMap.has(replacedTx.txid)) {
         const treeId = this.treeMap.get(replacedTx.txid);
@@ -55,7 +70,7 @@ class RbfCache {
           if (tree) {
             tree.interval = newTime - tree?.time;
             replacedTrees.push(tree);
-            fullRbf = fullRbf || tree.fullRbf || !tree.tx.rbf;
+            treeFullRbf = treeFullRbf || tree.fullRbf || !tree.tx.rbf;
           }
         }
       } else {
@@ -67,15 +82,16 @@ class RbfCache {
           fullRbf: !replacedTx.rbf,
           replaces: [],
         });
-        fullRbf = fullRbf || !replacedTx.rbf;
+        treeFullRbf = treeFullRbf || !replacedTx.rbf;
         this.txs.set(replacedTx.txid, replacedTxExtended);
       }
     }
+    newTx.fullRbf = txFullRbf;
     const treeId = replacedTrees[0].tx.txid;
     const newTree = {
       tx: newTx,
       time: newTime,
-      fullRbf,
+      fullRbf: treeFullRbf,
       replaces: replacedTrees
     };
     this.rbfTrees.set(treeId, newTree);
@@ -348,6 +364,27 @@ class RbfCache {
       this.dirtyTrees.add(root);
     }
     return tree;
+  }
+
+  public getLatestRbfSummary(): ReplacementInfo[] {
+    const rbfList = this.getRbfTrees(false);
+    return rbfList.slice(0, 6).map(rbfTree => {
+      let oldFee = 0;
+      let oldVsize = 0;
+      for (const replaced of rbfTree.replaces) {
+        oldFee += replaced.tx.fee;
+        oldVsize += replaced.tx.vsize;
+      }
+      return {
+        txid: rbfTree.tx.txid,
+        mined: !!rbfTree.tx.mined,
+        fullRbf: !!rbfTree.tx.fullRbf,
+        oldFee,
+        oldVsize,
+        newFee: rbfTree.tx.fee,
+        newVsize: rbfTree.tx.vsize,
+      };
+    });
   }
 }
 

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -75,36 +75,31 @@
     <div class="col" style="max-height: 410px">
       <div class="card">
         <div class="card-body">
-          <a class="title-link" href="" [routerLink]="['/blocks' | relativeUrl]">
-            <h5 class="card-title d-inline" i18n="dashboard.latest-blocks">Latest blocks</h5>
+          <a class="title-link" href="" [routerLink]="['/rbf' | relativeUrl]">
+            <h5 class="card-title d-inline" i18n="dashboard.latest-rbf-replacements">Latest Replacements</h5>
             <span>&nbsp;</span>
             <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
           </a>
-          <table class="table lastest-blocks-table">
+          <table class="table lastest-replacements-table">
             <thead>
-              <th class="table-cell-height" i18n="dashboard.latest-blocks.height">Height</th>
-              <th *ngIf="!stateService.env.MINING_DASHBOARD" class="table-cell-mined" i18n="dashboard.latest-blocks.mined">Mined</th>
-              <th *ngIf="stateService.env.MINING_DASHBOARD" class="table-cell-mined pl-lg-4" i18n="mining.pool-name">Pool</th>
-              <th class="table-cell-transaction-count" i18n="dashboard.latest-blocks.transaction-count">TXs</th>
-              <th class="table-cell-size" i18n="dashboard.latest-blocks.size">Size</th>
+              <th class="table-cell-txid" i18n="dashboard.latest-transactions.txid">TXID</th>
+              <th class="table-cell-old-fee" i18n="dashboard.old-transaction-fee">Old fee</th>
+              <th class="table-cell-new-fee" i18n="dashboard.new-transaction-fee">New fee</th>
+              <th class="table-cell-badges"></th>
             </thead>
             <tbody>
-              <tr *ngFor="let block of blocks$ | async; let i = index; trackBy: trackByBlock">
-                <td class="table-cell-height" ><a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
-                <td *ngIf="!stateService.env.MINING_DASHBOARD" class="table-cell-mined" ><app-time kind="since" [time]="block.timestamp" [fastRender]="true"></app-time></td>
-                <td *ngIf="stateService.env.MINING_DASHBOARD" class="table-cell-mined pl-lg-4">
-                  <a class="clear-link" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
-                    <img width="22" height="22" src="{{ block.extras.pool['logo'] }}"
-                      onError="this.src = '/resources/mining-pools/default.svg'">
-                    <span class="pool-name">{{ block.extras.pool.name }}</span>
+              <tr *ngFor="let replacement of replacements$ | async;">
+                <td class="table-cell-txid">
+                  <a [routerLink]="['/tx' | relativeUrl, replacement.txid]">
+                    <app-truncate [text]="replacement.txid" [lastChars]="5"></app-truncate>
                   </a>
                 </td>
-                <td class="table-cell-transaction-count">{{ block.tx_count | number }}</td>
-                <td class="table-cell-size">
-                  <div class="progress">
-                    <div class="progress-bar progress-mempool {{ network$ | async }}" role="progressbar" [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }">&nbsp;</div>
-                    <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
-                  </div>
+                <td class="table-cell-old-fee"><app-fee-rate [fee]="replacement.oldFee" [weight]="replacement.oldVsize * 4"></app-fee-rate></td>
+                <td class="table-cell-new-fee"><app-fee-rate [fee]="replacement.newFee" [weight]="replacement.newVsize * 4"></app-fee-rate></td>
+                <td class="table-cell-badges">
+                  <span *ngIf="replacement.mined" class="badge badge-success" i18n="transaction.rbf.mined">Mined</span>
+                  <span *ngIf="replacement.fullRbf" class="badge badge-info" i18n="transaction.full-rbf">Full RBF</span>
+                  <span *ngIf="!replacement.fullRbf" class="badge badge-success" i18n="transaction.rbf">RBF</span>
                 </td>
               </tr>
             </tbody>

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -76,16 +76,16 @@
       <div class="card">
         <div class="card-body">
           <a class="title-link" href="" [routerLink]="['/rbf' | relativeUrl]">
-            <h5 class="card-title d-inline" i18n="dashboard.latest-rbf-replacements">Latest Replacements</h5>
+            <h5 class="card-title d-inline" i18n="dashboard.latest-rbf-replacements">Latest replacements</h5>
             <span>&nbsp;</span>
             <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
           </a>
           <table class="table lastest-replacements-table">
             <thead>
               <th class="table-cell-txid" i18n="dashboard.latest-transactions.txid">TXID</th>
-              <th class="table-cell-old-fee" i18n="dashboard.old-transaction-fee">Old fee</th>
+              <th class="table-cell-old-fee" i18n="dashboard.previous-transaction-fee">Previous fee</th>
               <th class="table-cell-new-fee" i18n="dashboard.new-transaction-fee">New fee</th>
-              <th class="table-cell-badges"></th>
+              <th class="table-cell-badges" i18n="transaction.status|Transaction Status">Status</th>
             </thead>
             <tbody>
               <tr *ngFor="let replacement of replacements$ | async;">

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -175,40 +175,34 @@
   height: 18px;
 }
 
-.lastest-blocks-table {
+.lastest-replacements-table {
   width: 100%;
   text-align: left;
+  table-layout:fixed;
   tr, td, th {
     border: 0px;
-    padding-top: 0.65rem !important;
-    padding-bottom: 0.7rem !important;
+    padding-top: 0.71rem !important;
+    padding-bottom: 0.75rem !important;
   }
-  .table-cell-height {
-    width: 15%;
+  td {
+    overflow:hidden;
+    width: 25%;
   }
-  .table-cell-mined {
-    width: 35%;
-    text-align: left;
+  .table-cell-txid {
+    width: 33%;
+    text-align: start;
   }
-  .table-cell-transaction-count {
-    display: none;
-    text-align: right;
-    width: 20%;
-    display: table-cell;
+  .table-cell-old-fee {
+    width: 33%;
+    text-align: end;
   }
-  .table-cell-size {
-    display: none;
-    text-align: center;
-    width: 30%;
-    @media (min-width: 485px) {
-      display: table-cell;
-    }
-    @media (min-width: 768px) {
-      display: none;
-    }
-    @media (min-width: 992px) {
-      display: table-cell;
-    }
+  .table-cell-new-fee {
+    width: 33%;
+    text-align: end;
+  }
+  .table-cell-badges {
+    width: 25%;
+    text-align: end;
   }
 }
 

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -189,20 +189,30 @@
     width: 25%;
   }
   .table-cell-txid {
-    width: 33%;
+    width: 25%;
     text-align: start;
   }
   .table-cell-old-fee {
-    width: 33%;
+    width: 25%;
     text-align: end;
+
+    @media(max-width: 1080px) {
+      display: none;
+    }
   }
   .table-cell-new-fee {
-    width: 33%;
+    width: 20%;
     text-align: end;
   }
   .table-cell-badges {
-    width: 25%;
+    width: 23%;
+    padding-right: 0;
+    padding-left: 5px;
     text-align: end;
+
+    .badge {
+      margin-left: 5px;
+    }
   }
 }
 

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -18,6 +18,7 @@ export interface WebsocketResponse {
   txReplaced?: ReplacedTransaction;
   rbfInfo?: RbfTree;
   rbfLatest?: RbfTree[];
+  rbfLatestSummary?: ReplacementInfo[];
   utxoSpent?: object;
   transactions?: TransactionStripped[];
   loadingIndicators?: ILoadingIndicators;
@@ -29,6 +30,7 @@ export interface WebsocketResponse {
   'track-asset'?: string;
   'track-mempool-block'?: number;
   'track-rbf'?: string;
+  'track-rbf-summary'?: boolean;
   'watch-mempool'?: boolean;
   'track-bisq-market'?: string;
   'refresh-blocks'?: boolean;
@@ -36,6 +38,16 @@ export interface WebsocketResponse {
 
 export interface ReplacedTransaction extends Transaction {
   txid: string;
+}
+
+export interface ReplacementInfo {
+  mined: boolean;
+  fullRbf: boolean;
+  txid: string;
+  oldFee: number;
+  oldVsize: number;
+  newFee: number;
+  newVsize: number;
 }
 export interface MempoolBlock {
   blink?: boolean;

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, PLATFORM_ID, LOCALE_ID } from '@angular/core';
 import { ReplaySubject, BehaviorSubject, Subject, fromEvent, Observable, merge } from 'rxjs';
 import { Transaction } from '../interfaces/electrs.interface';
-import { IBackendInfo, MempoolBlock, MempoolBlockDelta, MempoolInfo, Recommendedfees, ReplacedTransaction, TransactionStripped } from '../interfaces/websocket.interface';
+import { IBackendInfo, MempoolBlock, MempoolBlockDelta, MempoolInfo, Recommendedfees, ReplacedTransaction, ReplacementInfo, TransactionStripped } from '../interfaces/websocket.interface';
 import { BlockExtended, DifficultyAdjustment, MempoolPosition, OptimizedMempoolStats, RbfTree } from '../interfaces/node-api.interface';
 import { Router, NavigationStart } from '@angular/router';
 import { isPlatformBrowser } from '@angular/common';
@@ -108,6 +108,7 @@ export class StateService {
   txReplaced$ = new Subject<ReplacedTransaction>();
   txRbfInfo$ = new Subject<RbfTree>();
   rbfLatest$ = new Subject<RbfTree[]>();
+  rbfLatestSummary$ = new Subject<ReplacementInfo[]>();
   utxoSpent$ = new Subject<object>();
   difficultyAdjustment$ = new ReplaySubject<DifficultyAdjustment>(1);
   mempoolTransactions$ = new Subject<Transaction>();

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -29,6 +29,7 @@ export class WebsocketService {
   private trackingTxId: string;
   private isTrackingMempoolBlock = false;
   private isTrackingRbf = false;
+  private isTrackingRbfSummary = false;
   private trackingMempoolBlock: number;
   private latestGitCommit = '';
   private onlineCheckTimeout: number;
@@ -185,6 +186,16 @@ export class WebsocketService {
     this.isTrackingRbf = false;
   }
 
+  startTrackRbfSummary() {
+    this.websocketSubject.next({ 'track-rbf-summary': true });
+    this.isTrackingRbfSummary = true;
+  }
+
+  stopTrackRbfSummary() {
+    this.websocketSubject.next({ 'track-rbf-summary': false });
+    this.isTrackingRbfSummary = false;
+  }
+
   startTrackBisqMarket(market: string) {
     this.websocketSubject.next({ 'track-bisq-market': market });
   }
@@ -281,6 +292,10 @@ export class WebsocketService {
 
     if (response.rbfLatest) {
       this.stateService.rbfLatest$.next(response.rbfLatest);
+    }
+
+    if (response.rbfLatestSummary) {
+      this.stateService.rbfLatestSummary$.next(response.rbfLatestSummary);
     }
 
     if (response.txReplaced) {


### PR DESCRIPTION
Resolves #3954 by changing the "latest blocks" widget to "latest replacements", which shows the last 6 RBF replacements:

<img width="1147" alt="Screenshot 2023-07-14 at 12 24 58 PM" src="https://github.com/mempool/mempool/assets/83316221/d5909e82-4e00-4902-a294-a6f30d1f3cbe">


The title of the widget links to the (formerly secret) `/rbf` page.