### PR TITLE
Minimum acceleration preview bar height

### DIFF
--- a/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.scss
+++ b/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.scss
@@ -18,6 +18,7 @@
       bottom: 0;
       left: 0;
       right: 0;
+      min-height: 30px;
       display: flex;
       flex-direction: column;
       justify-content: center;

--- a/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.ts
+++ b/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.ts
@@ -58,13 +58,15 @@ export class AccelerateFeeGraphComponent implements OnInit, OnChanges {
         fee: option.fee,
       }
     });
-    bars.push({
-      rate: this.estimate.targetFeeRate,
-      style: this.getStyle(this.estimate.targetFeeRate, maxRate, baseHeight),
-      class: 'target',
-      label: 'next block',
-      fee: this.estimate.nextBlockFee - this.estimate.txSummary.effectiveFee
-    });
+    if (this.estimate.nextBlockFee > this.estimate.txSummary.effectiveFee) {
+      bars.push({
+        rate: this.estimate.targetFeeRate,
+        style: this.getStyle(this.estimate.targetFeeRate, maxRate, baseHeight),
+        class: 'target',
+        label: 'next block',
+        fee: this.estimate.nextBlockFee - this.estimate.txSummary.effectiveFee
+      });
+    }
     bars.push({
       rate: baseRate,
       style: this.getStyle(baseRate, maxRate, 0),


### PR DESCRIPTION
Resolves #4380

Make the next block fee bar always at least 30px high, and hides it when the value is negative (i.e. transactions already paying more than the projected next block fee rate)

| Before | After |
|-|-|
| <img width="241" alt="Screenshot 2023-11-15 at 8 47 12 AM" src="https://github.com/mempool/mempool/assets/83316221/deb70a63-a00a-4e40-8254-79b14a7dd027"> | <img width="241" alt="Screenshot 2023-11-15 at 8 46 47 AM" src="https://github.com/mempool/mempool/assets/83316221/dcb6ff7c-2e51-4c7e-baa1-8e7bc5d66841"> |
