### PR TITLE
[UI] fix few menu issues

### DIFF
--- a/frontend/src/app/components/menu/menu.component.html
+++ b/frontend/src/app/components/menu/menu.component.html
@@ -3,7 +3,7 @@
 
     <nav class="scrollable menu-click">
       <span *ngIf="userAuth" class="menu-click">
-        <strong class="menu-click">@ {{ userAuth.user.username }}</strong>
+        <strong class="menu-click text-nowrap ellipsis">@ {{ userAuth.user.username }}</strong>
       </span>
       <a *ngIf="!userAuth" class="d-flex justify-content-center align-items-center nav-link m-0  menu-click" routerLink="/login" role="tab" (click)="onLinkClick('/login')">
         <fa-icon class="menu-click" [icon]="['fas', 'user-circle']" [fixedWidth]="true" style="font-size: 25px;margin-right: 15px;"></fa-icon>

--- a/frontend/src/app/components/menu/menu.component.scss
+++ b/frontend/src/app/components/menu/menu.component.scss
@@ -14,6 +14,12 @@
   }
 }
 
+.ellipsis {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .scrollable {
   overflow-x: hidden;
   overflow-y: auto;

--- a/frontend/src/app/components/menu/menu.component.scss
+++ b/frontend/src/app/components/menu/menu.component.scss
@@ -9,11 +9,14 @@
   margin-left: -250px;
   box-shadow: 5px 0px 30px 0px #000;
   padding-bottom: 20px;
+  @media (max-width: 613px) {
+    top: 105px;
+  }
 }
 
 .scrollable {
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .sidenav.open {


### PR DESCRIPTION
When the screen resolution is small (eg: 1496x967 on my macOS), the container for the scrollbar always shows. See screenshots below.

Also fixed the sticky y position on mobile device.
Also fixed overflowing username (now an ellipsis).

<img width="328" alt="Screenshot 2023-09-28 at 13 43 29" src="https://github.com/mempool/mempool/assets/9780671/30e30e8a-ecb1-4346-bcf2-b27ef05bddee">
<img width="341" alt="Screenshot 2023-09-28 at 13 43 38" src="https://github.com/mempool/mempool/assets/9780671/0684edd6-b214-440a-8630-156f78b3f378">
<img width="387" alt="Screenshot 2023-09-28 at 13 43 51" src="https://github.com/mempool/mempool/assets/9780671/b5866565-68c9-4ef1-8244-de2d1c72045a">