### PR TITLE
Support P2PK address types

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -14,6 +14,8 @@ export interface AbstractBitcoinApi {
   $getAddress(address: string): Promise<IEsploraApi.Address>;
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
   $getAddressPrefix(prefix: string): string[];
+  $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash>;
+  $getScriptHashTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
   $sendRawTransaction(rawTransaction: string): Promise<string>;
   $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend>;
   $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -108,6 +108,14 @@ class BitcoinApi implements AbstractBitcoinApi {
     throw new Error('Method getAddressTransactions not supported by the Bitcoin RPC API.');
   }
 
+  $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
+    throw new Error('Method getScriptHash not supported by the Bitcoin RPC API.');
+  }
+
+  $getScriptHashTransactions(scripthash: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]> {
+    throw new Error('Method getScriptHashTransactions not supported by the Bitcoin RPC API.');
+  }
+
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]> {
     return this.bitcoindClient.getRawMemPool();
   }

--- a/backend/src/api/bitcoin/electrum-api.ts
+++ b/backend/src/api/bitcoin/electrum-api.ts
@@ -126,6 +126,77 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
     }
   }
 
+  async $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
+    try {
+      const balance = await this.electrumClient.blockchainScripthash_getBalance(scripthash);
+      let history = memoryCache.get<IElectrumApi.ScriptHashHistory[]>('Scripthash_getHistory', scripthash);
+      if (!history) {
+        history = await this.electrumClient.blockchainScripthash_getHistory(scripthash);
+        memoryCache.set('Scripthash_getHistory', scripthash, history, 2);
+      }
+
+      const unconfirmed = history ? history.filter((h) => h.fee).length : 0;
+
+      return {
+        'scripthash': scripthash,
+        'chain_stats': {
+          'funded_txo_count': 0,
+          'funded_txo_sum': balance.confirmed ? balance.confirmed : 0,
+          'spent_txo_count': 0,
+          'spent_txo_sum': balance.confirmed < 0 ? balance.confirmed : 0,
+          'tx_count': (history?.length || 0) - unconfirmed,
+        },
+        'mempool_stats': {
+          'funded_txo_count': 0,
+          'funded_txo_sum': balance.unconfirmed > 0 ? balance.unconfirmed : 0,
+          'spent_txo_count': 0,
+          'spent_txo_sum': balance.unconfirmed < 0 ? -balance.unconfirmed : 0,
+          'tx_count': unconfirmed,
+        },
+        'electrum': true,
+      };
+    } catch (e: any) {
+      throw new Error(typeof e === 'string' ? e : e && e.message || e);
+    }
+  }
+
+  async $getScriptHashTransactions(scripthash: string, lastSeenTxId?: string): Promise<IEsploraApi.Transaction[]> {
+    try {
+      loadingIndicators.setProgress('address-' + scripthash, 0);
+
+      const transactions: IEsploraApi.Transaction[] = [];
+      let history = memoryCache.get<IElectrumApi.ScriptHashHistory[]>('Scripthash_getHistory', scripthash);
+      if (!history) {
+        history = await this.electrumClient.blockchainScripthash_getHistory(scripthash);
+        memoryCache.set('Scripthash_getHistory', scripthash, history, 2);
+      }
+      if (!history) {
+        throw new Error('failed to get scripthash history');
+      }
+      history.sort((a, b) => (b.height || 9999999) - (a.height || 9999999));
+
+      let startingIndex = 0;
+      if (lastSeenTxId) {
+        const pos = history.findIndex((historicalTx) => historicalTx.tx_hash === lastSeenTxId);
+        if (pos) {
+          startingIndex = pos + 1;
+        }
+      }
+      const endIndex = Math.min(startingIndex + 10, history.length);
+
+      for (let i = startingIndex; i < endIndex; i++) {
+        const tx = await this.$getRawTransaction(history[i].tx_hash, false, true);
+        transactions.push(tx);
+        loadingIndicators.setProgress('address-' + scripthash, (i + 1) / endIndex * 100);
+      }
+
+      return transactions;
+    } catch (e: any) {
+      loadingIndicators.setProgress('address-' + scripthash, 100);
+      throw new Error(typeof e === 'string' ? e : e && e.message || e);
+    }
+  }
+
   private $getScriptHashBalance(scriptHash: string): Promise<IElectrumApi.ScriptHashBalance> {
     return this.electrumClient.blockchainScripthash_getBalance(this.encodeScriptHash(scriptHash));
   }

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -99,6 +99,13 @@ export namespace IEsploraApi {
     electrum?: boolean;
   }
 
