### PR TITLE
Make search and select work for truncated text

### DIFF
--- a/frontend/src/app/shared/components/truncate/truncate.component.html
+++ b/frontend/src/app/shared/components/truncate/truncate.component.html
@@ -1,4 +1,5 @@
 <span class="truncate" [style.max-width]="maxWidth ? maxWidth + 'px' : null" [style.justify-content]="textAlign" [class.inline]="inline">
+  <div class="hidden">{{ text }}</div>
     <ng-container *ngIf="link">
       <a [routerLink]="link" class="truncate-link">
         <ng-container *ngIf="rtl; then rtlTruncated; else ltrTruncated;"></ng-container>
@@ -11,11 +12,10 @@
 </span>
 
 <ng-template #ltrTruncated>
-  <div class="hidden">{{ text }}</div>
+
   <span class="first">{{text.slice(0,-lastChars)}}</span><span class="last-four">{{text.slice(-lastChars)}}</span>
 </ng-template>
 
 <ng-template #rtlTruncated>
-  <div class="hidden">{{ text }}</div>
   <span class="first">{{text.slice(lastChars)}}</span><span class="last-four">{{text.slice(0,lastChars)}}</span>
 </ng-template>

--- a/frontend/src/app/shared/components/truncate/truncate.component.html
+++ b/frontend/src/app/shared/components/truncate/truncate.component.html
@@ -11,9 +11,11 @@
 </span>
 
 <ng-template #ltrTruncated>
+  <div class="hidden">{{ text }}</div>
   <span class="first">{{text.slice(0,-lastChars)}}</span><span class="last-four">{{text.slice(-lastChars)}}</span>
 </ng-template>
 
 <ng-template #rtlTruncated>
+  <div class="hidden">{{ text }}</div>
   <span class="first">{{text.slice(lastChars)}}</span><span class="last-four">{{text.slice(0,lastChars)}}</span>
 </ng-template>

--- a/frontend/src/app/shared/components/truncate/truncate.component.scss
+++ b/frontend/src/app/shared/components/truncate/truncate.component.scss
@@ -28,3 +28,8 @@
     display: inline-flex;
   }
 }
+
+.hidden { 
+  color: transparent;
+  position: absolute;
+}

--- a/frontend/src/app/shared/components/truncate/truncate.component.scss
+++ b/frontend/src/app/shared/components/truncate/truncate.component.scss
@@ -32,4 +32,12 @@
 .hidden { 
   color: transparent;
   position: absolute;
+  max-width: 300px;
+  overflow: hidden;
+}
+
+@media (max-width: 567px) {
+  .hidden {
+    max-width: 150px;
+  }
 }


### PR DESCRIPTION
fixes #4367

With this solution of a hidden transparent text, search and find is possible on transaction and address page for example.

Tried on Chrome, Firefox and Safari.

<img width="1436" alt="Screenshot 2023-11-13 at 17 43 39" src="https://github.com/mempool/mempool/assets/8561090/19c73e68-6e83-4e3d-afa8-ff22fd2b8bc7">
