### PR TITLE
Add seconds to the block view timestamp

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -47,7 +47,7 @@
               <tr>
                 <td i18n="block.timestamp">Timestamp</td>
                 <td>
-                  <app-timestamp [unixTime]="block.timestamp" [precision]="1" minUnit="minute"></app-timestamp>
+                  <app-timestamp [customFormat]="'yyyy-MM-dd HH:mm:ss'" [unixTime]="block.timestamp" [precision]="1" minUnit="minute"></app-timestamp>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Small feature request from Twitter:

<img width="596" alt="Screenshot 2024-01-13 at 1 52 40 PM" src="https://github.com/mempool/mempool/assets/100320/ed372aab-3017-438c-9efc-ceb6e570bce3">
<img width="569" alt="Screenshot 2024-01-13 at 1 52 29 PM" src="https://github.com/mempool/mempool/assets/100320/1a569e0a-e4c8-4173-88d0-691e160c6e43">
