### PR TITLE
load mempool txs in bulk from esplora

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -3,6 +3,7 @@ import { IEsploraApi } from './esplora-api.interface';
 export interface AbstractBitcoinApi {
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
   $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, lazyPrevouts?: boolean): Promise<IEsploraApi.Transaction>;
+  $getMempoolTransactions(expectedCount: number);
   $getTransactionHex(txId: string): Promise<string>;
   $getBlockHeightTip(): Promise<number>;
   $getBlockHashTip(): Promise<string>;

--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -3,7 +3,7 @@ import { IEsploraApi } from './esplora-api.interface';
 export interface AbstractBitcoinApi {
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
   $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, lazyPrevouts?: boolean): Promise<IEsploraApi.Transaction>;
-  $getMempoolTransactions(expectedCount: number);
+  $getMempoolTransactions(lastTxid: string);
   $getTransactionHex(txId: string): Promise<string>;
   $getBlockHeightTip(): Promise<number>;
   $getBlockHashTip(): Promise<string>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -59,7 +59,7 @@ class BitcoinApi implements AbstractBitcoinApi {
       });
   }
 
-  $getMempoolTransactions(expectedCount: number): Promise<IEsploraApi.Transaction[]> {
+  $getMempoolTransactions(lastTxid: string): Promise<IEsploraApi.Transaction[]> {
     return Promise.resolve([]);
   }
 

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -59,6 +59,10 @@ class BitcoinApi implements AbstractBitcoinApi {
       });
   }
 
+  $getMempoolTransactions(expectedCount: number): Promise<IEsploraApi.Transaction[]> {
+    return Promise.resolve([]);
+  }
+
   $getTransactionHex(txId: string): Promise<string> {
     return this.$getRawTransaction(txId, true)
       .then((tx) => tx.hex || '');

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -69,33 +69,8 @@ class ElectrsApi implements AbstractBitcoinApi {
     return this.$queryWrapper<IEsploraApi.Transaction>(config.ESPLORA.REST_API_URL + '/tx/' + txId);
   }
 
-  async $getMempoolTransactions(expectedCount: number): Promise<IEsploraApi.Transaction[]> {
-    const transactions: IEsploraApi.Transaction[] = [];
-    let count = 0;
-    let done = false;
-    let last_txid = '';
-    while (!done) {
-      try {
-        const result = await this.$queryWrapper<IEsploraApi.Transaction[]>(config.ESPLORA.REST_API_URL + '/mempool/txs' + (last_txid ? '/' + last_txid : ''));
-        if (result) {
-          for (const tx of result) {
-            transactions.push(tx);
-            count++;
-          }
-          logger.info(`Fetched ${count} of ${expectedCount} mempool transactions from esplora`);
-          if (result.length > 0) {
-            last_txid = result[result.length - 1].txid;
-          } else {
-            done = true;
-          }
-        } else {
-          done = true;
-        }
-      } catch(err) {
-        logger.err('failed to fetch bulk mempool transactions from esplora');
-      }
-    }
-    return transactions;
+  async $getMempoolTransactions(lastSeenTxid?: string): Promise<IEsploraApi.Transaction[]> {
+    return this.$queryWrapper<IEsploraApi.Transaction[]>(config.ESPLORA.REST_API_URL + '/mempool/txs' + (lastSeenTxid ? '/' + lastSeenTxid : ''));
   }
 
   $getTransactionHex(txId: string): Promise<string> {


### PR DESCRIPTION
This PR leverages a new bulk [`/mempool/txs` endpoint in mempool/electrs](https://github.com/mempool/electrs/pull/18) to synchronize the mempool faster on startup when the disk cache is unavailable.

Handling the extremely large JSON response requires a new dependency, JSONStream, which processes the response transaction-by-transaction instead of attempting to parse the entire array in one shot.

On an M1 mac this cuts the time to synchronize a 260k transaction mempool down from over 11 minutes to ~30 seconds.

Presumably there's some hard limit on how much data we can fetch and parse in a single request, so we may want to figure out how to break this into smaller batches.