### PR TITLE
Smooth out irregular mempool block updates

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-scene.ts
+++ b/frontend/src/app/components/block-overview-graph/block-scene.ts
@@ -11,7 +11,7 @@ export default class BlockScene {
   getColor: ((tx: TxView) => Color) = defaultColorFunction;
   orientation: string;
   flip: boolean;
-  animationDuration: number = 1000;
+  animationDuration: number = 900;
   configAnimationOffset: number | null;
   animationOffset: number;
   highlightingEnabled: boolean;

--- a/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
+++ b/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
@@ -3,8 +3,8 @@ import { Component, ComponentRef, ViewChild, HostListener, Input, Output, EventE
 import { StateService } from '../../services/state.service';
 import { MempoolBlockDelta, TransactionStripped } from '../../interfaces/websocket.interface';
 import { BlockOverviewGraphComponent } from '../../components/block-overview-graph/block-overview-graph.component';
-import { Subscription, BehaviorSubject, merge, of } from 'rxjs';
-import { switchMap, filter } from 'rxjs/operators';
+import { Subscription, BehaviorSubject, merge, of, timer } from 'rxjs';
+import { switchMap, filter, concatMap, map } from 'rxjs/operators';
 import { WebsocketService } from '../../services/websocket.service';
 import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
 import { Router } from '@angular/router';
@@ -33,7 +33,8 @@ export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChang
   poolDirection: string = 'left';
 
   blockSub: Subscription;
-  deltaSub: Subscription;
+  rateLimit = 1000;
+  private lastEventTime = Date.now() - this.rateLimit;
 
   firstLoad: boolean = true;
 
@@ -55,11 +56,32 @@ export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChang
 
   ngAfterViewInit(): void {
     this.blockSub = merge(
-        of(true),
-        this.stateService.connectionState$.pipe(filter((state) => state === 2))
-      )
-      .pipe(switchMap(() => this.stateService.mempoolBlockTransactions$))
-      .subscribe((transactionsStripped) => {
+      this.stateService.mempoolBlockTransactions$,
+      this.stateService.mempoolBlockDelta$,
+    ).pipe(
+      concatMap(event => {
+        const now = Date.now();
+        const timeSinceLastEvent = now - this.lastEventTime;
+        this.lastEventTime = Math.max(now, this.lastEventTime + this.rateLimit);
+
+        // If time since last event is less than X seconds, delay this event
+        if (timeSinceLastEvent < this.rateLimit) {
+          return timer(this.rateLimit - timeSinceLastEvent).pipe(
+            // Emit the event after the timer
+            map(() => event)
+          );
+        } else {
+          // If enough time has passed, emit the event immediately
+          return of(event);
+        }
+      })
+    ).subscribe((update) => {
+      if (update['added']) {
+        // delta
+        this.updateBlock(update as MempoolBlockDelta);
+      } else {
+        const transactionsStripped = update as TransactionStripped[];
+        // new transactions
         if (this.firstLoad) {
           this.replaceBlock(transactionsStripped);
         } else {
@@ -94,9 +116,7 @@ export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChang
             added
           });
         }
-      });
-    this.deltaSub = this.stateService.mempoolBlockDelta$.subscribe((delta) => {
-      this.updateBlock(delta);
+      }
     });
   }
 
@@ -113,7 +133,6 @@ export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChang
 
   ngOnDestroy(): void {
     this.blockSub.unsubscribe();
-    this.deltaSub.unsubscribe();
     this.timeLtrSubscription.unsubscribe();
     this.websocketService.stopTrackMempoolBlock();
   }


### PR DESCRIPTION
When GBT is running very fast (e.g. because the mempool is small, or `LIMIT_GBT` from #4555 is enabled), mempool block updates can be sent at very close to the `POLL_RATE_MS` rate.

Due to varying latency in different parts of the pipeline between a GBT calculation completing and results arriving at the client, pairs of updates can end up being received by the client much closer together than `POLL_RATE_MS`.

The projected block update animation isn't designed to handle updates more frequent than once per second, so this looks bad.

This PR adds some smoothing/buffering to the updates on the client side, to ensure updates are never applied less than 1 second apart. The animation duration is also reduced very slightly to compensate for delays.

The result is that the projected block animations look much smoother and more regular.

**note: this assumes a backend `POLL_RATE_MS` of at least 1 second. if `POLL_RATE_MS` is *less* than 1 second, then the client will gradually fall behind and eventually run out of space to buffer updates.**