### PR TITLE
Feature: Build Rust during build script AND install

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -45,3 +45,6 @@ testem.log
 #System Files
 .DS_Store
 Thumbs.db
+
+# package folder (npm run package output)
+/package

--- a/backend/npm_package.sh
+++ b/backend/npm_package.sh
@@ -1,14 +1,17 @@
 #/bin/sh
 set -e
 
+# Remove previous dist folder
+rm -rf dist
+# Build new dist folder
 npm run build
 # Remove previous package folder
 rm -rf package
 # Move JS and deps
 mv dist package
-mv node_modules package
+cp -R node_modules package
 # Remove symlink for rust-gbt and insert real folder
 rm package/node_modules/rust-gbt
-mv rust-gbt package/node_modules
+cp -R rust-gbt package/node_modules
 # Clean up deps
 npm run package-rm-build-deps

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
   "main": "index.ts",
   "scripts": {
     "tsc": "./node_modules/typescript/bin/tsc -p tsconfig.build.json",
-    "build": "npm run tsc && npm run create-resources",
+    "build": "npm run rust-build && npm run tsc && npm run create-resources",
     "create-resources": "cp ./src/tasks/price-feeds/mtgox-weekly.json ./dist/tasks && node dist/api/fetch-version.js",
     "package": "./npm_package.sh",
     "package-rm-build-deps": "./npm_package_rm_build_deps.sh",
@@ -33,7 +33,8 @@
     "test": "./node_modules/.bin/jest --coverage",
     "lint": "./node_modules/.bin/eslint . --ext .ts",
     "lint:fix": "./node_modules/.bin/eslint . --ext .ts --fix",
-    "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{js,ts}\""
+    "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{js,ts}\"",
+    "rust-build": "cd rust-gbt && npm run build-release"
   },
   "dependencies": {
     "@babel/core": "^7.21.3",


### PR DESCRIPTION
Developer eXperience fell due to the removal of rust build step from the `npm run build` script.

Since Rust caches build artifacts anyways, 2 build calls in quick succession will see the 2nd one only take a few ms anyways... so I put it back.

It was annoying to have to delete /package and `git restore rust-gbt` every time I tested the npm run package command, so I add a few QoL things. (cp -R instead of mv, and adding to .gitignore)