### PR TITLE
unsubscribe from mempool block tracking

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -968,7 +968,7 @@ class WebsocketHandler {
         if (client['track-tx']) {
           numTxSubs++;
         }
-        if (client['track-mempool-block'] >= 0) {
+        if (client['track-mempool-block'] != null && client['track-mempool-block'] >= 0) {
           numProjectedSubs++;
         }
         if (client['track-rbf']) {

--- a/frontend/src/app/components/mempool-block/mempool-block.component.ts
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.ts
@@ -75,6 +75,7 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stateService.markBlock$.next({});
+    this.websocketService.stopTrackMempoolBlock();
   }
 
   getOrdinal(mempoolBlock: MempoolBlock): string {


### PR DESCRIPTION
Adds a missing `stopTrackMempoolBlock()` call when navigating away from the projected mempool block page.