### PR TITLE
Multiple acceleration arrows

### DIFF
--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -25,7 +25,7 @@ class Mempool {
     deletedTransactions: MempoolTransactionExtended[], accelerationDelta: string[]) => Promise<void>) | undefined;
 
   private accelerations: { [txId: string]: Acceleration } = {};
-  private accelerationPositions: { [txid: string]: { [pool: number]: { block: number, vbytes: number } } } = {};
+  private accelerationPositions: { [txid: string]: { poolId: number, pool: string, block: number, vsize: number }[] } = {};
 
   private txPerSecondArray: number[] = [];
   private txPerSecond: number = 0;
@@ -432,11 +432,11 @@ class Mempool {
     }
   }
 
-  setAccelerationPositions(positions: { [txid: string]: { [pool: number]: { block: number, vbytes: number } } }): void {
+  setAccelerationPositions(positions: { [txid: string]: { poolId: number, pool: string, block: number, vsize: number }[] }): void {
     this.accelerationPositions = positions;
   }
 
-  getAccelerationPositions(txid: string): { [pool: number]: { block: number, vbytes: number } } | undefined {
+  getAccelerationPositions(txid: string): { [pool: number]: { poolId: number, pool: string, block: number, vsize: number } } | undefined {
     return this.accelerationPositions[txid];
   }
 

--- a/backend/src/api/mempool.ts
+++ b/backend/src/api/mempool.ts
@@ -25,6 +25,7 @@ class Mempool {
     deletedTransactions: MempoolTransactionExtended[], accelerationDelta: string[]) => Promise<void>) | undefined;
 
   private accelerations: { [txId: string]: Acceleration } = {};
+  private accelerationPositions: { [txid: string]: { [pool: number]: { block: number, vbytes: number } } } = {};
 
   private txPerSecondArray: number[] = [];
   private txPerSecond: number = 0;
@@ -429,6 +430,14 @@ class Mempool {
       logger.debug(`Failed to update accelerations: ` + (e instanceof Error ? e.message : e));
       return [];
     }
+  }
+
+  setAccelerationPositions(positions: { [txid: string]: { [pool: number]: { block: number, vbytes: number } } }): void {
+    this.accelerationPositions = positions;
+  }
+
+  getAccelerationPositions(txid: string): { [pool: number]: { block: number, vbytes: number } } | undefined {
+    return this.accelerationPositions[txid];
   }
 
   private startTimer() {

--- a/backend/src/api/services/acceleration.ts
+++ b/backend/src/api/services/acceleration.ts
@@ -7,6 +7,14 @@ export interface Acceleration {
   txid: string,
   feeDelta: number,
   pools: number[],
+  effectiveFee: number;
+  effectiveVsize: number;
+  positions?: {
+    [pool: number]: {
+      block: number,
+      vbytes: number,
+    },
+  },
 }
 
 class AccelerationApi {

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -192,7 +192,8 @@ class WebsocketHandler {
                 }
                 response['txPosition'] = JSON.stringify({
                   txid: trackTxid,
-                  position
+                  position,
+                  accelerationPositions: memPool.getAccelerationPositions(tx.txid),
                 });
               }
             } else {
@@ -674,7 +675,8 @@ class WebsocketHandler {
             position: {
               ...mempoolTx.position,
               accelerated: mempoolTx.acceleration || undefined,
-            }
+            },
+            accelerationPositions: memPool.getAccelerationPositions(mempoolTx.txid),
           };
           if (mempoolTx.cpfpDirty) {
             positionData['cpfp'] = {
@@ -684,7 +686,7 @@ class WebsocketHandler {
               effectiveFeePerVsize: mempoolTx.effectiveFeePerVsize || null,
               sigops: mempoolTx.sigops,
               adjustedVsize: mempoolTx.adjustedVsize,
-              acceleration: mempoolTx.acceleration
+              acceleration: mempoolTx.acceleration,
             };
           }
           response['txPosition'] = JSON.stringify(positionData);
@@ -896,7 +898,8 @@ class WebsocketHandler {
               position: {
                 ...mempoolTx.position,
                 accelerated: mempoolTx.acceleration || undefined,
-              }
+              },
+              accelerationPositions: memPool.getAccelerationPositions(mempoolTx.txid),
             });
           }
         }

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -49,7 +49,10 @@
         </div>
       </ng-template>
     </div>
