### PR TITLE
Use new electrs outspends API

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -24,7 +24,7 @@ class BitcoinRoutes {
   public initRoutes(app: Application) {
     app
       .get(config.MEMPOOL.API_URL_PREFIX + 'transaction-times', this.getTransactionTimes)
-      .get(config.MEMPOOL.API_URL_PREFIX + 'outspends', this.$getBatchedOutspends)
+      .get(config.MEMPOOL.API_URL_PREFIX + 'txs/outspends', this.$getBatchedOutspends)
       .get(config.MEMPOOL.API_URL_PREFIX + 'cpfp/:txId', this.$getCpfpInfo)
       .get(config.MEMPOOL.API_URL_PREFIX + 'difficulty-adjustment', this.getDifficultyChange)
       .get(config.MEMPOOL.API_URL_PREFIX + 'fees/recommended', this.getRecommendedFees)
@@ -175,19 +175,14 @@ class BitcoinRoutes {
   }
 
   private async $getBatchedOutspends(req: Request, res: Response) {
-    if (!Array.isArray(req.query.txId)) {
-      res.status(500).send('Not an array');
+    if (!req.query.hasOwnProperty('txids') || typeof req.query['txids'] !== 'string') {
+      res.status(500).send('Property txids is missing');
       return;
     }
-    if (req.query.txId.length > 50) {
+    const txIds: string[] = req.query.txids.split(',');
+    if (txIds.length > 50) {
       res.status(400).send('Too many txids requested');
       return;
-    }
-    const txIds: string[] = [];
-    for (const _txId in req.query.txId) {
-      if (typeof req.query.txId[_txId] === 'string') {
-        txIds.push(req.query.txId[_txId].toString());
-      }
     }
 
     try {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -290,13 +290,8 @@ class ElectrsApi implements AbstractBitcoinApi {
     return this.failoverRouter.$get<IEsploraApi.Outspend[]>('/tx/' + txId + '/outspends');
   }
 
-  async $getBatchedOutspends(txId: string[]): Promise<IEsploraApi.Outspend[][]> {
-    const outspends: IEsploraApi.Outspend[][] = [];
-    for (const tx of txId) {
-      const outspend = await this.$getOutspends(tx);
-      outspends.push(outspend);
-    }
-    return outspends;
+  $getBatchedOutspends(txId: string[]): Promise<IEsploraApi.Outspend[][]> {
+    throw new Error('Method not implemented.');
   }
 
   public startHealthChecks(): void {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -98,10 +98,8 @@ export class ApiService {
 
   getOutspendsBatched$(txIds: string[]): Observable<Outspend[][]> {
     let params = new HttpParams();
-    txIds.forEach((txId: string) => {
-      params = params.append('txId[]', txId);
-    });
-    return this.httpClient.get<Outspend[][]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/outspends', { params });
+    params = params.append('txids', txIds.join(','));
+    return this.httpClient.get<Outspend[][]>(this.apiBaseUrl + this.apiBasePath + '/api/txs/outspends', { params });
   }
 
   getAboutPageProfiles$(): Observable<any[]> {


### PR DESCRIPTION
* When using esplora as backend, this requires the new outspends API https://github.com/mempool/electrs/pull/36
* In Bitcoin Core mode, it just changes the API to behave like the new one.
* Removed to Core to Esplora "proxy" in the backend