### PR TITLE
Fix infinite address scroll

### DIFF
--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -258,8 +258,7 @@ export class AddressComponent implements OnInit, OnDestroy {
         if (transactions && transactions.length) {
           this.lastTransactionTxId = transactions[transactions.length - 1].txid;
           this.transactions = this.transactions.concat(transactions);
-        }
-        if (transactions?.length == null || transactions.length < 50) {
+        } else {
           this.fullyLoaded = true;
         }
         this.isLoadingTransactions = false;


### PR DESCRIPTION
The address page currently stops trying to load more transactions after fetching `chain_stats.tx_count`.

This PR fixes that and only stops trying to load more after we actually reach the end of the API pagination.
