### PR TITLE
Improve acceleration tracking

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -9,7 +9,7 @@ import loadingIndicators from './loading-indicators';
 import bitcoinClient from './bitcoin/bitcoin-client';
 import bitcoinSecondClient from './bitcoin/bitcoin-second-client';
 import rbfCache from './rbf-cache';
-import accelerationApi, { Acceleration } from './services/acceleration';
+import { Acceleration } from './services/acceleration';
 import redisCache from './redis-cache';
 
 class Mempool {
@@ -185,7 +185,7 @@ class Mempool {
     return txTimes;
   }
 
-  public async $updateMempool(transactions: string[], pollRate: number): Promise<void> {
+  public async $updateMempool(transactions: string[], accelerations: Acceleration[] | null, pollRate: number): Promise<void> {
     logger.debug(`Updating mempool...`);
 
     // warn if this run stalls the main loop for more than 2 minutes
@@ -330,7 +330,7 @@ class Mempool {
     const newTransactionsStripped = newTransactions.map((tx) => Common.stripTransaction(tx));
     this.latestTransactions = newTransactionsStripped.concat(this.latestTransactions).slice(0, 6);
 
-    const accelerationDelta = await this.$updateAccelerations();
+    const accelerationDelta = accelerations != null ? await this.$updateAccelerations(accelerations) : [];
     if (accelerationDelta.length) {
       hasChange = true;
     }
@@ -370,14 +370,12 @@ class Mempool {
     return this.accelerations;
   }
 
-  public async $updateAccelerations(): Promise<string[]> {
+  public $updateAccelerations(newAccelerations: Acceleration[]): string[] {
     if (!config.MEMPOOL_SERVICES.ACCELERATIONS) {
       return [];
     }
 
     try {
-      const newAccelerations = await accelerationApi.$fetchAccelerations();
-
       const changed: string[] = [];
 
       const newAccelerationMap: { [txid: string]: Acceleration } = {};

--- a/backend/src/api/services/acceleration.ts
+++ b/backend/src/api/services/acceleration.ts
@@ -1,6 +1,7 @@
-import { query } from '../../utils/axios-query';
 import config from '../../config';
+import logger from '../../logger';
 import { BlockExtended, PoolTag } from '../../mempool.interfaces';
+import axios from 'axios';
 
 export interface Acceleration {
   txid: string,
@@ -9,10 +10,15 @@ export interface Acceleration {
 }
 
 class AccelerationApi {
-  public async $fetchAccelerations(): Promise<Acceleration[]> {
+  public async $fetchAccelerations(): Promise<Acceleration[] | null> {
     if (config.MEMPOOL_SERVICES.ACCELERATIONS) {
-      const response = await query(`${config.MEMPOOL_SERVICES.API}/accelerator/accelerations`);
-      return (response as Acceleration[]) || [];
+      try {
+        const response = await axios.get(`${config.MEMPOOL_SERVICES.API}/accelerator/accelerations`, { responseType: 'json', timeout: 10000 });
+        return response.data as Acceleration[];
+      } catch (e) {
+        logger.warn('Failed to fetch current accelerations from the mempool services backend: ' + (e instanceof Error ? e.message : e));
+        return null;
+      }
     } else {
       return [];
     }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -43,6 +43,7 @@ import { AxiosError } from 'axios';
 import v8 from 'v8';
 import { formatBytes, getBytesUnit } from './utils/format';
 import redisCache from './api/redis-cache';
+import accelerationApi from './api/services/acceleration';
 
 class Server {
   private wss: WebSocket.Server | undefined;
@@ -205,10 +206,11 @@ class Server {
         }
       }
       const newMempool = await bitcoinApi.$getRawMempool();
+      const newAccelerations = await accelerationApi.$fetchAccelerations();
       const numHandledBlocks = await blocks.$updateBlocks();
       const pollRate = config.MEMPOOL.POLL_RATE_MS * (indexer.indexerIsRunning() ? 10 : 1);
       if (numHandledBlocks === 0) {
-        await memPool.$updateMempool(newMempool, pollRate);
+        await memPool.$updateMempool(newMempool, newAccelerations, pollRate);
       }
       indexer.$run();
       priceUpdater.$run();


### PR DESCRIPTION
Fixes some issues with the way we were tracking accelerated transactions.

Before, sometimes the backend would receive the updated list of accelerations *before* the block in which an acceleration was confirmed, and so fail to include the acceleration in the block audit.

This PR takes a similar approach to #3655, by fetching the list of accelerations first, then checking for new blocks, before finally applying the update.

It also switches to use axios directly instead of using the `axios-query` wrapper, which could have caused unnecessary delays and exceptions in the mempool update loop since it's intended for more async tasks.