### PR TITLE
Fix P2PK balance display in address page

### DIFF
--- a/contributors/ncois.txt
+++ b/contributors/ncois.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of November 16, 2023.
+
+Signed: ncois


### PR DESCRIPTION
This PR fixes a bug that prevents the correct display of the transferred balance in transactions with P2PK.
Before: 
<img width="1120" alt="genesis-p2pk" src="https://github.com/mempool/mempool/assets/46578910/f200c031-744a-4c78-977e-bf88389fda5f">
Examples: [uncompressed](https://mempool.space/address/04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f) and [compressed](https://mempool.space/address/02f1a8c87607f415c8f22c00593002775941dea48869ce23096af27b0cfdcc0b69) P2PK

Now: 
<img width="1115" alt="genesis-p2pk-fixed" src="https://github.com/mempool/mempool/assets/46578910/8e0dca9c-200f-4af7-837c-080d6ffb47a1">

Sorry for the duplicate, I wanted to squash commits and ended up closing the previous PR by mistake.