### PR TITLE
fix null coinbase fees in block summary

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -701,7 +701,7 @@ class Blocks {
       // fill in missing transaction fee data from verboseBlock
       for (let i = 0; i < transactions.length; i++) {
         if (!transactions[i].fee && transactions[i].txid === verboseBlock.tx[i].txid) {
-          transactions[i].fee = verboseBlock.tx[i].fee * 100_000_000;
+          transactions[i].fee = (verboseBlock.tx[i].fee * 100_000_000) || 0;
         }
       }
 
@@ -941,7 +941,7 @@ class Blocks {
         transactions: cpfpSummary.transactions.map(tx => {
           return {
             txid: tx.txid,
-            fee: tx.fee,
+            fee: tx.fee || 0,
             vsize: tx.vsize,
             value: Math.round(tx.vout.reduce((acc, vout) => acc + (vout.value ? vout.value : 0), 0)),
             rate: tx.effectiveFeePerVsize

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -108,7 +108,7 @@ export class Common {
   static stripTransaction(tx: TransactionExtended): TransactionStripped {
     return {
       txid: tx.txid,
-      fee: tx.fee,
+      fee: tx.fee || 0,
       vsize: tx.weight / 4,
       value: tx.vout.reduce((acc, vout) => acc + (vout.value ? vout.value : 0), 0),
       rate: tx.effectiveFeePerVsize,


### PR DESCRIPTION
Fixes a bug where the coinbase fee field in the block summaries could be left `null` instead of set to zero.

Block summaries created with the bug will need to be reindexed to fix.

Remember to also clear the redis block summaries cache before testing!
```
redis-cli DEL block-summaries
```