### PR TITLE
Change dual-licensed GPLv3/AGPLv3 to AGPLv3 only

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,15 +2,9 @@ The Mempool Open Source Project®
 Copyright (c) 2019-2023 The Mempool Space K.K. and other shadowy super-coders
 
 This program is free software; you can redistribute it and/or modify it under
-the terms of (at your option) either:
-
- 1) the GNU Affero General Public License as published by the Free Software
- Foundation, either version 3 of the License or any later version approved by a
- proxy statement published on <https://mempool.space/about>; or
-
- 2) the GNU General Public License as published by the Free Software
- Foundation, either version 3 of the License or any later version approved by a
- proxy statement published on <https://mempool.space/about>.
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License or any later version
+approved by a proxy statement published on <https://mempool.space/about>.
 
 However, this copyright license does not include an implied right or license
 to use any trademarks, service marks, logos, or trade names of Mempool Space K.K.
@@ -31,5 +25,4 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the full license terms for more details.
 
 You should have received a copy of both the GNU Affero General Public License
-and the GNU General Public License along with this program.  If not, see
-<http://www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/frontend/src/app/components/about/about.component.html
+++ b/frontend/src/app/components/about/about.component.html
@@ -410,16 +410,8 @@
       and other shadowy super-coders
     </div>
     <p>
-      <a href="https://github.com/mempool/mempool">The Mempool Open Source Project</a> is free software; you can redistribute it and/or modify it under the terms of (at your option) either:<br>
+      <a href="https://github.com/mempool/mempool">The Mempool Open Source Project</a> is free software; you can redistribute it and/or modify it under the terms of the <a href="https://www.gnu.org/licenses/agpl-3.0-standalone.html">GNU Affero General Public License</a> as published by the Free Software Foundation, either version 3 of the License or any later version approved by a proxy statement published on &lt;https://mempool.space/about&gt;.<br>
     </p>
-    <ul>
-      <li>
-        1) the <a href="https://www.gnu.org/licenses/agpl-3.0-standalone.html">GNU Affero General Public License</a> as published by the Free Software Foundation, either version 3 of the License or any later version approved by a proxy statement published on &lt;https://mempool.space/about&gt;; or<br>
-      </li>
-      <li>
-        2) the <a href="https://www.gnu.org/licenses/gpl-3.0-standalone.html">GNU General Public License</a> as published by the Free Software Foundation, either version 3 of the License or any later version approved by a proxy statement published on &lt;https://mempool.space/about&gt;.<br>
-      </li>
-    </ul>
     <p>
       This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the full license terms for more details.<br>
     </p>


### PR DESCRIPTION
This PR simplifies our FOSS license to AGPLv3 only.