+  export interface ScriptHash {
+    scripthash: string;
+    chain_stats: ChainStats;
+    mempool_stats: MempoolStats;
+    electrum?: boolean;
+  }
+
   export interface ChainStats {
     funded_txo_count: number;
     funded_txo_sum: number;

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -110,6 +110,14 @@ class ElectrsApi implements AbstractBitcoinApi {
     throw new Error('Method getAddressTransactions not implemented.');
   }
 
+  $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
+    throw new Error('Method getAddress not implemented.');
+  }
+
+  $getScriptHashTransactions(scripthash: string, txId?: string): Promise<IEsploraApi.Transaction[]> {
+    throw new Error('Method getAddressTransactions not implemented.');
+  }
+
   $getAddressPrefix(prefix: string): string[] {
     throw new Error('Method not implemented.');
   }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -111,11 +111,11 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
-    throw new Error('Method getAddress not implemented.');
+    throw new Error('Method getScriptHash not implemented.');
   }
 
   $getScriptHashTransactions(scripthash: string, txId?: string): Promise<IEsploraApi.Transaction[]> {
-    throw new Error('Method getAddressTransactions not implemented.');
+    throw new Error('Method getScriptHashTransactions not implemented.');
   }
 
   $getAddressPrefix(prefix: string): string[] {

--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -281,3 +281,12 @@ export function isFeatureActive(network: string, height: number, feature: 'rbf' 
     return false;
   }
 }
