### PR TITLE
Add links to enterprise page in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ It is an open-source project developed and operated for the benefit of the Bitco
 
 Mempool can be self-hosted on a wide variety of your own hardware, ranging from a simple one-click installation on a Raspberry Pi full-node distro all the way to a robust production instance on a powerful FreeBSD server. 
 
-**Most people should use a one-click install method.** Other install methods are meant for developers and others with experience managing servers. 
+Most people should use a <a href="#one-click-installation">one-click install method</a>.
+
+Other install methods are meant for developers and others with experience managing servers. If you want support for your own production instance of Mempool, or if you'd like to have your own instance of Mempool run by the mempool.space team on their own global ISP infrastructure—check out <a href="https://mempool.space/enterprise" target="_blank">Mempool Enterprise®</a>.
 
 <a id="one-click-installation"></a>
 ## One-Click Installation

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 These instructions are mostly intended for developers. 
 
-If you choose to use these instructions for a production setup, be aware that you will still probably need to do additional configuration for your specific OS, environment, use-case, etc. We do our best here to provide a good starting point, but only proceed if you know what you're doing. Mempool only provides support for custom setups to [enterprise sponsors](https://mempool.space/enterprise).
+If you choose to use these instructions for a production setup, be aware that you will still probably need to do additional configuration for your specific OS, environment, use-case, etc. We do our best here to provide a good starting point, but only proceed if you know what you're doing. Mempool only provides support for custom setups to project sponsors through [Mempool Enterprise®](https://mempool.space/enterprise).
 
 See other ways to set up Mempool on [the main README](/../../#installation-methods).
 

--- a/production/README.md
+++ b/production/README.md
@@ -2,7 +2,9 @@
 
 These instructions are for setting up a serious production Mempool website for Bitcoin (mainnet, testnet, signet), Liquid (mainnet, testnet), and Bisq.
 
-Again, this setup is no joke—home users should use [one of the other installation methods](../#installation-methods). Support is only provided to [enterprise sponsors](https://mempool.space/enterprise).
+Again, this setup is no joke—home users should use [one of the other installation methods](../#installation-methods). Support is only provided to project sponsors through [Mempool Enterprise®](https://mempool.space/enterprise).
+
+You can also have the mempool.space team run a highly-performant and highly-available instance of Mempool for you on their own global ISP infrastructure. See <a href="https://mempool.space/enterprise" target="_blank">Mempool Enterprise®</a> for more details.
 
 ### Server Hardware
 


### PR DESCRIPTION
Note & links are added on the main README as well those in production/ and backend/.