### PR TITLE
[mining] add /api/v1/pools API to list mining pools

### DIFF
--- a/backend/src/api/mining/mining-routes.ts
+++ b/backend/src/api/mining/mining-routes.ts
@@ -12,6 +12,7 @@ import PricesRepository from '../../repositories/PricesRepository';
 class MiningRoutes {
   public initRoutes(app: Application) {
     app
+      .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools', this.$listPools)
       .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pools/:interval', this.$getPools)
       .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:slug/hashrate', this.$getPoolHistoricalHashrate)
       .get(config.MEMPOOL.API_URL_PREFIX + 'mining/pool/:slug/blocks', this.$getPoolBlocks)
@@ -85,6 +86,29 @@ class MiningRoutes {
       } else {
         res.status(500).send(e instanceof Error ? e.message : e);
       }
+    }
+  }
+
+  private async $listPools(req: Request, res: Response): Promise<void> {
+    try {
+      res.header('Pragma', 'public');
+      res.header('Cache-control', 'public');
+      res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
+
+      const pools = await mining.$listPools();
+      if (!pools) {
+        res.status(500).end();
+        return;
+      }
+
+      res.header('X-total-count', pools.length.toString());
+      if (pools.length === 0) {
+        res.status(204).send();
+      } else {
+        res.json(pools);
+      }
+    } catch (e) {
+      res.status(500).send(e instanceof Error ? e.message : e);
     }
   }
 

--- a/backend/src/api/mining/mining.ts
+++ b/backend/src/api/mining/mining.ts
@@ -26,7 +26,7 @@ class Mining {
   /**
    * Get historical blocks health
    */
-   public async $getBlocksHealthHistory(interval: string | null = null): Promise<any> {
+  public async $getBlocksHealthHistory(interval: string | null = null): Promise<any> {
     return await BlocksAuditsRepository.$getBlocksHealthHistory(
       this.getTimeRange(interval),
       Common.getSqlInterval(interval)
@@ -56,7 +56,7 @@ class Mining {
   /**
    * Get historical block fee rates percentiles
    */
-   public async $getHistoricalBlockFeeRates(interval: string | null = null): Promise<any> {
+  public async $getHistoricalBlockFeeRates(interval: string | null = null): Promise<any> {
     return await BlocksRepository.$getHistoricalBlockFeeRates(
       this.getTimeRange(interval),
       Common.getSqlInterval(interval)
@@ -66,7 +66,7 @@ class Mining {
   /**
    * Get historical block sizes
    */
-   public async $getHistoricalBlockSizes(interval: string | null = null): Promise<any> {
+  public async $getHistoricalBlockSizes(interval: string | null = null): Promise<any> {
     return await BlocksRepository.$getHistoricalBlockSizes(
       this.getTimeRange(interval),
       Common.getSqlInterval(interval)
@@ -76,7 +76,7 @@ class Mining {
   /**
    * Get historical block weights
    */
-   public async $getHistoricalBlockWeights(interval: string | null = null): Promise<any> {
+  public async $getHistoricalBlockWeights(interval: string | null = null): Promise<any> {
     return await BlocksRepository.$getHistoricalBlockWeights(
       this.getTimeRange(interval),
       Common.getSqlInterval(interval)
@@ -593,6 +593,20 @@ class Mining {
     } else {
       logger.debug(`Indexing missing coinstatsindex data completed. Indexed 0.`, logger.tags.mining);
     }
+  }
+
+  /**
+   * List existing mining pools
+   */
+  public async $listPools(): Promise<{name: string, slug: string, unique_id: number}[] | null> {
+    const [rows] = await database.query(`
+      SELECT
+        name,
+        slug,
+        unique_id
+      FROM pools`
+    );
+    return rows as {name: string, slug: string, unique_id: number}[];
   }
 
   private getDateMidnight(date: Date): Date {


### PR DESCRIPTION
Added new `GET /api/v1/mining/pools` api to get a list of mining pool without running all the mining dashboard related calculations from using `GET /api/v1/mining/pools/:timeframe`.

We'll use it in the services backend to load mining pool when the services backend starts.

```
nymkappa @ /Users/nymkappa $ curl -sv localhost:8999/api/v1/mining/pools | jq
*   Trying 127.0.0.1:8999...
* Connected to localhost (127.0.0.1) port 8999 (#0)
> GET /api/v1/mining/pools HTTP/1.1
> Host: localhost:8999
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Pragma: public
< Cache-control: public
< Expires: Mon, 07 Aug 2023 05:07:50 GMT
< X-total-count: 141
< Content-Type: application/json; charset=utf-8
< Content-Length: 7669
< ETag: W/"1df5-7rfaOZUhn4wEoZ0pN3NohgBWESE"
< Date: Mon, 07 Aug 2023 05:06:50 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
{ [7669 bytes data]
* Connection #0 to host localhost left intact
[
  {
    "name": "Unknown",
    "slug": "unknown",
    "unique_id": 0
  },
  {
    "name": "BlockFills",
    "slug": "blockfills",
    "unique_id": 1
  },
  {
    "name": "ULTIMUSPOOL",
    "slug": "ultimuspool",
    "unique_id": 2
  },
  {
    "name": "Terra Pool",
    "slug": "terrapool",
    "unique_id": 3
  },
  ...
]