### PR TITLE
Expand toggle for RBF history view

### DIFF
--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
@@ -1,6 +1,6 @@
 <div class="rbf-timeline box" [class.mined]="replacements.mined">
   <div class="timeline-wrapper">
-    <div class="timeline" *ngFor="let timeline of rows; let j = index" [class.fade-out]="!timelineExpanded && j === rowLimit - 1">
+    <div class="timeline" *ngFor="let timeline of rows; let j = index">
       <div class="intervals" *ngIf="j < rowLimit || timelineExpanded">
         <ng-container *ngFor="let cell of timeline; let i = index;">
           <div class="node-spacer"></div>
@@ -50,15 +50,16 @@
         </ng-container>
       </div>
     </div>
-    <div class="toggle-wrapper" *ngIf="rows.length > rowLimit && rowLimit !== 0">
-      <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(true);" *ngIf="!timelineExpanded; else collapseBtn">
-        <span i18n="show-all">Show all</span>
-        (<ng-container *ngTemplateOutlet="xRemaining; context: {$implicit: rows.length - rowLimit}"></ng-container>)
-      </button>
-      <ng-template #collapseBtn>
-        <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(false);"><span i18n="show-less">Show less</span></button>
-      </ng-template>
-    </div>
+  </div>
+  <div [class.fade-out]="!timelineExpanded && rows.length > rowLimit"></div>
+  <div class="toggle-wrapper" *ngIf="rows.length > rowLimit && rowLimit !== 0">
+    <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(true);" *ngIf="!timelineExpanded; else collapseBtn">
+      <span i18n="show-all">Show all</span>
+      (<ng-container *ngTemplateOutlet="xRemaining; context: {$implicit: rows.length - rowLimit}"></ng-container>)
+    </button>
+    <ng-template #collapseBtn>
+      <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(false);"><span i18n="show-less">Show less</span></button>
+    </ng-template>
   </div>
 
   <ng-template #nodeSpacer>

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
@@ -1,6 +1,6 @@
 <div class="rbf-timeline box" [class.mined]="replacements.mined">
   <div class="timeline-wrapper">
-    <div class="timeline" *ngFor="let timeline of rows; let j = index">
+    <div class="timeline" *ngFor="let timeline of rows; let j = index" [class.fade-out]="!timelineExpanded && j === rowLimit - 1">
       <div class="intervals" *ngIf="j < rowLimit || timelineExpanded">
         <ng-container *ngFor="let cell of timeline; let i = index;">
           <div class="node-spacer"></div>
@@ -37,7 +37,7 @@
           </ng-container>
           <ng-template #nonNode>
             <ng-container [ngSwitch]="cell.connector">
-              <div class="connector" [class.fullrbf]="cell.fullRbf" *ngSwitchCase="'pipe'"><div class="pipe" [class.fullrbf]="cell.fullRbf"></div></div>
+              <div class="connector" [class.fullrbf]="cell.fullRbf" *ngSwitchCase="'pipe'"><div class="pipe" [class.fullrbf]="cell.fullRbf" [class.last-pipe]="!timelineExpanded && j === rowLimit - 1"></div></div>
               <div class="connector" *ngSwitchCase="'corner'"><div class="corner" [class.fullrbf]="cell.fullRbf"></div></div>
               <div class="node-spacer" *ngSwitchDefault></div>
             </ng-container>

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.html
@@ -1,7 +1,7 @@
 <div class="rbf-timeline box" [class.mined]="replacements.mined">
   <div class="timeline-wrapper">
-    <div class="timeline" *ngFor="let timeline of rows">
-      <div class="intervals">
+    <div class="timeline" *ngFor="let timeline of rows; let j = index">
+      <div class="intervals" *ngIf="j < rowLimit || timelineExpanded">
         <ng-container *ngFor="let cell of timeline; let i = index;">
           <div class="node-spacer"></div>
           <ng-container *ngIf="i < timeline.length - 1">
@@ -13,7 +13,7 @@
           </ng-container>
         </ng-container>
       </div>
-      <div class="nodes">
+      <div class="nodes" *ngIf="j < rowLimit || timelineExpanded">
         <ng-container *ngFor="let cell of timeline; let i = index;">
           <ng-container *ngIf="cell.replacement?.tx; else nonNode">
             <div class="node"
@@ -50,6 +50,15 @@
         </ng-container>
       </div>
     </div>
+    <div class="toggle-wrapper" *ngIf="rows.length > rowLimit && rowLimit !== 0">
+      <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(true);" *ngIf="!timelineExpanded; else collapseBtn">
+        <span i18n="show-all">Show all</span>
+        (<ng-container *ngTemplateOutlet="xRemaining; context: {$implicit: rows.length - rowLimit}"></ng-container>)
+      </button>
+      <ng-template #collapseBtn>
+        <button class="btn btn-sm btn-primary graph-toggle" (click)="toggleTimeline(false);"><span i18n="show-less">Show less</span></button>
+      </ng-template>
+    </div>
   </div>
 
   <ng-template #nodeSpacer>
