### PR TITLE
restore incoming tx clearance line, smooth moving avg

### DIFF
--- a/frontend/src/app/graphs/echarts.ts
+++ b/frontend/src/app/graphs/echarts.ts
@@ -1,7 +1,7 @@
 // Import tree-shakeable echarts
 import * as echarts from 'echarts/core';
 import { LineChart, LinesChart, BarChart, TreemapChart, PieChart, ScatterChart } from 'echarts/charts';
-import { TitleComponent, TooltipComponent, GridComponent, LegendComponent, GeoComponent, DataZoomComponent, VisualMapComponent } from 'echarts/components';
+import { TitleComponent, TooltipComponent, GridComponent, LegendComponent, GeoComponent, DataZoomComponent, VisualMapComponent, MarkLineComponent } from 'echarts/components';
 import { SVGRenderer, CanvasRenderer } from 'echarts/renderers';
 // Typescript interfaces
 import { EChartsOption, TreemapSeriesOption, LineSeriesOption, PieSeriesOption } from 'echarts';
@@ -11,7 +11,7 @@ echarts.use([
   SVGRenderer, CanvasRenderer,
   TitleComponent, TooltipComponent, GridComponent,
   LegendComponent, GeoComponent, DataZoomComponent,
-  VisualMapComponent,
+  VisualMapComponent, MarkLineComponent,
   LineChart, LinesChart, BarChart, TreemapChart, PieChart, ScatterChart
 ]);
 export { echarts, EChartsOption, TreemapSeriesOption, LineSeriesOption, PieSeriesOption };


### PR DESCRIPTION
Fixes #4362

Restores the horizontal dotted clearance rate line, smooths out the moving average line a bit more, and hides the moving average line on the dashboard widget

<img width="565" alt="Screenshot 2023-11-12 at 8 00 57 AM" src="https://github.com/mempool/mempool/assets/83316221/90f00594-fe1e-4e49-ad04-426327ee99b0">
<img width="1243" alt="Screenshot 2023-11-12 at 8 01 28 AM" src="https://github.com/mempool/mempool/assets/83316221/8a7279ae-8d89-4734-89cd-c9d907134608">
