### PR TITLE
unbork mining pool blocks list

### DIFF
--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -37,7 +37,7 @@ export class PoolComponent implements OnInit {
 
   auditAvailable = false;
 
-  loadMoreSubject: BehaviorSubject<number> = new BehaviorSubject(this.blocks[0]?.height);
+  loadMoreSubject: BehaviorSubject<number> = new BehaviorSubject(this.blocks[this.blocks.length - 1]?.height);
 
   constructor(
     @Inject(LOCALE_ID) public locale: string,
@@ -91,7 +91,7 @@ export class PoolComponent implements OnInit {
           if (this.slug === undefined) {
             return [];
           }
-          return this.apiService.getPoolBlocks$(this.slug, this.blocks[0]?.height);
+          return this.apiService.getPoolBlocks$(this.slug, this.blocks[this.blocks.length - 1]?.height);
         }),
         tap((newBlocks) => {
           this.blocks = this.blocks.concat(newBlocks);
@@ -237,7 +237,7 @@ export class PoolComponent implements OnInit {
   }
 
   loadMore() {
-    this.loadMoreSubject.next(this.blocks[0]?.height);
+    this.loadMoreSubject.next(this.blocks[this.blocks.length - 1]?.height);
   }
 
   trackByBlock(index: number, block: BlockExtended) {


### PR DESCRIPTION
Fixes an issue in the blocks list on the `/pool/:slug` page, where we were using the wrong block height to load more blocks.

| Before | After |
|-|-|
| <img width="1268" alt="Screenshot 2023-07-17 at 11 21 13 AM" src="https://github.com/mempool/mempool/assets/83316221/5a6e2095-21d9-46d6-a572-c34ef5f54f4f"> | <img width="1268" alt="Screenshot 2023-07-17 at 11 20 43 AM" src="https://github.com/mempool/mempool/assets/83316221/87ae1d6c-1556-4e89-bcaa-c1b0e12b0c3e">
