### PR TITLE
Handle failures while fetching block transactions

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -160,7 +160,6 @@ class Blocks {
     // Require the first transaction to be a coinbase
     const coinbase = transactionMap[txIds[0]];
     if (!coinbase || !coinbase.vin[0].is_coinbase) {
-      console.log(coinbase);
       const msg = `Expected first tx in a block to be a coinbase, but found something else`;
       logger.err(msg);
       throw new Error(msg);


### PR DESCRIPTION
Fixes a bug where the newly refactored `$getTransactionsExtended` would filter out failed transaction responses instead of retrying and/or throwing errors, which could produce templates etc with missing transactions.

This PR retries failed tx requests (falling back to Core), and adds sanity checks to ensure the final list of transactions is fully formed.

If any transactions are missing, or the coinbase is malformed, the function throws an error.