### PR TITLE
Feature: track-mempool websocket subscriptions

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -558,6 +558,10 @@ class WebsocketHandler {
 
     const latestTransactions = memPool.getLatestTransactions();
 
+    if (memPool.isInSync()) {
+      this.mempoolSequence++;
+    }
+
     const replacedTransactions: { replaced: string, by: TransactionExtended }[] = [];
     for (const tx of newTransactions) {
       if (rbfTransactions[tx.txid]) {
@@ -567,12 +571,14 @@ class WebsocketHandler {
       }
     }
     const mempoolDeltaTxids: MempoolDeltaTxids = {
+      sequence: this.mempoolSequence,
       added: newTransactions.map(tx => tx.txid),
       removed: deletedTransactions.map(tx => tx.txid),
       mined: [],
       replaced: replacedTransactions.map(replacement => ({ replaced: replacement.replaced, by: replacement.by.txid })),
     };
     const mempoolDelta: MempoolDelta = {
+      sequence: this.mempoolSequence,
       added: newTransactions,
       removed: deletedTransactions.map(tx => tx.txid),
       mined: [],
@@ -637,10 +643,6 @@ class WebsocketHandler {
     // pre-compute address transactions
     const addressCache = this.makeAddressCache(newTransactions);
     const removedAddressCache = this.makeAddressCache(deletedTransactions);
-
-    if (memPool.isInSync()) {
-      this.mempoolSequence++;
-    }
 
     // TODO - Fix indentation after PR is merged
     for (const server of this.webSocketServers) {
@@ -1034,6 +1036,10 @@ class WebsocketHandler {
 
     const mBlocksWithTransactions = mempoolBlocks.getMempoolBlocksWithTransactions();
 
+    if (memPool.isInSync()) {
+      this.mempoolSequence++;
+    }
+
     const replacedTransactions: { replaced: string, by: TransactionExtended }[] = [];
     for (const txid of Object.keys(rbfTransactions)) {
       for (const replaced of rbfTransactions[txid].replaced) {
@@ -1041,12 +1047,14 @@ class WebsocketHandler {
       }
     }
     const mempoolDeltaTxids: MempoolDeltaTxids = {
+      sequence: this.mempoolSequence,
       added: [],
       removed: [],
       mined: transactions.map(tx => tx.txid),
       replaced: replacedTransactions.map(replacement => ({ replaced: replacement.replaced, by: replacement.by.txid })),
     };
     const mempoolDelta: MempoolDelta = {
+      sequence: this.mempoolSequence,
       added: [],
       removed: [],
       mined: transactions.map(tx => tx.txid),
@@ -1059,10 +1067,6 @@ class WebsocketHandler {
         responseCache[key] = JSON.stringify(data);
       }
       return responseCache[key];
-    }
-
-    if (memPool.isInSync()) {
-      this.mempoolSequence++;
     }
 
     // TODO - Fix indentation after PR is merged

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -71,6 +71,20 @@ export interface MempoolBlockDelta {
   changed: MempoolDeltaChange[];
 }
 
+export interface MempoolDeltaTxids {
+  added: string[];
+  removed: string[];
+  mined: string[];
+  replaced: { replaced: string, by: string }[];
+}
+
+export interface MempoolDelta {
+  added: MempoolTransactionExtended[];
+  removed: string[];
+  mined: string[];
+  replaced: { replaced: string, by: TransactionExtended }[];
+}
+
 interface VinStrippedToScriptsig {
   scriptsig: string;
 }

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -72,6 +72,7 @@ export interface MempoolBlockDelta {
 }
 
 export interface MempoolDeltaTxids {
+  sequence: number,
   added: string[];
   removed: string[];
   mined: string[];
@@ -79,6 +80,7 @@ export interface MempoolDeltaTxids {
 }
 
 export interface MempoolDelta {
+  sequence: number,
   added: MempoolTransactionExtended[];
   removed: string[];
   mined: string[];


### PR DESCRIPTION
Some common use-cases involve fetching a copy of every transaction that enters the mempool, e.g:
 - syncing a local copy of the mempool with a Mempool backend.
 - monitoring for new transactions matching certain criteria.
 - running statistics on newly broadcast transactions.
 
Currently, the easiest way to achieve this via the Mempool API is to poll the `/api/mempool/txids` endpoint, calculate diffs between the results, and then fetch new txids individually from the `/api/tx/<txid>` endpoint.

But the `/api/mempool/txids` endpoint is extremely slow and expensive, especially when there are a very large number of transactions in the mempool.

This PR implements a much more efficient alternative via some new websocket subscriptions `track-mempool` and `track-mempool-txids`.

---

On every mempool update and new block, any websocket clients subscribed to `track-mempool` receive an object in the `mempool-transactions` field of the websocket response like:
```ts
{
...
  "mempool-transactions": {
      added: MempoolTransactionExtended[], // new transactions
      removed: string[], // txids of transactions evicted from the mempool for non-block-inclusion reasons
      mined: string[], // txids of transactions mined into the latest block
      replaced: { replaced: string, by: MempoolTransactionExtended }[], // RBF replacements
  }
}
```

Alternatively, websocket clients subscribed to `track-mempool-txids` receive an object in the `mempool-txids` field of the websocket response like:

```ts
{
...
  "mempool-txids": {
      added: string[], // txids of new transactions
      removed: string[], // txids of transactions evicted from the mempool for non-block-inclusion reasons
      mined: string[], // txids of transactions mined into the latest block
      replaced: { replaced: string, by: string }[], // RBF replacements
  }
}
```

---

The `track-mempool` subscription is potentially a lot of data, since it sends the full transaction objects for every new mempool transaction, although we do serialize the data once and reuse it across all subscribed clients which is fairly efficient.

If that's too much, we could lock the full `track-mempool` feature behind a config setting and only support `track-mempool-txids` by default. Then users would still need to make individual `/api/tx/<txid>` requests to get transaction data and be subject to the REST API rate limits etc. I think this would still be a huge improvement over polling `api/mempool/txids`.