### PR TITLE
Display pool tags on dashboard

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -56,7 +56,7 @@
               <app-time kind="since" [time]="block.timestamp" [fastRender]="true" [precision]="1" minUnit="minute"></app-time></div>
           </ng-container>
         </div>
-        <div class="animated" [class]="showMiningInfo ? 'show' : 'hide'" *ngIf="block.extras?.pool != undefined">
+        <div class="animated" [class]="markHeight === block.height ? 'hide' : 'show'" *ngIf="block.extras?.pool != undefined">
           <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge badge-primary"
             [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
             {{ block.extras.pool.name}}</a>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -166,7 +166,7 @@
   opacity: 1;
 }
 .hide {
-  opacity: 0;
+  opacity: 0.4;
   pointer-events : none;
 }
 


### PR DESCRIPTION
Trying out this idea of always displaying the pool tags, except when we focus on a block, dim the tag behind instead of removing it so it doesn't look too weird.

The reason is so I don't constantly have to switch to the miner dashboard and back, just to see the pool name.

Default dashboard
<img width="1517" alt="Screenshot 2024-01-29 at 01 51 07" src="https://github.com/mempool/mempool/assets/8561090/0a16bd60-a0a4-4c6c-bef6-5a902b18f08b">

Block open

<img width="1532" alt="Screenshot 2024-01-29 at 01 52 07" src="https://github.com/mempool/mempool/assets/8561090/592159ff-aa74-4d9e-9c8f-289022a2eb0c">
