### PR TITLE
Fix: Use bits to calculate difficulty instead of floating points

### DIFF
--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -16,6 +16,68 @@ export interface DifficultyAdjustment {
   expectedBlocks: number;         // Block count
 }
 
+/**
+ * Calculate the difficulty increase/decrease by using the `bits` integer contained in two
+ * block headers.
+ *
+ * Warning: Only compare `bits` from blocks in two adjacent difficulty periods. This code
+ * assumes the maximum difference is x4 or /4 (as per the protocol) and will throw an
+ * error if an exponent difference of 2 or more is seen.
+ *
+ * @param {number} oldBits The 32 bit `bits` integer from a block header.
+ * @param {number} newBits The 32 bit `bits` integer from a block header in the next difficulty period.
+ * @returns {number} A floating point decimal of the difficulty change from old to new.
+ *          (ie. 21.3 means 21.3% increase in difficulty, -21.3 is a 21.3% decrease in difficulty)
+ */
+export function calcBitsDifference(oldBits: number, newBits: number): number {
+  // Must be
+  // - integer
+  // - highest exponent is 0x1f, so max value (as integer) is 0x1f0000ff
+  // - min value is 1 (exponent = 0)
+  // - highest bit of the number-part is +- sign, it must not be 1
+  const verifyBits = (bits: number): void => {
+    if (
+      Math.floor(bits) !== bits ||
+      bits > 0x1f0000ff ||
+      bits < 1 ||
+      (bits & 0x00800000) !== 0 ||
+      (bits & 0x007fffff) === 0
+    ) {
+      throw new Error('Invalid bits');
+    }
+  };
+  verifyBits(oldBits);
+  verifyBits(newBits);
+
+  // No need to mask exponents because we checked the bounds above
+  const oldExp = oldBits >> 24;
+  const newExp = newBits >> 24;
+  const oldNum = oldBits & 0x007fffff;
+  const newNum = newBits & 0x007fffff;
+  // The diff can only possibly be 1, 0, -1
+  // (because maximum difficulty change is x4 or /4 (2 bits up or down))
+  let result: number;
+  switch (newExp - oldExp) {
+    // New less than old, target lowered, difficulty increased
+    case -1:
+      result = ((oldNum << 8) * 100) / newNum - 100;
+      break;
+    // Same exponent, compare numbers as is.
+    case 0:
+      result = (oldNum * 100) / newNum - 100;
+      break;
+    // Old less than new, target raised, difficulty decreased
+    case 1:
+      result = (oldNum * 100) / (newNum << 8) - 100;
+      break;
+    default:
+      throw new Error('Impossible exponent difference');
+  }
+
+  // Min/Max values
+  return result > 300 ? 300 : result < -75 ? -75 : result;
+}
+
 export function calcDifficultyAdjustment(
   DATime: number,
   nowSeconds: number,


### PR DESCRIPTION
Apparently bringing the difficulty float from electrs after PR 5 caused problems because we use difficulty (which is inherently inaccurate) to calculate the difficulty changes.

This PR should remove the reliance on the difficulty float in important calculations.

See this comment: https://github.com/mempool/electrs/pull/5#issuecomment-1657856555

Things to verify in review:

Will this affect a running instance's caches etc.? If so, how can we migrate the existing database? (or if we just want to re-index, how long will that take?)

Note:

We could have hit this issue due to a change in the compiler used by Bitcoin Core etc. as the float JSON representation is not guaranteed. This is why the actual mining code in Core only uses integers.