### PR TITLE
Refactor difficulty reindexing to process blocks in height order

### DIFF
--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -541,7 +541,7 @@ class BlocksRepository {
    */
   public async $getBlocksDifficulty(): Promise<object[]> {
     try {
-      const [rows]: any[] = await DB.query(`SELECT UNIX_TIMESTAMP(blockTimestamp) as time, height, difficulty, bits FROM blocks`);
+      const [rows]: any[] = await DB.query(`SELECT UNIX_TIMESTAMP(blockTimestamp) as time, height, difficulty, bits FROM blocks ORDER BY height ASC`);
       return rows;
     } catch (e) {
       logger.err('Cannot get blocks difficulty list from the db. Reason: ' + (e instanceof Error ? e.message : e));


### PR DESCRIPTION
This PR slightly simplifies the `$indexDifficultyAdjustments()` function, and fixes an obscure bug which could fill the difficulty adjustments table with garbage, requiring a manual difficulty reindex.

The bug occurs when there is a gap in the blocks table for some reason when `$indexDifficultyAdjustments()` runs. In that case, an adjustment of `difficulty%` would be inserted into the DB for *every* block height below the gap.

This PR enforces processing blocks sequentially in ascending order during difficulty indexing, which allows us to simplify the reindexing logic (and fix the bug).