### PR TITLE
Drop MSRV to 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           node-version: ${{ matrix.node }}
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install 1.70.x Rust toolchain
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install 1.63.x Rust toolchain
+        uses: dtolnay/rust-toolchain@1.63
 
       - name: Install
         if: ${{ matrix.flavor == 'dev'}}

--- a/backend/rust-gbt/Cargo.toml
+++ b/backend/rust-gbt/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["mononaut"]
 edition = "2021"
 publish = false
 
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/backend/rust-gbt/src/gbt.rs
+++ b/backend/rust-gbt/src/gbt.rs
@@ -335,13 +335,15 @@ fn set_relatives(txid: u32, audit_pool: &mut AuditPool) {
     let mut total_sigops: u32 = 0;
 
     for ancestor_id in &ancestors {
-        let Some(ancestor) = audit_pool
+        if let Some(ancestor) = audit_pool
             .get(*ancestor_id as usize)
-            .expect("audit_pool contains all ancestors") else { todo!() };
-        total_fee += ancestor.fee;
-        total_sigop_adjusted_weight += ancestor.sigop_adjusted_weight;
-        total_sigop_adjusted_vsize += ancestor.sigop_adjusted_vsize;
-        total_sigops += ancestor.sigops;
+            .expect("audit_pool contains all ancestors")
+        {
+            total_fee += ancestor.fee;
+            total_sigop_adjusted_weight += ancestor.sigop_adjusted_weight;
+            total_sigop_adjusted_vsize += ancestor.sigop_adjusted_vsize;
+            total_sigops += ancestor.sigops;
+        } else { todo!() };
     }
 
     if let Some(Some(tx)) = audit_pool.get_mut(txid as usize) {

--- a/contributors/TheBlueMatt.txt
+++ b/contributors/TheBlueMatt.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file with sha256 hash c80c5ee4c71c5a76a1f6cd35339bd0c45b25b491933ea7b02a66470e9f43a6fd.
+
+Signed: TheBlueMatt


### PR DESCRIPTION
Debian bookworm ships with 1.63, and since the change is trivial,
there's little reason to not support people running mempool on
Debian.