### PR TITLE
Fix memory cache cleanup logic

### DIFF
--- a/backend/src/api/memory-cache.ts
+++ b/backend/src/api/memory-cache.ts
@@ -31,7 +31,7 @@ class MemoryCache {
   }
 
   private cleanup() {
-    this.cache = this.cache.filter((cache) => cache.expires < (new Date()));
+    this.cache = this.cache.filter((cache) => cache.expires > (new Date()));
   }
 }
 

--- a/contributors/TKone7.txt
+++ b/contributors/TKone7.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of October 23, 2023.
+
+Signed: TKone7


### PR DESCRIPTION
Keep (filter) cache entries with an expiry in the future.

Currently all active cache entries are immediately removed, while expired ones are kept in cache forever.