### PR TITLE
Support different log levels for database query error messages

### DIFF
--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -157,4 +157,6 @@ class Logger {
   }
 }
 
+export type LogLevel = 'emerg' | 'alert' | 'crit' | 'err' | 'warn' | 'notice' | 'info' | 'debug';
+
 export default new Logger();

--- a/backend/src/repositories/NodesSocketsRepository.ts
+++ b/backend/src/repositories/NodesSocketsRepository.ts
@@ -14,7 +14,7 @@ class NodesSocketsRepository {
       await DB.query(`
         INSERT INTO nodes_sockets(public_key, socket, type)
         VALUE (?, ?, ?)
-      `, [socket.publicKey, socket.addr, socket.network]);
+      `, [socket.publicKey, socket.addr, socket.network], 'silent');
     } catch (e: any) {
       if (e.errno !== 1062) { // ER_DUP_ENTRY - Not an issue, just ignore this
         logger.err(`Cannot save node socket (${[socket.publicKey, socket.addr, socket.network]}) into db. Reason: ` + (e instanceof Error ? e.message : e));


### PR DESCRIPTION
With #4373, the backend logs are full of garbage from expected-to-fail db queries:

```
Nov 14 07:49:12 [6124] INFO: <lightning> database query "
        INSERT INTO nodes_sockets(public_key, socket, type)
        VALUE (?, ?, ?)
      " failed!
Nov 14 07:49:12 [6124] INFO: <lightning> database query "
        INSERT INTO nodes_sockets(public_key, socket, type)
        VALUE (?, ?, ?)
      " failed!
Nov 14 07:49:12 [6124] INFO: <lightning> database query "
        INSERT INTO nodes_sockets(public_key, socket, type)
        VALUE (?, ?, ?)
      " failed!
Nov 14 07:49:12 [6124] INFO: <lightning> database query "
        INSERT INTO nodes_sockets(public_key, socket, type)
        VALUE (?, ?, ?)
      " failed!
Nov 14 07:49:12 [6124] INFO: <lightning> database query "
        INSERT INTO nodes_sockets(public_key, socket, type)
        VALUE (?, ?, ?)
      " failed!
```

This PR adds support for passing a preferred error message log level to the `DB.query` function, and sets the logging priority to 'silent' for these node socket queries.