### PR TITLE
Fix bad coinbase price url, switch to median prices

### DIFF
--- a/backend/src/tasks/price-feeds/coinbase-api.ts
+++ b/backend/src/tasks/price-feeds/coinbase-api.ts
@@ -5,14 +5,14 @@ class CoinbaseApi implements PriceFeed {
   public name: string = 'Coinbase';
   public currencies: string[] = ['USD', 'EUR', 'GBP'];
 
-  public url: string = 'https://api.coinbase.com/v2/prices/spot?currency=';
+  public url: string = 'https://api.coinbase.com/v2/prices/BTC-{CURRENCY}/spot';
   public urlHist: string = 'https://api.exchange.coinbase.com/products/BTC-{CURRENCY}/candles?granularity={GRANULARITY}';
 
   constructor() {
   }
 
   public async $fetchPrice(currency): Promise<number> {
-    const response = await query(this.url + currency);
+    const response = await query(this.url.replace('{CURRENCY}', currency));
     if (response && response['data'] && response['data']['amount']) {
       return parseInt(response['data']['amount'], 10);
     } else {


### PR DESCRIPTION
Fixes a deprecated API format for Coinbase prices, and changes the price updater to use the *median* price, not the mean, so that outliers don't distort our reported exchange rates in future.