### PR TITLE
Goggle Indexing

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -1,3 +1,4 @@
+import { IBitcoinApi } from './bitcoin-api.interface';
 import { IEsploraApi } from './esplora-api.interface';
 
 export interface AbstractBitcoinApi {

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -566,7 +566,7 @@ class Blocks {
    */
   public async $classifyBlocks(): Promise<void> {
     // classification requires an esplora backend
-    if (config.MEMPOOL.BACKEND !== 'esplora') {
+    if (!Common.blocksSummariesIndexingEnabled() || config.MEMPOOL.BACKEND !== 'esplora') {
       return;
     }
 
@@ -577,7 +577,7 @@ class Blocks {
     const unclassifiedTemplatesList = await BlocksSummariesRepository.$getTemplatesWithVersion(0);
 
     // nothing to do
-    if (!unclassifiedBlocksList.length && !unclassifiedTemplatesList.length) {
+    if (!unclassifiedBlocksList?.length && !unclassifiedTemplatesList?.length) {
       return;
     }
 
@@ -586,8 +586,8 @@ class Blocks {
     let indexedTotal = 0;
 
     const minHeight = Math.min(
-      unclassifiedBlocksList[unclassifiedBlocksList.length - 1].height ?? Infinity,
-      unclassifiedTemplatesList[unclassifiedTemplatesList.length - 1].height ?? Infinity,
+      unclassifiedBlocksList[unclassifiedBlocksList.length - 1]?.height ?? Infinity,
+      unclassifiedTemplatesList[unclassifiedTemplatesList.length - 1]?.height ?? Infinity,
     );
     const numToIndex = Math.max(
       unclassifiedBlocksList.length,

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -562,6 +562,115 @@ class Blocks {
   }
 
   /**
+   * [INDEXING] Index transaction classification flags for Goggles
+   */
+  public async $classifyBlocks(): Promise<void> {
+    // classification requires an esplora backend
+    if (config.MEMPOOL.BACKEND !== 'esplora') {
+      return;
+    }
+
+    const blockchainInfo = await bitcoinClient.getBlockchainInfo();
+    const currentBlockHeight = blockchainInfo.blocks;
+
+    const unclassifiedBlocksList = await BlocksSummariesRepository.$getSummariesWithVersion(0);
+    const unclassifiedTemplatesList = await BlocksSummariesRepository.$getTemplatesWithVersion(0);
+
+    // nothing to do
+    if (!unclassifiedBlocksList.length && !unclassifiedTemplatesList.length) {
+      return;
+    }
+
+    let timer = Date.now();
+    let indexedThisRun = 0;
+    let indexedTotal = 0;
+
+    const minHeight = Math.min(
+      unclassifiedBlocksList[unclassifiedBlocksList.length - 1].height ?? Infinity,
+      unclassifiedTemplatesList[unclassifiedTemplatesList.length - 1].height ?? Infinity,
+    );
+    const numToIndex = Math.max(
+      unclassifiedBlocksList.length,
+      unclassifiedTemplatesList.length,
+    );
+
+    const unclassifiedBlocks = {};
+    const unclassifiedTemplates = {};
+    for (const block of unclassifiedBlocksList) {
+      unclassifiedBlocks[block.height] = block.id;
+    }
+    for (const template of unclassifiedTemplatesList) {
+      unclassifiedTemplates[template.height] = template.id;
+    }
+
+    logger.debug(`Classifying blocks and templates from #${currentBlockHeight} to #${minHeight}`, logger.tags.goggles);
+
+    for (let height = currentBlockHeight; height >= 0; height--) {
+      let txs: TransactionExtended[] | null = null;
+      if (unclassifiedBlocks[height]) {
+        const blockHash = unclassifiedBlocks[height];
+        // fetch transactions
+        txs = (await bitcoinApi.$getTxsForBlock(blockHash)).map(tx => transactionUtils.extendTransaction(tx));
+        // add CPFP
+        const cpfpSummary = Common.calculateCpfp(height, txs, true);
+        // classify
+        const { transactions: classifiedTxs } = this.summarizeBlockTransactions(blockHash, cpfpSummary.transactions);
+        BlocksSummariesRepository.$saveTransactions(height, blockHash, classifiedTxs, 1);
+      }
+      if (unclassifiedTemplates[height]) {
+        // classify template
+        const blockHash = unclassifiedTemplates[height];
+        const template = await BlocksSummariesRepository.$getTemplate(blockHash);
+        const alreadyClassified = template?.transactions.reduce((classified, tx) => (classified || tx.flags > 0), false);
+        let classifiedTemplate = template?.transactions || [];
+        if (!alreadyClassified) {
+          const templateTxs: (TransactionExtended | TransactionClassified)[] = [];
+          const blockTxMap: { [txid: string]: TransactionExtended } = {};
+          for (const tx of (txs || [])) {
+            blockTxMap[tx.txid] = tx;
+          }
+          for (const templateTx of (template?.transactions || [])) {
+            let tx: TransactionExtended | null = blockTxMap[templateTx.txid];
+            if (!tx) {
+              try {
+                tx = await transactionUtils.$getTransactionExtended(templateTx.txid, false, true, false);
+              } catch (e) {
+                // transaction probably not found
+              }
+            }
+            templateTxs.push(tx || templateTx);
+          }
+          const cpfpSummary = Common.calculateCpfp(height, txs?.filter(tx => tx.effectiveFeePerVsize != null) as TransactionExtended[], true);
+          // classify
+          const { transactions: classifiedTxs } = this.summarizeBlockTransactions(blockHash, cpfpSummary.transactions);
+          const classifiedTxMap: { [txid: string]: TransactionClassified } = {};
+          for (const tx of classifiedTxs) {
+            classifiedTxMap[tx.txid] = tx;
+          }
+          classifiedTemplate = classifiedTemplate.map(tx => {
+            if (classifiedTxMap[tx.txid]) {
+              tx.flags = classifiedTxMap[tx.txid].flags || 0;
+            }
+            return tx;
+          });
+        }
+        BlocksSummariesRepository.$saveTemplate({ height, template: { id: blockHash, transactions: classifiedTemplate }, version: 1 });
+      }
+
+      // timing & logging
+      indexedThisRun++;
+      indexedTotal++;
+      const elapsedSeconds = (Date.now() - timer) / 1000;
+      if (elapsedSeconds > 5) {
+        const perSecond = indexedThisRun / elapsedSeconds;
+        logger.debug(`Classified #${height}: ${indexedTotal} / ${numToIndex} blocks (${perSecond.toFixed(1)}/s)`);
+        timer = Date.now();
+        indexedThisRun = 0;
+      }
+    }
+  }
+
+  /**
    * [INDEXING] Index all blocks metadata for the mining dashboard
    */
   public async $generateBlockDatabase(): Promise<boolean> {
@@ -966,6 +1075,7 @@ class Blocks {
 
     let height = blockHeight;
     let summary: BlockSummary;
+    let summaryVersion = 0;
     if (cpfpSummary && !Common.isLiquid()) {
       summary = {
         id: hash,
@@ -980,10 +1090,12 @@ class Blocks {
           };
         }),
       };
+      summaryVersion = 1;
     } else {
       if (config.MEMPOOL.BACKEND === 'esplora') {
         const txs = (await bitcoinApi.$getTxsForBlock(hash)).map(tx => transactionUtils.extendTransaction(tx));
         summary = this.summarizeBlockTransactions(hash, txs);
+        summaryVersion = 1;
       } else {
         // Call Core RPC
         const block = await bitcoinClient.getBlock(hash, 2);
@@ -998,7 +1110,7 @@ class Blocks {
 
     // Index the response if needed
     if (Common.blocksSummariesIndexingEnabled() === true) {
-      await BlocksSummariesRepository.$saveTransactions(height, hash, summary.transactions);
+      await BlocksSummariesRepository.$saveTransactions(height, hash, summary.transactions, summaryVersion);
     }
 
     return summary.transactions;
@@ -1114,16 +1226,18 @@ class Blocks {
         if (cleanBlock.fee_amt_percentiles === null) {
 
           let summary;
+          let summaryVersion = 0;
           if (config.MEMPOOL.BACKEND === 'esplora') {
             const txs = (await bitcoinApi.$getTxsForBlock(cleanBlock.hash)).map(tx => transactionUtils.extendTransaction(tx));
             summary = this.summarizeBlockTransactions(cleanBlock.hash, txs);
+            summaryVersion = 1;
           } else {
             // Call Core RPC
             const block = await bitcoinClient.getBlock(cleanBlock.hash, 2);
             summary = this.summarizeBlock(block);
           }
 
-          await BlocksSummariesRepository.$saveTransactions(cleanBlock.height, cleanBlock.hash, summary.transactions);
+          await BlocksSummariesRepository.$saveTransactions(cleanBlock.height, cleanBlock.hash, summary.transactions, summaryVersion);
           cleanBlock.fee_amt_percentiles = await BlocksSummariesRepository.$getFeePercentilesByBlockId(cleanBlock.hash);
         }
         if (cleanBlock.fee_amt_percentiles !== null) {

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -1,10 +1,9 @@
 import * as bitcoinjs from 'bitcoinjs-lib';
 import { Request } from 'express';
-import { Ancestor, CpfpInfo, CpfpSummary, CpfpCluster, EffectiveFeeStats, MempoolBlockWithTransactions, TransactionExtended, MempoolTransactionExtended, TransactionStripped, WorkingEffectiveFeeStats, TransactionClassified, TransactionFlags } from '../mempool.interfaces';
+import { CpfpInfo, CpfpSummary, CpfpCluster, EffectiveFeeStats, MempoolBlockWithTransactions, TransactionExtended, MempoolTransactionExtended, TransactionStripped, WorkingEffectiveFeeStats, TransactionClassified, TransactionFlags } from '../mempool.interfaces';
 import config from '../config';
 import { NodeSocket } from '../repositories/NodesSocketsRepository';
 import { isIP } from 'net';
-import rbfCache from './rbf-cache';
 import transactionUtils from './transaction-utils';
 import { isPoint } from '../utils/secp256k1';
 export class Common {
@@ -349,12 +348,16 @@ export class Common {
   }
 
   static classifyTransaction(tx: TransactionExtended): TransactionClassified {
-    const flags = this.getTransactionFlags(tx);
+    const flags = Common.getTransactionFlags(tx);
     tx.flags = flags;
     return {
-      ...this.stripTransaction(tx),
+      ...Common.stripTransaction(tx),
       flags,
     };
+  }
+
+  static classifyTransactions(txs: TransactionExtended[]): TransactionClassified[] {
+    return txs.map(Common.classifyTransaction);
   }
 
   static stripTransaction(tx: TransactionExtended): TransactionStripped {
@@ -369,7 +372,7 @@ export class Common {
   }
 
   static stripTransactions(txs: TransactionExtended[]): TransactionStripped[] {
-    return txs.map(this.stripTransaction);
+    return txs.map(Common.stripTransaction);
   }
 
   static sleep$(ms: number): Promise<void> {

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 66;
+  private static currentVersion = 67;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -557,6 +557,14 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 66) {
       await this.$executeQuery('ALTER TABLE `statistics` ADD min_fee FLOAT UNSIGNED DEFAULT NULL');
       await this.updateToSchemaVersion(66);
+    }
+
+    if (databaseSchemaVersion < 67) {
+      await this.$executeQuery('ALTER TABLE `blocks_summaries` ADD version INT NOT NULL DEFAULT 0');
+      await this.$executeQuery('ALTER TABLE `blocks_summaries` ADD INDEX `version` (`version`)');
+      await this.$executeQuery('ALTER TABLE `blocks_templates` ADD version INT NOT NULL DEFAULT 0');
+      await this.$executeQuery('ALTER TABLE `blocks_templates` ADD INDEX `version` (`version`)');
+      await this.updateToSchemaVersion(67);
     }
   }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -559,7 +559,7 @@ class DatabaseMigration {
       await this.updateToSchemaVersion(66);
     }
 
-    if (databaseSchemaVersion < 67) {
+    if (databaseSchemaVersion < 67  && isBitcoin === true) {
       await this.$executeQuery('ALTER TABLE `blocks_summaries` ADD version INT NOT NULL DEFAULT 0');
       await this.$executeQuery('ALTER TABLE `blocks_summaries` ADD INDEX `version` (`version`)');
       await this.$executeQuery('ALTER TABLE `blocks_templates` ADD version INT NOT NULL DEFAULT 0');

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -1,6 +1,6 @@
 import { GbtGenerator, GbtResult, ThreadTransaction as RustThreadTransaction, ThreadAcceleration as RustThreadAcceleration } from 'rust-gbt';
 import logger from '../logger';
-import { MempoolBlock, MempoolTransactionExtended, TransactionStripped, MempoolBlockWithTransactions, MempoolBlockDelta, Ancestor, CompactThreadTransaction, EffectiveFeeStats, PoolTag, TransactionClassified } from '../mempool.interfaces';
+import { MempoolBlock, MempoolTransactionExtended, MempoolBlockWithTransactions, MempoolBlockDelta, Ancestor, CompactThreadTransaction, EffectiveFeeStats, PoolTag, TransactionClassified } from '../mempool.interfaces';
 import { Common, OnlineFeeStatsCalculator } from './common';
 import config from '../config';
 import { Worker } from 'worker_threads';

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -703,7 +703,8 @@ class WebsocketHandler {
           template: {
             id: block.id,
             transactions: stripped,
-          }
+          },
+          version: 1,
         });
 
         BlocksAuditsRepository.$saveAudit({

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -185,6 +185,7 @@ class Indexer {
       await blocks.$generateCPFPDatabase();
       await blocks.$generateAuditStats();
       await auditReplicator.$sync();
+      await blocks.$classifyBlocks();
     } catch (e) {
       this.indexerRunning = false;
       logger.err(`Indexer failed, trying again in 10 seconds. Reason: ` + (e instanceof Error ? e.message : e));

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -35,6 +35,7 @@ class Logger {
   public tags = {
     mining: 'Mining',
     ln: 'Lightning',
+    goggles: 'Goggles',
   };  
 
   // @ts-ignore

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -280,7 +280,7 @@ export interface BlockExtended extends IEsploraApi.Block {
 
 export interface BlockSummary {
   id: string;
-  transactions: TransactionStripped[];
+  transactions: TransactionClassified[];
 }
 
 export interface AuditSummary extends BlockAudit {
@@ -288,8 +288,8 @@ export interface AuditSummary extends BlockAudit {
   size?: number,
   weight?: number,
   tx_count?: number,
-  transactions: TransactionStripped[];
-  template?: TransactionStripped[];
+  transactions: TransactionClassified[];
+  template?: TransactionClassified[];
 }
 
 export interface BlockPrice {

--- a/backend/src/replication/AuditReplication.ts
+++ b/backend/src/replication/AuditReplication.ts
@@ -105,7 +105,8 @@ class AuditReplication {
       template: {
         id: blockHash,
         transactions: auditSummary.template || []
-      }
+      },
+      version: 1,
     });
     await blocksAuditsRepository.$saveAudit({
       hash: blockHash,

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1040,16 +1040,18 @@ class BlocksRepository {
       if (extras.feePercentiles === null) {
 
         let summary;
+        let summaryVersion = 0;
         if (config.MEMPOOL.BACKEND === 'esplora') {
           const txs = (await bitcoinApi.$getTxsForBlock(dbBlk.id)).map(tx => transactionUtils.extendTransaction(tx));
           summary = blocks.summarizeBlockTransactions(dbBlk.id, txs);
+          summaryVersion = 1;
         } else {
           // Call Core RPC
           const block = await bitcoinClient.getBlock(dbBlk.id, 2);
           summary = blocks.summarizeBlock(block);
         }
 
-        await BlocksSummariesRepository.$saveTransactions(dbBlk.height, dbBlk.id, summary.transactions);
+        await BlocksSummariesRepository.$saveTransactions(dbBlk.height, dbBlk.id, summary.transactions, summaryVersion);
         extras.feePercentiles = await BlocksSummariesRepository.$getFeePercentilesByBlockId(dbBlk.id);
       }
       if (extras.feePercentiles !== null) {

--- a/backend/src/repositories/BlocksSummariesRepository.ts
+++ b/backend/src/repositories/BlocksSummariesRepository.ts
@@ -1,6 +1,6 @@
 import DB from '../database';
 import logger from '../logger';
-import { BlockSummary, TransactionStripped } from '../mempool.interfaces';
+import { BlockSummary, TransactionClassified } from '../mempool.interfaces';
 
 class BlocksSummariesRepository {
   public async $getByBlockId(id: string): Promise<BlockSummary | undefined> {
@@ -17,7 +17,7 @@ class BlocksSummariesRepository {
     return undefined;
   }
 
-  public async $saveTransactions(blockHeight: number, blockId: string, transactions: TransactionStripped[]): Promise<void> {
+  public async $saveTransactions(blockHeight: number, blockId: string, transactions: TransactionClassified[]): Promise<void> {
     try {
       const transactionsStr = JSON.stringify(transactions);
       await DB.query(`

--- a/frontend/src/app/components/block-filters/block-filters.component.html
+++ b/frontend/src/app/components/block-filters/block-filters.component.html
@@ -18,7 +18,7 @@
       <h5>{{ group.label }}</h5>
       <div class="filter-group">
         <ng-container *ngFor="let filter of group.filters;">
-          <button class="btn filter-tag" [class.selected]="filterFlags[filter.key]" (click)="toggleFilter(filter.key)">{{ filter.label }}</button>
+          <button *ngIf="!disabledFilters[filter.key]" class="btn filter-tag" [class.selected]="filterFlags[filter.key]" (click)="toggleFilter(filter.key)">{{ filter.label }}</button>
         </ng-container>
       </div>
     </ng-container>

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -13,6 +13,6 @@
       [auditEnabled]="auditHighlighting"
       [blockConversion]="blockConversion"
     ></app-block-overview-tooltip>
-    <app-block-filters *ngIf="showFilters" [cssWidth]="cssWidth" (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
+    <app-block-filters *ngIf="showFilters && filtersAvailable" [excludeFilters]="excludeFilters" [cssWidth]="cssWidth" (onFilterChanged)="setFilterFlags($event)"></app-block-filters>
   </div>
 </div>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -115,6 +115,8 @@
             [orientation]="'top'"
             [flip]="false"
             [blockConversion]="blockConversion"
+            [showFilters]="true"
+            [excludeFilters]="['replacement']"
             (txClickEvent)="onTxClick($event)"
           ></app-block-overview-graph>
           <ng-container *ngTemplateOutlet="emptyBlockInfo"></ng-container>
@@ -229,7 +231,8 @@
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="isLoadingOverview" [resolution]="86"
             [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" [auditHighlighting]="showAudit"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit"></app-block-overview-graph>
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit"
+            [showFilters]="true" [excludeFilters]="['replacement']"></app-block-overview-graph>
           <ng-container *ngIf="!isMobile || mode !== 'actual'; else emptyBlockInfo"></ng-container>
         </div>
         <ng-container *ngIf="network !== 'liquid'">
@@ -243,7 +246,8 @@
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphActual [isLoading]="isLoadingOverview" [resolution]="86"
             [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"  [auditHighlighting]="showAudit"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit"></app-block-overview-graph>
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit"
+            [showFilters]="true" [excludeFilters]="['replacement']"></app-block-overview-graph>
           <ng-container *ngTemplateOutlet="emptyBlockInfo"></ng-container>
         </div>
         <ng-container *ngIf="network !== 'liquid'">

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -150,6 +150,8 @@ export class StateService {
   searchFocus$: Subject<boolean> = new Subject<boolean>();
   menuOpen$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
+  activeGoggles$: BehaviorSubject<string[]> = new BehaviorSubject([]);
+
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
     @Inject(LOCALE_ID) private locale: string,


### PR DESCRIPTION
_(builds on PR #4526)_

This PR adds an indexing stage to retroactively add Goggles classification flags to block summaries and projected block templates, which enables the Goggles view on historic mined blocks.

Classification requires full copies of the relevant transactions, so this is only enabled with `mempool/electrs` backends, and takes a very very long time to complete (although it should speed up a bit once it reaches blocks from before the audit feature was enabled, and continue accelerating into the earlier parts of the blockchain).

It should be possible to parallelize a lot of this for maybe a 3-5x speedup by maxing out electrs threads and doing the classification in separate nodejs workers, however this would probably render the mempool/electrs instance unusable for normal workloads.

Another alternative is not to preemptively classify historic blocks at all, and simply fill in the data lazily as and when blocks are requested.