### PR TITLE
Set dependabot to fix the package.json file in addition to the lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    versioning-strategy: increase
     directory: "/backend"
     schedule:
       interval: daily
@@ -14,6 +15,7 @@ updates:
 
   - package-ecosystem: npm
     directory: "/frontend"
+    versioning-strategy: increase
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot pull requests are only updating the lockfile, so `npm ci` fails.

Set the versioning strategy per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy