### PR TITLE
Update canonical link with block hash

### DIFF
--- a/frontend/src/app/bisq/bisq-block/bisq-block.component.ts
+++ b/frontend/src/app/bisq/bisq-block/bisq-block.component.ts
@@ -69,6 +69,7 @@ export class BisqBlockComponent implements OnInit, OnDestroy {
                   this.location.replaceState(
                     this.router.createUrlTree(['/bisq/block/', hash]).toString()
                   );
+                  this.seoService.updateCanonical(this.location.path());
                   return this.bisqApiService.getBlock$(this.blockHash)
                     .pipe(catchError(this.caughtHttpError.bind(this)));
                 }),

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -202,6 +202,7 @@ export class BlockComponent implements OnInit, OnDestroy {
                   this.location.replaceState(
                     this.router.createUrlTree([(this.network ? '/' + this.network : '') + '/block/', hash]).toString()
                   );
+                  this.seoService.updateCanonical(this.location.path());
                   return this.apiService.getBlock$(hash).pipe(
                     catchError((err) => {
                       this.error = err;

--- a/frontend/src/app/services/seo.service.ts
+++ b/frontend/src/app/services/seo.service.ts
@@ -12,6 +12,8 @@ export class SeoService {
   baseTitle = 'mempool';
   baseDescription = 'Explore the full Bitcoin ecosystem with The Mempool Open Project™.';
 
+  canonicalLink: HTMLElement = document.getElementById('canonical');
+
   constructor(
     private titleService: Title,
     private metaService: Meta,
@@ -63,6 +65,16 @@ export class SeoService {
     this.metaService.updateTag({ name: 'description', content: this.getDescription()});
     this.metaService.updateTag({ name: 'twitter:description', content: this.getDescription()});
     this.metaService.updateTag({ property: 'og:description', content: this.getDescription()});
+  }
+
+  updateCanonical(path) {
+    let domain = 'mempool.space';
+    if (this.stateService.env.BASE_MODULE === 'liquid') {
+      domain = 'liquid.network';
+    } else if (this.stateService.env.BASE_MODULE === 'bisq') {
+      domain = 'bisq.markets';
+    }
+    this.canonicalLink.setAttribute('href', 'https://' + domain + path);
   }
 
   getTitle(): string {


### PR DESCRIPTION
Adds a `updateCanonical(path)` method to the seoService, and uses it to point the `rel="canonical"` link at the block *hash* when a block is accessed by height.