### PR TITLE
Fix scripthash lookup for Electrum*

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -576,7 +576,7 @@ class BitcoinRoutes {
     }
 
     try {
-      const addressData = await bitcoinApi.$getScriptHash(req.params.address);
+      const addressData = await bitcoinApi.$getScriptHash(req.params.scripthash);
       res.json(addressData);
     } catch (e) {
       if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
@@ -597,7 +597,7 @@ class BitcoinRoutes {
       if (req.query.after_txid && typeof req.query.after_txid === 'string') {
         lastTxId = req.query.after_txid;
       }
-      const transactions = await bitcoinApi.$getScriptHashTransactions(req.params.address, lastTxId);
+      const transactions = await bitcoinApi.$getScriptHashTransactions(req.params.scripthash, lastTxId);
       res.json(transactions);
     } catch (e) {
       if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {


### PR DESCRIPTION
"Fixes" scripthash lookup although it returns empty balance and no transactions using `romanz/electrs`, it might work with Fulctrum though.