### PR TITLE
Add seconds to block timestamp in the mining pool view and blocks list

### DIFF
--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -46,7 +46,7 @@
             </div>
           </td>
           <td class="timestamp" *ngIf="!widget" [ngClass]="{'widget': widget, 'legacy': !isMempoolModule}">
-            &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
+            &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss' }}
           </td>
           <td *ngIf="auditAvailable" class="health text-right" [ngClass]="{'widget': widget, 'legacy': !isMempoolModule}">
             <a

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -224,7 +224,7 @@
             <a [routerLink]="['/block' | relativeUrl, block.id]">{{ block.height }}</a>
           </td>
           <td class="timestamp">
-            &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm' }}
+            &lrm;{{ block.timestamp * 1000 | date:'yyyy-MM-dd HH:mm:ss' }}
           </td>
           <td class="mined">
             <app-time kind="since" [time]="block.timestamp" [fastRender]="true"></app-time>


### PR DESCRIPTION
Same as #4578 but on the mining pool view and blocks list

<img width="1382" alt="Screenshot 2024-01-13 at 6 10 02 PM" src="https://github.com/mempool/mempool/assets/100320/6dc49514-63bd-441f-adb6-89b7713b58b0">
<img width="1367" alt="Screenshot 2024-01-13 at 6 09 41 PM" src="https://github.com/mempool/mempool/assets/100320/de63014f-efab-444c-a066-2334139a07f5">
<img width="1385" alt="Screenshot 2024-01-13 at 6 07 44 PM" src="https://github.com/mempool/mempool/assets/100320/e47a38e3-f587-42dd-83e1-80ea404c9bbb">
<img width="1416" alt="Screenshot 2024-01-13 at 6 03 09 PM" src="https://github.com/mempool/mempool/assets/100320/d64525af-59d1-4ea8-b4d9-2e1fbffbb83f">

