### PR TITLE
fix: incorrect `HTTP_PORT` docker compose field in docker README.md

### DIFF
--- a/contributors/0xBEEFCAF3.txt
+++ b/contributors/0xBEEFCAF3.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of November 17, 2023.
+
+Signed: 0xBEEFCAF3

--- a/docker/README.md
+++ b/docker/README.md
@@ -124,7 +124,7 @@ Corresponding `docker-compose.yml` overrides:
     environment:
       MEMPOOL_NETWORK: ""
       MEMPOOL_BACKEND: ""
-      MEMPOOL_HTTP_PORT: ""
+      BACKEND_HTTP_PORT: ""
       MEMPOOL_SPAWN_CLUSTER_PROCS: ""
       MEMPOOL_API_URL_PREFIX: ""
       MEMPOOL_POLL_RATE_MS: ""


### PR DESCRIPTION
The override is BACKEND_HTTP_PORT [defined here](https://github.com/mempool/mempool/blob/59c513f2a52a96d125944b42230e1fb7b13b130e/docker/backend/start.sh#L7)


Just found this while setting up docker compose. 
Idk if it makes sense to update `start.sh` instead. Lmk


