### PR TITLE
Nginx: Ignore all internal-api paths

### DIFF
--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -238,7 +238,7 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/block/' + hash + '/txs');
+    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/internal/block/' + hash + '/txs');
   }
 
   $getBlockHash(height: number): Promise<string> {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -214,11 +214,11 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   async $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/mempool/txs', txids, 'json');
+    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal-api/mempool/txs', txids, 'json');
   }
 
   async $getAllMempoolTransactions(lastSeenTxid?: string): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/mempool/txs' + (lastSeenTxid ? '/' + lastSeenTxid : ''));
+    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/internal-api/mempool/txs' + (lastSeenTxid ? '/' + lastSeenTxid : ''));
   }
 
   $getTransactionHex(txId: string): Promise<string> {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -214,11 +214,11 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   async $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal-api/mempool/txs', txids, 'json');
+    return this.failoverRouter.$post<IEsploraApi.Transaction[]>('/internal/mempool/txs', txids, 'json');
   }
 
   async $getAllMempoolTransactions(lastSeenTxid?: string): Promise<IEsploraApi.Transaction[]> {
-    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/internal-api/mempool/txs' + (lastSeenTxid ? '/' + lastSeenTxid : ''));
+    return this.failoverRouter.$get<IEsploraApi.Transaction[]>('/internal/mempool/txs' + (lastSeenTxid ? '/' + lastSeenTxid : ''));
   }
 
   $getTransactionHex(txId: string): Promise<string> {

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -39,11 +39,6 @@
 		try_files $uri $uri/ /$1/index.html =404;
 	}
 
-	# any path containing .*/internal-api/.* anywhere is ignored
-	location ~ ^/.*?/internal-api/ {
-		return 404;
-	}
-
 	# static API docs
 	location = /api {
 		try_files $uri $uri/ /en-US/index.html =404;

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -39,6 +39,11 @@
 		try_files $uri $uri/ /$1/index.html =404;
 	}
 
+	# any path containing .*/internal-api/.* anywhere is ignored
+	location ~ ^/.*?/internal-api/ {
+		return 404;
+	}
+
 	# static API docs
 	location = /api {
 		try_files $uri $uri/ /en-US/index.html =404;

--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -2,12 +2,14 @@
 # mempool #
 ###########
 
+# Block the internal APIs of esplora
 location /api/internal/ {
 	return 404;
 }
 location /api/v1/internal/ {
 	return 404;
 }
+
 # websocket has special HTTP headers
 location /api/v1/ws {
 	try_files /dev/null @mempool-api-v1-websocket;

--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -2,6 +2,11 @@
 # mempool #
 ###########
 
+# any path containing .*/internal-api/.* anywhere is ignored
+location ~ ^/.*?/internal-api/ {
+	return 404;
+}
+
 # websocket has special HTTP headers
 location /api/v1/ws {
 	try_files /dev/null @mempool-api-v1-websocket;

--- a/production/nginx/location-api.conf
+++ b/production/nginx/location-api.conf
@@ -2,11 +2,12 @@
 # mempool #
 ###########
 
-# any path containing .*/internal-api/.* anywhere is ignored
-location ~ ^/.*?/internal-api/ {
+location /api/internal/ {
 	return 404;
 }
-
+location /api/v1/internal/ {
+	return 404;
+}
 # websocket has special HTTP headers
 location /api/v1/ws {
 	try_files /dev/null @mempool-api-v1-websocket;

--- a/production/nginx/location-liquid-api.conf
+++ b/production/nginx/location-liquid-api.conf
@@ -2,6 +2,14 @@
 # mempool #
 ###########
 
+# Block the internal APIs of esplora
+location /liquid/api/internal/ {
+	return 404;
+}
+location /liquid/api/v1/internal/ {
+	return 404;
+}
+
 # websocket has special HTTP headers
 location /liquid/api/v1/ws {
 	rewrite ^/liquid/(.*) /$1 break;

--- a/production/nginx/location-liquidtestnet-api.conf
+++ b/production/nginx/location-liquidtestnet-api.conf
@@ -2,6 +2,14 @@
 # mempool #
 ###########
 
+# Block the internal APIs of esplora
+location /liquidtestnet/api/internal/ {
+	return 404;
+}
+location /liquidtestnet/api/v1/internal/ {
+	return 404;
+}
+
 # websocket has special HTTP headers
 location /liquidtestnet/api/v1/ws {
 	rewrite ^/liquidtestnet/(.*) /$1 break;

--- a/production/nginx/location-signet-api.conf
+++ b/production/nginx/location-signet-api.conf
@@ -2,6 +2,14 @@
 # mempool #
 ###########
 
+# Block the internal APIs of esplora
+location /signet/api/internal/ {
+	return 404;
+}
+location /signet/api/v1/internal/ {
+	return 404;
+}
+
 # websocket has special HTTP headers
 location /signet/api/v1/ws {
 	rewrite ^/signet/(.*) /$1 break;

--- a/production/nginx/location-testnet-api.conf
+++ b/production/nginx/location-testnet-api.conf
@@ -2,6 +2,14 @@
 # mempool #
 ###########
 
+# Block the internal APIs of esplora
+location /testnet/api/internal/ {
+	return 404;
+}
+location /testnet/api/v1/internal/ {
+	return 404;
+}
+
 # websocket has special HTTP headers
 location /testnet/api/v1/ws {
 	rewrite ^/testnet/(.*) /$1 break;


### PR DESCRIPTION
TODO: Cleanup these new intensive endpoints that have been added recently.

- [ ] Remove the endpoints from the backend so they are not exposed to the frontend.
- [ ] Ensure that only the backend can access the mempool-electrs.