### PR TITLE
Fix health score when mempool was empty

### DIFF
--- a/backend/src/api/audit.ts
+++ b/backend/src/api/audit.ts
@@ -144,7 +144,12 @@ class Audit {
 
     const numCensored = Object.keys(isCensored).length;
     const numMatches = matches.length - 1; // adjust for coinbase tx
-    const score = numMatches > 0 ? (numMatches / (numMatches + numCensored)) : 0;
+    let score = 0;
+    if (numMatches <= 0 && numCensored <= 0) {
+      score = 1;
+    } else if (numMatches > 0) {
+      score = (numMatches / (numMatches + numCensored));
+    }
     const similarity = projectedWeight ? matchedWeight / projectedWeight : 1;
 
     return {

--- a/backend/src/api/audit.ts
+++ b/backend/src/api/audit.ts
@@ -9,7 +9,7 @@ class Audit {
   auditBlock(transactions: MempoolTransactionExtended[], projectedBlocks: MempoolBlockWithTransactions[], mempool: { [txId: string]: MempoolTransactionExtended }, useAccelerations: boolean = false)
    : { censored: string[], added: string[], fresh: string[], sigop: string[], fullrbf: string[], accelerated: string[], score: number, similarity: number } {
     if (!projectedBlocks?.[0]?.transactionIds || !mempool) {
-      return { censored: [], added: [], fresh: [], sigop: [], fullrbf: [], accelerated: [], score: 0, similarity: 1 };
+      return { censored: [], added: [], fresh: [], sigop: [], fullrbf: [], accelerated: [], score: 1, similarity: 1 };
     }
 
     const matches: string[] = []; // present in both mined block and template


### PR DESCRIPTION
We currently assign empty blocks a health score of 0%, even if the mempool may have been genuinely empty when the miner constructed their template.

e.g:
https://mempool.space/testnet/block/000000000000001d6b8026c28825d56acc8a2341b59fd5edfe2acc04bea38df5
<img width="1090" alt="Screenshot 2023-11-22 at 1 15 04 PM" src="https://github.com/mempool/mempool/assets/83316221/a016c7b3-7475-423e-9103-4f76d68a7004">

This PR explicitly handles that edge case by assigning a health score of 100% if the mempool is empty or only contains recently broadcast transactions.