### PR TITLE
Fix missing mempool fee chart when webgl disabled

### DIFF
--- a/frontend/src/app/components/mempool-block/mempool-block.component.ts
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.ts
@@ -64,6 +64,7 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
         }),
         tap(() => {
           this.stateService.markBlock$.next({ mempoolBlockIndex: this.mempoolBlockIndex });
+          this.websocketService.startTrackMempoolBlock(this.mempoolBlockIndex);
         })
       );
 

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -183,14 +183,18 @@ export class WebsocketService {
   }
 
   startTrackMempoolBlock(block: number) {
-    this.websocketSubject.next({ 'track-mempool-block': block });
-    this.isTrackingMempoolBlock = true
-    this.trackingMempoolBlock = block
+    // skip duplicate tracking requests
+    if (this.trackingMempoolBlock !== block) {
+      this.websocketSubject.next({ 'track-mempool-block': block });
+      this.isTrackingMempoolBlock = true;
+      this.trackingMempoolBlock = block;
+    }
   }
 
   stopTrackMempoolBlock() {
     this.websocketSubject.next({ 'track-mempool-block': -1 });
-    this.isTrackingMempoolBlock = false
+    this.isTrackingMempoolBlock = false;
+    this.trackingMempoolBlock = null;
   }
 
   startTrackRbf(mode: 'all' | 'fullRbf') {


### PR DESCRIPTION
When webgl is disabled, the next block visualization is hidden and the `/mempool-block/...` pages only show the fee distribution chart.

However the transaction data required for that chart was requested by the block visualization component, so the chart would show up empty in that case.

This PR fixes the websocket subscription to ensure the correct data is available whether or not webgl is enabled.

| Before | After |
|-|-|
| ![Screenshot 2023-12-21 at 1 05 48 PM](https://github.com/mempool/mempool/assets/83316221/9b85434a-8767-4332-98cc-7e16d501e495) | ![Screenshot 2023-12-21 at 1 05 38 PM](https://github.com/mempool/mempool/assets/83316221/941f588c-4e3a-43f6-99e6-eb25ea1e54e7) |
