### PR TITLE
More verbose RBF cache check logs

### DIFF
--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -480,14 +480,15 @@ class RbfCache {
     };
 
     if (config.MEMPOOL.BACKEND === 'esplora') {
+      let processedCount = 0;
       const sliceLength = Math.ceil(config.ESPLORA.BATCH_QUERY_BASE_SIZE / 40);
       for (let i = 0; i < Math.ceil(txids.length / sliceLength); i++) {
         const slice = txids.slice(i * sliceLength, (i + 1) * sliceLength);
+        processedCount += slice.length;
         try {
           const txs = await bitcoinApi.$getRawTransactions(slice);
-          logger.debug(`fetched ${slice.length} cached rbf transactions`);
           processTxs(txs);
-          logger.debug(`processed ${slice.length} cached rbf transactions`);
+          logger.debug(`fetched and processed ${processedCount} of ${txids.length} cached rbf transactions (${(processedCount / txids.length * 100).toFixed(2)}%)`);
         } catch (err) {
           logger.err(`failed to fetch or process ${slice.length} cached rbf transactions`);
         }


### PR DESCRIPTION
```
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 900 of 1653 cached rbf transactions (54.45%)
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 925 of 1653 cached rbf transactions (55.96%)
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 950 of 1653 cached rbf transactions (57.47%)
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 975 of 1653 cached rbf transactions (58.98%)
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 1000 of 1653 cached rbf transactions (60.50%)
Nov 17 07:06:08 [11145] DEBUG: <lightning> fetched and processed 1025 of 1653 cached rbf transactions (62.01%)
Nov 17 07:06:09 [11145] DEBUG: <lightning> fetched and processed 1050 of 1653 cached rbf transactions (63.52%)
Nov 17 07:06:09 [11145] DEBUG: <lightning> fetched and processed 1075 of 1653 cached rbf transactions (65.03%)
Nov 17 07:06:09 [11145] DEBUG: <lightning> fetched and processed 1100 of 1653 cached rbf transactions (66.55%
```