### PR TITLE
Fix a typo in the french version of the frontend

### DIFF
--- a/contributors/ncois.txt
+++ b/contributors/ncois.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of July 25, 2022.
+
+Signed: ncois

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -4993,7 +4993,7 @@
       </trans-unit>
       <trans-unit id="e1d63108bdf06fa14ec13f038e23eebd4d391b16" datatype="html">
         <source>P2WSH witness script</source>
-        <target>Script témoin PW2SH</target>
+        <target>Script témoin P2WSH</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/transactions-list/transactions-list.component.html</context>
           <context context-type="linenumber">134,136</context>


### PR DESCRIPTION
There is a typo in the french translation of P2WSH: 

<img width="1116" alt="Screenshot 2023-11-10 at 19 11 38" src="https://github.com/mempool/mempool/assets/46578910/643e021a-883a-49d5-b922-fd53e058a6d8">

https://mempool.space/fr/tx/490148cae63d120bf20566111e89a779fd827d10e850f0a03fe73f5b4e01162d