### PR TITLE
Stack all footer select boxes on small mobile

### DIFF
--- a/frontend/src/app/components/fiat-selector/fiat-selector.component.html
+++ b/frontend/src/app/components/fiat-selector/fiat-selector.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="fiatForm" class="text-small text-center">
-    <select formControlName="fiat" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 150px;" (change)="changeFiat()">
+    <select formControlName="fiat" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" (change)="changeFiat()">
         <option *ngFor="let currency of currencies" [value]="currency[1].code">{{ currency[1].name + " (" + currency[1].code + ")" }}</option>
     </select>
 </div>

--- a/frontend/src/app/components/fiat-selector/fiat-selector.component.scss
+++ b/frontend/src/app/components/fiat-selector/fiat-selector.component.scss
@@ -1,0 +1,9 @@
+select {
+  width: 150px;
+}
+
+@media (max-width: 500px) {
+  select {
+    width: 200px;
+  }
+}

--- a/frontend/src/app/components/language-selector/language-selector.component.html
+++ b/frontend/src/app/components/language-selector/language-selector.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="languageForm" class="text-small text-center">
-    <select formControlName="language" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 100px;" (change)="changeLanguage()">
+    <select formControlName="language" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" (change)="changeLanguage()">
         <option *ngFor="let lang of languages" [value]="lang.code">{{ lang.name }}</option>
     </select>
 </div>

--- a/frontend/src/app/components/language-selector/language-selector.component.scss
+++ b/frontend/src/app/components/language-selector/language-selector.component.scss
@@ -1,0 +1,9 @@
+select {
+  width: 100px;
+}
+
+@media (max-width: 500px) {
+  select {
+    width: 200px;
+  }
+}

--- a/frontend/src/app/components/rate-unit-selector/rate-unit-selector.component.html
+++ b/frontend/src/app/components/rate-unit-selector/rate-unit-selector.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="rateUnitForm" class="text-small text-center">
-    <select formControlName="rateUnits" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 100px;" (change)="changeUnits()">
+    <select formControlName="rateUnits" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" (change)="changeUnits()">
         <option *ngFor="let unit of units" [value]="unit.name">{{ unit.label }}</option>
     </select>
 </div>

--- a/frontend/src/app/components/rate-unit-selector/rate-unit-selector.component.scss
+++ b/frontend/src/app/components/rate-unit-selector/rate-unit-selector.component.scss
@@ -1,0 +1,9 @@
+select {
+  width: 100px;
+}
+
+@media (max-width: 500px) {
+  select {
+    width: 200px;
+  }
+}

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.scss
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.scss
@@ -180,3 +180,15 @@ footer .row.version p a {
     margin-right: 10px;
   }
 }
+
+@media (max-width: 500px) {
+
+  footer .selector {
+    display: block;
+  }
+
+  footer .selector:not(:last-child) {
+    margin-right: 0;
+  }
+
+}


### PR DESCRIPTION
PR #4121 caused select boxes in the footer to look like this:

![Screenshot from 2023-08-11 12-31-45](https://github.com/mempool/mempool/assets/93150691/344b1990-ba3c-4553-bb87-f8609c828a38)

These changes stack the boxes on <500px screens so it looks like this:

![Screenshot from 2023-08-11 12-29-08](https://github.com/mempool/mempool/assets/93150691/7c06062d-c512-4d7f-b8fa-7f5e396b5bac)

Screens >500px still look like this:

![Screenshot from 2023-08-11 12-34-02](https://github.com/mempool/mempool/assets/93150691/3ae58979-8b39-4e3b-93bc-52d1953e39f4)
