### PR TITLE
BUGFIX: docker mempool/backend copy rust-gbt outside /package

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -22,6 +22,7 @@ FROM node:16.16.0-buster-slim
 WORKDIR /backend
 
 RUN chown 1000:1000 ./
+COPY --from=builder --chown=1000:1000 /build/package/rust-gbt ./rust-gbt/
 COPY --from=builder --chown=1000:1000 /build/package ./package/
 COPY --from=builder --chown=1000:1000 /build/GeoIP ./GeoIP/
 COPY --from=builder --chown=1000:1000 /build/mempool-config.json /build/start.sh /build/wait-for-it.sh ./


### PR DESCRIPTION
```COPY --from=builder --chown=1000:1000 /build/package/rust-gbt ./rust-gbt/``` this is still needed inside docker because its included like below, which means inside the package context its outside of the package.

https://github.com/mempool/mempool/blob/cac2a984abac022cf20630ce44465cca7383f85f/backend/src/api/mempool-blocks.ts#L1

otherwise after you run the docker image you will get: 

![screenshot-1691089880](https://github.com/mempool/mempool/assets/1743657/d48b0788-b324-469e-9834-0022238fa8c0)