### PR TITLE
Pool chart hashrate format in power of ten

### DIFF
--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -163,10 +163,8 @@ export class PoolComponent implements OnInit {
           let hashratePowerOfTen: any = selectPowerOfTen(1);
           let hashrate = ticks[0].data[1];
 
-          if (this.isMobile()) {
-            hashratePowerOfTen = selectPowerOfTen(ticks[0].data[1]);
-            hashrate = Math.round(ticks[0].data[1] / hashratePowerOfTen.divider);
-          }
+          hashratePowerOfTen = selectPowerOfTen(ticks[0].data[1]);
+          hashrate = Math.round(ticks[0].data[1] / hashratePowerOfTen.divider);
 
           return `
             <b style="color: white; margin-left: 18px">${ticks[0].axisValueLabel}</b><br>


### PR DESCRIPTION
For coherence with #4451, this formats in power of ten the hashrate in pools charts (example https://mempool.space/mining/pool/binancepool)

| Before  | After |
| ------------- | ------------- |
|  <img width="336" alt="Screenshot 2023-12-01 at 12 58 21" src="https://github.com/mempool/mempool/assets/46578910/470e0d14-9c83-4d08-9030-d9bb7e1b15cb"> | <img width="219" alt="Screenshot 2023-12-01 at 12 58 37" src="https://github.com/mempool/mempool/assets/46578910/0c794990-171f-4bf9-928b-b4b03faa6097"> |