### PR TITLE
Add P2WSH Liquid peg out to input label

### DIFF
--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -43,7 +43,7 @@ export class AddressLabelsComponent implements OnChanges {
 
   handleVin() {
     if (this.vin.inner_witnessscript_asm) {
-      if (this.vin.inner_witnessscript_asm.indexOf('OP_DEPTH OP_PUSHNUM_12 OP_EQUAL OP_IF OP_PUSHNUM_11') === 0) {
+      if (this.vin.inner_witnessscript_asm.indexOf('OP_DEPTH OP_PUSHNUM_12 OP_EQUAL OP_IF OP_PUSHNUM_11') === 0 || this.vin.inner_witnessscript_asm.indexOf('OP_PUSHNUM_15 OP_CHECKMULTISIG OP_IFDUP OP_NOTIF OP_PUSHBYTES_2') === 1259) {
         if (this.vin.witness.length > 11) {
           this.label = 'Liquid Peg Out';
         } else {


### PR DESCRIPTION
This PR adds a Liquid peg out label that was missing due to the transition from P2SH to P2WSH of Federation addresses.

Before: 

<img width="1159" alt="Screenshot 2024-02-06 at 11 40 35" src="https://github.com/mempool/mempool/assets/46578910/e7f22cac-d0a5-490c-9f28-5425903ff5c2">

After: 
<img width="1138" alt="Screenshot 2024-02-06 at 11 40 52" src="https://github.com/mempool/mempool/assets/46578910/2a3fa7f7-77b8-4872-9734-c5124626cf7b">

Peg out `745620c4bc5d130c63d897779226c14775d44e37746a184cd068cbab3c52d153`