### PR TITLE
Enable fullrbf in production frontend config

### DIFF
--- a/production/mempool-frontend-config.mainnet.json
+++ b/production/mempool-frontend-config.mainnet.json
@@ -11,5 +11,6 @@
   "BISQ_WEBSITE_URL": "https://bisq.markets",
   "ITEMS_PER_PAGE": 25,
   "LIGHTNING": true,
-  "AUDIT": true
+  "AUDIT": true,
+  "FULL_RBF_ENABLED": true
 }


### PR DESCRIPTION
Adds `FULL_RBF_ENABLED` to the production `mempool-frontend-config.mainnet.json` config file, which enables this toggle on the RBF Replacements page:

<img width="1164" alt="Screenshot 2023-07-18 at 10 47 39 AM" src="https://github.com/mempool/mempool/assets/83316221/5d46c92b-d956-47f7-a228-bc297e5f750c">
