### PR TITLE
Difficulty adjustment chart: format the hashrate and difficulty

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -249,10 +249,8 @@ export class HashrateChartComponent implements OnInit {
           for (const tick of ticks) {
             if (tick.seriesIndex === 0) { // Hashrate
               let hashrate = tick.data[1];
-              if (this.isMobile()) {
-                hashratePowerOfTen = selectPowerOfTen(tick.data[1]);
-                hashrate = Math.round(tick.data[1] / hashratePowerOfTen.divider);
-              }
+              hashratePowerOfTen = selectPowerOfTen(tick.data[1]);
+              hashrate = Math.round(tick.data[1] / hashratePowerOfTen.divider);
               hashrateString = `${tick.marker} ${tick.seriesName}: ${formatNumber(hashrate, this.locale, '1.0-0')} ${hashratePowerOfTen.unit}H/s<br>`;
             } else if (tick.seriesIndex === 1) { // Difficulty
               let difficultyPowerOfTen = hashratePowerOfTen;
@@ -260,18 +258,14 @@ export class HashrateChartComponent implements OnInit {
               if (difficulty === null) {
                 difficultyString = `${tick.marker} ${tick.seriesName}: No data<br>`;
               } else {
-                if (this.isMobile()) {
-                  difficultyPowerOfTen = selectPowerOfTen(tick.data[1]);
-                  difficulty = Math.round(tick.data[1] / difficultyPowerOfTen.divider);
-                }
+                difficultyPowerOfTen = selectPowerOfTen(tick.data[1]);
+                difficulty = Math.round(tick.data[1] / difficultyPowerOfTen.divider);
                 difficultyString = `${tick.marker} ${tick.seriesName}: ${formatNumber(difficulty, this.locale, '1.2-2')} ${difficultyPowerOfTen.unit}<br>`;
               }
             } else if (tick.seriesIndex === 2) { // Hashrate MA
               let hashrate = tick.data[1];
-              if (this.isMobile()) {
-                hashratePowerOfTen = selectPowerOfTen(tick.data[1]);
-                hashrate = Math.round(tick.data[1] / hashratePowerOfTen.divider);
-              }
+              hashratePowerOfTen = selectPowerOfTen(tick.data[1]);
+              hashrate = Math.round(tick.data[1] / hashratePowerOfTen.divider);  
               hashrateStringMA = `${tick.marker} ${tick.seriesName}: ${formatNumber(hashrate, this.locale, '1.0-0')} ${hashratePowerOfTen.unit}H/s`;
             }
           }

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -259,7 +259,7 @@ export class HashrateChartComponent implements OnInit {
                 difficultyString = `${tick.marker} ${tick.seriesName}: No data<br>`;
               } else {
                 difficultyPowerOfTen = selectPowerOfTen(tick.data[1]);
-                difficulty = Math.round(tick.data[1] / difficultyPowerOfTen.divider);
+                difficulty = tick.data[1] / difficultyPowerOfTen.divider;
                 difficultyString = `${tick.marker} ${tick.seriesName}: ${formatNumber(difficulty, this.locale, '1.2-2')} ${difficultyPowerOfTen.unit}<br>`;
               }
             } else if (tick.seriesIndex === 2) { // Hashrate MA


### PR DESCRIPTION
Fixes #4442 by displaying formatted values on all screen sizes

I also removed the rounding for the difficulty value, which caused to always display the difficulty with two zeroes fraction digits on mobile:

| Before (desktop) | Before (mobile) | After (mobile + desktop) |
| ------------- | ------------- | ------------- |
| <img width="372" alt="Screenshot 2023-11-29 at 11 31 38" src="https://github.com/mempool/mempool/assets/46578910/75e480e6-e4a3-422a-93d4-d539fc4a0085"> | <img width="177" alt="Screenshot 2023-11-29 at 11 32 36" src="https://github.com/mempool/mempool/assets/46578910/56be6700-041b-4433-80c7-9fa06d28bcd2">  | <img width="228" alt="Screenshot 2023-11-29 at 11 34 12" src="https://github.com/mempool/mempool/assets/46578910/b2d918a7-495e-458f-9a81-43af1af326ab">|  