@@ -72,3 +81,5 @@
     [isConnector]="hoverConnector"
   ></app-rbf-timeline-tooltip> -->
 </div>
+
+<ng-template #xRemaining let-x i18n="x-remaining">{{ x }} remaining</ng-template>

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
@@ -30,29 +30,30 @@
     overflow-x: auto;
     -ms-overflow-style: none;
     scrollbar-width: none;
-
-    .fade-out {
-      position: relative;
-
-      &::before {
-        content: '';
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(to bottom, rgba(36, 39, 62, 0) 0%, rgba(36, 39, 62, 1) 100%);
-        z-index: 1;
-      }
-    }
-    
+  
     &::-webkit-scrollbar {
       display: none;
     }
+  }
 
-    .toggle-wrapper {
+  .fade-out {
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
       width: 100%;
-      text-align: center;
-      margin: 1.25em 0 0;
+      height: 70px;
+      top: -70px;
+      background: linear-gradient(to bottom, rgba(36, 39, 62, 0) 0%, rgba(36, 39, 62, 1) 100%);
+      z-index: 1;
     }
+  }
+
+  .toggle-wrapper {
+    width: 100%;
+    text-align: center;
+    margin: 1.25em 0 0;
   }
 
   .intervals, .nodes {

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
@@ -34,6 +34,12 @@
     &::-webkit-scrollbar {
       display: none;
     }
+
+    .toggle-wrapper {
+      width: 100%;
+      text-align: center;
+      margin: 1.25em 0 0;
+    }
   }
 
   .intervals, .nodes {

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.scss
@@ -31,6 +31,19 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
 
+    .fade-out {
+      position: relative;
+
+      &::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(to bottom, rgba(36, 39, 62, 0) 0%, rgba(36, 39, 62, 1) 100%);
+        z-index: 1;
+      }
+    }
+    
     &::-webkit-scrollbar {
       display: none;
     }
@@ -196,6 +209,10 @@
         border-right: solid 10px #105fb0;
         &.fullrbf {
           border-right: solid 10px #1bd8f4;
+        }
+        &.last-pipe {
+          height: 150px;
+          bottom: -42px;
         }
       }
 

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
@@ -25,7 +25,9 @@ function isTimelineCell(val: RbfTree | TimelineCell): boolean {
 export class RbfTimelineComponent implements OnInit, OnChanges {
   @Input() replacements: RbfTree;
   @Input() txid: string;
+  @Input() rowLimit: number = 5; // If explicitly set to 0, all timelines rows will be displayed by default
   rows: TimelineCell[][] = [];
+  timelineExpanded: boolean = this.rowLimit === 0;
 
   hoverInfo: RbfTree | null = null;
   tooltipPosition = null;
@@ -189,6 +191,10 @@ export class RbfTimelineComponent implements OnInit, OnChanges {
       });
     });
     return rows;
+  }
+
+  toggleTimeline(expand: boolean): void {
+    this.timelineExpanded = expand;
   }
 
   scrollToSelected() {


### PR DESCRIPTION
Fixes #4423 

Collapsed: 

![after](https://github.com/mempool/mempool/assets/46578910/7ee59bf6-9de8-4191-9975-c0eb027d2eed)

Expanded: 

![after1](https://github.com/mempool/mempool/assets/46578910/29a4468f-3bdd-41a7-911a-df9095e5c846)

(the images come from transaction [e133f000020371ef29f093e9f6362fccc198e7ad66903bf03ff54786ed4b8dcf](https://mempool.space/tx/e133f000020371ef29f093e9f6362fccc198e7ad66903bf03ff54786ed4b8dcf) with this tweak added in the init function of `rbd-timeline` component to create fake leafs in the RBF tree) 
```
for (let i = 0; i < 9; i++) {
  let newReplace = JSON.parse(JSON.stringify(this.replacements.replaces[0]));
  newReplace.tx.txid = (i.toString());
  this.replacements.replaces.push(newReplace);
}
```
*******************
A more complex RBF tree ([be3606d9f558aa5d2032e3feb66e90968b4fdffed40c09fa51c85e6520f06634](https://mempool.space/tx/be3606d9f558aa5d2032e3feb66e90968b4fdffed40c09fa51c85e6520f06634)):

Collapsed:

<img width="1126" alt="Screenshot 2023-12-17 at 19 52 13" src="https://github.com/mempool/mempool/assets/46578910/0be16d9b-f78b-433d-866c-824a373fcb9a">

Is it a problem that the branch just stops halfway here? Any idea to avoid this behaviour?

Expanded: 

<img width="1119" alt="Screenshot 2023-12-17 at 19 56 03" src="https://github.com/mempool/mempool/assets/46578910/bf6b8b45-1c56-4153-ae5c-2bb2ec735385">
