### PR TITLE
[Liquid] Fix missing assets/featured route

### DIFF
--- a/frontend/src/app/liquid/liquid-master-page.module.ts
+++ b/frontend/src/app/liquid/liquid-master-page.module.ts
@@ -10,6 +10,7 @@ import { PushTransactionComponent } from '../components/push-transaction/push-tr
 import { BlocksList } from '../components/blocks-list/blocks-list.component';
 import { AssetGroupComponent } from '../components/assets/asset-group/asset-group.component';
 import { AssetsComponent } from '../components/assets/assets.component';
+import { AssetsFeaturedComponent } from '../components/assets/assets-featured/assets-featured.component'
 import { AssetComponent } from '../components/asset/asset.component';
 import { AssetsNavComponent } from '../components/assets/assets-nav/assets-nav.component';
 
@@ -72,6 +73,11 @@ const routes: Routes = [
             path: 'all',
             data: { networks: ['liquid'] },
             component: AssetsComponent,
+          },
+          {
+            path: 'featured',
+            data: { networks: ['liquid'] },
+            component: AssetsFeaturedComponent,
           },
           {
             path: 'asset/:id',


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/4547

The featured assets page is now reachable: 

<img width="1151" alt="Screenshot 2024-01-03 at 14 23 22" src="https://github.com/mempool/mempool/assets/46578910/73c96903-1d02-430c-bbd9-ddc0c5fa3cc7">
