### PR TITLE
Fix faq nav bar overflow

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs.component.scss
+++ b/frontend/src/app/docs/api-docs/api-docs.component.scss
@@ -157,7 +157,7 @@ ul.no-bull.block-audit code{
   position: fixed;
   top: 80px;
   overflow-y: auto;
-  height: calc(100vh - 50px);
+  height: calc(100vh - 75px);
   scrollbar-color: #2d3348 #11131f;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
Fixes a little overflow at the bottom of the navigation bar in `/docs/faq` and `/docs/api/rest`: 
| Before  | After |
| ------------- | ------------- |
|  <img width="326" alt="Screenshot 2023-12-22 at 10 41 37" src="https://github.com/mempool/mempool/assets/46578910/9880a20b-55b8-4691-86c9-161f8b55d98f"> | <img width="307" alt="Screenshot 2023-12-22 at 10 42 01" src="https://github.com/mempool/mempool/assets/46578910/309737ea-d7bd-43e4-8d20-6c5f5ac88f0a">  |