### PR TITLE
Fix acceleration list css, move to /acceleration/list

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
@@ -66,7 +66,6 @@ export class AccelerationFeesGraphComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.seoService.setTitle($localize`:@@bcf34abc2d9ed8f45a2f65dd464c46694e9a181e:Acceleration Fees`);
     this.isLoading = true;
     if (this.widget) {
       this.miningWindowPreference = '1m';
@@ -86,6 +85,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnDestroy {
         }),
       );
     } else {
+      this.seoService.setTitle($localize`:@@bcf34abc2d9ed8f45a2f65dd464c46694e9a181e:Acceleration Fees`);
       this.miningWindowPreference = this.miningService.getDefaultTimespan('1w');
       this.radioGroupForm = this.formBuilder.group({ dateSpan: this.miningWindowPreference });
       this.radioGroupForm.controls.dateSpan.setValue(this.miningWindowPreference);

--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
@@ -63,66 +63,82 @@ tr, td, th {
 }
 
 .txid {
-  width: 25%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 30%;
-  @media (max-width: 1060px) and (min-width: 768px) {
-    display: none;
-  }
   @media (max-width: 500px) {
     display: none;
   }
 }
 
-.fee-rate {
-  width: 20%;
-  @media (max-width: 1060px) and (min-width: 768px) {
-    text-align: start !important;
-  }
-  @media (max-width: 500px) {
-    text-align: start !important;
-  }
-  @media (max-width: 840px) and (min-width: 768px) {
-    display: none;
-  }
-  @media (max-width: 410px) {
-    display: none;
+.fee, .block, .status {
+  width: 15%;
+
+  @media (max-width: 720px) {
+    width: 20%;
   }
 }
 
-.bid {
-  width: 30%;
-  min-width: 150px;
-  @media (max-width: 840px) and (min-width: 768px) {
-    text-align: start !important;
+.widget {
+  .txid {
+    width: 30%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 30%;
+    @media (max-width: 1060px) and (min-width: 768px) {
+      display: none;
+    }
+    @media (max-width: 500px) {
+      display: none;
+    }
   }
-  @media (max-width: 410px) {
-    text-align: start !important;
+
+  .fee-rate {
+    width: 20%;
+    @media (max-width: 1060px) and (min-width: 768px) {
+      text-align: start !important;
+    }
+    @media (max-width: 500px) {
+      text-align: start !important;
+    }
+    @media (max-width: 840px) and (min-width: 768px) {
+      display: none;
+    }
+    @media (max-width: 410px) {
+      display: none;
+    }
   }
-}
 
-.time {
-  width: 25%;
-}
-
-.fee {
-  width: 35%;
-  @media (max-width: 1060px) and (min-width: 768px) {
-    text-align: start !important;
+  .bid {
+    width: 30%;
+    min-width: 150px;
+    @media (max-width: 840px) and (min-width: 768px) {
+      text-align: start !important;
+    }
+    @media (max-width: 410px) {
+      text-align: start !important;
+    }
   }
-  @media (max-width: 500px) {
-    text-align: start !important;
+
+  .time {
+    width: 25%;
   }
-}
 
-.block {
-  width: 20%;
-}
+  .fee {
+    width: 30%;
+    @media (max-width: 1060px) and (min-width: 768px) {
+      text-align: start !important;
+    }
+    @media (max-width: 500px) {
+      text-align: start !important;
+    }
+  }
 
-.status {
-  width: 20%
+  .block {
+    width: 20%;
+  }
+
+  .status {
+    width: 20%
+  }
 }
 
 /* Tooltip text */

--- a/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.html
+++ b/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.html
@@ -80,7 +80,7 @@
     <div class="col">
       <div class="card list-card">
         <div class="card-body">
-          <a class="title-link" href="" [routerLink]="['/acceleration-list' | relativeUrl]">
+          <a class="title-link" href="" [routerLink]="['/acceleration/list' | relativeUrl]">
             <h5 class="card-title d-inline" i18n="dashboard.recent-accelerations">Recent Accelerations</h5>
             <span>&nbsp;</span>
             <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: 'text-top'; font-size: 13px; color: #4a68b9"></fa-icon>

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -52,7 +52,7 @@ const routes: Routes = [
         ]
       },
       {
-        path: 'acceleration-list',
+        path: 'acceleration/list',
         data: { networks: ['bitcoin'] },
         component: AccelerationsListComponent,
       },


### PR DESCRIPTION
Fixes the responsive layout for the standalone Acceleration List page, and changes the URL to `/acceleration/list`.

Before:
<img width="991" alt="Screenshot 2024-01-27 at 4 47 43 PM" src="https://github.com/mempool/mempool/assets/83316221/96442396-2216-4f29-ab52-c69adb862eed">

After:
<img width="991" alt="Screenshot 2024-01-27 at 4 48 24 PM" src="https://github.com/mempool/mempool/assets/83316221/1dde69ec-35c1-4b07-8c8f-9b786e3224af">


