### PR TITLE
Support p2pk track-address websocket subscriptions

### DIFF
--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -3,6 +3,7 @@ import { IEsploraApi } from './bitcoin/esplora-api.interface';
 import { Common } from './common';
 import bitcoinApi, { bitcoinCoreApi } from './bitcoin/bitcoin-api-factory';
 import * as bitcoinjs from 'bitcoinjs-lib';
+import crypto from 'node:crypto';
 
 class TransactionUtils {
   constructor() { }
@@ -169,6 +170,14 @@ class TransactionUtils {
         txid.substr(56, 2),
       16
     );
+  }
+
+  public calcScriptHash(script: string): string {
+    if (!/^[0-9a-fA-F]*$/.test(script) || script.length % 2 !== 0) {
+      throw new Error('script is not a valid hex string');
+    }
+    const buf = Buffer.from(script, 'hex');
+    return crypto.createHash('sha256').update(buf).digest('hex');
   }
 }
 

--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -3,7 +3,6 @@ import { IEsploraApi } from './bitcoin/esplora-api.interface';
 import { Common } from './common';
 import bitcoinApi, { bitcoinCoreApi } from './bitcoin/bitcoin-api-factory';
 import * as bitcoinjs from 'bitcoinjs-lib';
-import crypto from 'node:crypto';
 
 class TransactionUtils {
   constructor() { }
@@ -170,14 +169,6 @@ class TransactionUtils {
         txid.substr(56, 2),
       16
     );
-  }
-
-  public calcScriptHash(script: string): string {
-    if (!/^[0-9a-fA-F]*$/.test(script) || script.length % 2 !== 0) {
-      throw new Error('script is not a valid hex string');
-    }
-    const buf = Buffer.from(script, 'hex');
-    return crypto.createHash('sha256').update(buf).digest('hex');
   }
 }
 

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -183,15 +183,22 @@ class WebsocketHandler {
           }
 
           if (parsedMessage && parsedMessage['track-address']) {
-            if (/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100})$/
+            if (/^([a-km-zA-HJ-NP-Z1-9]{26,35}|[a-km-zA-HJ-NP-Z1-9]{80}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}|[0-9a-fA-F]{130})$/
               .test(parsedMessage['track-address'])) {
               let matchedAddress = parsedMessage['track-address'];
               if (/^[A-Z]{2,5}1[AC-HJ-NP-Z02-9]{8,100}$/.test(parsedMessage['track-address'])) {
                 matchedAddress = matchedAddress.toLowerCase();
               }
-              client['track-address'] = matchedAddress;
+              if (/^[0-9a-fA-F]{130}$/.test(parsedMessage['track-address'])) {
+                client['track-address'] = null;
+                client['track-scripthash'] = transactionUtils.calcScriptHash('41' + matchedAddress + 'ac');
+              } else {
+                client['track-address'] = matchedAddress;
+                client['track-scripthash'] = null;
+              }
             } else {
               client['track-address'] = null;
+              client['track-scripthash'] = null;
             }
           }
 
@@ -546,6 +553,44 @@ class WebsocketHandler {
         }
       }
 
