### PR TITLE
[graphs] fix min height in mobile landscape

### DIFF
--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.scss
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.scss
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/block-health-graph/block-health-graph.component.scss
+++ b/frontend/src/app/components/block-health-graph/block-health-graph.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.scss
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.scss
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.scss
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/lightning/nodes-map/nodes-map.component.scss
+++ b/frontend/src/app/lightning/nodes-map/nodes-map.component.scss
@@ -14,7 +14,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.scss
+++ b/frontend/src/app/lightning/nodes-networks-chart/nodes-networks-chart.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }

--- a/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.scss
+++ b/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.scss
@@ -25,7 +25,8 @@
   flex-direction: column;
   padding: 0px 15px;
   width: 100%;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 225px);
+  min-height: 400px;
   @media (min-width: 992px) {
     height: calc(100vh - 150px);
   }


### PR DESCRIPTION
Mobile landscape fix for invisible charts

### Prod

<img width="853" alt="Screenshot 2023-07-22 at 17 42 44" src="https://github.com/mempool/mempool/assets/9780671/c8f5d62d-582f-47cb-aa7a-c8b2e088eac4">

### Fixed

<img width="847" alt="Screenshot 2023-07-22 at 17 42 23" src="https://github.com/mempool/mempool/assets/9780671/6c3303e5-ac95-4b55-a22b-2dfd7cd4224b">
