### PR TITLE
Fix clock horizontal scroll bug

### DIFF
--- a/frontend/src/app/components/clock/clock.component.scss
+++ b/frontend/src/app/components/clock/clock.component.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  overflow: hidden;
 
   --chain-height: 60px;
   --clock-width: 300px;


### PR DESCRIPTION
This PR fixes a css bug which lets the clock scroll off the page horizontally:


https://github.com/mempool/mempool/assets/83316221/cb8cf72c-8d9d-4b38-bf42-d06a4893b4c2

