### PR TITLE
Set missing websocket init data

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -236,7 +236,7 @@ class WebsocketHandler {
           }
 
           if (parsedMessage.action === 'init') {
-            if (!this.socketData['blocks']?.length || !this.socketData['da']) {
+            if (!this.socketData['blocks']?.length || !this.socketData['da'] || !this.socketData['backendInfo'] || !this.socketData['conversions']) {
               this.updateSocketData();
             }
             if (!this.socketData['blocks']?.length) {


### PR DESCRIPTION
Fixes a bug where the websocket init data could sometimes be set incompletely, leading to missing prices and backend version info.