### PR TITLE
Fix silently unhandled database exceptions

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -761,8 +761,13 @@ class Blocks {
         this.updateTimerProgress(timer, `saved ${this.currentBlockHeight} to database`);
 
         if (!fastForwarded) {
-          const lastestPriceId = await PricesRepository.$getLatestPriceId();
-          this.updateTimerProgress(timer, `got latest price id ${this.currentBlockHeight}`);
+          let lastestPriceId;
+          try {
+            lastestPriceId = await PricesRepository.$getLatestPriceId();
+            this.updateTimerProgress(timer, `got latest price id ${this.currentBlockHeight}`);
+          } catch (e) {
+            logger.debug('failed to fetch latest price id from db: ' + (e instanceof Error ? e.message : e));
+          }
           if (priceUpdater.historyInserted === true && lastestPriceId !== null) {
             await blocksRepository.$saveBlockPrices([{
               height: blockExtended.height,

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -55,14 +55,20 @@ import { execSync } from 'child_process';
         }).then(result => {
           resolve(result);
         }).catch(error => {
+          logger.debug(`database query "${query.slice(0, 100)}" failed!`);
           reject(error);
         }).finally(() => {
           clearTimeout(timer);
         });
       });
     } else {
-      const pool = await this.getPool();
-      return pool.query(query, params);
+      try {
+        const pool = await this.getPool();
+        return pool.query(query, params);
+      } catch (e) {
+        logger.debug(`database query "${query.slice(0, 100)}" failed!`);
+        throw e;
+      }
     }
   }
 

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -55,7 +55,7 @@ import { execSync } from 'child_process';
         }).then(result => {
           resolve(result);
         }).catch(error => {
-          logger.debug(`database query "${query.slice(0, 100)}" failed!`);
+          logger.debug(`database query "${query?.slice(0, 100)}" failed!`);
           reject(error);
         }).finally(() => {
           clearTimeout(timer);
@@ -66,7 +66,7 @@ import { execSync } from 'child_process';
         const pool = await this.getPool();
         return pool.query(query, params);
       } catch (e) {
-        logger.debug(`database query "${query.slice(0, 100)}" failed!`);
+        logger.debug(`database query "${query?.slice(0, 100)}" failed!`);
         throw e;
       }
     }

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -55,7 +55,7 @@ import { execSync } from 'child_process';
         }).then(result => {
           resolve(result);
         }).catch(error => {
-          logger.debug(`database query "${query?.slice(0, 100)}" failed!`);
+          logger.debug(`database query "${query?.sql?.slice(0, 160) || (typeof(query) === 'string' || query instanceof String ? query?.slice(0, 160) : 'unknown query')}" failed!`);
           reject(error);
         }).finally(() => {
           clearTimeout(timer);
@@ -66,7 +66,7 @@ import { execSync } from 'child_process';
         const pool = await this.getPool();
         return pool.query(query, params);
       } catch (e) {
-        logger.debug(`database query "${query?.slice(0, 100)}" failed!`);
+        logger.debug(`database query "${query?.sql?.slice(0, 160) || (typeof(query) === 'string' || query instanceof String ? query?.slice(0, 160) : 'unknown query')}" failed!`);
         throw e;
       }
     }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -92,8 +92,14 @@ class Server {
     logger.notice(`Starting Mempool Server${worker ? ' (worker)' : ''}... (${backendInfo.getShortCommitHash()})`);
 
     // Register cleanup listeners for exit events
-    ['exit', 'SIGHUP', 'SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2', 'uncaughtException', 'unhandledRejection'].forEach(event => {
+    ['exit', 'SIGHUP', 'SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'].forEach(event => {
       process.on(event, () => { this.onExit(event); });
+    });
+    process.on('uncaughtException', (error) => {
+      this.onUnhandledException('uncaughtException', error);
+    });
+    process.on('unhandledRejection', (reason, promise) => {
+      this.onUnhandledException('unhandledRejection', reason);
     });
 
     if (config.MEMPOOL.BACKEND === 'esplora') {
@@ -314,14 +320,18 @@ class Server {
     }
   }
 
-  onExit(exitEvent): void {
+  onExit(exitEvent, code = 0): void {
+    logger.debug(`onExit for signal: ${exitEvent}`);
     if (config.DATABASE.ENABLED) {
       DB.releasePidLock();
     }
-    process.exit(0);
+    process.exit(code);
+  }
+
+  onUnhandledException(type, error): void {
+    console.error(`${type}:`, error);
+    this.onExit(type, 1);
   }
 }
-
-
 
 ((): Server => new Server())();

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -76,7 +76,12 @@ class Indexer {
 
     if (task === 'blocksPrices' && !this.tasksRunning.includes(task) && !['testnet', 'signet'].includes(config.MEMPOOL.NETWORK)) {
       this.tasksRunning.push(task);
-      const lastestPriceId = await PricesRepository.$getLatestPriceId();
+      let lastestPriceId;
+      try {
+        lastestPriceId = await PricesRepository.$getLatestPriceId();
+      } catch (e) {
+        logger.debug('failed to fetch latest price id from db: ' + (e instanceof Error ? e.message : e));
+      }
       if (priceUpdater.historyInserted === false || lastestPriceId === null) {
         logger.debug(`Blocks prices indexer is waiting for the price updater to complete`, logger.tags.mining);
         setTimeout(() => {


### PR DESCRIPTION
Adds missing try/catch handling to some `PricesRepository.$getLatestPriceId()` calls, and fixes and issue introduced by the pid cleanup exit handler where unhandled exceptions would cause the process to end silently without printing any error logs or traces.