-    <div *ngIf="arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + 75 + 'px', transition: transition }" [class.blink]="txPosition?.accelerated"></div>
+    <div *ngIf="arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + 75 + 'px', transition: transition }"></div>
+    <ng-container *ngFor="let pool of accelerationPositions; trackBy: accTrackByFn">
+      <div class="acceleration-arrow blink" [ngStyle]="{'right': pool.offset + 75 + 'px', transition: 'background 2s, right 2s, transform 1s' }"></div>
+    </ng-container>
   </div>
 </ng-container>
 

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -122,6 +122,17 @@
   border-bottom: 35px solid #FFF;
 }
 
+.acceleration-arrow {
+  position: relative;
+  right: 75px;
+  top: 105px;
+  width: 0;
+  height: 0;
+  border-left: 35px solid transparent;
+  border-right: 35px solid transparent;
+  border-bottom: 35px solid #FFF;
+}
+
 .blockLink {
   width: 100%;
   height: 100%;
@@ -154,7 +165,7 @@
 }
 
 :host-context(.rtl-layout) {
-  #arrow-up {
+  #arrow-up, .acceleration-arrow {
     transform: translateX(70px);
   }
 }
@@ -172,8 +183,6 @@
 }
 
 .blink{
-  width:400px;
-  height:400px;
   border-bottom: 35px solid #FFF;
   animation: blink 0.2s infinite;
 }

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -196,6 +196,11 @@ export interface MempoolPosition {
   accelerated?: boolean
 }
 
+export interface AccelerationPosition extends MempoolPosition {
+  pool: string;
+  offset?: number;
+}
+
 export interface RewardStats {
   startBlock: number;
   endBlock: number;

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, PLATFORM_ID, LOCALE_ID } from '@angular/core';
 import { ReplaySubject, BehaviorSubject, Subject, fromEvent, Observable, merge } from 'rxjs';
 import { Transaction } from '../interfaces/electrs.interface';
 import { IBackendInfo, MempoolBlock, MempoolBlockDelta, MempoolInfo, Recommendedfees, ReplacedTransaction, ReplacementInfo, TransactionStripped } from '../interfaces/websocket.interface';
-import { BlockExtended, CpfpInfo, DifficultyAdjustment, MempoolPosition, OptimizedMempoolStats, RbfTree } from '../interfaces/node-api.interface';
+import { AccelerationPosition, BlockExtended, CpfpInfo, DifficultyAdjustment, MempoolPosition, OptimizedMempoolStats, RbfTree } from '../interfaces/node-api.interface';
 import { Router, NavigationStart } from '@angular/router';
 import { isPlatformBrowser } from '@angular/common';
 import { filter, map, scan, shareReplay } from 'rxjs/operators';
@@ -16,6 +16,7 @@ export interface MarkBlockState {
   mempoolBlockIndex?: number;
   txFeePerVSize?: number;
   mempoolPosition?: MempoolPosition;
+  accelerationPositions?: AccelerationPosition[];
 }
 
 export interface ILoadingIndicators { [name: string]: number; }
@@ -116,7 +117,7 @@ export class StateService {
   utxoSpent$ = new Subject<object>();
   difficultyAdjustment$ = new ReplaySubject<DifficultyAdjustment>(1);
   mempoolTransactions$ = new Subject<Transaction>();
-  mempoolTxPosition$ = new Subject<{ txid: string, position: MempoolPosition, cpfp: CpfpInfo | null}>();
+  mempoolTxPosition$ = new Subject<{ txid: string, position: MempoolPosition, cpfp: CpfpInfo | null, accelerationPositions?: AccelerationPosition[] }>();
   mempoolRemovedTransactions$ = new Subject<Transaction>();
   blockTransactions$ = new Subject<Transaction>();
   isLoadingWebSocket$ = new ReplaySubject<boolean>(1);


### PR DESCRIPTION
This draft PR estimates the position of accelerated transactions in different pool mempools, and displays each as a separate arrow in the mempool blocks.

If any pool accepted all active accelerations, then we know exactly where each transaction should be, so the corresponding arrows are placed using the GBT-calculated positions.

The PR also calculates an approximate un-accelerated mempool position, and displays the regular white arrow in that position.

https://github.com/mempool/mempool/assets/83316221/4f1c3725-07bd-4f01-b3c9-dcb890bdc69d

drawbacks:
 - the accuracy of the un-accelerated arrow is pretty bad, especially when the transaction is one of many with a similar fee rate.
 - most of the time accelerated transactions will end up in more or less the same place in all accepting pools, and so the accelerating arrows will strongly overlap.
     - maybe it would be better to simply only ever show one arrow for the original position and one for the accelerated position, and accept that this won't be a perfect representation in more complex conditions.