+
+export async function calcScriptHash$(script: string): Promise<string> {
+  const buf = Uint8Array.from(script.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buf);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray
+    .map((bytes) => bytes.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -283,7 +283,10 @@ export function isFeatureActive(network: string, height: number, feature: 'rbf' 
 }
 
 export async function calcScriptHash$(script: string): Promise<string> {
-  const buf = Uint8Array.from(script.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+  if (!/^[0-9a-fA-F]*$/.test(script) || script.length % 2 !== 0) {
+    throw new Error('script is not a valid hex string');
+  }
+  const buf = Uint8Array.from(script.match(/.{2}/g).map((byte) => parseInt(byte, 16)));
   const hashBuffer = await crypto.subtle.digest('SHA-256', buf);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray

--- a/frontend/src/app/components/address/address-preview.component.ts
+++ b/frontend/src/app/components/address/address-preview.component.ts
@@ -64,13 +64,15 @@ export class AddressPreviewComponent implements OnInit, OnDestroy {
           this.address = null;
           this.addressInfo = null;
           this.addressString = params.get('id') || '';
-          if (/^[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}$/.test(this.addressString)) {
+          if (/^[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}|[A-F0-9]{130}$/.test(this.addressString)) {
             this.addressString = this.addressString.toLowerCase();
           }
           this.seoService.setTitle($localize`:@@address.component.browser-title:Address: ${this.addressString}:INTERPOLATION:`);
 
-          return this.electrsApiService.getAddress$(this.addressString)
-            .pipe(
+          return (this.addressString.match(/[a-f0-9]{130}/)
+              ? this.electrsApiService.getPubKeyAddress$(this.addressString)
+              : this.electrsApiService.getAddress$(this.addressString)
+            ).pipe(
               catchError((err) => {
                 this.isLoadingAddress = false;
                 this.error = err;

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -81,6 +81,7 @@ h1 {
     top: 11px;
 	}
   @media (min-width: 768px) {
+    max-width: calc(100% - 180px);
     top: 17px;
   }
 }

--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -34,7 +34,7 @@ export class SearchFormComponent implements OnInit {
     }
   }
 
-  regexAddress = /^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[A-z]{2,5}1[a-zA-HJ-NP-Z0-9]{39,59})$/;
+  regexAddress = /^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[A-z]{2,5}1[a-zA-HJ-NP-Z0-9]{39,59}|[0-9a-fA-F]{130})$/;
   regexBlockhash = /^[0]{8}[a-fA-F0-9]{56}$/;
   regexTransaction = /^([a-fA-F0-9]{64})(:\d+)?$/;
   regexBlockheight = /^[0-9]{1,9}$/;

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -56,7 +56,9 @@
                       <span i18n="transactions-list.peg-in">Peg-in</span>
                     </ng-container>
                     <ng-container *ngSwitchCase="vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk'">
-                      <span>P2PK</span>
+                      <span>P2PK <a class="address p2pk-address" [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey.slice(2, 132)]" title="{{ vin.prevout.scriptpubkey.slice(2, 132) }}">
+                        <app-truncate [text]="vin.prevout.scriptpubkey.slice(2, 132)" [lastChars]="8"></app-truncate>
+                      </a></span>
                     </ng-container>
                     <ng-container *ngSwitchDefault>
                       <ng-template [ngIf]="!vin.prevout" [ngIfElse]="defaultAddress">
@@ -182,12 +184,19 @@
             <ng-template ngFor let-vout let-vindex="index" [ngForOf]="tx.vout.slice(0, getVoutLimit(tx))" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{
                 'assetBox': assetsMinimal && assetsMinimal[vout.asset] && vout.scriptpubkey_address && tx.vin && !tx.vin[0].is_coinbase && tx._unblinded || outputIndex === vindex,
-                'highlight': vout.scriptpubkey_address === this.address && this.address !== ''
+                'highlight': this.address !== '' && (vout.scriptpubkey_address === this.address || (vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey.slice(2, 132) === this.address))
               }">
                 <td class="address-cell">
-                  <a class="address" *ngIf="vout.scriptpubkey_address; else scriptpubkey_type" [routerLink]="['/address/' | relativeUrl, vout.scriptpubkey_address]" title="{{ vout.scriptpubkey_address }}">
+                  <a class="address" *ngIf="vout.scriptpubkey_address; else pubkey_type" [routerLink]="['/address/' | relativeUrl, vout.scriptpubkey_address]" title="{{ vout.scriptpubkey_address }}">
                     <app-truncate [text]="vout.scriptpubkey_address" [lastChars]="8"></app-truncate>
                   </a>
+                  <ng-template #pubkey_type>
+                    <ng-container *ngIf="vout.scriptpubkey_type === 'p2pk'; else scriptpubkey_type">
+                      P2PK <a class="address p2pk-address" [routerLink]="['/address/' | relativeUrl, vout.scriptpubkey.slice(2, 132)]" title="{{ vout.scriptpubkey.slice(2, 132) }}">
+                        <app-truncate [text]="vout.scriptpubkey.slice(2, 132)" [lastChars]="8"></app-truncate>
+                      </a>
+                    </ng-container>
+                  </ng-template>
                   <div>
                     <app-address-labels [vout]="vout" [channel]="tx._channels && tx._channels.outputs[vindex] ? tx._channels.outputs[vindex] : null"></app-address-labels>
                   </div>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -23,7 +23,7 @@
             <ng-template ngFor let-vin let-vindex="index" [ngForOf]="tx.vin.slice(0, getVinLimit(tx))" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{
                 'assetBox': (assetsMinimal && vin.prevout && assetsMinimal[vin.prevout.asset] && !vin.is_coinbase && vin.prevout.scriptpubkey_address && tx._unblinded) || inputIndex === vindex,
-                'highlight': vin.prevout?.scriptpubkey_address === this.address && this.address !== ''
+                'highlight': this.address !== '' && (vin.prevout?.scriptpubkey_address === this.address || (vin.prevout?.scriptpubkey_type === 'p2pk' && vin.prevout?.scriptpubkey.slice(2, 132) === this.address))
               }">
                 <td class="arrow-td">
                   <ng-template [ngIf]="vin.prevout === null && !vin.is_pegin" [ngIfElse]="hasPrevout">

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -143,7 +143,10 @@ h2 {
 .p2pk-address {
 	display: inline-block;
 	margin-left: 1em;
-	max-width: 140px;
+	max-width: 100px;
+	@media (min-width: 576px) {
+		max-width: 200px
+	}
 }
 
 .grey-info-text {

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -140,6 +140,12 @@ h2 {
 	font-family: monospace;
 }
 
+.p2pk-address {
+	display: inline-block;
+	margin-left: 1em;
+	max-width: 140px;
+}
+
 .grey-info-text {
 	color:#6c757d;
 	font-style: italic;

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -129,6 +129,22 @@ export interface Address {
   address: string;
   chain_stats: ChainStats;
   mempool_stats: MempoolStats;
+  is_pubkey?: boolean;
+}
+
+export interface ScriptHash {
+  electrum?: boolean;
+  scripthash: string;
+  chain_stats: ChainStats;
+  mempool_stats: MempoolStats;
+}
+
+export interface AddressOrScriptHash {
+  electrum?: boolean;
+  address?: string;
+  scripthash?: string;
+  chain_stats: ChainStats;
+  mempool_stats: MempoolStats;
 }
 
 export interface ChainStats {


### PR DESCRIPTION
This PR resolves #4019 by adding support for P2PK pubkeys as a valid address type:

<img width="1147" alt="Screenshot 2023-07-22 at 5 54 34 PM" src="https://github.com/mempool/mempool/assets/83316221/f81c73bb-b80b-4799-9eb7-dff7a61a81fb">

The address page detects if an address is a P2PK pubkey, and replaces requests to `/address/:address` and `/address/:address/txs` with requests to `/scripthash/:scripthash` and `/scripthash/:scripthash/txs` instead