### PR TITLE
Handle historical price API calls when using any testnet

### DIFF
--- a/backend/src/api/mining/mining-routes.ts
+++ b/backend/src/api/mining/mining-routes.ts
@@ -41,6 +41,10 @@ class MiningRoutes {
       res.header('Pragma', 'public');
       res.header('Cache-control', 'public');
       res.setHeader('Expires', new Date(Date.now() + 1000 * 300).toUTCString());
+      if (['testnet', 'signet', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
+        res.status(400).send('Prices are not available on testnets.');
+        return;
+      }
       if (req.query.timestamp) {
         res.status(200).send(await PricesRepository.$getNearestHistoricalPrice(
           parseInt(<string>req.query.timestamp ?? 0, 10)

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { CpfpInfo, OptimizedMempoolStats, AddressInformation, LiquidPegs, ITranslators,
   PoolStat, BlockExtended, TransactionStripped, RewardStats, AuditScore, BlockSizesAndWeights, RbfTree, BlockAudit } from '../interfaces/node-api.interface';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { StateService } from './state.service';
 import { WebsocketResponse } from '../interfaces/websocket.interface';
 import { Outspend, Transaction } from '../interfaces/electrs.interface';
@@ -312,6 +312,19 @@ export class ApiService {
   }
 
   getHistoricalPrice$(timestamp: number | undefined): Observable<Conversion> {
+    if (this.stateService.isAnyTestnet()) {
+      return of({
+        prices: [],
+        exchangeRates: {
+          USDEUR: 0,
+          USDGBP: 0,
+          USDCAD: 0,
+          USDCHF: 0,
+          USDAUD: 0,
+          USDJPY: 0,
+        }
+      });
+    }
     return this.httpClient.get<Conversion>(
       this.apiBaseUrl + this.apiBasePath + '/api/v1/historical-price' +
         (timestamp ? `?timestamp=${timestamp}` : '')

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -339,6 +339,10 @@ export class StateService {
     return this.network === 'liquid' || this.network === 'liquidtestnet';
   }
 
+  isAnyTestnet(): boolean {
+    return ['testnet', 'signet', 'liquidtestnet'].includes(this.network);
+  }
+
   resetChainTip() {
     this.latestBlockHeight = -1;
     this.chainTip$.next(-1);


### PR DESCRIPTION
This PR fixes:

* A failing DB lookup and bad http backend response when the testnet frontend is asking for historical prices
* The frontend will not longer call the historical prices API and error out