### PR TITLE
restore latest blocks on liquid

### DIFF
--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -73,7 +73,7 @@
       </div>
     </div>
     <div class="col" style="max-height: 410px">
-      <div class="card">
+      <div class="card" *ngIf="(network$ | async) !== 'liquid' && (network$ | async) !== 'liquidtestnet'; else latestBlocks">
         <div class="card-body">
           <a class="title-link" href="" [routerLink]="['/rbf' | relativeUrl]">
             <h5 class="card-title d-inline" i18n="dashboard.latest-rbf-replacements">Latest replacements</h5>
@@ -106,6 +106,46 @@
           </table>
         </div>
       </div>
+      <ng-template #latestBlocks>
+        <div class="card">
+          <div class="card-body">
+            <a class="title-link" href="" [routerLink]="['/blocks' | relativeUrl]">
+              <h5 class="card-title d-inline" i18n="dashboard.latest-blocks">Latest blocks</h5>
+              <span>&nbsp;</span>
+              <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: '#4a68b9'"></fa-icon>
+            </a>
+            <table class="table lastest-blocks-table">
+              <thead>
+                <th class="table-cell-height" i18n="dashboard.latest-blocks.height">Height</th>
+                <th *ngIf="!stateService.env.MINING_DASHBOARD" class="table-cell-mined" i18n="dashboard.latest-blocks.mined">Mined</th>
+                <th *ngIf="stateService.env.MINING_DASHBOARD" class="table-cell-mined pl-lg-4" i18n="mining.pool-name">Pool</th>
+                <th class="table-cell-transaction-count" i18n="dashboard.latest-blocks.transaction-count">TXs</th>
+                <th class="table-cell-size" i18n="dashboard.latest-blocks.size">Size</th>
+              </thead>
+              <tbody>
+                <tr *ngFor="let block of blocks$ | async; let i = index; trackBy: trackByBlock">
+                  <td class="table-cell-height" ><a [routerLink]="['/block' | relativeUrl, block.id]" [state]="{ data: { block: block } }">{{ block.height }}</a></td>
+                  <td *ngIf="!stateService.env.MINING_DASHBOARD" class="table-cell-mined" ><app-time kind="since" [time]="block.timestamp" [fastRender]="true"></app-time></td>
+                  <td *ngIf="stateService.env.MINING_DASHBOARD" class="table-cell-mined pl-lg-4">
+                    <a class="clear-link" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
+                      <img width="22" height="22" src="{{ block.extras.pool['logo'] }}"
+                        onError="this.src = '/resources/mining-pools/default.svg'">
+                      <span class="pool-name">{{ block.extras.pool.name }}</span>
+                    </a>
+                  </td>
+                  <td class="table-cell-transaction-count">{{ block.tx_count | number }}</td>
+                  <td class="table-cell-size">
+                    <div class="progress">
+                      <div class="progress-bar progress-mempool {{ network$ | async }}" role="progressbar" [ngStyle]="{'width': (block.weight / stateService.env.BLOCK_WEIGHT_UNITS)*100 + '%' }">&nbsp;</div>
+                      <div class="progress-text" [innerHTML]="block.size | bytes: 2"></div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </ng-template>
     </div>
     <div class="col" style="max-height: 410px">
       <div class="card">

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -175,6 +175,43 @@
   height: 18px;
 }
 
+.lastest-blocks-table {
+  width: 100%;
+  text-align: left;
+  tr, td, th {
+    border: 0px;
+    padding-top: 0.65rem !important;
+    padding-bottom: 0.7rem !important;
+  }
+  .table-cell-height {
+    width: 15%;
+  }
+  .table-cell-mined {
+    width: 35%;
+    text-align: left;
+  }
+  .table-cell-transaction-count {
+    display: none;
+    text-align: right;
+    width: 20%;
+    display: table-cell;
+  }
+  .table-cell-size {
+    display: none;
+    text-align: center;
+    width: 30%;
+    @media (min-width: 485px) {
+      display: table-cell;
+    }
+    @media (min-width: 768px) {
+      display: none;
+    }
+    @media (min-width: 992px) {
+      display: table-cell;
+    }
+  }
+}
+
 .lastest-replacements-table {
   width: 100%;
   text-align: left;


### PR DESCRIPTION
Changes "Latest replacements" back to "Latest blocks" on Liquid.

Before:

<img width="1152" alt="Screenshot 2023-07-19 at 1 25 13 PM" src="https://github.com/mempool/mempool/assets/83316221/02e06d9c-4603-4286-94e9-c7e26275a966">

After:

<img width="1152" alt="Screenshot 2023-07-19 at 1 24 59 PM" src="https://github.com/mempool/mempool/assets/83316221/463743e3-4d73-4666-b9be-db3293f77b44">
