### PR TITLE
Better code-splitting

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AppPreloadingStrategy } from './app.preloading-strategy'
 import { StartComponent } from './components/start/start.component';
-import { TransactionComponent } from './components/transaction/transaction.component';
 import { BlockViewComponent } from './components/block-view/block-view.component';
 import { MempoolBlockViewComponent } from './components/mempool-block-view/mempool-block-view.component';
 import { ClockComponent } from './components/clock/clock.component';
@@ -88,13 +87,8 @@ let routes: Routes = [
           {
             path: 'tx',
             component: StartComponent,
-            data: { networkSpecific: true },
-            children: [
-              {
-                path: ':id',
-                component: TransactionComponent
-              },
-            ],
+            data: { preload: true, networkSpecific: true },
+            loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
           },
           {
             path: 'block',
@@ -189,14 +183,9 @@ let routes: Routes = [
           },
           {
             path: 'tx',
-            data: { networkSpecific: true },
             component: StartComponent,
-            children: [
-              {
-                path: ':id',
-                component: TransactionComponent
-              },
-            ],
+            data: { preload: true, networkSpecific: true },
+            loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
           },
           {
             path: 'block',
@@ -291,14 +280,9 @@ let routes: Routes = [
       },
       {
         path: 'tx',
-        data: { networkSpecific: true },
         component: StartComponent,
-        children: [
-          {
-            path: ':id',
-            component: TransactionComponent
-          },
-        ],
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
       },
       {
         path: 'block',
@@ -430,14 +414,9 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
             },
             {
               path: 'tx',
-              data: { networkSpecific: true },
               component: StartComponent,
-              children: [
-                {
-                  path: ':id',
-                  component: TransactionComponent
-                },
-              ],
+              data: { preload: true, networkSpecific: true },
+              loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
             },
             {
               path: 'block',
@@ -540,14 +519,9 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: 'tx',
-          data: { networkSpecific: true },
           component: StartComponent,
-          children: [
-            {
-              path: ':id',
-              component: TransactionComponent
-            },
-          ],
+          data: { preload: true, networkSpecific: true },
+          loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
         },
         {
           path: 'block',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -33,6 +33,7 @@ let routes: Routes = [
       {
         path: '',
         loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
+        data: { preload: true },
       },
       {
         path: '**',
@@ -52,6 +53,7 @@ let routes: Routes = [
         path: '',
         pathMatch: 'full',
         loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
+        data: { preload: true },
       },
       {
         path: '',
@@ -66,6 +68,7 @@ let routes: Routes = [
       {
         path: '',
         loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
+        data: { preload: true },
       },
       {
         path: '**',
@@ -77,6 +80,7 @@ let routes: Routes = [
     path: '',
     pathMatch: 'full',
     loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
+    data: { preload: true },
   },
   {
     path: '',
@@ -128,6 +132,7 @@ let routes: Routes = [
   {
     path: '',
     loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
+    data: { preload: true },
   },
   {
     path: '**',
@@ -151,10 +156,12 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
           path: '',
           pathMatch: 'full',
           loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+          data: { preload: true },
         },
         {
           path: '',
-          loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule)
+          loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule),
+          data: { preload: true },
         },
         {
           path: 'status',
@@ -164,6 +171,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         {
           path: '',
           loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+          data: { preload: true },
         },
         {
           path: '**',
@@ -175,10 +183,12 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
       path: '',
       pathMatch: 'full',
       loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+      data: { preload: true },
     },
     {
       path: '',
-      loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule)
+      loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule),
+      data: { preload: true },
     },
     {
       path: 'preview',
@@ -201,6 +211,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
     {
       path: '',
       loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+      data: { preload: true },
     },
     {
       path: '**',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -6,19 +6,14 @@ import { BlockViewComponent } from './components/block-view/block-view.component
 import { MempoolBlockViewComponent } from './components/mempool-block-view/mempool-block-view.component';
 import { ClockComponent } from './components/clock/clock.component';
 import { AddressComponent } from './components/address/address.component';
-import { MasterPageComponent } from './components/master-page/master-page.component';
 import { StatusViewComponent } from './components/status-view/status-view.component';
-import { BisqMasterPageComponent } from './components/bisq-master-page/bisq-master-page.component';
 import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
 import { BlocksList } from './components/blocks-list/blocks-list.component';
-import { RbfList } from './components/rbf-list/rbf-list.component';
-import { LiquidMasterPageComponent } from './components/liquid-master-page/liquid-master-page.component';
 import { AssetGroupComponent } from './components/assets/asset-group/asset-group.component';
 import { AssetsFeaturedComponent } from './components/assets/assets-featured/assets-featured.component';
 import { AssetsComponent } from './components/assets/assets.component';
 import { AssetComponent } from './components/asset/asset.component';
 import { AssetsNavComponent } from './components/assets/assets-nav/assets-nav.component';
-import { CalculatorComponent } from './components/calculator/calculator.component';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -36,77 +31,8 @@ let routes: Routes = [
       },
       {
         path: '',
-        component: MasterPageComponent,
-        children: [
-          {
-            path: 'mining/blocks',
-            redirectTo: 'blocks',
-            pathMatch: 'full'
-          },
-          {
-            path: 'tx/push',
-            component: PushTransactionComponent,
-          },
-          {
-            path: 'about',
-            loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
-          },
-          {
-            path: 'blocks',
-            component: BlocksList,
-          },
-          {
-            path: 'rbf',
-            component: RbfList,
-          },
-          {
-            path: 'terms-of-service',
-            loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-          },
-          {
-            path: 'privacy-policy',
-            loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
-          },
-          {
-            path: 'trademark-policy',
-            loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
-          },
-          {
-            path: 'address/:id',
-            children: [],
-            component: AddressComponent,
-            data: {
-              ogImage: true,
-              networkSpecific: true,
-            }
-          },
-          {
-            path: 'tx',
-            component: StartComponent,
-            data: { preload: true, networkSpecific: true },
-            loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
-          },
-          {
-            path: 'block',
-            component: StartComponent,
-            data: { preload: true, networkSpecific: true },
-            loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
-          },
-          {
-            path: 'docs',
-            loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule),
-            data: { preload: true },
-          },
-          {
-            path: 'api',
-            loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-          },
-          {
-            path: 'lightning',
-            loadChildren: () => import('./lightning/lightning.module').then(m => m.LightningModule),
-            data: { preload: browserWindowEnv && browserWindowEnv.LIGHTNING === true, networks: ['bitcoin'] },
-          },
-        ],
+        loadChildren: () => import('./master-page.module').then(m => m.MasterPageModule),
+        data: { preload: true },
       },
       {
         path: 'status',
@@ -138,71 +64,8 @@ let routes: Routes = [
       },
       {
         path: '',
-        component: MasterPageComponent,
-        children: [
-          {
-            path: 'tx/push',
-            component: PushTransactionComponent,
-          },
-          {
-            path: 'about',
-            loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
-          },
-          {
-            path: 'blocks',
-            component: BlocksList,
-          },
-          {
-            path: 'rbf',
-            component: RbfList,
-          },
-          {
-            path: 'terms-of-service',
-            loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-          },
-          {
-            path: 'privacy-policy',
-            loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
-          },
-          {
-            path: 'trademark-policy',
-            loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
-          },
-          {
-            path: 'address/:id',
-            children: [],
-            component: AddressComponent,
-            data: {
-              ogImage: true,
-              networkSpecific: true,
-            }
-          },
-          {
-            path: 'tx',
-            component: StartComponent,
-            data: { preload: true, networkSpecific: true },
-            loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
-          },
-          {
-            path: 'block',
-            component: StartComponent,
-            data: { preload: true, networkSpecific: true },
-            loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
-          },
-          {
-            path: 'docs',
-            loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-          },
-          {
-            path: 'api',
-            loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-          },
-          {
-            path: 'lightning',
-            data: { networks: ['bitcoin'] },
-            loadChildren: () => import('./lightning/lightning.module').then(m => m.LightningModule)
-          },
-        ],
+        loadChildren: () => import('./master-page.module').then(m => m.MasterPageModule),
+        data: { preload: true },
       },
       {
         path: 'status',
@@ -226,80 +89,8 @@ let routes: Routes = [
   },
   {
     path: '',
-    component: MasterPageComponent,
-    children: [
-      {
-        path: 'mining/blocks',
-        redirectTo: 'blocks',
-        pathMatch: 'full'
-      },
-      {
-        path: 'tx/push',
-        component: PushTransactionComponent,
-      },
-      {
-        path: 'about',
-        loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
-      },
-      {
-        path: 'blocks',
-        component: BlocksList,
-      },
-      {
-        path: 'rbf',
-        component: RbfList,
-      },
-      {
-        path: 'tools/calculator',
-        component: CalculatorComponent
-      },
-      {
-        path: 'terms-of-service',
-        loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-      },
-      {
-        path: 'privacy-policy',
-        loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
-      },
-      {
-        path: 'trademark-policy',
-        loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
-      },
-      {
-        path: 'address/:id',
-        children: [],
-        component: AddressComponent,
-        data: {
-          ogImage: true,
-          networkSpecific: true,
-        }
-      },
-      {
-        path: 'tx',
-        component: StartComponent,
-        data: { preload: true, networkSpecific: true },
-        loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
-      },
-      {
-        path: 'block',
-        component: StartComponent,
-        data: { preload: true, networkSpecific: true },
-        loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
-      },
-      {
-        path: 'docs',
-        loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-      },
-      {
-        path: 'api',
-        loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-      },
-      {
-        path: 'lightning',
-        data: { networks: ['bitcoin'] },
-        loadChildren: () => import('./lightning/lightning.module').then(m => m.LightningModule)
-      },
-    ],
+    loadChildren: () => import('./master-page.module').then(m => m.MasterPageModule),
+    data: { preload: true },
   },
   {
     path: 'preview',
@@ -356,7 +147,6 @@ let routes: Routes = [
 if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'bisq') {
   routes = [{
     path: '',
-    component: BisqMasterPageComponent,
     loadChildren: () => import('./bisq/bisq.module').then(m => m.BisqModule)
   }];
 }
@@ -373,88 +163,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: '',
-          component: LiquidMasterPageComponent,
-          children: [
-            {
-              path: 'tx/push',
-              component: PushTransactionComponent,
-            },
-            {
-              path: 'about',
-              loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
-            },
-            {
-              path: 'blocks',
-              component: BlocksList,
-            },
-            {
-              path: 'terms-of-service',
-              loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-            },
-            {
-              path: 'privacy-policy',
-              loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
-            },
-            {
-              path: 'trademark-policy',
-              loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
-            },
-            {
-              path: 'address/:id',
-              children: [],
-              component: AddressComponent,
-              data: {
-                ogImage: true,
-                networkSpecific: true,
-              }
-            },
-            {
-              path: 'tx',
-              component: StartComponent,
-              data: { preload: true, networkSpecific: true },
-              loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
-            },
-            {
-              path: 'block',
-              component: StartComponent,
-              data: { preload: true, networkSpecific: true },
-              loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
-            },
-            {
-              path: 'assets',
-              data: { networks: ['liquid'] },
-              component: AssetsNavComponent,
-              children: [
-                {
-                  path: 'all',
-                  data: { networks: ['liquid'] },
-                  component: AssetsComponent,
-                },
-                {
-                  path: 'asset/:id',
-                  data: { networkSpecific: true },
-                  component: AssetComponent
-                },
-                {
-                  path: 'group/:id',
-                  data: { networkSpecific: true },
-                  component: AssetGroupComponent
-                },
-                {
-                  path: '**',
-                  redirectTo: 'all'
-                }
-              ]
-            },
-            {
-              path: 'docs',
-              loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-            },
-            {
-              path: 'api',
-              loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-            },
-          ],
+          loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule)
         },
         {
           path: 'status',
@@ -478,93 +187,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
     },
     {
       path: '',
-      component: LiquidMasterPageComponent,
-      children: [
-        {
-          path: 'tx/push',
-          component: PushTransactionComponent,
-        },
-        {
-          path: 'about',
-          loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
-        },
-        {
-          path: 'blocks',
-          component: BlocksList,
-        },
-        {
-          path: 'terms-of-service',
-          loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-        },
-        {
-          path: 'privacy-policy',
-          loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
-        },
-        {
-          path: 'trademark-policy',
-          loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
-        },
-        {
-          path: 'address/:id',
-          children: [],
-          component: AddressComponent,
-          data: {
-            ogImage: true,
-            networkSpecific: true,
-          }
-        },
-        {
-          path: 'tx',
-          component: StartComponent,
-          data: { preload: true, networkSpecific: true },
-          loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
-        },
-        {
-          path: 'block',
-          component: StartComponent,
-          data: { preload: true, networkSpecific: true },
-          loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
-        },
-        {
-          path: 'assets',
-          data: { networks: ['liquid'] },
-          component: AssetsNavComponent,
-          children: [
-            {
-              path: 'featured',
-              data: { networkSpecific: true },
-              component: AssetsFeaturedComponent,
-            },
-            {
-              path: 'all',
-              data: { networks: ['liquid'] },
-              component: AssetsComponent,
-            },
-            {
-              path: 'asset/:id',
-              data: { networkSpecific: true },
-              component: AssetComponent
-            },
-            {
-              path: 'group/:id',
-              data: { networkSpecific: true },
-              component: AssetGroupComponent
-            },
-            {
-              path: '**',
-              redirectTo: 'featured'
-            }
-          ]
-        },
-        {
-          path: 'docs',
-          loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-        },
-        {
-          path: 'api',
-          loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
-        },
-      ],
+      loadChildren: () => import ('./liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule)
     },
     {
       path: 'preview',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,19 +1,10 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AppPreloadingStrategy } from './app.preloading-strategy'
-import { StartComponent } from './components/start/start.component';
 import { BlockViewComponent } from './components/block-view/block-view.component';
 import { MempoolBlockViewComponent } from './components/mempool-block-view/mempool-block-view.component';
 import { ClockComponent } from './components/clock/clock.component';
-import { AddressComponent } from './components/address/address.component';
 import { StatusViewComponent } from './components/status-view/status-view.component';
-import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
-import { BlocksList } from './components/blocks-list/blocks-list.component';
-import { AssetGroupComponent } from './components/assets/asset-group/asset-group.component';
-import { AssetsFeaturedComponent } from './components/assets/assets-featured/assets-featured.component';
-import { AssetsComponent } from './components/assets/assets.component';
-import { AssetComponent } from './components/asset/asset.component';
-import { AssetsNavComponent } from './components/assets/assets-nav/assets-nav.component';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -26,7 +17,7 @@ let routes: Routes = [
       {
         path: '',
         pathMatch: 'full',
-        loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule),
+        loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
         data: { preload: true },
       },
       {
@@ -41,7 +32,7 @@ let routes: Routes = [
       },
       {
         path: '',
-        loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+        loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
       },
       {
         path: '**',
@@ -60,7 +51,7 @@ let routes: Routes = [
       {
         path: '',
         pathMatch: 'full',
-        loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+        loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
       },
       {
         path: '',
@@ -74,7 +65,7 @@ let routes: Routes = [
       },
       {
         path: '',
-        loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+        loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
       },
       {
         path: '**',
@@ -85,7 +76,7 @@ let routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+    loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
   },
   {
     path: '',
@@ -136,7 +127,7 @@ let routes: Routes = [
   },
   {
     path: '',
-    loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+    loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
   },
   {
     path: '**',
@@ -159,7 +150,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         {
           path: '',
           pathMatch: 'full',
-          loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+          loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
         },
         {
           path: '',
@@ -172,7 +163,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: '',
-          loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+          loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
         },
         {
           path: '**',
@@ -183,7 +174,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
     {
       path: '',
       pathMatch: 'full',
-      loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+      loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
     },
     {
       path: '',
@@ -209,7 +200,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
     },
     {
       path: '',
-      loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+      loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
     },
     {
       path: '**',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -7,7 +7,6 @@ import { MempoolBlockViewComponent } from './components/mempool-block-view/mempo
 import { ClockComponent } from './components/clock/clock.component';
 import { AddressComponent } from './components/address/address.component';
 import { MasterPageComponent } from './components/master-page/master-page.component';
-import { AboutComponent } from './components/about/about.component';
 import { StatusViewComponent } from './components/status-view/status-view.component';
 import { TermsOfServiceComponent } from './components/terms-of-service/terms-of-service.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
@@ -53,7 +52,7 @@ let routes: Routes = [
           },
           {
             path: 'about',
-            component: AboutComponent,
+            loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
           },
           {
             path: 'blocks',
@@ -150,7 +149,7 @@ let routes: Routes = [
           },
           {
             path: 'about',
-            component: AboutComponent,
+            loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
           },
           {
             path: 'blocks',
@@ -243,7 +242,7 @@ let routes: Routes = [
       },
       {
         path: 'about',
-        component: AboutComponent,
+        loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
       },
       {
         path: 'blocks',
@@ -385,7 +384,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
             },
             {
               path: 'about',
-              component: AboutComponent,
+              loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
             },
             {
               path: 'blocks',
@@ -490,7 +489,7 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: 'about',
-          component: AboutComponent,
+          loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
         },
         {
           path: 'blocks',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -3,7 +3,6 @@ import { Routes, RouterModule } from '@angular/router';
 import { AppPreloadingStrategy } from './app.preloading-strategy'
 import { StartComponent } from './components/start/start.component';
 import { TransactionComponent } from './components/transaction/transaction.component';
-import { BlockComponent } from './components/block/block.component';
 import { BlockViewComponent } from './components/block-view/block-view.component';
 import { MempoolBlockViewComponent } from './components/mempool-block-view/mempool-block-view.component';
 import { ClockComponent } from './components/clock/clock.component';
@@ -100,16 +99,8 @@ let routes: Routes = [
           {
             path: 'block',
             component: StartComponent,
-            data: { networkSpecific: true },
-              children: [
-              {
-                path: ':id',
-                component: BlockComponent,
-                data: {
-                  ogImage: true
-                }
-              },
-            ],
+            data: { preload: true, networkSpecific: true },
+            loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
           },
           {
             path: 'docs',
@@ -209,17 +200,9 @@ let routes: Routes = [
           },
           {
             path: 'block',
-            data: { networkSpecific: true },
             component: StartComponent,
-            children: [
-              {
-                path: ':id',
-                component: BlockComponent,
-                data: {
-                  ogImage: true
-                }
-              },
-            ],
+            data: { preload: true, networkSpecific: true },
+            loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
           },
           {
             path: 'docs',
@@ -319,17 +302,9 @@ let routes: Routes = [
       },
       {
         path: 'block',
-        data: { networkSpecific: true },
         component: StartComponent,
-        children: [
-          {
-            path: ':id',
-            component: BlockComponent,
-            data: {
-              ogImage: true
-            }
-          },
-        ],
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
       },
       {
         path: 'docs',
@@ -466,17 +441,9 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
             },
             {
               path: 'block',
-              data: { networkSpecific: true },
               component: StartComponent,
-              children: [
-                {
-                  path: ':id',
-                  component: BlockComponent,
-                  data: {
-                    ogImage: true
-                  }
-                },
-              ],
+              data: { preload: true, networkSpecific: true },
+              loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
             },
             {
               path: 'assets',
@@ -584,17 +551,9 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: 'block',
-          data: { networkSpecific: true },
           component: StartComponent,
-          children: [
-            {
-              path: ':id',
-              component: BlockComponent,
-              data: {
-                ogImage: true
-              }
-            },
-          ],
+          data: { preload: true, networkSpecific: true },
+          loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
         },
         {
           path: 'assets',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -8,9 +8,6 @@ import { ClockComponent } from './components/clock/clock.component';
 import { AddressComponent } from './components/address/address.component';
 import { MasterPageComponent } from './components/master-page/master-page.component';
 import { StatusViewComponent } from './components/status-view/status-view.component';
-import { TermsOfServiceComponent } from './components/terms-of-service/terms-of-service.component';
-import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
-import { TrademarkPolicyComponent } from './components/trademark-policy/trademark-policy.component';
 import { BisqMasterPageComponent } from './components/bisq-master-page/bisq-master-page.component';
 import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
 import { BlocksList } from './components/blocks-list/blocks-list.component';
@@ -64,15 +61,15 @@ let routes: Routes = [
           },
           {
             path: 'terms-of-service',
-            component: TermsOfServiceComponent
+            loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
           },
           {
             path: 'privacy-policy',
-            component: PrivacyPolicyComponent
+            loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
           },
           {
             path: 'trademark-policy',
-            component: TrademarkPolicyComponent
+            loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
           },
           {
             path: 'address/:id',
@@ -161,15 +158,15 @@ let routes: Routes = [
           },
           {
             path: 'terms-of-service',
-            component: TermsOfServiceComponent
+            loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
           },
           {
             path: 'privacy-policy',
-            component: PrivacyPolicyComponent
+            loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
           },
           {
             path: 'trademark-policy',
-            component: TrademarkPolicyComponent
+            loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
           },
           {
             path: 'address/:id',
@@ -258,15 +255,15 @@ let routes: Routes = [
       },
       {
         path: 'terms-of-service',
-        component: TermsOfServiceComponent
+        loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
       },
       {
         path: 'privacy-policy',
-        component: PrivacyPolicyComponent
+        loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
       },
       {
         path: 'trademark-policy',
-        component: TrademarkPolicyComponent
+        loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
       },
       {
         path: 'address/:id',
@@ -392,15 +389,15 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
             },
             {
               path: 'terms-of-service',
-              component: TermsOfServiceComponent
+              loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
             },
             {
               path: 'privacy-policy',
-              component: PrivacyPolicyComponent
+              loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
             },
             {
               path: 'trademark-policy',
-              component: TrademarkPolicyComponent
+              loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
             },
             {
               path: 'address/:id',
@@ -497,15 +494,15 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
         },
         {
           path: 'terms-of-service',
-          component: TermsOfServiceComponent
+          loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
         },
         {
           path: 'privacy-policy',
-          component: PrivacyPolicyComponent
+          loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
         },
         {
           path: 'trademark-policy',
-          component: TrademarkPolicyComponent
+          loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
         },
         {
           path: 'address/:id',

--- a/frontend/src/app/bisq/bisq.module.ts
+++ b/frontend/src/app/bisq/bisq.module.ts
@@ -27,9 +27,11 @@ import { AutofocusDirective } from '../components/ngx-bootstrap-multiselect/auto
 import { MultiSelectSearchFilter } from '../components/ngx-bootstrap-multiselect/search-filter.pipe';
 import { OffClickDirective } from '../components/ngx-bootstrap-multiselect/off-click.directive';
 import { NgxDropdownMultiselectComponent } from '../components/ngx-bootstrap-multiselect/ngx-bootstrap-multiselect.component';
+import { BisqMasterPageComponent } from '../components/bisq-master-page/bisq-master-page.component';
 
 @NgModule({
   declarations: [
+    BisqMasterPageComponent,
     BisqTransactionsComponent,
     BisqTransactionComponent,
     BisqBlockComponent,

--- a/frontend/src/app/bisq/bisq.routing.module.ts
+++ b/frontend/src/app/bisq/bisq.routing.module.ts
@@ -9,7 +9,6 @@ import { BisqStatsComponent } from './bisq-stats/bisq-stats.component';
 import { BisqDashboardComponent } from './bisq-dashboard/bisq-dashboard.component';
 import { BisqMarketComponent } from './bisq-market/bisq-market.component';
 import { BisqMainDashboardComponent } from './bisq-main-dashboard/bisq-main-dashboard.component';
-import { TermsOfServiceComponent } from '../components/terms-of-service/terms-of-service.component';
 import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
 
 const routes: Routes = [
@@ -75,7 +74,7 @@ const routes: Routes = [
     },
     {
       path: 'terms-of-service',
-      component: TermsOfServiceComponent
+      loadChildren: () => import('../components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
     },
     {
       path: '**',

--- a/frontend/src/app/bisq/bisq.routing.module.ts
+++ b/frontend/src/app/bisq/bisq.routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { BisqMasterPageComponent } from '../components/bisq-master-page/bisq-master-page.component';
 import { BisqTransactionsComponent } from './bisq-transactions/bisq-transactions.component';
 import { BisqTransactionComponent } from './bisq-transaction/bisq-transaction.component';
 import { BisqBlockComponent } from './bisq-block/bisq-block.component';
@@ -12,74 +13,80 @@ import { BisqMainDashboardComponent } from './bisq-main-dashboard/bisq-main-dash
 import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
 
 const routes: Routes = [
-    {
-      path: '',
-      component: BisqMainDashboardComponent,
-    },
-    {
-      path: 'markets',
-      data: { networks: ['bisq'] },
-      component: BisqDashboardComponent,
-    },
-    {
-      path: 'transactions',
-      data: { networks: ['bisq'] },
-      component: BisqTransactionsComponent
-    },
-    {
-      path: 'market/:pair',
-      data: { networkSpecific: true },
-      component: BisqMarketComponent,
-    },
-    {
-      path: 'tx/push',
-      component: PushTransactionComponent,
-    },
-    {
-      path: 'tx/:id',
-      data: { networkSpecific: true },
-      component: BisqTransactionComponent
-    },
-    {
-      path: 'blocks',
-      children: [],
-      component: BisqBlocksComponent
-    },
-    {
-      path: 'block/:id',
-      data: { networkSpecific: true },
-      component: BisqBlockComponent,
-    },
-    {
-      path: 'address/:id',
-      data: { networkSpecific: true },
-      component: BisqAddressComponent,
-    },
-    {
-      path: 'stats',
-      data: { networks: ['bisq'] },
-      component: BisqStatsComponent,
-    },
-    {
-      path: 'about',
-      loadChildren: () => import('../components/about/about.module').then(m => m.AboutModule),
-    },
-    {
-      path: 'docs',
-      loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
-    },
-    {
-      path: 'api',
-      loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
-    },
-    {
-      path: 'terms-of-service',
-      loadChildren: () => import('../components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
-    },
-    {
-      path: '**',
-      redirectTo: ''
-    }
+  {
+    path: '',
+    component: BisqMasterPageComponent,
+    children: [
+      {
+        path: '',
+        component: BisqMainDashboardComponent,
+      },
+      {
+        path: 'markets',
+        data: { networks: ['bisq'] },
+        component: BisqDashboardComponent,
+      },
+      {
+        path: 'transactions',
+        data: { networks: ['bisq'] },
+        component: BisqTransactionsComponent
+      },
+      {
+        path: 'market/:pair',
+        data: { networkSpecific: true },
+        component: BisqMarketComponent,
+      },
+      {
+        path: 'tx/push',
+        component: PushTransactionComponent,
+      },
+      {
+        path: 'tx/:id',
+        data: { networkSpecific: true },
+        component: BisqTransactionComponent
+      },
+      {
+        path: 'blocks',
+        children: [],
+        component: BisqBlocksComponent
+      },
+      {
+        path: 'block/:id',
+        data: { networkSpecific: true },
+        component: BisqBlockComponent,
+      },
+      {
+        path: 'address/:id',
+        data: { networkSpecific: true },
+        component: BisqAddressComponent,
+      },
+      {
+        path: 'stats',
+        data: { networks: ['bisq'] },
+        component: BisqStatsComponent,
+      },
+      {
+        path: 'about',
+        loadChildren: () => import('../components/about/about.module').then(m => m.AboutModule),
+      },
+      {
+        path: 'docs',
+        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
+      },
+      {
+        path: 'api',
+        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
+      },
+      {
+        path: 'terms-of-service',
+        loadChildren: () => import('../components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
+      },
+      {
+        path: '**',
+        redirectTo: ''
+      }
+    ]
+  }
 ];
 
 @NgModule({

--- a/frontend/src/app/bisq/bisq.routing.module.ts
+++ b/frontend/src/app/bisq/bisq.routing.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { AboutComponent } from '../components/about/about.component';
 import { BisqTransactionsComponent } from './bisq-transactions/bisq-transactions.component';
 import { BisqTransactionComponent } from './bisq-transaction/bisq-transaction.component';
 import { BisqBlockComponent } from './bisq-block/bisq-block.component';
@@ -64,7 +63,7 @@ const routes: Routes = [
     },
     {
       path: 'about',
-      component: AboutComponent,
+      loadChildren: () => import('../components/about/about.module').then(m => m.AboutModule),
     },
     {
       path: 'docs',

--- a/frontend/src/app/bitcoin-graphs.module.ts
+++ b/frontend/src/app/bitcoin-graphs.module.ts
@@ -7,7 +7,8 @@ const routes: Routes = [
   {
     path: '',
     component: MasterPageComponent,
-    loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+    loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule),
+    data: { preload: true },
   }
 ];
 

--- a/frontend/src/app/bitcoin-graphs.module.ts
+++ b/frontend/src/app/bitcoin-graphs.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { MasterPageComponent } from './components/master-page/master-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: MasterPageComponent,
+    loadChildren: () => import('./graphs/graphs.module').then(m => m.GraphsModule)
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class BitcoinGraphsRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    BitcoinGraphsRoutingModule,
+  ],
+})
+export class BitcoinGraphsModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/about/about.module.ts
+++ b/frontend/src/app/components/about/about.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { AboutComponent } from './about.component';
+import { SharedModule } from '../../shared/shared.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AboutComponent,
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class AboutRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    AboutRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    AboutComponent,
+  ]
+})
+export class AboutModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/block/block.module.ts
+++ b/frontend/src/app/components/block/block.module.ts
@@ -1,0 +1,43 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { BlockComponent } from './block.component';
+import { SharedModule } from '../../shared/shared.module';
+
+const routes: Routes = [
+  {
+    path: ':id',
+    component: BlockComponent,
+    data: {
+      ogImage: true
+    }
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class BlockRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    BlockRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    BlockComponent,
+  ]
+})
+export class BlockModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/privacy-policy/privacy-policy.module.ts
+++ b/frontend/src/app/components/privacy-policy/privacy-policy.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { PrivacyPolicyComponent } from './privacy-policy.component';
+import { SharedModule } from '../../shared/shared.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PrivacyPolicyComponent,
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class PrivacyPolicyRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    PrivacyPolicyRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    PrivacyPolicyComponent,
+  ]
+})
+export class PrivacyPolicyModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/terms-of-service/terms-of-service.module.ts
+++ b/frontend/src/app/components/terms-of-service/terms-of-service.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { TermsOfServiceComponent } from './terms-of-service.component';
+import { SharedModule } from '../../shared/shared.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TermsOfServiceComponent,
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class TermsModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TermsModule,
+    SharedModule,
+  ],
+  declarations: [
+    TermsOfServiceComponent,
+  ]
+})
+export class TermsOfServiceModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/trademark-policy/trademark-policy.module.ts
+++ b/frontend/src/app/components/trademark-policy/trademark-policy.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { TrademarkPolicyComponent } from './trademark-policy.component';
+import { SharedModule } from '../../shared/shared.module';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TrademarkPolicyComponent,
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class TrademarkRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TrademarkRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    TrademarkPolicyComponent,
+  ]
+})
+export class TrademarkModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/transaction/transaction.module.ts
+++ b/frontend/src/app/components/transaction/transaction.module.ts
@@ -1,0 +1,45 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { TransactionComponent } from './transaction.component';
+import { SharedModule } from '../../shared/shared.module';
+import { TxBowtieModule } from '../tx-bowtie-graph/tx-bowtie.module';
+
+const routes: Routes = [
+  {
+    path: ':id',
+    component: TransactionComponent,
+    data: {
+      ogImage: true
+    }
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class TransactionRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TransactionRoutingModule,
+    SharedModule,
+    TxBowtieModule,
+  ],
+  declarations: [
+    TransactionComponent,
+  ]
+})
+export class TransactionModule { }
+
+
+
+
+
+

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie.module.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from '../../shared/shared.module';
+import { TxBowtieGraphComponent } from '../tx-bowtie-graph/tx-bowtie-graph.component';
+import { TxBowtieGraphTooltipComponent } from '../tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SharedModule,
+  ],
+  declarations: [
+    TxBowtieGraphComponent,
+    TxBowtieGraphTooltipComponent,
+  ],
+  exports: [
+    TxBowtieGraphComponent,
+    TxBowtieGraphTooltipComponent,
+  ]
+})
+export class TxBowtieModule { }
+
+
+
+
+
+

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -8,8 +8,6 @@ import { BlockSizesWeightsGraphComponent } from '../components/block-sizes-weigh
 import { GraphsComponent } from '../components/graphs/graphs.component';
 import { HashrateChartComponent } from '../components/hashrate-chart/hashrate-chart.component';
 import { HashrateChartPoolsComponent } from '../components/hashrates-chart-pools/hashrate-chart-pools.component';
-import { LiquidMasterPageComponent } from '../components/liquid-master-page/liquid-master-page.component';
-import { MasterPageComponent } from '../components/master-page/master-page.component';
 import { MempoolBlockComponent } from '../components/mempool-block/mempool-block.component';
 import { MiningDashboardComponent } from '../components/mining-dashboard/mining-dashboard.component';
 import { PoolRankingComponent } from '../components/pool-ranking/pool-ranking.component';
@@ -18,22 +16,10 @@ import { StartComponent } from '../components/start/start.component';
 import { StatisticsComponent } from '../components/statistics/statistics.component';
 import { TelevisionComponent } from '../components/television/television.component';
 import { DashboardComponent } from '../dashboard/dashboard.component';
-import { NodesNetworksChartComponent } from '../lightning/nodes-networks-chart/nodes-networks-chart.component';
-import { LightningStatisticsChartComponent } from '../lightning/statistics-chart/lightning-statistics-chart.component';
-import { NodesPerISPChartComponent } from '../lightning/nodes-per-isp-chart/nodes-per-isp-chart.component';
-import { NodesPerCountryChartComponent } from '../lightning/nodes-per-country-chart/nodes-per-country-chart.component';
-import { NodesMap } from '../lightning/nodes-map/nodes-map.component';
-import { NodesChannelsMap } from '../lightning/nodes-channels-map/nodes-channels-map.component';
-
-const browserWindow = window || {};
-// @ts-ignore
-const browserWindowEnv = browserWindow.__env || {};
-const isLiquid = browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid';
 
 const routes: Routes = [
   {
     path: '',
-    component: isLiquid ? LiquidMasterPageComponent : MasterPageComponent,
     children: [
       {
         path: 'mining/pool/:slug',
@@ -108,34 +94,9 @@ const routes: Routes = [
             component: BlockSizesWeightsGraphComponent,
           },
           {
-            path: 'lightning/nodes-networks',
+            path: 'lightning',
             data: { networks: ['bitcoin'] },
-            component: NodesNetworksChartComponent,
-          },
-          {
-            path: 'lightning/capacity',
-            data: { networks: ['bitcoin'] },
-            component: LightningStatisticsChartComponent,
-          },
-          {
-            path: 'lightning/nodes-per-isp',
-            data: { networks: ['bitcoin'] },
-            component: NodesPerISPChartComponent,
-          },
-          {
-            path: 'lightning/nodes-per-country',
-            data: { networks: ['bitcoin'] },
-            component: NodesPerCountryChartComponent,
-          },
-          {
-            path: 'lightning/nodes-map',
-            data: { networks: ['bitcoin'] },
-            component: NodesMap,
-          },
-          {
-            path: 'lightning/nodes-channels-map',
-            data: { networks: ['bitcoin'] },
-            component: NodesChannelsMap,
+            loadChildren: () => import ('./lightning-graphs.module').then(m => m.LightningGraphsModule)
           },
           {
             path: '',

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -95,8 +95,8 @@ const routes: Routes = [
           },
           {
             path: 'lightning',
-            data: { networks: ['bitcoin'] },
-            loadChildren: () => import ('./lightning-graphs.module').then(m => m.LightningGraphsModule)
+            data: { preload: true, networks: ['bitcoin'] },
+            loadChildren: () => import ('./lightning-graphs.module').then(m => m.LightningGraphsModule),
           },
           {
             path: '',

--- a/frontend/src/app/graphs/lightning-graphs.module.ts
+++ b/frontend/src/app/graphs/lightning-graphs.module.ts
@@ -1,0 +1,58 @@
+import { NgModule } from '@angular/core';
+import { SharedModule } from '../shared/shared.module';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { NodesNetworksChartComponent } from '../lightning/nodes-networks-chart/nodes-networks-chart.component';
+import { LightningStatisticsChartComponent } from '../lightning/statistics-chart/lightning-statistics-chart.component';
+import { NodesPerISPChartComponent } from '../lightning/nodes-per-isp-chart/nodes-per-isp-chart.component';
+import { NodesPerCountryChartComponent } from '../lightning/nodes-per-country-chart/nodes-per-country-chart.component';
+import { NodesMap } from '../lightning/nodes-map/nodes-map.component';
+import { NodesChannelsMap } from '../lightning/nodes-channels-map/nodes-channels-map.component';
+
+const routes: Routes = [
+  {
+    path: 'nodes-networks',
+    data: { networks: ['bitcoin'] },
+    component: NodesNetworksChartComponent,
+  },
+  {
+    path: 'capacity',
+    data: { networks: ['bitcoin'] },
+    component: LightningStatisticsChartComponent,
+  },
+  {
+    path: 'nodes-per-isp',
+    data: { networks: ['bitcoin'] },
+    component: NodesPerISPChartComponent,
+  },
+  {
+    path: 'nodes-per-country',
+    data: { networks: ['bitcoin'] },
+    component: NodesPerCountryChartComponent,
+  },
+  {
+    path: 'nodes-map',
+    data: { networks: ['bitcoin'] },
+    component: NodesMap,
+  },
+  {
+    path: 'nodes-channels-map',
+    data: { networks: ['bitcoin'] },
+    component: NodesChannelsMap,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class LightningGraphsRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SharedModule,
+    LightningGraphsRoutingModule,
+  ],
+})
+export class LightningGraphsModule { }

--- a/frontend/src/app/liquid/liquid-graphs.module.ts
+++ b/frontend/src/app/liquid/liquid-graphs.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { LiquidMasterPageComponent } from '../components/liquid-master-page/liquid-master-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: LiquidMasterPageComponent,
+    loadChildren: () => import('../graphs/graphs.module').then(m => m.GraphsModule)
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class LiquidGraphsRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    LiquidGraphsRoutingModule,
+  ],
+})
+export class LiquidGraphsModule { }
+
+
+
+
+
+

--- a/frontend/src/app/liquid/liquid-graphs.module.ts
+++ b/frontend/src/app/liquid/liquid-graphs.module.ts
@@ -7,7 +7,8 @@ const routes: Routes = [
   {
     path: '',
     component: LiquidMasterPageComponent,
-    loadChildren: () => import('../graphs/graphs.module').then(m => m.GraphsModule)
+    loadChildren: () => import('../graphs/graphs.module').then(m => m.GraphsModule),
+    data: { preload: true },
   }
 ];
 

--- a/frontend/src/app/liquid/liquid-master-page.module.ts
+++ b/frontend/src/app/liquid/liquid-master-page.module.ts
@@ -1,0 +1,124 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { SharedModule } from '../shared/shared.module';
+import { LiquidMasterPageComponent } from '../components/liquid-master-page/liquid-master-page.component';
+
+import { StartComponent } from '../components/start/start.component';
+import { AddressComponent } from '../components/address/address.component';
+import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
+import { BlocksList } from '../components/blocks-list/blocks-list.component';
+import { AssetGroupComponent } from '../components/assets/asset-group/asset-group.component';
+import { AssetsComponent } from '../components/assets/assets.component';
+import { AssetComponent } from '../components/asset/asset.component';
+import { AssetsNavComponent } from '../components/assets/assets-nav/assets-nav.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: LiquidMasterPageComponent,
+    children: [
+      {
+        path: 'tx/push',
+        component: PushTransactionComponent,
+      },
+      {
+        path: 'about',
+        loadChildren: () => import('../components/about/about.module').then(m => m.AboutModule),
+      },
+      {
+        path: 'blocks',
+        component: BlocksList,
+      },
+      {
+        path: 'terms-of-service',
+        loadChildren: () => import('../components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
+      },
+      {
+        path: 'privacy-policy',
+        loadChildren: () => import('../components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
+      },
+      {
+        path: 'trademark-policy',
+        loadChildren: () => import('../components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
+      },
+      {
+        path: 'address/:id',
+        children: [],
+        component: AddressComponent,
+        data: {
+          ogImage: true,
+          networkSpecific: true,
+        }
+      },
+      {
+        path: 'tx',
+        component: StartComponent,
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('../components/transaction/transaction.module').then(m => m.TransactionModule),
+      },
+      {
+        path: 'block',
+        component: StartComponent,
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('../components/block/block.module').then(m => m.BlockModule),
+      },
+      {
+        path: 'assets',
+        data: { networks: ['liquid'] },
+        component: AssetsNavComponent,
+        children: [
+          {
+            path: 'all',
+            data: { networks: ['liquid'] },
+            component: AssetsComponent,
+          },
+          {
+            path: 'asset/:id',
+            data: { networkSpecific: true },
+            component: AssetComponent
+          },
+          {
+            path: 'group/:id',
+            data: { networkSpecific: true },
+            component: AssetGroupComponent
+          },
+          {
+            path: '**',
+            redirectTo: 'all'
+          }
+        ]
+      },
+      {
+        path: 'docs',
+        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
+      },
+      {
+        path: 'api',
+        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
+      },
+    ],
+  },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class LiquidRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    LiquidRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    LiquidMasterPageComponent,
+  ]
+})
+export class LiquidMasterPageModule { }

--- a/frontend/src/app/liquid/liquid-master-page.module.ts
+++ b/frontend/src/app/liquid/liquid-master-page.module.ts
@@ -91,7 +91,8 @@ const routes: Routes = [
       },
       {
         path: 'docs',
-        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule)
+        loadChildren: () => import('../docs/docs.module').then(m => m.DocsModule),
+        data: { preload: true },
       },
       {
         path: 'api',

--- a/frontend/src/app/master-page.module.ts
+++ b/frontend/src/app/master-page.module.ts
@@ -16,6 +16,7 @@ const browserWindowEnv = browserWindow.__env || {};
 
 const routes: Routes = [
   {
+    path: '',
     component: MasterPageComponent,
     children: [
       {

--- a/frontend/src/app/master-page.module.ts
+++ b/frontend/src/app/master-page.module.ts
@@ -1,0 +1,119 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Routes, RouterModule } from '@angular/router';
+import { MasterPageComponent } from './components/master-page/master-page.component';
+import { SharedModule } from './shared/shared.module';
+
+import { StartComponent } from './components/start/start.component';
+import { AddressComponent } from './components/address/address.component';
+import { PushTransactionComponent } from './components/push-transaction/push-transaction.component';
+import { BlocksList } from './components/blocks-list/blocks-list.component';
+import { RbfList } from './components/rbf-list/rbf-list.component';
+
+const browserWindow = window || {};
+// @ts-ignore
+const browserWindowEnv = browserWindow.__env || {};
+
+const routes: Routes = [
+  {
+    component: MasterPageComponent,
+    children: [
+      {
+        path: 'mining/blocks',
+        redirectTo: 'blocks',
+        pathMatch: 'full'
+      },
+      {
+        path: 'tx/push',
+        component: PushTransactionComponent,
+      },
+      {
+        path: 'about',
+        loadChildren: () => import('./components/about/about.module').then(m => m.AboutModule),
+      },
+      {
+        path: 'blocks',
+        component: BlocksList,
+      },
+      {
+        path: 'rbf',
+        component: RbfList,
+      },
+      {
+        path: 'terms-of-service',
+        loadChildren: () => import('./components/terms-of-service/terms-of-service.module').then(m => m.TermsOfServiceModule),
+      },
+      {
+        path: 'privacy-policy',
+        loadChildren: () => import('./components/privacy-policy/privacy-policy.module').then(m => m.PrivacyPolicyModule),
+      },
+      {
+        path: 'trademark-policy',
+        loadChildren: () => import('./components/trademark-policy/trademark-policy.module').then(m => m.TrademarkModule),
+      },
+      {
+        path: 'address/:id',
+        children: [],
+        component: AddressComponent,
+        data: {
+          ogImage: true,
+          networkSpecific: true,
+        }
+      },
+      {
+        path: 'tx',
+        component: StartComponent,
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('./components/transaction/transaction.module').then(m => m.TransactionModule),
+      },
+      {
+        path: 'block',
+        component: StartComponent,
+        data: { preload: true, networkSpecific: true },
+        loadChildren: () => import('./components/block/block.module').then(m => m.BlockModule),
+      },
+      {
+        path: 'docs',
+        loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule),
+        data: { preload: true },
+      },
+      {
+        path: 'api',
+        loadChildren: () => import('./docs/docs.module').then(m => m.DocsModule)
+      },
+      {
+        path: 'lightning',
+        loadChildren: () => import('./lightning/lightning.module').then(m => m.LightningModule),
+        data: { preload: browserWindowEnv && browserWindowEnv.LIGHTNING === true, networks: ['bitcoin'] },
+      },
+    ],
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes)
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class MasterPageRoutingModule { }
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MasterPageRoutingModule,
+    SharedModule,
+  ],
+  declarations: [
+    MasterPageComponent,
+  ]
+})
+export class MasterPageModule { }
+
+
+
+
+
+

--- a/frontend/src/app/previews.module.ts
+++ b/frontend/src/app/previews.module.ts
@@ -9,6 +9,7 @@ import { BlockPreviewComponent } from './components/block/block-preview.componen
 import { AddressPreviewComponent } from './components/address/address-preview.component';
 import { PoolPreviewComponent } from './components/pool/pool-preview.component';
 import { MasterPagePreviewComponent } from './components/master-page-preview/master-page-preview.component';
+import { TxBowtieModule } from './components/tx-bowtie-graph/tx-bowtie.module';
 @NgModule({
   declarations: [
     TransactionPreviewComponent,
@@ -23,6 +24,7 @@ import { MasterPagePreviewComponent } from './components/master-page-preview/mas
     RouterModule,
     PreviewsRoutingModule,
     GraphsModule,
+    TxBowtieModule,
   ],
 })
 export class PreviewsModule { }

--- a/frontend/src/app/previews.routing.module.ts
+++ b/frontend/src/app/previews.routing.module.ts
@@ -31,7 +31,8 @@ const routes: Routes = [
       },
       {
         path: 'lightning',
-        loadChildren: () => import('./lightning/lightning-previews.module').then(m => m.LightningPreviewsModule)
+        loadChildren: () => import('./lightning/lightning-previews.module').then(m => m.LightningPreviewsModule),
+        data: { preload: true },
       },
     ],
   }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -45,7 +45,6 @@ import { AmountComponent } from '../components/amount/amount.component';
 import { RouterModule } from '@angular/router';
 import { CapAddressPipe } from './pipes/cap-address-pipe/cap-address-pipe';
 import { StartComponent } from '../components/start/start.component';
-import { TransactionComponent } from '../components/transaction/transaction.component';
 import { TransactionsListComponent } from '../components/transactions-list/transactions-list.component';
 import { BlockOverviewGraphComponent } from '../components/block-overview-graph/block-overview-graph.component';
 import { BlockOverviewTooltipComponent } from '../components/block-overview-tooltip/block-overview-tooltip.component';
@@ -64,8 +63,6 @@ import { DifficultyMiningComponent } from '../components/difficulty-mining/diffi
 import { TermsOfServiceComponent } from '../components/terms-of-service/terms-of-service.component';
 import { RbfTimelineComponent } from '../components/rbf-timeline/rbf-timeline.component';
 import { RbfTimelineTooltipComponent } from '../components/rbf-timeline/rbf-timeline-tooltip.component';
-import { TxBowtieGraphComponent } from '../components/tx-bowtie-graph/tx-bowtie-graph.component';
-import { TxBowtieGraphTooltipComponent } from '../components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component';
 import { PrivacyPolicyComponent } from '../components/privacy-policy/privacy-policy.component';
 import { TrademarkPolicyComponent } from '../components/trademark-policy/trademark-policy.component';
 import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
@@ -147,7 +144,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     BisqMasterPageComponent,
     LiquidMasterPageComponent,
     StartComponent,
-    TransactionComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
     TransactionsListComponent,
@@ -164,8 +160,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     DifficultyTooltipComponent,
     RbfTimelineComponent,
     RbfTimelineTooltipComponent,
-    TxBowtieGraphComponent,
-    TxBowtieGraphTooltipComponent,
     TermsOfServiceComponent,
     PrivacyPolicyComponent,
     TrademarkPolicyComponent,
@@ -273,7 +267,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     BlockchainBlocksComponent,
     AmountComponent,
     StartComponent,
-    TransactionComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
     TransactionsListComponent,
@@ -290,8 +283,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     DifficultyTooltipComponent,
     RbfTimelineComponent,
     RbfTimelineTooltipComponent,
-    TxBowtieGraphComponent,
-    TxBowtieGraphTooltipComponent,
     TermsOfServiceComponent,
     PrivacyPolicyComponent,
     TrademarkPolicyComponent,

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -47,7 +47,6 @@ import { CapAddressPipe } from './pipes/cap-address-pipe/cap-address-pipe';
 import { StartComponent } from '../components/start/start.component';
 import { TransactionComponent } from '../components/transaction/transaction.component';
 import { TransactionsListComponent } from '../components/transactions-list/transactions-list.component';
-import { BlockComponent } from '../components/block/block.component';
 import { BlockOverviewGraphComponent } from '../components/block-overview-graph/block-overview-graph.component';
 import { BlockOverviewTooltipComponent } from '../components/block-overview-tooltip/block-overview-tooltip.component';
 import { AddressComponent } from '../components/address/address.component';
@@ -149,7 +148,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     LiquidMasterPageComponent,
     StartComponent,
     TransactionComponent,
-    BlockComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
     TransactionsListComponent,
@@ -276,7 +274,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     AmountComponent,
     StartComponent,
     TransactionComponent,
-    BlockComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
     TransactionsListComponent,

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -6,11 +6,8 @@ import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, fa
   faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faClock, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown,
   faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl, faDownload, faQrcode, faArrowRightArrowLeft, faArrowsRotate, faCircleLeft, faFastForward, faWallet, faUserClock, faWrench, faUserFriends, faQuestionCircle, faHistory, faSignOutAlt, faKey, faSuitcase, faIdCardAlt, faNetworkWired, faUserCheck, faCircleCheck, faUserCircle } from '@fortawesome/free-solid-svg-icons';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
-import { MasterPageComponent } from '../components/master-page/master-page.component';
 import { MenuComponent } from '../components/menu/menu.component';
 import { PreviewTitleComponent } from '../components/master-page-preview/preview-title.component';
-import { BisqMasterPageComponent } from '../components/bisq-master-page/bisq-master-page.component';
-import { LiquidMasterPageComponent } from '../components/liquid-master-page/liquid-master-page.component';
 import { VbytesPipe } from './pipes/bytes-pipe/vbytes.pipe';
 import { ShortenStringPipe } from './pipes/shorten-string-pipe/shorten-string.pipe';
 import { CeilPipe } from './pipes/math-ceil/math-ceil.pipe';
@@ -133,11 +130,8 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     MempoolBlocksComponent,
     BlockchainBlocksComponent,
     AmountComponent,
-    MasterPageComponent,
     MenuComponent,
     PreviewTitleComponent,
-    BisqMasterPageComponent,
-    LiquidMasterPageComponent,
     StartComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
@@ -217,7 +211,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     AmountShortenerPipe,
   ],
   exports: [
-    MasterPageComponent,
     MenuComponent,
     RouterModule,
     ReactiveFormsModule,
@@ -297,6 +290,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     ConfirmationsComponent,
     ToggleComponent,
     GeolocationComponent,
+    TestnetAlertComponent,
     PreviewTitleComponent,
     GlobalFooterComponent,
     AcceleratePreviewComponent,

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -59,11 +59,8 @@ import { FeesBoxComponent } from '../components/fees-box/fees-box.component';
 import { DifficultyComponent } from '../components/difficulty/difficulty.component';
 import { DifficultyTooltipComponent } from '../components/difficulty/difficulty-tooltip.component';
 import { DifficultyMiningComponent } from '../components/difficulty-mining/difficulty-mining.component';
-import { TermsOfServiceComponent } from '../components/terms-of-service/terms-of-service.component';
 import { RbfTimelineComponent } from '../components/rbf-timeline/rbf-timeline.component';
 import { RbfTimelineTooltipComponent } from '../components/rbf-timeline/rbf-timeline-tooltip.component';
-import { PrivacyPolicyComponent } from '../components/privacy-policy/privacy-policy.component';
-import { TrademarkPolicyComponent } from '../components/trademark-policy/trademark-policy.component';
 import { PushTransactionComponent } from '../components/push-transaction/push-transaction.component';
 import { AssetsFeaturedComponent } from '../components/assets/assets-featured/assets-featured.component';
 import { AssetGroupComponent } from '../components/assets/asset-group/asset-group.component';
@@ -158,9 +155,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     DifficultyTooltipComponent,
     RbfTimelineComponent,
     RbfTimelineTooltipComponent,
-    TermsOfServiceComponent,
-    PrivacyPolicyComponent,
-    TrademarkPolicyComponent,
     PushTransactionComponent,
     AssetsNavComponent,
     AssetsFeaturedComponent,
@@ -281,9 +275,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     DifficultyTooltipComponent,
     RbfTimelineComponent,
     RbfTimelineTooltipComponent,
-    TermsOfServiceComponent,
-    PrivacyPolicyComponent,
-    TrademarkPolicyComponent,
     PushTransactionComponent,
     AssetsNavComponent,
     AssetsFeaturedComponent,

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -11,7 +11,6 @@ import { MenuComponent } from '../components/menu/menu.component';
 import { PreviewTitleComponent } from '../components/master-page-preview/preview-title.component';
 import { BisqMasterPageComponent } from '../components/bisq-master-page/bisq-master-page.component';
 import { LiquidMasterPageComponent } from '../components/liquid-master-page/liquid-master-page.component';
-import { AboutComponent } from '../components/about/about.component';
 import { VbytesPipe } from './pipes/bytes-pipe/vbytes.pipe';
 import { ShortenStringPipe } from './pipes/shorten-string-pipe/shorten-string.pipe';
 import { CeilPipe } from './pipes/math-ceil/math-ceil.pipe';
@@ -137,7 +136,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     MempoolBlocksComponent,
     BlockchainBlocksComponent,
     AmountComponent,
-    AboutComponent,
     MasterPageComponent,
     MenuComponent,
     PreviewTitleComponent,


### PR DESCRIPTION
This PR splits the frontend build into finer-grained lazily-loaded modules, in order to reduce the initial download size for each page and minimize the time to *first contentful paint* on slower connections.

The main changes are:
 - splitting the largest page components into their own individual modules.
 - separating the bitcoin, liquid and bisq "master pages" and routes.
 - refactoring the routing modules to reduce code duplication.