### PR TITLE
Projected block filters

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -171,8 +171,8 @@ export class Common {
     // heuristic to detect probable DER signatures
     return (w.length >= 18
       && w.startsWith('30') // minimum DER signature length is 8 bytes + sighash flag (see https://mempool.space/testnet/tx/c6c232a36395fa338da458b86ff1327395a9afc28c5d2daa4273e410089fd433)
-      && ['01, 02, 03, 81, 82, 83'].includes(w.slice(-2)) // signature must end with a valid sighash flag
-      && (w.length === parseInt(w.slice(2, 4), 16) + 6) // second byte encodes the combined length of the R and S components
+      && ['01', '02', '03', '81', '82', '83'].includes(w.slice(-2)) // signature must end with a valid sighash flag
+      && (w.length === (2 * parseInt(w.slice(2, 4), 16)) + 6) // second byte encodes the combined length of the R and S components
     );
   }
 

--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -1,7 +1,9 @@
 import { MempoolBlock } from '../mempool.interfaces';
-import { Common } from './common';
+import config from '../config';
 import mempool from './mempool';
 import projectedBlocks from './mempool-blocks';
+
+const isLiquid = config.MEMPOOL.NETWORK === 'liquid' || config.MEMPOOL.NETWORK === 'liquidtestnet';
 
 interface RecommendedFees {
   fastestFee: number,
@@ -14,8 +16,8 @@ interface RecommendedFees {
 class FeeApi {
   constructor() { }
 
-  defaultFee = Common.isLiquid() ? 0.1 : 1;
-  minimumIncrement = Common.isLiquid() ? 0.1 : 1;
+  defaultFee = isLiquid ? 0.1 : 1;
+  minimumIncrement = isLiquid ? 0.1 : 1;
 
   public getRecommendedFee(): RecommendedFees {
     const pBlocks = projectedBlocks.getMempoolBlocks();

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -1,6 +1,6 @@
 import { GbtGenerator, GbtResult, ThreadTransaction as RustThreadTransaction, ThreadAcceleration as RustThreadAcceleration } from 'rust-gbt';
 import logger from '../logger';
-import { MempoolBlock, MempoolTransactionExtended, TransactionStripped, MempoolBlockWithTransactions, MempoolBlockDelta, Ancestor, CompactThreadTransaction, EffectiveFeeStats, PoolTag } from '../mempool.interfaces';
+import { MempoolBlock, MempoolTransactionExtended, TransactionStripped, MempoolBlockWithTransactions, MempoolBlockDelta, Ancestor, CompactThreadTransaction, EffectiveFeeStats, PoolTag, TransactionClassified } from '../mempool.interfaces';
 import { Common, OnlineFeeStatsCalculator } from './common';
 import config from '../config';
 import { Worker } from 'worker_threads';
@@ -169,7 +169,7 @@ class MempoolBlocks {
   private calculateMempoolDeltas(prevBlocks: MempoolBlockWithTransactions[], mempoolBlocks: MempoolBlockWithTransactions[]): MempoolBlockDelta[] {
     const mempoolBlockDeltas: MempoolBlockDelta[] = [];
     for (let i = 0; i < Math.max(mempoolBlocks.length, prevBlocks.length); i++) {
-      let added: TransactionStripped[] = [];
+      let added: TransactionClassified[] = [];
       let removed: string[] = [];
       const changed: { txid: string, rate: number | undefined, acc: boolean | undefined }[] = [];
       if (mempoolBlocks[i] && !prevBlocks[i]) {
@@ -582,6 +582,7 @@ class MempoolBlocks {
       const deltas = this.calculateMempoolDeltas(this.mempoolBlocks, mempoolBlocks);
       this.mempoolBlocks = mempoolBlocks;
       this.mempoolBlockDeltas = deltas;
+
     }
 
     return mempoolBlocks;
@@ -599,7 +600,7 @@ class MempoolBlocks {
       medianFee: feeStats.medianFee, // Common.percentile(transactions.map((tx) => tx.effectiveFeePerVsize), config.MEMPOOL.RECOMMENDED_FEE_PERCENTILE),
       feeRange: feeStats.feeRange, //Common.getFeesInRange(transactions, rangeLength),
       transactionIds: transactionIds,
-      transactions: transactions.map((tx) => Common.stripTransaction(tx)),
+      transactions: transactions.map((tx) => Common.classifyTransaction(tx)),
     };
   }
 

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -100,6 +100,9 @@ class Mempool {
       if (this.mempoolCache[txid].order == null) {
         this.mempoolCache[txid].order = transactionUtils.txidToOrdering(txid);
       }
+      for (const vin of this.mempoolCache[txid].vin) {
+        transactionUtils.addInnerScriptsToVin(vin);
+      }
       count++;
       if (config.MEMPOOL.CACHE_ENABLED && config.REDIS.ENABLED) {
         await redisCache.$addTransaction(this.mempoolCache[txid]);

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -61,13 +61,13 @@ export interface MempoolBlock {
 
 export interface MempoolBlockWithTransactions extends MempoolBlock {
   transactionIds: string[];
-  transactions: TransactionStripped[];
+  transactions: TransactionClassified[];
 }
 
 export interface MempoolBlockDelta {
-  added: TransactionStripped[];
+  added: TransactionClassified[];
   removed: string[];
-  changed: { txid: string, rate: number | undefined }[];
+  changed: { txid: string, rate: number | undefined, flags?: number }[];
 }
 
 interface VinStrippedToScriptsig {
@@ -189,6 +189,45 @@ export interface TransactionStripped {
   acc?: boolean;
   rate?: number; // effective fee rate
 }
+
+export interface TransactionClassified extends TransactionStripped {
+  flags: number;
+}
+
+// binary flags for transaction classification
+export const TransactionFlags = {
+  // features
+  rbf:                                                         0b00000001n,
+  no_rbf:                                                      0b00000010n,
+  v1:                                                          0b00000100n,
+  v2:                                                          0b00001000n,
+  // address types
+  p2pk:                                               0b00000001_00000000n,
+  p2ms:                                               0b00000010_00000000n,
+  p2pkh:                                              0b00000100_00000000n,
+  p2sh:                                               0b00001000_00000000n,
+  p2wpkh:                                             0b00010000_00000000n,
+  p2wsh:                                              0b00100000_00000000n,
+  p2tr:                                               0b01000000_00000000n,
+  // behavior
+  cpfp_parent:                               0b00000001_00000000_00000000n,
+  cpfp_child:                                0b00000010_00000000_00000000n,
+  replacement:                               0b00000100_00000000_00000000n,
+  // data
+  op_return:                        0b00000001_00000000_00000000_00000000n,
+  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
+  inscription:                      0b00000100_00000000_00000000_00000000n,
+  // heuristics
+  coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,
+  consolidation:           0b00000010_00000000_00000000_00000000_00000000n,
+  batch_payout:            0b00000100_00000000_00000000_00000000_00000000n,
+  // sighash
+  sighash_all:    0b00000001_00000000_00000000_00000000_00000000_00000000n,
+  sighash_none:   0b00000010_00000000_00000000_00000000_00000000_00000000n,
+  sighash_single: 0b00000100_00000000_00000000_00000000_00000000_00000000n,
+  sighash_default:0b00001000_00000000_00000000_00000000_00000000_00000000n,
+  sighash_acp:    0b00010000_00000000_00000000_00000000_00000000_00000000n,
+};
 
 export interface BlockExtension {
   totalFees: number;

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -215,7 +215,7 @@ export const TransactionFlags = {
   replacement:                               0b00000100_00000000_00000000n,
   // data
   op_return:                        0b00000001_00000000_00000000_00000000n,
-  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
+  fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
   inscription:                      0b00000100_00000000_00000000_00000000n,
   // heuristics
   coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,

--- a/backend/src/utils/secp256k1.ts
+++ b/backend/src/utils/secp256k1.ts
@@ -1,0 +1,74 @@
+function powMod(x: bigint, power: number, modulo: bigint): bigint {
+  for (let i = 0; i < power; i++) {
+    x = (x * x) % modulo;
+  }
+  return x;
+}
+
+function sqrtMod(x: bigint, P: bigint): bigint {
+  const b2 = (x * x * x) % P;
+  const b3 = (b2 * b2 * x) % P;
+  const b6 = (powMod(b3, 3, P) * b3) % P;
+  const b9 = (powMod(b6, 3, P) * b3) % P;
+  const b11 = (powMod(b9, 2, P) * b2) % P;
+  const b22 = (powMod(b11, 11, P) * b11) % P;
+  const b44 = (powMod(b22, 22, P) * b22) % P;
+  const b88 = (powMod(b44, 44, P) * b44) % P;
+  const b176 = (powMod(b88, 88, P) * b88) % P;
+  const b220 = (powMod(b176, 44, P) * b44) % P;
+  const b223 = (powMod(b220, 3, P) * b3) % P;
+  const t1 = (powMod(b223, 23, P) * b22) % P;
+  const t2 = (powMod(t1, 6, P) * b2) % P;
+  const root = powMod(t2, 2, P);
+  return root;
+}
+
+const curveP = BigInt(`0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F`);
+
+/**
+ * This function tells whether the point given is a DER encoded point on the ECDSA curve.
+ * @param {string} pointHex The point as a hex string (*must not* include a '0x' prefix)
+ * @returns {boolean} true if the point is on the SECP256K1 curve
+ */
+export function isPoint(pointHex: string): boolean {
+  if (
+    !(
+      // is uncompressed
+      (
+        (pointHex.length === 130 && pointHex.startsWith('04')) ||
+        // OR is compressed
+        (pointHex.length === 66 &&
+          (pointHex.startsWith('02') || pointHex.startsWith('03')))
+      )
+    )
+  ) {
+    return false;
+  }
+
+  // Function modified slightly from noble-curves
+  
+
+  // Now we know that pointHex is a 33 or 65 byte hex string.
+  const isCompressed = pointHex.length === 66;
+
+  const x = BigInt(`0x${pointHex.slice(2, 66)}`);
+  if (x >= curveP) {
+    return false;
+  }
+
+  if (!isCompressed) {
+    const y = BigInt(`0x${pointHex.slice(66, 130)}`);
+    if (y >= curveP) {
+      return false;
+    }
+    // Just check y^2 = x^3 + 7 (secp256k1 curve)
+    return (y * y) % curveP === (x * x * x + 7n) % curveP;
+  } else {
+    // Get unaltered y^2 (no mod p)
+    const ySquared = (x * x * x + 7n) % curveP;
+    // Try to sqrt it, it will round down if not perfect root
+    const y = sqrtMod(ySquared, curveP);
+    // If we square and it's equal, then it was a perfect root and valid point.
+    return (y * y) % curveP === ySquared;
+  }
+}

--- a/frontend/src/app/components/block-filters/block-filters.component.html
+++ b/frontend/src/app/components/block-filters/block-filters.component.html
@@ -1,4 +1,4 @@
-<div class="block-filters" [class.filters-active]="activeFilters.length > 0" [class.menu-open]="menuOpen">
+<div class="block-filters" [class.filters-active]="activeFilters.length > 0" [class.menu-open]="menuOpen" [class.small]="cssWidth < 500" [class.vsmall]="cssWidth < 400" [class.tiny]="cssWidth < 200">
   <div class="filter-bar">
     <button class="menu-toggle" (click)="menuOpen = !menuOpen">
       <fa-icon [icon]="['fas', 'filter']"></fa-icon>
@@ -9,7 +9,7 @@
       </ng-container>
     </div>
   </div>
-  <div class="filter-menu" *ngIf="menuOpen">
+  <div class="filter-menu" *ngIf="menuOpen && cssWidth > 280">
     <ng-container *ngFor="let group of filterGroups;">
       <h5>{{ group.label }}</h5>
       <div class="filter-group">
@@ -17,6 +17,13 @@
           <button class="btn filter-tag" [class.selected]="filterFlags[filter.key]" (click)="toggleFilter(filter.key)">{{ filter.label }}</button>
         </ng-container>
       </div>
+    </ng-container>
+  </div>
+  <div class="filter-menu" *ngIf="menuOpen && cssWidth <= 280">
+    <ng-container *ngFor="let group of filterGroups;">
+      <ng-container *ngFor="let filter of group.filters;">
+        <button *ngIf="filter.important" class="btn filter-tag" [class.selected]="filterFlags[filter.key]" (click)="toggleFilter(filter.key)">{{ filter.label }}</button>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/frontend/src/app/components/block-filters/block-filters.component.html
+++ b/frontend/src/app/components/block-filters/block-filters.component.html
@@ -1,0 +1,22 @@
+<div class="block-filters" [class.filters-active]="activeFilters.length > 0" [class.menu-open]="menuOpen">
+  <div class="filter-bar">
+    <button class="menu-toggle" (click)="menuOpen = !menuOpen">
+      <fa-icon [icon]="['fas', 'filter']"></fa-icon>
+    </button>
+    <div class="active-tags">
+      <ng-container *ngFor="let filter of activeFilters;">
+        <button class="btn filter-tag selected" (click)="toggleFilter(filter)">{{ filters[filter].label }}</button>
+      </ng-container>
+    </div>
+  </div>
+  <div class="filter-menu" *ngIf="menuOpen">
+    <ng-container *ngFor="let group of filterGroups;">
+      <h5>{{ group.label }}</h5>
+      <div class="filter-group">
+        <ng-container *ngFor="let filter of group.filters;">
+          <button class="btn filter-tag" [class.selected]="filterFlags[filter.key]" (click)="toggleFilter(filter.key)">{{ filter.label }}</button>
+        </ng-container>
+      </div>
+    </ng-container>
+  </div>
+</div>

--- a/frontend/src/app/components/block-filters/block-filters.component.scss
+++ b/frontend/src/app/components/block-filters/block-filters.component.scss
@@ -1,0 +1,104 @@
+.block-filters {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  padding: 1em;
+  z-index: 10;
+  pointer-events: none;
+
+  .filter-bar, .active-tags {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .active-tags {
+    flex-wrap: wrap;
+    row-gap: 0.25em;
+    margin-left: 0.5em;
+  }
+
+  .menu-toggle {
+    opacity: 0;
+    cursor: pointer;
+    color: white;
+    background: none;
+    border: solid 2px white;
+    border-radius: 0.35em;
+    pointer-events: all;
+  }
+
+  .filter-menu {
+    h5 {
+      font-size: 0.8rem;
+      color: white;
+      margin: 0;
+      margin-top: 0.5em;
+    }
+  }
+
+  .filter-group {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: 0.25em;
+    margin-bottom: 0.5em;
+  }
+
+  .filter-tag {
+    font-size: 0.9em;
+    background: #181b2daf;
+    border: solid 1px #105fb0;
+    color: white;
+    border-radius: 0.2rem;
+    padding: 0.2em 0.5em;
+    transition: background-color 300ms;
+    margin-right: 0.25em;
+    pointer-events: all;
+
+    &.selected {
+      background-color: #105fb0;
+    }
+  }
+
+  :host-context(.block-overview-graph:hover) &, &:hover, &:active {
+    .menu-toggle {
+      opacity: 0.5;
+      background: #181b2d;
+
+      &:hover {
+        opacity: 1;
+        background: #181b2d7f;
+      }
+    }
+
+    &.menu-open, &.filters-active {
+      .menu-toggle {
+        opacity: 1;
+        background: none;
+
+        &:hover {
+          background: #181b2d7f;
+        }
+      }
+    }
+  }
+
+  &.menu-open, &.filters-active {
+    .menu-toggle {
+      opacity: 1;
+      background: none;
+
+      &:hover {
+        background: #181b2d7f;
+      }
+    }
+  }
+
+  &.menu-open {
+    pointer-events: all;
+    background: #181b2d7f;
+  }
+}

--- a/frontend/src/app/components/block-filters/block-filters.component.scss
+++ b/frontend/src/app/components/block-filters/block-filters.component.scss
@@ -101,4 +101,28 @@
     pointer-events: all;
     background: #181b2d7f;
   }
+
+  &.small {
+    .filter-tag {
+      font-size: 0.8em;
+    }
+  }
+
+  &.vsmall {
+    .filter-menu {
+      margin-top: 0.25em;
+      h5 {
+        display: none;
+      }
+    }
+    .filter-tag {
+      font-size: 0.7em;
+    }
+  }
+
+  &.tiny {
+    .filter-tag {
+      font-size: 0.5em;
+    }
+  }
 }

--- a/frontend/src/app/components/block-filters/block-filters.component.ts
+++ b/frontend/src/app/components/block-filters/block-filters.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, HostListener } from '@angular/core';
+import { Component, EventEmitter, Output, HostListener, Input, ChangeDetectorRef, OnChanges, SimpleChanges } from '@angular/core';
 import { FilterGroups, TransactionFilters } from '../../shared/filters.utils';
 
 
@@ -7,7 +7,8 @@ import { FilterGroups, TransactionFilters } from '../../shared/filters.utils';
   templateUrl: './block-filters.component.html',
   styleUrls: ['./block-filters.component.scss'],
 })
-export class BlockFiltersComponent {
+export class BlockFiltersComponent implements OnChanges {
+  @Input() cssWidth: number = 800;
   @Output() onFilterChanged: EventEmitter<bigint | null> = new EventEmitter();
 
   filters = TransactionFilters;
@@ -15,6 +16,16 @@ export class BlockFiltersComponent {
   activeFilters: string[] = [];
   filterFlags: { [key: string]: boolean } = {};
   menuOpen: boolean = false;
+
+  constructor(
+    private cd: ChangeDetectorRef,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.cssWidth) {
+      this.cd.markForCheck();
+    }
+  }
 
   toggleFilter(key): void {
     const filter = this.filters[key];

--- a/frontend/src/app/components/block-filters/block-filters.component.ts
+++ b/frontend/src/app/components/block-filters/block-filters.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnChanges, EventEmitter, Output, SimpleChanges, HostListener } from '@angular/core';
+import { FilterGroups, TransactionFilters, Filter, TransactionFlags } from '../../shared/filters.utils';
+
+
+@Component({
+  selector: 'app-block-filters',
+  templateUrl: './block-filters.component.html',
+  styleUrls: ['./block-filters.component.scss'],
+})
+export class BlockFiltersComponent implements OnChanges {
+  @Output() onFilterChanged: EventEmitter<bigint | null> = new EventEmitter();
+
+  filters = TransactionFilters;
+  filterGroups = FilterGroups;
+  activeFilters: string[] = [];
+  filterFlags: { [key: string]: boolean } = {};
+  menuOpen: boolean = false;
+
+  constructor() {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    
+  }
+
+  toggleFilter(key): void {
+    const filter = this.filters[key];
+    this.filterFlags[key] = !this.filterFlags[key];
+    if (this.filterFlags[key]) {
+      // remove any other flags in the same toggle group
+      if (filter.toggle) {
+        this.activeFilters.forEach(f => {
+          if (this.filters[f].toggle === filter.toggle) {
+            this.filterFlags[f] = false;
+          }
+        });
+        this.activeFilters = this.activeFilters.filter(f => this.filters[f].toggle !== filter.toggle);
+      }
+      // add new active filter
+      this.activeFilters.push(key);
+    } else {
+      // remove active filter
+      this.activeFilters = this.activeFilters.filter(f => f != key);
+    }
+    this.onFilterChanged.emit(this.getBooleanFlags());
+  }
+  
+  getBooleanFlags(): bigint | null {
+    let flags = 0n;
+    for (const key of Object.keys(this.filterFlags)) {
+      if (this.filterFlags[key]) {
+        flags |= this.filters[key].flag;
+      }
+    }
+    return flags || null;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onClick(event): boolean {
+    // click away from menu
+    if (!event.target.closest('button')) {
+      this.menuOpen = false;
+    }
+    return true;
+  }
+}

--- a/frontend/src/app/components/block-filters/block-filters.component.ts
+++ b/frontend/src/app/components/block-filters/block-filters.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnChanges, EventEmitter, Output, SimpleChanges, HostListener } from '@angular/core';
-import { FilterGroups, TransactionFilters, Filter, TransactionFlags } from '../../shared/filters.utils';
+import { Component, EventEmitter, Output, HostListener } from '@angular/core';
+import { FilterGroups, TransactionFilters } from '../../shared/filters.utils';
 
 
 @Component({
@@ -7,7 +7,7 @@ import { FilterGroups, TransactionFilters, Filter, TransactionFlags } from '../.
   templateUrl: './block-filters.component.html',
   styleUrls: ['./block-filters.component.scss'],
 })
-export class BlockFiltersComponent implements OnChanges {
+export class BlockFiltersComponent {
   @Output() onFilterChanged: EventEmitter<bigint | null> = new EventEmitter();
 
   filters = TransactionFilters;
@@ -15,12 +15,6 @@ export class BlockFiltersComponent implements OnChanges {
   activeFilters: string[] = [];
   filterFlags: { [key: string]: boolean } = {};
   menuOpen: boolean = false;
-
-  constructor() {}
-
-  ngOnChanges(changes: SimpleChanges): void {
-    
-  }
 
   toggleFilter(key): void {
     const filter = this.filters[key];

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -13,6 +13,6 @@
       [auditEnabled]="auditHighlighting"
       [blockConversion]="blockConversion"
     ></app-block-overview-tooltip>
-    <app-block-filters (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
+    <app-block-filters [cssWidth]="cssWidth" (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
   </div>
 </div>

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -13,6 +13,6 @@
       [auditEnabled]="auditHighlighting"
       [blockConversion]="blockConversion"
     ></app-block-overview-tooltip>
-    <app-block-filters [cssWidth]="cssWidth" (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
+    <app-block-filters *ngIf="showFilters" [cssWidth]="cssWidth" (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
   </div>
 </div>

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -13,5 +13,6 @@
       [auditEnabled]="auditHighlighting"
       [blockConversion]="blockConversion"
     ></app-block-overview-tooltip>
+    <app-block-filters (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
   </div>
 </div>

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -26,6 +26,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
   @Input() mirrorTxid: string | void;
   @Input() unavailable: boolean = false;
   @Input() auditHighlighting: boolean = false;
+  @Input() filterFlags: bigint | null = 0b00000100_00000000_00000000_00000000n;
   @Input() blockConversion: Price;
   @Input() overrideColors: ((tx: TxView) => Color) | null = null;
   @Output() txClickEvent = new EventEmitter<{ tx: TransactionStripped, keyModifier: boolean}>();
@@ -458,6 +459,14 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
   setHighlightingEnabled(enabled: boolean): void {
     if (this.scene) {
       this.scene.setHighlighting(enabled);
+      this.start();
+    }
+  }
+
+  setFilterFlags(flags: bigint | null): void {
+    if (this.scene) {
+      console.log('setting filter flags to ', this.filterFlags.toString(2));
+      this.scene.setFilterFlags(flags);
       this.start();
     }
   }

--- a/frontend/src/app/components/block-overview-graph/block-scene.ts
+++ b/frontend/src/app/components/block-overview-graph/block-scene.ts
@@ -27,6 +27,7 @@ export default class BlockScene {
   configAnimationOffset: number | null;
   animationOffset: number;
   highlightingEnabled: boolean;
+  filterFlags: bigint | null = 0b00000100_00000000_00000000_00000000n;
   width: number;
   height: number;
   gridWidth: number;
@@ -277,6 +278,20 @@ export default class BlockScene {
     this.animateUntil = Math.max(this.animateUntil, tx.update(update));
   }
 
+  private updateTxColor(tx: TxView, startTime: number, delay: number, animate: boolean = true, duration?: number): void {
+    if (tx.dirty || this.dirty) {
+      const txColor = tx.getColor();
+      this.applyTxUpdate(tx, {
+        display: {
+          color: txColor
+        },
+        duration: animate ? (duration || this.animationDuration) : 1,
+        start: startTime,
+        delay: animate ? delay : 0,
+      });
+    }
+  }
+
   private updateTx(tx: TxView, startTime: number, delay: number, direction: string = 'left', animate: boolean = true): void {
     if (tx.dirty || this.dirty) {
       this.saveGridToScreenPosition(tx);
@@ -325,7 +340,7 @@ export default class BlockScene {
     } else {
       this.applyTxUpdate(tx, {
         display: {
-          position: tx.screenPosition
+          position: tx.screenPosition,
         },
         duration: animate ? this.animationDuration : 0,
         minDuration: animate ? (this.animationDuration / 2) : 0,

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -1,9 +1,9 @@
 import TxSprite from './tx-sprite';
 import { FastVertexArray } from './fast-vertex-array';
-import { TransactionStripped } from '../../interfaces/websocket.interface';
 import { SpriteUpdateParams, Square, Color, ViewUpdateParams } from './sprite-types';
 import { hexToColor } from './utils';
 import BlockScene from './block-scene';
+import { TransactionStripped } from '../../interfaces/node-api.interface';
 
 const hoverTransitionTime = 300;
 const defaultHoverColor = hexToColor('1bd8f4');
@@ -29,6 +29,7 @@ export default class TxView implements TransactionStripped {
   feerate: number;
   acc?: boolean;
   rate?: number;
+  bigintFlags?: bigint | null = 0b00000100_00000000_00000000_00000000n;
   status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'censored' | 'selected' | 'rbf' | 'accelerated';
   context?: 'projected' | 'actual';
   scene?: BlockScene;
@@ -57,6 +58,7 @@ export default class TxView implements TransactionStripped {
     this.acc = tx.acc;
     this.rate = tx.rate;
     this.status = tx.status;
+    this.bigintFlags = tx.flags ? BigInt(tx.flags) : 0n;
     this.initialised = false;
     this.vertexArray = scene.vertexArray;
 

--- a/frontend/src/app/components/block-overview-graph/utils.ts
+++ b/frontend/src/app/components/block-overview-graph/utils.ts
@@ -1,4 +1,6 @@
+import { feeLevels, mempoolFeeColors } from '../../app.constants';
 import { Color } from './sprite-types';
+import TxView from './tx-view';
 
 export function hexToColor(hex: string): Color {
   return {
@@ -25,5 +27,75 @@ export function darken(color: Color, amount: number): Color {
     g: color.g * amount,
     b: color.b * amount,
     a: color.a,
+  };
+}
+
+export function setOpacity(color: Color, opacity: number): Color {
+  return {
+    ...color,
+    a: opacity
+  };
+}
+
+// precomputed colors
+export const defaultFeeColors = mempoolFeeColors.map(hexToColor);
+export const defaultAuditFeeColors = defaultFeeColors.map((color) => darken(desaturate(color, 0.3), 0.9));
+export const defaultMarginalFeeColors = defaultFeeColors.map((color) => darken(desaturate(color, 0.8), 1.1));
+export const defaultAuditColors = {
+  censored: hexToColor('f344df'),
+  missing: darken(desaturate(hexToColor('f344df'), 0.3), 0.7),
+  added: hexToColor('0099ff'),
+  selected: darken(desaturate(hexToColor('0099ff'), 0.3), 0.7),
+  accelerated: hexToColor('8F5FF6'),
+};
+
+export function defaultColorFunction(
+  tx: TxView,
+  feeColors: Color[] = defaultFeeColors,
+  auditFeeColors: Color[] = defaultAuditFeeColors,
+  marginalFeeColors: Color[] = defaultMarginalFeeColors,
+  auditColors: { [status: string]: Color } = defaultAuditColors
+): Color {
+  const rate = tx.fee / tx.vsize; // color by simple single-tx fee rate
+  const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, rate) < feeLvl) - 1;
+  const feeLevelColor = feeColors[feeLevelIndex] || feeColors[mempoolFeeColors.length - 1];
+  // Normal mode
+  if (!tx.scene?.highlightingEnabled) {
+    if (tx.acc) {
+      return auditColors.accelerated;
+    } else {
+      return feeLevelColor;
+    }
+    return feeLevelColor;
+  }
+  // Block audit
+  switch(tx.status) {
+    case 'censored':
+      return auditColors.censored;
+    case 'missing':
+    case 'sigop':
+    case 'rbf':
+      return marginalFeeColors[feeLevelIndex] || marginalFeeColors[mempoolFeeColors.length - 1];
+    case 'fresh':
+    case 'freshcpfp':
+      return auditColors.missing;
+    case 'added':
+      return auditColors.added;
+    case 'selected':
+      return marginalFeeColors[feeLevelIndex] || marginalFeeColors[mempoolFeeColors.length - 1];
+    case 'accelerated':
+      return auditColors.accelerated;
+    case 'found':
+      if (tx.context === 'projected') {
+        return auditFeeColors[feeLevelIndex] || auditFeeColors[mempoolFeeColors.length - 1];
+      } else {
+        return feeLevelColor;
+      }
+    default:
+      if (tx.acc) {
+        return auditColors.accelerated;
+      } else {
+        return feeLevelColor;
+      }
   }
 }

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, ViewChild, Input, OnChanges, ChangeDetectionStrategy } from '@angular/core';
-import { TransactionStripped } from '../../interfaces/websocket.interface';
 import { Position } from '../../components/block-overview-graph/sprite-types.js';
 import { Price } from '../../services/price.service';
+import { TransactionStripped } from '../../interfaces/node-api.interface.js';
 
 @Component({
   selector: 'app-block-overview-tooltip',

--- a/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.html
+++ b/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.html
@@ -5,6 +5,7 @@
   [blockLimit]="stateService.blockVSize"
   [orientation]="timeLtr ? 'right' : 'left'"
   [flip]="true"
+  [showFilters]="showFilters"
   [overrideColors]="overrideColors"
   (txClickEvent)="onTxClick($event)"
 ></app-block-overview-graph>

--- a/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
+++ b/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
@@ -18,6 +18,7 @@ import TxView from '../block-overview-graph/tx-view';
 })
 export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChanges, AfterViewInit {
   @Input() index: number;
+  @Input() showFilters: boolean = false;
   @Input() overrideColors: ((tx: TxView) => Color) | null = null;
   @Output() txPreviewEvent = new EventEmitter<TransactionStripped | void>();
 

--- a/frontend/src/app/components/mempool-block-view/mempool-block-view.component.html
+++ b/frontend/src/app/components/mempool-block-view/mempool-block-view.component.html
@@ -1,5 +1,5 @@
 <div class="block-wrapper">
   <div class="block-container">
-    <app-mempool-block-overview [index]="index" [filterFlags]="filterFlags"></app-mempool-block-overview>
+    <app-mempool-block-overview [index]="index" [showFilters]="true"></app-mempool-block-overview>
   </div>
 </div>

--- a/frontend/src/app/components/mempool-block-view/mempool-block-view.component.html
+++ b/frontend/src/app/components/mempool-block-view/mempool-block-view.component.html
@@ -1,5 +1,5 @@
 <div class="block-wrapper">
   <div class="block-container">
-    <app-mempool-block-overview [index]="index"></app-mempool-block-overview>
+    <app-mempool-block-overview [index]="index" [filterFlags]="filterFlags"></app-mempool-block-overview>
   </div>
 </div>

--- a/frontend/src/app/components/mempool-block-view/mempool-block-view.component.ts
+++ b/frontend/src/app/components/mempool-block-view/mempool-block-view.component.ts
@@ -27,6 +27,7 @@ export class MempoolBlockViewComponent implements OnInit, OnDestroy {
   autofit: boolean = false;
   resolution: number = 80;
   index: number = 0;
+  filterFlags: bigint | null = 0n;
 
   routeParamsSubscription: Subscription;
   queryParamsSubscription: Subscription;
@@ -38,6 +39,8 @@ export class MempoolBlockViewComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
+    window['setFlags'] = this.setFilterFlags.bind(this);
+
     this.websocketService.want(['blocks', 'mempool-blocks']);
 
     this.routeParamsSubscription = this.route.paramMap
@@ -81,5 +84,9 @@ export class MempoolBlockViewComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.routeParamsSubscription.unsubscribe();
     this.queryParamsSubscription.unsubscribe();
+  }
+
+  setFilterFlags(flags: bigint | null) {
+    this.filterFlags = flags;
   }
 }

--- a/frontend/src/app/components/mempool-block/mempool-block.component.html
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.html
@@ -46,7 +46,9 @@
         <app-fee-distribution-graph *ngIf="webGlEnabled" [transactions]="mempoolBlockTransactions$ | async" [feeRange]="mempoolBlock.isStack ? mempoolBlock.feeRange : []" [vsize]="mempoolBlock.blockVSize" ></app-fee-distribution-graph>
       </div>
       <div class="col-md chart-container">
-        <app-mempool-block-overview *ngIf="webGlEnabled" [index]="mempoolBlockIndex" [filterFlags]="filterFlags" (txPreviewEvent)="setTxPreview($event)"></app-mempool-block-overview>
+        <div class="block-with-filters" *ngIf="webGlEnabled">
+          <app-mempool-block-overview [index]="mempoolBlockIndex" (txPreviewEvent)="setTxPreview($event)" [showFilters]="true"></app-mempool-block-overview>
+        </div>
         <app-fee-distribution-graph *ngIf="!webGlEnabled" [transactions]="mempoolBlockTransactions$ | async" [feeRange]="mempoolBlock.isStack ? mempoolBlock.feeRange : []" [vsize]="mempoolBlock.blockVSize" ></app-fee-distribution-graph>
       </div>
     </div>

--- a/frontend/src/app/components/mempool-block/mempool-block.component.html
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.html
@@ -46,7 +46,7 @@
         <app-fee-distribution-graph *ngIf="webGlEnabled" [transactions]="mempoolBlockTransactions$ | async" [feeRange]="mempoolBlock.isStack ? mempoolBlock.feeRange : []" [vsize]="mempoolBlock.blockVSize" ></app-fee-distribution-graph>
       </div>
       <div class="col-md chart-container">
-        <app-mempool-block-overview *ngIf="webGlEnabled" [index]="mempoolBlockIndex" (txPreviewEvent)="setTxPreview($event)"></app-mempool-block-overview>
+        <app-mempool-block-overview *ngIf="webGlEnabled" [index]="mempoolBlockIndex" [filterFlags]="filterFlags" (txPreviewEvent)="setTxPreview($event)"></app-mempool-block-overview>
         <app-fee-distribution-graph *ngIf="!webGlEnabled" [transactions]="mempoolBlockTransactions$ | async" [feeRange]="mempoolBlock.isStack ? mempoolBlock.feeRange : []" [vsize]="mempoolBlock.blockVSize" ></app-fee-distribution-graph>
       </div>
     </div>

--- a/frontend/src/app/components/mempool-block/mempool-block.component.ts
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { StateService } from '../../services/state.service';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { switchMap, map, tap, filter } from 'rxjs/operators';
@@ -21,6 +21,7 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
   mempoolBlockTransactions$: Observable<TransactionStripped[]>;
   ordinal$: BehaviorSubject<string> = new BehaviorSubject('');
   previewTx: TransactionStripped | void;
+  filterFlags: bigint | null = 0n;
   webGlEnabled: boolean;
 
   constructor(
@@ -28,11 +29,13 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
     public stateService: StateService,
     private seoService: SeoService,
     private websocketService: WebsocketService,
+    private cd: ChangeDetectorRef,
   ) {
     this.webGlEnabled = detectWebGL();
   }
 
   ngOnInit(): void {
+    window['setFlags'] = this.setFilterFlags.bind(this);
     this.websocketService.want(['blocks', 'mempool-blocks']);
 
     this.mempoolBlock$ = this.route.paramMap
@@ -88,6 +91,11 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
 
   setTxPreview(event: TransactionStripped | void): void {
     this.previewTx = event;
+  }
+
+  setFilterFlags(flags: bigint | null) {
+    this.filterFlags = flags;
+    this.cd.markForCheck();
   }
 }
 

--- a/frontend/src/app/components/mempool-block/mempool-block.component.ts
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.ts
@@ -21,7 +21,6 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
   mempoolBlockTransactions$: Observable<TransactionStripped[]>;
   ordinal$: BehaviorSubject<string> = new BehaviorSubject('');
   previewTx: TransactionStripped | void;
-  filterFlags: bigint | null = 0n;
   webGlEnabled: boolean;
 
   constructor(
@@ -35,7 +34,6 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    window['setFlags'] = this.setFilterFlags.bind(this);
     this.websocketService.want(['blocks', 'mempool-blocks']);
 
     this.mempoolBlock$ = this.route.paramMap
@@ -91,11 +89,6 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
 
   setTxPreview(event: TransactionStripped | void): void {
     this.previewTx = event;
-  }
-
-  setFilterFlags(flags: bigint | null) {
-    this.filterFlags = flags;
-    this.cd.markForCheck();
   }
 }
 

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -180,9 +180,45 @@ export interface TransactionStripped {
   value: number;
   rate?: number; // effective fee rate
   acc?: boolean;
+  flags?: number | null;
   status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'censored' | 'selected' | 'rbf' | 'accelerated';
   context?: 'projected' | 'actual';
 }
+
+// binary flags for transaction classification
+export const TransactionFlags = {
+  // features
+  rbf:                                                         0b00000001n,
+  no_rbf:                                                      0b00000010n,
+  v1:                                                          0b00000100n,
+  v2:                                                          0b00001000n,
+  // address types
+  p2pk:                                               0b00000001_00000000n,
+  p2ms:                                               0b00000010_00000000n,
+  p2pkh:                                              0b00000100_00000000n,
+  p2sh:                                               0b00001000_00000000n,
+  p2wpkh:                                             0b00010000_00000000n,
+  p2wsh:                                              0b00100000_00000000n,
+  p2tr:                                               0b01000000_00000000n,
+  // behavior
+  cpfp_parent:                               0b00000001_00000000_00000000n,
+  cpfp_child:                                0b00000010_00000000_00000000n,
+  replacement:                               0b00000100_00000000_00000000n,
+  // data
+  op_return:                        0b00000001_00000000_00000000_00000000n,
+  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
+  inscription:                      0b00000100_00000000_00000000_00000000n,
+  // heuristics
+  coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,
+  consolidation:           0b00000010_00000000_00000000_00000000_00000000n,
+  batch_payout:            0b00000100_00000000_00000000_00000000_00000000n,
+  // sighash
+  sighash_all:    0b00000001_00000000_00000000_00000000_00000000_00000000n,
+  sighash_none:   0b00000010_00000000_00000000_00000000_00000000_00000000n,
+  sighash_single: 0b00000100_00000000_00000000_00000000_00000000_00000000n,
+  sighash_default:0b00001000_00000000_00000000_00000000_00000000_00000000n,
+  sighash_acp:    0b00010000_00000000_00000000_00000000_00000000_00000000n,
+};
 
 export interface RbfTransaction extends TransactionStripped {
   rbf?: boolean;

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -185,41 +185,6 @@ export interface TransactionStripped {
   context?: 'projected' | 'actual';
 }
 
-// binary flags for transaction classification
-export const TransactionFlags = {
-  // features
-  rbf:                                                         0b00000001n,
-  no_rbf:                                                      0b00000010n,
-  v1:                                                          0b00000100n,
-  v2:                                                          0b00001000n,
-  // address types
-  p2pk:                                               0b00000001_00000000n,
-  p2ms:                                               0b00000010_00000000n,
-  p2pkh:                                              0b00000100_00000000n,
-  p2sh:                                               0b00001000_00000000n,
-  p2wpkh:                                             0b00010000_00000000n,
-  p2wsh:                                              0b00100000_00000000n,
-  p2tr:                                               0b01000000_00000000n,
-  // behavior
-  cpfp_parent:                               0b00000001_00000000_00000000n,
-  cpfp_child:                                0b00000010_00000000_00000000n,
-  replacement:                               0b00000100_00000000_00000000n,
-  // data
-  op_return:                        0b00000001_00000000_00000000_00000000n,
-  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
-  inscription:                      0b00000100_00000000_00000000_00000000n,
-  // heuristics
-  coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,
-  consolidation:           0b00000010_00000000_00000000_00000000_00000000n,
-  batch_payout:            0b00000100_00000000_00000000_00000000_00000000n,
-  // sighash
-  sighash_all:    0b00000001_00000000_00000000_00000000_00000000_00000000n,
-  sighash_none:   0b00000010_00000000_00000000_00000000_00000000_00000000n,
-  sighash_single: 0b00000100_00000000_00000000_00000000_00000000_00000000n,
-  sighash_default:0b00001000_00000000_00000000_00000000_00000000_00000000n,
-  sighash_acp:    0b00010000_00000000_00000000_00000000_00000000_00000000n,
-};
-
 export interface RbfTransaction extends TransactionStripped {
   rbf?: boolean;
   mined?: boolean,

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -90,6 +90,7 @@ export interface TransactionStripped {
   value: number;
   acc?: boolean; // is accelerated?
   rate?: number; // effective fee rate
+  flags?: number;
   status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'censored' | 'selected' | 'rbf' | 'accelerated';
   context?: 'projected' | 'actual';
 }

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -4,6 +4,7 @@ export interface Filter {
   flag: bigint,
   toggle?: string,
   group?: string,
+  important?: boolean,
 }
 
 // binary flags for transaction classification
@@ -44,29 +45,29 @@ export const TransactionFlags = {
 
 export const TransactionFilters: { [key: string]: Filter } = {
     /* features */
-    rbf: { key: 'rbf', label: 'RBF enabled', flag: TransactionFlags.rbf, toggle: 'rbf' },
-    no_rbf: { key: 'no_rbf', label: 'RBF disabled', flag: TransactionFlags.no_rbf, toggle: 'rbf' },
+    rbf: { key: 'rbf', label: 'RBF enabled', flag: TransactionFlags.rbf, toggle: 'rbf', important: true },
+    no_rbf: { key: 'no_rbf', label: 'RBF disabled', flag: TransactionFlags.no_rbf, toggle: 'rbf', important: true },
     v1: { key: 'v1', label: 'Version 1', flag: TransactionFlags.v1, toggle: 'version' },
     v2: { key: 'v2', label: 'Version 2', flag: TransactionFlags.v2, toggle: 'version' },
     // multisig: { key: 'multisig', label: 'Multisig', flag: TransactionFlags.multisig },
     /* address types */
-    p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk },
-    p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms },
-    p2pkh: { key: 'p2pkh', label: 'P2PKH', flag: TransactionFlags.p2pkh },
-    p2sh: { key: 'p2sh', label: 'P2SH', flag: TransactionFlags.p2sh },
-    p2wpkh: { key: 'p2wpkh', label: 'P2WPKH', flag: TransactionFlags.p2wpkh },
-    p2wsh: { key: 'p2wsh', label: 'P2WSH', flag: TransactionFlags.p2wsh },
-    p2tr: { key: 'p2tr', label: 'Taproot', flag: TransactionFlags.p2tr },
+    p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk, important: true },
+    p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms, important: true },
+    p2pkh: { key: 'p2pkh', label: 'P2PKH', flag: TransactionFlags.p2pkh, important: true },
+    p2sh: { key: 'p2sh', label: 'P2SH', flag: TransactionFlags.p2sh, important: true },
+    p2wpkh: { key: 'p2wpkh', label: 'P2WPKH', flag: TransactionFlags.p2wpkh, important: true },
+    p2wsh: { key: 'p2wsh', label: 'P2WSH', flag: TransactionFlags.p2wsh, important: true },
+    p2tr: { key: 'p2tr', label: 'Taproot', flag: TransactionFlags.p2tr, important: true },
     /* behavior */
-    cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent },
-    cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child },
-    replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement },
+    cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent, important: true },
+    cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child, important: true },
+    replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement, important: true },
     /* data */
-    op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return },
+    op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return, important: true },
     // fake_multisig: { key: 'fake_multisig', label: 'Fake multisig', flag: TransactionFlags.fake_multisig },
-    inscription: { key: 'inscription', label: 'Inscription', flag: TransactionFlags.inscription },
+    inscription: { key: 'inscription', label: 'Inscription', flag: TransactionFlags.inscription, important: true },
     /* heuristics */
-    coinjoin: { key: 'coinjoin', label: 'Coinjoin', flag: TransactionFlags.coinjoin },
+    coinjoin: { key: 'coinjoin', label: 'Coinjoin', flag: TransactionFlags.coinjoin, important: true },
     consolidation: { key: 'consolidation', label: 'Consolidation', flag: TransactionFlags.consolidation },
     batch_payout: { key: 'batch_payout', label: 'Batch payment', flag: TransactionFlags.batch_payout },
     /* sighash */

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -1,0 +1,87 @@
+export interface Filter {
+  key: string,
+  label: string,
+  flag: bigint,
+  toggle?: string,
+  group?: string,
+}
+
+// binary flags for transaction classification
+export const TransactionFlags = {
+  // features
+  rbf:                                                         0b00000001n,
+  no_rbf:                                                      0b00000010n,
+  v1:                                                          0b00000100n,
+  v2:                                                          0b00001000n,
+  multisig:                                                    0b00010000n,
+  // address types
+  p2pk:                                               0b00000001_00000000n,
+  p2ms:                                               0b00000010_00000000n,
+  p2pkh:                                              0b00000100_00000000n,
+  p2sh:                                               0b00001000_00000000n,
+  p2wpkh:                                             0b00010000_00000000n,
+  p2wsh:                                              0b00100000_00000000n,
+  p2tr:                                               0b01000000_00000000n,
+  // behavior
+  cpfp_parent:                               0b00000001_00000000_00000000n,
+  cpfp_child:                                0b00000010_00000000_00000000n,
+  replacement:                               0b00000100_00000000_00000000n,
+  // data
+  op_return:                        0b00000001_00000000_00000000_00000000n,
+  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
+  inscription:                      0b00000100_00000000_00000000_00000000n,
+  // heuristics
+  coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,
+  consolidation:           0b00000010_00000000_00000000_00000000_00000000n,
+  batch_payout:            0b00000100_00000000_00000000_00000000_00000000n,
+  // sighash
+  sighash_all:    0b00000001_00000000_00000000_00000000_00000000_00000000n,
+  sighash_none:   0b00000010_00000000_00000000_00000000_00000000_00000000n,
+  sighash_single: 0b00000100_00000000_00000000_00000000_00000000_00000000n,
+  sighash_default:0b00001000_00000000_00000000_00000000_00000000_00000000n,
+  sighash_acp:    0b00010000_00000000_00000000_00000000_00000000_00000000n,
+};
+
+export const TransactionFilters: { [key: string]: Filter } = {
+    // features
+    rbf: { key: 'rbf', label: 'RBF enabled', flag: TransactionFlags.rbf, toggle: 'rbf' },
+    no_rbf: { key: 'no_rbf', label: 'RBF disabled', flag: TransactionFlags.no_rbf, toggle: 'rbf' },
+    v1: { key: 'v1', label: 'Version 1', flag: TransactionFlags.v1, toggle: 'version' },
+    v2: { key: 'v2', label: 'Version 2', flag: TransactionFlags.v2, toggle: 'version' },
+    multisig: { key: 'multisig', label: 'Multisig', flag: TransactionFlags.multisig },
+    // address types
+    p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk },
+    p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms },
+    p2pkh: { key: 'p2pkh', label: 'P2PKH', flag: TransactionFlags.p2pkh },
+    p2sh: { key: 'p2sh', label: 'P2SH', flag: TransactionFlags.p2sh },
+    p2wpkh: { key: 'p2wpkh', label: 'P2WPKH', flag: TransactionFlags.p2wpkh },
+    p2wsh: { key: 'p2wsh', label: 'P2WSH', flag: TransactionFlags.p2wsh },
+    p2tr: { key: 'p2tr', label: 'Taproot', flag: TransactionFlags.p2tr },
+    // behavior
+    cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent },
+    cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child },
+    replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement },
+    // data
+    op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return },
+    // fake_multisig: { key: 'fake_multisig', label: 'Fake multisig', flag: TransactionFlags.fake_multisig },
+    inscription: { key: 'inscription', label: 'Inscription', flag: TransactionFlags.inscription },
+    // heuristics
+    coinjoin: { key: 'coinjoin', label: 'Coinjoin', flag: TransactionFlags.coinjoin },
+    consolidation: { key: 'consolidation', label: 'Consolidation', flag: TransactionFlags.consolidation },
+    batch_payout: { key: 'batch_payout', label: 'Batch payment', flag: TransactionFlags.batch_payout },
+    // sighash
+    sighash_all: { key: 'sighash_all', label: 'sighash_all', flag: TransactionFlags.sighash_all },
+    sighash_none: { key: 'sighash_none', label: 'sighash_none', flag: TransactionFlags.sighash_none },
+    sighash_single: { key: 'sighash_single', label: 'sighash_single', flag: TransactionFlags.sighash_single },
+    sighash_default: { key: 'sighash_default', label: 'sighash_default', flag: TransactionFlags.sighash_default },
+    sighash_acp: { key: 'sighash_acp', label: 'sighash_anyonecanpay', flag: TransactionFlags.sighash_acp },
+};
+
+export const FilterGroups: { label: string, filters: Filter[]}[] = [
+  { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'multisig'] },
+  { label: 'Address Types', filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
+  { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement'] },
+  { label: 'Data', filters: ['op_return', 'fake_multisig', 'inscription'] },
+  { label: 'Heuristics', filters: ['coinjoin', 'consolidation', 'batch_payout'] },
+  { label: 'Sighash Flags', filters: ['sighash_all', 'sighash_none', 'sighash_single', 'sighash_default', 'sighash_acp'] },
+].map(group => ({ label: group.label, filters: group.filters.map(filter => TransactionFilters[filter] || null).filter(f => f != null) }));

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -29,7 +29,7 @@ export const TransactionFlags = {
   replacement:                               0b00000100_00000000_00000000n,
   // data
   op_return:                        0b00000001_00000000_00000000_00000000n,
-  fake_multisig:                    0b00000010_00000000_00000000_00000000n,
+  fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
   inscription:                      0b00000100_00000000_00000000_00000000n,
   // heuristics
   coinjoin:                0b00000001_00000000_00000000_00000000_00000000n,
@@ -64,7 +64,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement, important: true },
     /* data */
     op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return, important: true },
-    // fake_multisig: { key: 'fake_multisig', label: 'Fake multisig', flag: TransactionFlags.fake_multisig },
+    fake_pubkey: { key: 'fake_pubkey', label: 'Fake pubkey', flag: TransactionFlags.fake_pubkey },
     inscription: { key: 'inscription', label: 'Inscription', flag: TransactionFlags.inscription, important: true },
     /* heuristics */
     coinjoin: { key: 'coinjoin', label: 'Coinjoin', flag: TransactionFlags.coinjoin, important: true },
@@ -82,7 +82,7 @@ export const FilterGroups: { label: string, filters: Filter[]}[] = [
   { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'multisig'] },
   { label: 'Address Types', filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
   { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement'] },
-  { label: 'Data', filters: ['op_return', 'fake_multisig', 'inscription'] },
+  { label: 'Data', filters: ['op_return', 'fake_pubkey', 'inscription'] },
   { label: 'Heuristics', filters: ['coinjoin', 'consolidation', 'batch_payout'] },
   { label: 'Sighash Flags', filters: ['sighash_all', 'sighash_none', 'sighash_single', 'sighash_default', 'sighash_acp'] },
 ].map(group => ({ label: group.label, filters: group.filters.map(filter => TransactionFilters[filter] || null).filter(f => f != null) }));

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -43,13 +43,13 @@ export const TransactionFlags = {
 };
 
 export const TransactionFilters: { [key: string]: Filter } = {
-    // features
+    /* features */
     rbf: { key: 'rbf', label: 'RBF enabled', flag: TransactionFlags.rbf, toggle: 'rbf' },
     no_rbf: { key: 'no_rbf', label: 'RBF disabled', flag: TransactionFlags.no_rbf, toggle: 'rbf' },
     v1: { key: 'v1', label: 'Version 1', flag: TransactionFlags.v1, toggle: 'version' },
     v2: { key: 'v2', label: 'Version 2', flag: TransactionFlags.v2, toggle: 'version' },
-    multisig: { key: 'multisig', label: 'Multisig', flag: TransactionFlags.multisig },
-    // address types
+    // multisig: { key: 'multisig', label: 'Multisig', flag: TransactionFlags.multisig },
+    /* address types */
     p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk },
     p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms },
     p2pkh: { key: 'p2pkh', label: 'P2PKH', flag: TransactionFlags.p2pkh },
@@ -57,19 +57,19 @@ export const TransactionFilters: { [key: string]: Filter } = {
     p2wpkh: { key: 'p2wpkh', label: 'P2WPKH', flag: TransactionFlags.p2wpkh },
     p2wsh: { key: 'p2wsh', label: 'P2WSH', flag: TransactionFlags.p2wsh },
     p2tr: { key: 'p2tr', label: 'Taproot', flag: TransactionFlags.p2tr },
-    // behavior
+    /* behavior */
     cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent },
     cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child },
     replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement },
-    // data
+    /* data */
     op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return },
     // fake_multisig: { key: 'fake_multisig', label: 'Fake multisig', flag: TransactionFlags.fake_multisig },
     inscription: { key: 'inscription', label: 'Inscription', flag: TransactionFlags.inscription },
-    // heuristics
+    /* heuristics */
     coinjoin: { key: 'coinjoin', label: 'Coinjoin', flag: TransactionFlags.coinjoin },
     consolidation: { key: 'consolidation', label: 'Consolidation', flag: TransactionFlags.consolidation },
     batch_payout: { key: 'batch_payout', label: 'Batch payment', flag: TransactionFlags.batch_payout },
-    // sighash
+    /* sighash */
     sighash_all: { key: 'sighash_all', label: 'sighash_all', flag: TransactionFlags.sighash_all },
     sighash_none: { key: 'sighash_none', label: 'sighash_none', flag: TransactionFlags.sighash_none },
     sighash_single: { key: 'sighash_single', label: 'sighash_single', flag: TransactionFlags.sighash_single },

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -44,6 +44,7 @@ import { StartComponent } from '../components/start/start.component';
 import { TransactionsListComponent } from '../components/transactions-list/transactions-list.component';
 import { BlockOverviewGraphComponent } from '../components/block-overview-graph/block-overview-graph.component';
 import { BlockOverviewTooltipComponent } from '../components/block-overview-tooltip/block-overview-tooltip.component';
+import { BlockFiltersComponent } from '../components/block-filters/block-filters.component';
 import { AddressComponent } from '../components/address/address.component';
 import { SearchFormComponent } from '../components/search-form/search-form.component';
 import { AddressLabelsComponent } from '../components/address-labels/address-labels.component';
@@ -141,6 +142,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     StartComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
+    BlockFiltersComponent,
     TransactionsListComponent,
     AddressComponent,
     SearchFormComponent,
@@ -266,6 +268,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     StartComponent,
     BlockOverviewGraphComponent,
     BlockOverviewTooltipComponent,
+    BlockFiltersComponent,
     TransactionsListComponent,
     AddressComponent,
     SearchFormComponent,


### PR DESCRIPTION
This PR adds basic filtering functionality to the projected block visualizations:

https://github.com/mempool/mempool/assets/83316221/86e9c2fd-9117-4ab4-b667-f84811316bb2

---

### UI

Mousing over/tapping the projected block visualization reveals the "filter" icon button in the top left, which toggles a filter menu overlay.

The menu consists of 24 toggleable filter tags arranged in logical-ish groups:

![Screenshot 2023-12-13 at 11 08 49 AM](https://github.com/mempool/mempool/assets/83316221/14384d8c-77b0-4899-abdc-8bfbbfbdd769)

Any active filters are listed at the top of the visualization next to the filter icon, and continue to show after the menu is closed (so that it's obvious which filters are applied in screenshots etc).

Transactions matching the active filters are displayed in their regular colors, while everything else has opacity reduced to 20% to create a dimming/highlighting effect.

![Screenshot 2023-12-13 at 11 06 45 AM](https://github.com/mempool/mempool/assets/83316221/112f41f6-52e0-4cfb-b555-ca6f909c5b0c)

Filters are *conjunctive* - i.e. transactions are highlighted *only* if they match *every* active filter. Perhaps in future we can add more complex logic, or support multiple sets of filters in different colors.

Some pairs of filters are mutually exclusive, and so act like radio buttons (e.g. RBF enabled/disabled and transaction versions).

---

### Implementation

In the backend, mempool transactions are classified according to the 24 different filter criteria, and the result stored compactly as bitwise flags encoded in a single new numeric "flags" field.

Then in the frontend, the transactions in the block visualization are efficiently tested against the selected set of filters by applying the filter to the flags field as a bitmask.

---

### Limitations

So far, the filters are only implemented for projected blocks. Supporting mined blocks will require a lengthy reindexing of block templates, so I want to iterate on and finalize the filter spec first.

I've tried to keep the transaction classification algorithm as efficient as possible, but it does involve iterating over all of the inputs, outputs and witnesses of each transaction. If that turns out to be unacceptably slow we might need to optimize further and maybe disable some of the more expensive filters (like the sighash flags).

The coinjoin, consolidation and batch payment flags rely on fairly arbitrary heuristics. We'll want to iterate on these over time.

For the sake of efficiency, signature detection for the sighash flags also relies on heuristics instead of fully parsing scripts, which may produce occasional false positives.

Many of the filters operate at the input/output level, but they're actually applied to whole transactions. This means some combinations of filters can be misleading/unintuitive - e.g. filtering for `sighash_single` and `sighash_anyonecanpay` will match transactions where one input is signed using `sighash_single` and a different input is signed with `sighash_anyonecanpay`, rather than only transactions with `sighash_single | acp` signatures.

On very small screens, there's limited space within the block visualization area, so we can only show a subset of filter options.

We should probably add an FAQ entry and some tooltips to explain all of this.

---

### Future improvements/extensions
 - Make the active filters persistent when you leave and return to the projected blocks page.
 - Extend filter functionality to mined blocks
 - Add the full list of matched filters to the "features" badge area on the transaction page.
 - Add filter options for other transaction and script types (lightning channel operations, timelocks, multisig etc etc).