### PR TITLE
Fix spurious ln channel typeahead matches

### DIFF
--- a/backend/src/api/explorer/channels.api.ts
+++ b/backend/src/api/explorer/channels.api.ts
@@ -80,7 +80,13 @@ class ChannelsApi {
 
   public async $searchChannelsById(search: string): Promise<any[]> {
     try {
-      const searchStripped = search.replace(/[^0-9x]/g, '') + '%';
+      // restrict search to valid id/short_id prefix formats
+      let searchStripped = search.match(/[0-9]+[0-9x]*/)?.[0] || '';
+      if (!searchStripped.length) {
+        return [];
+      }
+      // add wildcard to search by prefix
+      searchStripped += '%';
       const query = `SELECT id, short_id, capacity, status FROM channels WHERE id LIKE ? OR short_id LIKE ? LIMIT 10`;
       const [rows]: any = await DB.query(query, [searchStripped, searchStripped]);
       return rows;


### PR DESCRIPTION
Fixes #4427

This PR changes the `$searchChannelsById(search)` function to return no channels if the search query is empty after sanitization. Previously we would return the first 10 channels matching that empty query (i.e. just the first 10 channels in the DB).

| Before | After |
|-|-|
| <img width="506" alt="Screenshot 2023-11-26 at 9 24 46 AM" src="https://github.com/mempool/mempool/assets/83316221/eee81aa4-e1f4-4a3b-85c7-741a4826d7f6"> | <img width="506" alt="Screenshot 2023-11-26 at 9 22 27 AM" src="https://github.com/mempool/mempool/assets/83316221/449e107f-ef08-460d-ad63-738724eaa9b0"> |
| <img width="506" alt="Screenshot 2023-11-26 at 9 24 59 AM" src="https://github.com/mempool/mempool/assets/83316221/4ffdd04b-3a8a-4d10-b0d6-1cc3d2f318e2"> | <img width="506" alt="Screenshot 2023-11-26 at 9 22 20 AM" src="https://github.com/mempool/mempool/assets/83316221/3fa0e531-a3de-4237-8b2b-f571140cd641"> |
