### PR TITLE
Add a form on address page to display only credit or debit transactions

### DIFF
--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -57,11 +57,30 @@
       <h2 class="text-left">
         <ng-template [ngIf]="!transactions?.length">&nbsp;</ng-template>
         <ng-template i18n="X of X Address Transaction" [ngIf]="transactions?.length === 1">{{ (transactions?.length | number) || '?' }} of {{ txCount | number }} transaction</ng-template>
-        <ng-template i18n="X of X Address Transactions (Plural)" [ngIf]="transactions?.length > 1">{{ (transactions?.length | number) || '?' }} of {{ txCount | number }} transactions</ng-template>
+        <ng-template i18n="X of X Address Transactions (Plural)" [ngIf]="transactions?.length > 1">
+          {{ ((transactionsStatusForm.get('status').value === 'all' ? transactions?.length : filteredTransactions?.length) | number) || '?' }} of {{ txCount | number }} transactions 
+        </ng-template>
       </h2>
     </div>
+    <div class="formRadioGroup">
+      <form *ngIf="transactions?.length > 1 && (network !== 'liquid' && network !== 'liquidtestnet')" [formGroup]="transactionsStatusForm">
+        <div class="btn-group btn-group-toggle" name="radioBasic">
+          <label class="btn btn-primary btn-sm" [class.active]="transactionsStatusForm.get('status').value === 'all'" style="margin-right: 5px;">
+            <input type="radio" [value]="'all'" fragment="all" formControlName="status"><span i18n="all">All</span>
+          </label>
+        </div>
+        <div class="btn-group btn-group-toggle" name="radioBasic">
+          <label class="btn btn-success btn-sm" [class.active]="transactionsStatusForm.get('status').value === 'credit'">
+            <input type="radio" [value]="'credit'" fragment="credit" formControlName="status"><span i18n="credit">Credit</span>
+          </label>
+          <label class="btn btn-danger btn-sm" [class.active]="transactionsStatusForm.get('status').value === 'debit'">
+            <input type="radio" [value]="'debit'" fragment="debit" formControlName="status"><span i18n="debit">Debit</span>
+          </label>
+        </div>
+      </form>
+    </div>
 
-    <app-transactions-list [transactions]="transactions" [showConfirmations]="true" [address]="address.address" (loadMore)="loadMore()"></app-transactions-list>
+    <app-transactions-list [transactions]="transactionsStatusForm.get('status').value === 'all'  ? transactions : filteredTransactions" [showConfirmations]="true" [address]="address.address" (loadMore)="loadMore()"></app-transactions-list>
 
     <div class="text-center">
       <ng-template [ngIf]="isLoadingTransactions">
@@ -90,6 +109,24 @@
       <ng-template [ngIf]="retryLoadMore">
         <br>
         <button type="button" class="btn btn-outline-info btn-sm" (click)="loadMore()"><fa-icon [icon]="['fas', 'redo-alt']" [fixedWidth]="true"></fa-icon></button>
+      </ng-template>
+
+      <ng-template [ngIf]="transactionsStatusForm.get('status').value !== 'all' && keepDigging">
+        <br>
+        <ng-container>
+          <i>No {{transactionsStatusForm.get('status').value}} transactions found in the last {{ (filteredOutTxCount | number) || '?' }} transactions loaded ({{ (this.transactions?.length | number) || '?' }} of {{ txCount | number }} loaded so far)</i>
+          <br>
+          <i></i>
+        </ng-container>
+        <br>
+        <button type="button" class="btn btn-primary btn-sm" (click)="loadMore()">Load more</button>
+      </ng-template>
+
+      <ng-template [ngIf]="transactionsStatusForm.get('status').value !== 'all' && this.transactions?.length > 50 && this.loadedConfirmedTxCount >= this.totalConfirmedTxCount">
+        <br>
+        <ng-container>
+          <i>All {{ (filteredTransactions?.length | number) || '?' }} {{transactionsStatusForm.get('status').value}} transactions {{ transactionsStatusForm.get('status').value === 'debit' ? 'from' : 'to' }} this address have been loaded</i>
+        </ng-container>
       </ng-template>
     </div>
 

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -21,6 +21,17 @@
   }
 }
 
+.formRadioGroup {
+  position: relative;
+    form {
+    @media (min-width: 500px) {
+      position: absolute;
+      right: 0;
+      top: -40px;
+    }
+  }
+}
+
 .table {
   tr td {
     &:last-child {

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -131,6 +131,9 @@ export class AddressComponent implements OnInit, OnDestroy {
           this.updateChainStats();
           this.isLoadingAddress = false;
           this.isLoadingTransactions = true;
+          this.transactionsStatusForm.get('status').setValue('all');
+          this.filteredTransactions = [];
+          this.keepDigging = false;
           return address.is_pubkey
               ? this.electrsApiService.getScriptHashTransactions$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
               : this.electrsApiService.getAddressTransactions$(address.address);
@@ -208,7 +211,7 @@ export class AddressComponent implements OnInit, OnDestroy {
 
       this.transactionsStatusForm.get('status').valueChanges.subscribe(() => {
         // Only display the 50 most recent transactions to avoid lag on switch
-        if (this.transactions.length > 50) {
+        if (this.transactions?.length > 50) {
           this.transactions = this.transactions.slice(0, 50);
           this.lastTransactionTxId = this.transactions[49].txid;
           this.loadedConfirmedTxCount = this.transactions.filter((tx) => tx.status.confirmed).length;


### PR DESCRIPTION
This PR adds a feature to the address page that allows the filtering of transactions based on whether they are credit or debit to the address. I tried to keep the original transactions structure untouched to avoid unwanted behaviour. 
<img width="1131" alt="Screenshot 2023-11-21 at 16 55 55" src="https://github.com/mempool/mempool/assets/46578910/525cbc33-7707-4600-ab89-239ad3c02ee8">

I think I took into account most edge cases, like what if there is no debit transaction, or what if there is no credit transaction loaded in the 50 fetched txs during the scroll, etc. But I might have missed some things, so any feedback is welcome.