### PR TITLE
Fix electrum p2pk/scripthash format

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -573,7 +573,9 @@ class BitcoinRoutes {
     }
 
     try {
-      const addressData = await bitcoinApi.$getScriptHash(req.params.scripthash);
+      // electrum expects scripthashes in little-endian
+      const electrumScripthash = req.params.scripthash.match(/../g)?.reverse().join('') ?? '';
+      const addressData = await bitcoinApi.$getScriptHash(electrumScripthash);
       res.json(addressData);
     } catch (e) {
       if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
@@ -590,11 +592,13 @@ class BitcoinRoutes {
     }
 
     try {
+      // electrum expects scripthashes in little-endian
+      const electrumScripthash = req.params.scripthash.match(/../g)?.reverse().join('') ?? '';
       let lastTxId: string = '';
       if (req.query.after_txid && typeof req.query.after_txid === 'string') {
         lastTxId = req.query.after_txid;
       }
-      const transactions = await bitcoinApi.$getScriptHashTransactions(req.params.scripthash, lastTxId);
+      const transactions = await bitcoinApi.$getScriptHashTransactions(electrumScripthash, lastTxId);
       res.json(transactions);
     } catch (e) {
       if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {


### PR DESCRIPTION
This PR fixes an issue with P2PK "address" lookups using electrum/fulcrum backends.

P2PKs do not have an address format, so we query their balances and transactions by scripthash.

Very helpfully, the esplora and electrum APIs use different endianness for their scripthashes, so API queries that work for esplora backends return no results from electrum/fulcrum backends.

This PR converts the scripthashes in these queries to little-endian before proxying them to the electrum/fulcrum backend, which resolves the issue.

Before:
<img width="918" alt="Screenshot 2023-11-17 at 3 58 13 AM" src="https://github.com/mempool/mempool/assets/83316221/4548ada9-1657-4228-ba0a-dab85613d040">

After:

<img width="918" alt="Screenshot 2023-11-17 at 3 56 01 AM" src="https://github.com/mempool/mempool/assets/83316221/ccff3b1f-0112-4fe6-bf66-d4d2067dff89">


