### PR TITLE
Pause recording statistics during esplora failover

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -1,7 +1,7 @@
 import { IEsploraApi } from './esplora-api.interface';
 
 export interface AbstractBitcoinApi {
-  $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]>;
+  $getRawMempool(): Promise<{ txids: IEsploraApi.Transaction['txid'][], local: boolean}>;
   $getRawTransaction(txId: string, skipConversion?: boolean, addPrevout?: boolean, lazyPrevouts?: boolean): Promise<IEsploraApi.Transaction>;
   $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]>;
   $getAllMempoolTransactions(lastTxid: string);

--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -25,6 +25,7 @@ export interface AbstractBitcoinApi {
   $getBatchedOutspends(txId: string[]): Promise<IEsploraApi.Outspend[][]>;
 
   startHealthChecks(): void;
+  isFailedOver(): boolean;
 }
 export interface BitcoinRpcCredentials {
   host: string;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -356,6 +356,9 @@ class BitcoinApi implements AbstractBitcoinApi {
   }
 
   public startHealthChecks(): void {};
+  public isFailedOver(): boolean {
+    return false;
+  }
 }
 
 export default BitcoinApi;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -137,8 +137,12 @@ class BitcoinApi implements AbstractBitcoinApi {
     throw new Error('Method getScriptHashTransactions not supported by the Bitcoin RPC API.');
   }
 
-  $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]> {
-    return this.bitcoindClient.getRawMemPool();
+  async $getRawMempool(): Promise<{ txids: IEsploraApi.Transaction['txid'][], local: boolean}> {
+    const txids = await this.bitcoindClient.getRawMemPool();
+    return {
+      txids,
+      local: true,
+    };
   }
 
   $getAddressPrefix(prefix: string): string[] {

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -638,8 +638,8 @@ class BitcoinRoutes {
 
   private async getMempoolTxIds(req: Request, res: Response) {
     try {
-      const rawMempool = await bitcoinApi.$getRawMempool();
-      res.send(rawMempool);
+      const { txids } = await bitcoinApi.$getRawMempool();
+      res.send(txids);
     } catch (e) {
       res.status(500).send(e instanceof Error ? e.message : e);
     }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -17,6 +17,8 @@ interface FailoverHost {
 }
 
 class FailoverRouter {
+  isFailedOver: boolean = false;
+  preferredHost: FailoverHost;
   activeHost: FailoverHost;
   fallbackHost: FailoverHost;
   hosts: FailoverHost[];
@@ -46,6 +48,7 @@ class FailoverRouter {
       socket: !!config.ESPLORA.UNIX_SOCKET_PATH,
       preferred: true,
     };
+    this.preferredHost = this.activeHost;
     this.fallbackHost = this.activeHost;
     this.hosts.unshift(this.activeHost);
     this.multihost = this.hosts.length > 1;
@@ -151,6 +154,7 @@ class FailoverRouter {
     this.sortHosts();
     this.activeHost = this.hosts[0];
     logger.warn(`Switching esplora host to ${this.activeHost.host}`);
+    this.isFailedOver = this.activeHost !== this.preferredHost;
   }
 
   private addFailure(host: FailoverHost): FailoverHost {
@@ -301,6 +305,10 @@ class ElectrsApi implements AbstractBitcoinApi {
 
   public startHealthChecks(): void {
     this.failoverRouter.startHealthChecks();
+  }
+
+  public isFailedOver(): boolean {
+    return this.failoverRouter.isFailedOver;
   }
 }
 

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -171,6 +171,11 @@ class Mempool {
     return this.statisticsPaused;
   }
 
+  public logFailover(): void {
+    this.failoverTimes.push(Date.now());
+    this.statisticsPaused = true;
+  }
+
   public getTxPerSecond(): number {
     return this.txPerSecond;
   }

--- a/backend/src/api/statistics/statistics.ts
+++ b/backend/src/api/statistics/statistics.ts
@@ -29,9 +29,10 @@ class Statistics {
   }
 
   private async runStatistics(): Promise<void> {
-    if (!memPool.isInSync()) {
+    if (!memPool.isInSync() || memPool.getStatisticsIsPaused()) {
       return;
     }
+
     const currentMempool = memPool.getMempool();
     const txPerSecond = memPool.getTxPerSecond();
     const vBytesPerSecond = memPool.getVBytesPerSecond();

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -73,7 +73,7 @@ class WebsocketHandler {
     const da = difficultyAdjustment.getDifficultyAdjustment();
     this.updateSocketDataFields({
       'mempoolInfo': memPool.getMempoolInfo(),
-      'vBytesPerSecond': memPool.getVBytesPerSecond(),
+      'vBytesPerSecond': memPool.getStatisticsIsPaused() ? null : memPool.getVBytesPerSecond(),
       'blocks': _blocks,
       'conversions': priceUpdater.getLatestPrices(),
       'mempool-blocks': mempoolBlocks.getMempoolBlocks(),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -191,10 +191,14 @@ class Server {
           logger.debug(msg);
         }
       }
-      const newMempool = await bitcoinApi.$getRawMempool();
+
+      const { txids: newMempool, local: fromLocalNode } = await bitcoinApi.$getRawMempool();
       const numHandledBlocks = await blocks.$updateBlocks();
       const pollRate = config.MEMPOOL.POLL_RATE_MS * (indexer.indexerRunning ? 10 : 1);
       if (numHandledBlocks === 0) {
+        if (!fromLocalNode) {
+          memPool.logFailover();
+        }
         await memPool.$updateMempool(newMempool, pollRate);
       }
       indexer.$run();


### PR DESCRIPTION
When the backend fails over to another esplora instance, differences in mempool composition can produce spurious transaction statistics.

This PR extends the failover mechanism to report the active esplora host, as well as which host fulfilled a particular request, and then "pauses" statistics until the effect of a failover has passed.

While statistics are "paused", we skip writing new statistics rows to the database, and stop sending new statistics updates over the websocket.

Due to the moving window averaging uses for some of these statistic, the "pause" lasts at least `TX_PER_SECOND_SAMPLE_PERIOD` seconds after recovering from a failover, to ensure all bad data has timed out of the sample window.