### PR TITLE
get chain tip direct from Bitcoin Core to avoid race conditions

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -65,17 +65,11 @@ class BitcoinApi implements AbstractBitcoinApi {
   }
 
   $getBlockHeightTip(): Promise<number> {
-    return this.bitcoindClient.getChainTips()
-      .then((result: IBitcoinApi.ChainTips[]) => {
-        return result.find(tip => tip.status === 'active')!.height;
-      });
+    return this.bitcoindClient.getBlockCount();
   }
 
   $getBlockHashTip(): Promise<string> {
-    return this.bitcoindClient.getChainTips()
-      .then((result: IBitcoinApi.ChainTips[]) => {
-        return result.find(tip => tip.status === 'active')!.hash;
-      });
+    return this.bitcoindClient.getBestBlockHash();
   }
 
   $getTxIdsForBlock(hash: string): Promise<string[]> {


### PR DESCRIPTION
PR #3655 mitigated but did not fully solve a race condition where newly confirmed transactions could get removed from the mempool before the corresponding block is detected (leading to zero-score audits).

It seems that the same race condition also occurs within `mempool/electrs`, so this PR attempts to eliminate the issue by checking for new blocks directly from Bitcoin Core.