### PR TITLE
Fix websocket null data for undefined rbfSummary

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -229,7 +229,9 @@ class WebsocketHandler {
           if (parsedMessage && parsedMessage['track-rbf-summary'] != null) {
             if (parsedMessage['track-rbf-summary']) {
               client['track-rbf-summary'] = true;
-              response['rbfLatestSummary'] = this.socketData['rbfSummary'];
+              if (this.socketData['rbfSummary'] != null) {
+                response['rbfLatestSummary'] = this.socketData['rbfSummary'];
+              }
             } else {
               client['track-rbf-summary'] = false;
             }


### PR DESCRIPTION
This PR fixes a bug where which occurs if `rbfSummary` hasn't been set in the websocket init data when a client starts a `track-rbf-summary` subscription, we would set an undefined value in the response and send the client invalid json.