### PR TITLE
[mining] add missing empty td at the bottom of pool ranking

### DIFF
--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -139,6 +139,8 @@
           <td class="" *ngIf="this.miningWindowPreference === '24h'"><b>{{ miningStats.lastEstimatedHashrate}} {{
               miningStats.miningUnits.hashrateUnit }}</b></td>
           <td class=""><b>{{ miningStats.blockCount }}</b></td>
+          <td *ngIf="auditAvailable"></td>
+          <td *ngIf="auditAvailable"></td>
           <td class="d-none d-md-table-cell"><b>{{ miningStats.totalEmptyBlock }} ({{ miningStats.totalEmptyBlockRatio
               }}%)</b></td>
         </tr>


### PR DESCRIPTION
### On the last line, the empty block summary is not aligned with the column

<img width="1141" alt="Screenshot 2023-07-20 at 10 31 55" src="https://github.com/mempool/mempool/assets/9780671/cc10bc4e-800d-4867-9ced-281d76f89ca5">

### Fixed

<img width="1146" alt="Screenshot 2023-07-20 at 10 32 02" src="https://github.com/mempool/mempool/assets/9780671/bd0ade63-0273-4447-9e61-3adfcf724fa9">
