### PR TITLE
Highlight accelerations in block previews & non-audit mode

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -58,6 +58,10 @@
           <td *ngSwitchCase="'accelerated'"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></td>
         </ng-container>
       </tr>
+      <tr *ngIf="!auditEnabled && tx && tx.status === 'accelerated'">
+        <td class="td-width"></td>
+        <td><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -328,15 +328,26 @@ export class BlockComponent implements OnInit, OnDestroy {
                 this.overviewError = err;
                 return of(null);
               })
-            )
+            ),
+          block.height > 819500 ? this.apiService.getAccelerationHistory$({ blockHash: block.id }) : of([])
         ]);
       })
     )
-    .subscribe(([transactions, blockAudit]) => {
+    .subscribe(([transactions, blockAudit, accelerations]) => {
       if (transactions) {
         this.strippedTransactions = transactions;
       } else {
         this.strippedTransactions = [];
+      }
+
+      const acceleratedInBlock = {};
+      for (const acc of accelerations) {
+        acceleratedInBlock[acc.txid] = acc;
+      }
+      for (const tx of transactions) {
+        if (acceleratedInBlock[tx.txid]) {
+          tx.acc = true;
+        }
       }
 
       this.blockAudit = null;


### PR DESCRIPTION
This PR extends acceleration highlighting to the regular (non-audit) block visualization, and the corresponding opengraph preview images.

<img width="1134" alt="Screenshot 2023-12-29 at 2 19 41 PM" src="https://github.com/mempool/mempool/assets/83316221/3ba1150e-5f3e-4c2a-89dc-74be1eaa07ef">
<img width="1200" alt="Screenshot 2023-12-29 at 2 19 25 PM" src="https://github.com/mempool/mempool/assets/83316221/3a4464b3-9356-4ca4-b562-dccf9d2424ee">
