### PR TITLE
Use more reliable Github Action for Rust toolchain install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install 1.70.x Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.70
+        uses: dtolnay/rust-toolchain@1.70
 
       - name: Install
         if: ${{ matrix.flavor == 'dev'}}


### PR DESCRIPTION
@knorrium This is probably more well maintained.

We need it whitelisted though:

`dtolnay/rust-toolchain@*`

This should be added to the Actions whitelist.