### PR TITLE
Fix block pagination for liquid

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -478,7 +478,7 @@ class BitcoinRoutes {
       }
 
       let nextHash = startFromHash;
-      for (let i = 0; i < 10 && nextHash; i++) {
+      for (let i = 0; i < 15 && nextHash; i++) {
         const localBlock = blocks.getBlocks().find((b) => b.id === nextHash);
         if (localBlock) {
           returnBlocks.push(localBlock);


### PR DESCRIPTION
While testing another PR I noticed the amount of blocks loaded in the block list is mismatching the hard coded value in the blocks list frontend component, which is 15 here https://github.com/mempool/mempool/blob/master/frontend/src/app/components/blocks-list/blocks-list.component.ts#L136

You. can reproduce the bug by just going to liquid.network/blocks and go to page 2.

The `/api/v1/blocks` and `getBlocks` now returns 15 blocks both on mainnet and liquid, bisq.