### PR TITLE
Fix key navigation subscription leak

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -50,6 +50,8 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
   blockSubscription: Subscription;
   networkSubscription: Subscription;
   chainTipSubscription: Subscription;
+  keySubscription: Subscription;
+  isTabHiddenSubscription: Subscription;
   network = '';
   now = new Date().getTime();
   timeOffset = 0;
@@ -116,7 +118,7 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
       this.calculateTransactionPosition();
     });
     this.reduceMempoolBlocksToFitScreen(this.mempoolBlocks);
-    this.stateService.isTabHidden$.subscribe((tabHidden) => this.tabHidden = tabHidden);
+    this.isTabHiddenSubscription = this.stateService.isTabHidden$.subscribe((tabHidden) => this.tabHidden = tabHidden);
     this.loadingBlocks$ = combineLatest([
       this.stateService.isLoadingWebSocket$,
       this.stateService.isLoadingMempool$
@@ -224,7 +226,7 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
     this.networkSubscription = this.stateService.networkChanged$
       .subscribe((network) => this.network = network);
 
-    this.stateService.keyNavigation$.subscribe((event) => {
+    this.keySubscription = this.stateService.keyNavigation$.subscribe((event) => {
       if (this.markIndex === undefined) {
         return;
       }
@@ -235,13 +237,12 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
         if (this.mempoolBlocks[this.markIndex - 1]) {
           this.router.navigate([this.relativeUrlPipe.transform('mempool-block/'), this.markIndex - 1]);
         } else {
-          this.stateService.blocks$
-            .pipe(map((blocks) => blocks[0]))
-            .subscribe((block) => {
-              if (this.stateService.latestBlockHeight === block.height) {
-                this.router.navigate([this.relativeUrlPipe.transform('/block/'), block.id], { state: { data: { block } }});
-              }
-            });
+          const blocks = this.stateService.blocksSubject$.getValue();
+          for (const block of (blocks || [])) {
+            if (this.stateService.latestBlockHeight === block.height) {
+              this.router.navigate([this.relativeUrlPipe.transform('/block/'), block.id], { state: { data: { block } }});
+            }
+          }
         }
       } else if (event.key === nextKey) {
         if (this.mempoolBlocks[this.markIndex + 1]) {
@@ -265,6 +266,8 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
     this.networkSubscription.unsubscribe();
     this.timeLtrSubscription.unsubscribe();
     this.chainTipSubscription.unsubscribe();
+    this.keySubscription.unsubscribe();
+    this.isTabHiddenSubscription.unsubscribe();
     clearTimeout(this.resetTransitionTimeout);
   }
 


### PR DESCRIPTION
After navigating to and from the next mempool block using the arrow keys, a stray rxjs subscription persists which will trigger a navigation to the latest mined block when the blocks observable next changes.

Previously the `blocks$` observable was a `BehaviorSubject` which always immediately returned a result, so the leak did not produce visible effects. However #3937 changed `blocks$` to a simple `Observable` which causes the weird navigation effects.

This PR fixes the issue by not subscribing to `blocks$` on every arrow key event and fetching the latest value of `blocksSubject$` directly instead.

Before:

https://github.com/mempool/mempool/assets/83316221/2a1d3d34-398f-4134-9a98-0915ac6ea2bc

After:

https://github.com/mempool/mempool/assets/83316221/7955defe-459e-40ef-8b24-3ac5a175779d