+      if (client['track-scripthash']) {
+        const foundTransactions: TransactionExtended[] = [];
+
+        for (const tx of newTransactions) {
+          const someVin = tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scripthash']);
+          if (someVin) {
+            if (config.MEMPOOL.BACKEND !== 'esplora') {
+              try {
+                const fullTx = await transactionUtils.$getMempoolTransactionExtended(tx.txid, true);
+                foundTransactions.push(fullTx);
+              } catch (e) {
+                logger.debug('Error finding transaction in mempool: ' + (e instanceof Error ? e.message : e));
+              }
+            } else {
+              foundTransactions.push(tx);
+            }
+            return;
+          }
+          const someVout = tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scripthash']);
+          if (someVout) {
+            if (config.MEMPOOL.BACKEND !== 'esplora') {
+              try {
+                const fullTx = await transactionUtils.$getMempoolTransactionExtended(tx.txid, true);
+                foundTransactions.push(fullTx);
+              } catch (e) {
+                logger.debug('Error finding transaction in mempool: ' + (e instanceof Error ? e.message : e));
+              }
+            } else {
+              foundTransactions.push(tx);
+            }
+          }
+        }
+
+        if (foundTransactions.length) {
+          response['address-transactions'] = JSON.stringify(foundTransactions);
+        }
+      }
+
       if (client['track-asset']) {
         const foundTransactions: TransactionExtended[] = [];
 
@@ -803,6 +848,33 @@ class WebsocketHandler {
             return;
           }
           if (tx.vout && tx.vout.some((vout) => vout.scriptpubkey_address === client['track-address'])) {
+            foundTransactions.push(tx);
+          }
+        });
+
+        if (foundTransactions.length) {
+          foundTransactions.forEach((tx) => {
+            tx.status = {
+              confirmed: true,
+              block_height: block.height,
+              block_hash: block.id,
+              block_time: block.timestamp,
+            };
+          });
+
+          response['block-transactions'] = JSON.stringify(foundTransactions);
+        }
+      }
+
+      if (client['track-scripthash']) {
+        const foundTransactions: TransactionExtended[] = [];
+
+        transactions.forEach((tx) => {
+          if (tx.vin && tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scripthash'])) {
+            foundTransactions.push(tx);
+            return;
+          }
+          if (tx.vout && tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scripthash'])) {
             foundTransactions.push(tx);
           }
         });

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -191,14 +191,14 @@ class WebsocketHandler {
               }
               if (/^[0-9a-fA-F]{130}$/.test(parsedMessage['track-address'])) {
                 client['track-address'] = null;
-                client['track-scripthash'] = transactionUtils.calcScriptHash('41' + matchedAddress + 'ac');
+                client['track-scriptpubkey'] = '41' + matchedAddress + 'ac';
               } else {
                 client['track-address'] = matchedAddress;
-                client['track-scripthash'] = null;
+                client['track-scriptpubkey'] = null;
               }
             } else {
               client['track-address'] = null;
-              client['track-scripthash'] = null;
+              client['track-scriptpubkey'] = null;
             }
           }
 
@@ -553,11 +553,11 @@ class WebsocketHandler {
         }
       }
 
-      if (client['track-scripthash']) {
+      if (client['track-scriptpubkey']) {
         const foundTransactions: TransactionExtended[] = [];
 
         for (const tx of newTransactions) {
-          const someVin = tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scripthash']);
+          const someVin = tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scriptpubkey']);
           if (someVin) {
             if (config.MEMPOOL.BACKEND !== 'esplora') {
               try {
@@ -571,7 +571,7 @@ class WebsocketHandler {
             }
             return;
           }
-          const someVout = tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scripthash']);
+          const someVout = tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scriptpubkey']);
           if (someVout) {
             if (config.MEMPOOL.BACKEND !== 'esplora') {
               try {
@@ -866,15 +866,15 @@ class WebsocketHandler {
         }
       }
 
-      if (client['track-scripthash']) {
+      if (client['track-scriptpubkey']) {
         const foundTransactions: TransactionExtended[] = [];
 
         transactions.forEach((tx) => {
-          if (tx.vin && tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scripthash'])) {
+          if (tx.vin && tx.vin.some((vin) => !!vin.prevout && vin.prevout.scriptpubkey_type === 'p2pk' && vin.prevout.scriptpubkey === client['track-scriptpubkey'])) {
             foundTransactions.push(tx);
             return;
           }
-          if (tx.vout && tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scripthash'])) {
+          if (tx.vout && tx.vout.some((vout) => vout.scriptpubkey_type === 'p2pk' && vout.scriptpubkey === client['track-scriptpubkey'])) {
             foundTransactions.push(tx);
           }
         });


### PR DESCRIPTION
This PR extends #4027 by adding backend support for `track-address` websocket subscriptions with p2pk addresses.