### PR TITLE
Show tool list when no other networks available in footer

### DIFF
--- a/frontend/src/app/shared/components/global-footer/global-footer.component.html
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.html
@@ -42,13 +42,20 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-lg-6 links" *ngIf="env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.BISQ_ENABLED || env.LIQUID_TESTNET_ENABLED">
+          <div class="col-lg-6 links" *ngIf="officialMempoolSpace || env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.LIQUID_TESTNET_ENABLED">
             <p class="category">Networks</p>
             <p *ngIf="(officialMempoolSpace || (env.BASE_MODULE === 'mempool')) && (currentNetwork !== '') && (currentNetwork !== 'mainnet')"><a [href]="networkLink('mainnet')">Mainnet Explorer</a></p>
             <p *ngIf="(officialMempoolSpace || (env.BASE_MODULE === 'mempool')) && (currentNetwork !== 'testnet') && env.TESTNET_ENABLED"><a [href]="networkLink('testnet')">Testnet Explorer</a></p>
             <p *ngIf="(officialMempoolSpace || (env.BASE_MODULE === 'mempool')) && (currentNetwork !== 'signet') && env.SIGNET_ENABLED"><a [href]="networkLink('signet')">Signet Explorer</a></p>
-            <p *ngIf="env.LIQUID_ENABLED && (currentNetwork !== 'liquid') && (currentNetwork !== 'liquidtestnet')"><a [href]="networkLink('liquid')">Liquid Explorer</a></p>
-            <p *ngIf="env.BISQ_ENABLED && (currentNetwork !== 'bisq')"><a [href]="networkLink('bisq')">Bisq Explorer</a></p>
+            <p *ngIf="(officialMempoolSpace || env.LIQUID_ENABLED) && (currentNetwork !== 'liquidtestnet')"><a [href]="networkLink('liquidtestnet')">Liquid Testnet Explorer</a></p>
+            <p *ngIf="(officialMempoolSpace || env.LIQUID_ENABLED) && (currentNetwork !== 'liquid')"><a [href]="networkLink('liquid')">Liquid Explorer</a></p>
+            <p *ngIf="(officialMempoolSpace && (currentNetwork !== 'bisq'))"><a [href]="networkLink('bisq')">Bisq Explorer</a></p>
+          </div>
+          <div class="col-lg-6 links" *ngIf="!(officialMempoolSpace || env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.LIQUID_TESTNET_ENABLED)">
+            <p class="category">Tools</p>
+            <p><a [routerLink]="['/clock/mempool/0']">Clock (Mempool)</a></p>
+            <p><a [routerLink]="['/clock/mined/0']">Clock (Mined)</a></p>
+            <p><a [routerLink]="['/tools/calculator']">BTC/Fiat Converter</a></p>
           </div>
           <div class="col-lg-6 links">
             <p class="category">Legal</p>

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.html
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.html
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-lg-6 links" *ngIf="officialMempoolSpace || env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.LIQUID_TESTNET_ENABLED">
+          <div class="col-lg-6 links" *ngIf="officialMempoolSpace || env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.LIQUID_TESTNET_ENABLED else toolBox" >
             <p class="category">Networks</p>
             <p *ngIf="(officialMempoolSpace || (env.BASE_MODULE === 'mempool')) && (currentNetwork !== '') && (currentNetwork !== 'mainnet')"><a [href]="networkLink('mainnet')">Mainnet Explorer</a></p>
             <p *ngIf="(officialMempoolSpace || (env.BASE_MODULE === 'mempool')) && (currentNetwork !== 'testnet') && env.TESTNET_ENABLED"><a [href]="networkLink('testnet')">Testnet Explorer</a></p>
@@ -51,12 +51,14 @@
             <p *ngIf="(officialMempoolSpace || env.LIQUID_ENABLED) && (currentNetwork !== 'liquid')"><a [href]="networkLink('liquid')">Liquid Explorer</a></p>
             <p *ngIf="(officialMempoolSpace && (currentNetwork !== 'bisq'))"><a [href]="networkLink('bisq')">Bisq Explorer</a></p>
           </div>
-          <div class="col-lg-6 links" *ngIf="!(officialMempoolSpace || env.TESTNET_ENABLED || env.SIGNET_ENABLED || env.LIQUID_ENABLED || env.LIQUID_TESTNET_ENABLED)">
+          <ng-template #toolBox>
+          <div class="col-lg-6 links">
             <p class="category">Tools</p>
             <p><a [routerLink]="['/clock/mempool/0']">Clock (Mempool)</a></p>
             <p><a [routerLink]="['/clock/mined/0']">Clock (Mined)</a></p>
             <p><a [routerLink]="['/tools/calculator']">BTC/Fiat Converter</a></p>
           </div>
+          </ng-template>
           <div class="col-lg-6 links">
             <p class="category">Legal</p>
             <p><a [routerLink]="['/terms-of-service']" i18n="shared.terms-of-service|Terms of Service">Terms of Service</a></p>


### PR DESCRIPTION
In some cases, such as on Raspberry Pi distros, no other networks will show in the networks list, making the footer look like this:

![Screenshot from 2023-08-01 18-42-35](https://github.com/mempool/mempool/assets/93150691/e0feeb5e-ccb5-44aa-baa1-7d086c967c53)

This PR adds another list in the footer to maintain aesthetic balance:

![Screenshot from 2023-08-01 18-42-18](https://github.com/mempool/mempool/assets/93150691/9a9599a0-afb4-42e2-9aa2-37385086fb07)
