### PR TITLE
Use log10 scale for projected block fee graph

### DIFF
--- a/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
+++ b/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
@@ -74,14 +74,14 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
     this.labelInterval = this.numSamples / this.numLabels;
     while (nextSample <= maxBlockVSize) {
       if (txIndex >= txs.length) {
-        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, 0]);
+        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, 0.000001]);
         nextSample += sampleInterval;
         sampleIndex++;
         continue;
       }
 
       while (txs[txIndex] && nextSample < cumVSize + txs[txIndex].vsize) {
-        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, txs[txIndex].rate]);
+        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, txs[txIndex].rate || 0.000001]);
         nextSample += sampleInterval;
         sampleIndex++;
       }
@@ -118,7 +118,9 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
         },
       },
       yAxis: {
-        type: 'value',
+        type: 'log',
+        min: 1,
+        max: this.data.reduce((min, val) => Math.max(min, val[1]), 1),
         // name: 'Effective Fee Rate s/vb',
         // nameLocation: 'middle',
         splitLine: {
@@ -129,12 +131,16 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
           }
         },
         axisLabel: {
+          show: true,
           formatter: (value: number): string => {
             const unitValue = this.weightMode ? value / 4 : value;
             const selectedPowerOfTen = selectPowerOfTen(unitValue);
             const newVal = Math.round(unitValue / selectedPowerOfTen.divider);
             return `${newVal}${selectedPowerOfTen.unit}`;
           },
+        },
+        axisTick: {
+          show: true,
         }
       },
       series: [{


### PR DESCRIPTION
This PR changes the projected fee graph y-axis to a logarithmic scale to make the chart more readable when it includes extremely high fee transactions.

Before:
<img width="1135" alt="Screenshot 2023-07-30 at 6 58 06 PM" src="https://github.com/mempool/mempool/assets/83316221/d523c478-bfe3-47b2-a2ce-ff5f52de42e2">

After:
<img width="1135" alt="Screenshot 2023-07-30 at 6 57 54 PM" src="https://github.com/mempool/mempool/assets/83316221/a34e8107-c187-4b6e-9c8c-7a2dce1cd362">

