### PR TITLE
[footer] fix positioning when menu component is not loaded

### DIFF
--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -78,6 +78,7 @@
 
 <div class="d-flex" style="overflow: clip">
   <app-menu *ngIf="servicesEnabled" [navOpen]="menuOpen" (loggedOut)="onLoggedOut()" (menuToggled)="menuToggled($event)"></app-menu>
+  <div *ngIf="!servicesEnabled" class="sidenav"><!-- empty sidenav needed to push footer down the screen --></div>
 
   <div class="flex-grow-1 d-flex flex-column">
     <app-testnet-alert *ngIf="network.val === 'testnet' || network.val === 'signet'"></app-testnet-alert>

--- a/frontend/src/app/components/master-page/master-page.component.scss
+++ b/frontend/src/app/components/master-page/master-page.component.scss
@@ -239,3 +239,17 @@ main {
   transition: 0.2s;
   transition-property: max-width;
 }
+
+// empty sidenav
+.sidenav {
+  z-index: 1;
+  background-color: transparent;
+  width: 225px;
+  height: calc(100vh - 65px);
+  position: sticky;
+  top: 65px;
+  transition: 0.25s;
+  margin-left: -250px;
+  box-shadow: 5px 0px 30px 0px #000;
+  padding-bottom: 20px;
+}


### PR DESCRIPTION
When we build in foss only, the menu component is not injected into the html, so the footer is not being pushed down the screen. This PR fixes this by adding an empty div with the menu css when building foss only.