### PR TITLE
Search bar: add Liquid confidential addresses to addresses regex

### DIFF
--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -105,7 +105,7 @@ export class AddressComponent implements OnInit, OnDestroy {
       .pipe(
         filter((address) => !!address),
         tap((address: Address) => {
-          if ((this.stateService.network === 'liquid' || this.stateService.network === 'liquidtestnet') && /^([m-zA-HJ-NP-Z1-9]{26,35}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[a-km-zA-HJ-NP-Z1-9]{80})$/.test(address.address)) {
+          if ((this.stateService.network === 'liquid' || this.stateService.network === 'liquidtestnet') && /^([a-zA-HJ-NP-Z1-9]{26,35}|[a-z]{2,5}1[ac-hj-np-z02-9]{8,100}|[a-km-zA-HJ-NP-Z1-9]{80})$/.test(address.address)) {
             this.apiService.validateAddress$(address.address)
               .subscribe((addressInfo) => {
                 this.addressInfo = addressInfo;

--- a/frontend/src/app/shared/regex.utils.ts
+++ b/frontend/src/app/shared/regex.utils.ts
@@ -77,11 +77,15 @@ const ADDRESS_CHARS: {
       + `)`,
   },
   liquid: {
-    base58: `[GHPQ]` // G|H is P2PKH, P|Q is P2SH
-      + BASE58_CHARS
-      + `{33}`, // All min-max lengths are 34
+    base58: `[GHPQ]` // PQ is P2PKH, GH is P2SH
+        + BASE58_CHARS
+        + `{33}` // All min-max lengths are 34
+      + `|`
+        + `[V][TJ]` // Confidential P2PKH or P2SH starts with VT or VJ
+        + BASE58_CHARS
+        + `{78}`, 
     bech32: `(?:`
-        + `(?:` // bech32 liquid starts with ex1 or lq1
+        + `(?:` // bech32 liquid starts with ex1 (unconfidential) or lq1 (confidential)
           + `ex1`
           + `|`
           + `lq1`


### PR DESCRIPTION
This PR adds support for confidential addresses in the search bar regex.

P2SH:
```
> elements-cli getnewaddress '' 'p2sh-segwit'
VJLGqLPHb2aEA2jTaMQzzjPuA6tZVSQqybWsDhGcXFN1XzTkKfqzc316Tv3fH42qtKRdziANEA7VYrzT
```

P2PKH:
```
> elements-cli getnewaddress '' 'legacy'
VTpzabAWxkER1bXjNuSP8YCzLQ3bb7eaty94DKx1crLEwB8jqBgyVnJVbskP2HhPhvfnHX5UjqsttHfA
```

Bech32 (already included): 
```
> elements-cli getnewaddress
lq1qqd6j9vmp4sjexh2nmzeuyqsjksan2dgep6vxuzhewpq38npfkpfdwy2juzlt7szq0hkvxdm96tmy7cax8cs5j9hh8xh30sct2
```
