### PR TITLE
[sync-assets] More logging, add MEMPOOL_CDN and DRY_RUN options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
 
       - name: Sync-assets
         run: npm run sync-assets-dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MEMPOOL_CDN: 1
+          VERBOSE: 1
         working-directory: assets/frontend
 
       - name: Zip mining-pool assets
@@ -237,6 +241,8 @@ jobs:
         working-directory: ${{ matrix.node }}/${{ matrix.flavor }}/frontend
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MEMPOOL_CDN: 1
+          VERBOSE: 1
   
   e2e:
     if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"


### PR DESCRIPTION
- Improved logging (better indentation of log entries)
- Add new DRY_RUN option for local runs (still hits the GH API for the assets list)
- Add new MEMPOOL_CDN option to download assets from the CDN instead of GH