### PR TITLE
use bulk mempool post api to batch mempool update requests

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -3,7 +3,8 @@ import { IEsploraApi } from './esplora-api.interface';
 export interface AbstractBitcoinApi {
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
   $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, lazyPrevouts?: boolean): Promise<IEsploraApi.Transaction>;
-  $getMempoolTransactions(lastTxid: string);
+  $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]>;
+  $getAllMempoolTransactions(lastTxid: string);
   $getTransactionHex(txId: string): Promise<string>;
   $getBlockHeightTip(): Promise<number>;
   $getBlockHashTip(): Promise<string>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -60,8 +60,13 @@ class BitcoinApi implements AbstractBitcoinApi {
       });
   }
 
-  $getMempoolTransactions(lastTxid: string): Promise<IEsploraApi.Transaction[]> {
-    return Promise.resolve([]);
+  $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
+    throw new Error('Method getMempoolTransactions not supported by the Bitcoin RPC API.');
+  }
+
+  $getAllMempoolTransactions(lastTxid: string): Promise<IEsploraApi.Transaction[]> {
+    throw new Error('Method getAllMempoolTransactions not supported by the Bitcoin RPC API.');
+
   }
 
   async $getTransactionHex(txId: string): Promise<string> {


### PR DESCRIPTION
This PR uses the new `/mempool/txs` POST api added in https://github.com/mempool/electrs/pull/31 to fetch missing mempool transactions from mempool/electrs in batches, which can be significantly faster than requesting transactions individually during the mempool update loop.


