### PR TITLE
use bulk /txs endpoint to check cached rbf tx status

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -3,6 +3,7 @@ import { IEsploraApi } from './esplora-api.interface';
 export interface AbstractBitcoinApi {
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
   $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, lazyPrevouts?: boolean): Promise<IEsploraApi.Transaction>;
+  $getRawTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]>;
   $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]>;
   $getAllMempoolTransactions(lastTxid: string);
   $getTransactionHex(txId: string): Promise<string>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -60,6 +60,10 @@ class BitcoinApi implements AbstractBitcoinApi {
       });
   }
 
+  $getRawTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
+    throw new Error('Method getRawTransactions not supported by the Bitcoin RPC API.');
+  }
+
   $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
     throw new Error('Method getMempoolTransactions not supported by the Bitcoin RPC API.');
   }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -213,6 +213,10 @@ class ElectrsApi implements AbstractBitcoinApi {
     return this.failoverRouter.$get<IEsploraApi.Transaction>('/tx/' + txId);
   }
 
+  async $getRawTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
+    return this.$postWrapper<IEsploraApi.Transaction[]>(config.ESPLORA.REST_API_URL + '/txs', txids, 'json');
+  }
+
   async $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
     return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal/mempool/txs', txids, 'json');
   }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -214,7 +214,7 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   async $getRawTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
-    return this.$postWrapper<IEsploraApi.Transaction[]>(config.ESPLORA.REST_API_URL + '/txs', txids, 'json');
+    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal-api/txs', txids, 'json');
   }
 
   async $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -214,7 +214,7 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   async $getRawTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal-api/txs', txids, 'json');
+    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal/txs', txids, 'json');
   }
 
   async $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -181,7 +181,8 @@ class FailoverRouter {
       .catch((e) => {
         let fallbackHost = this.fallbackHost;
         if (e?.response?.status !== 404) {
-          logger.warn(`esplora request failed ${e?.response?.status || 500} ${host.host}${path}`);
+          logger.warn(`esplora request failed ${e?.response?.status} ${host.host}${path}`);
+          logger.warn(e instanceof Error ? e.message : e);
           fallbackHost = this.addFailure(host);
         }
         if (retry && e?.code === 'ECONNREFUSED' && this.multihost) {

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -480,14 +480,16 @@ class RbfCache {
     };
 
     if (config.MEMPOOL.BACKEND === 'esplora') {
-      const sliceLength = 10000;
+      const sliceLength = 1000;
       for (let i = 0; i < Math.ceil(txids.length / sliceLength); i++) {
         const slice = txids.slice(i * sliceLength, (i + 1) * sliceLength);
         try {
           const txs = await bitcoinApi.$getRawTransactions(slice);
+          logger.debug(`fetched ${slice.length} cached rbf transactions`);
           processTxs(txs);
+          logger.debug(`processed ${slice.length} cached rbf transactions`);
         } catch (err) {
-          logger.err('failed to fetch some cached rbf transactions');
+          logger.err(`failed to fetch or process ${slice.length} cached rbf transactions`);
         }
       }
     } else {

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -480,7 +480,7 @@ class RbfCache {
     };
 
     if (config.MEMPOOL.BACKEND === 'esplora') {
-      const sliceLength = 1000;
+      const sliceLength = 250;
       for (let i = 0; i < Math.ceil(txids.length / sliceLength); i++) {
         const slice = txids.slice(i * sliceLength, (i + 1) * sliceLength);
         try {

--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -505,10 +505,13 @@ class RbfCache {
 
     if (config.MEMPOOL.BACKEND === 'esplora') {
       const sliceLength = 10000;
+      let count = 0;
       for (let i = 0; i < Math.ceil(txids.length / sliceLength); i++) {
         const slice = txids.slice(i * sliceLength, (i + 1) * sliceLength);
         try {
           const txs = await bitcoinApi.$getRawTransactions(slice);
+          count += txs.length;
+          logger.info(`Fetched ${count} of ${txids.length} unknown-status RBF transactions from esplora`);
           processTxs(txs);
         } catch (err) {
           logger.err('failed to fetch some cached rbf transactions');


### PR DESCRIPTION
_(builds on #4158)_

After we load RBF data in from the cache, we need to check if anything got mined or removed from the mempool while we were offline.

Currently, we fetch these transactions one by one, but that can be slow when there are a lot of transactions in the RBF cache.

This PR uses a new esplora `/internal-api/txs` endpoint to fetch the transactions in bulk, which speeds up the process significantly.

(we can't use the `/internal-api/mempool/txs` esplora endpoint because we need differentiate between transactions being confirmed and evicted from the mempool)