### PR TITLE
Clean rust-gbt directory before build

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -35,7 +35,8 @@
     "lint": "./node_modules/.bin/eslint . --ext .ts",
     "lint:fix": "./node_modules/.bin/eslint . --ext .ts --fix",
     "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{js,ts}\"",
-    "rust-build": "cd rust-gbt && npm run build-release"
+    "rust-clean": "cd rust-gbt && rm -f *.node index.d.ts index.js && rm -rf target && cd ../",
+    "rust-build": "npm run rust-clean && cd rust-gbt && npm run build-release"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",


### PR DESCRIPTION
Deletes `*.node`, `index.d.ts`, `index.js` files and the `target` directory in the `rust-gbt` folder before building the rust module, to ensure the latest version is always built.