### PR TITLE
resume tracking subscriptions after websocket reconnect

### DIFF
--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -28,8 +28,9 @@ export class WebsocketService {
   private isTrackingTx = false;
   private trackingTxId: string;
   private isTrackingMempoolBlock = false;
-  private isTrackingRbf = false;
+  private isTrackingRbf: 'all' | 'fullRbf' | false = false;
   private isTrackingRbfSummary = false;
+  private isTrackingAddress: string | false = false;
   private trackingMempoolBlock: number;
   private latestGitCommit = '';
   private onlineCheckTimeout: number;
@@ -110,6 +111,15 @@ export class WebsocketService {
           if (this.isTrackingMempoolBlock) {
             this.startTrackMempoolBlock(this.trackingMempoolBlock);
           }
+          if (this.isTrackingRbf) {
+            this.startTrackRbf(this.isTrackingRbf);
+          }
+          if (this.isTrackingRbfSummary) {
+            this.startTrackRbfSummary();
+          }
+          if (this.isTrackingAddress) {
+            this.startTrackAddress(this.isTrackingAddress);
+          }
           this.stateService.connectionState$.next(2);
         }
 
@@ -151,10 +161,12 @@ export class WebsocketService {
 
   startTrackAddress(address: string) {
     this.websocketSubject.next({ 'track-address': address });
+    this.isTrackingAddress = address;
   }
 
   stopTrackingAddress() {
     this.websocketSubject.next({ 'track-address': 'stop' });
+    this.isTrackingAddress = false;
   }
 
   startTrackAsset(asset: string) {
@@ -178,7 +190,7 @@ export class WebsocketService {
 
   startTrackRbf(mode: 'all' | 'fullRbf') {
     this.websocketSubject.next({ 'track-rbf': mode });
-    this.isTrackingRbf = true;
+    this.isTrackingRbf = mode;
   }
 
   stopTrackRbf() {


### PR DESCRIPTION
Fixes #4069.

This PR makes the frontend restart any existing RBF or address subscriptions after reconnecting to the websocket, which allows e.g. the latest replacements section on the main dashboard to resume properly after network issues.