### PR TITLE
Blockchain component: display dash when feerate is undefined

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -26,7 +26,7 @@
             </div>
             <ng-template #emptyfees>
               <div [attr.data-cy]="'bitcoin-block-offset=' + offset + '-index-' + i + '-fees'" class="fees">
-                &nbsp;
+                <app-fee-rate unitClass=""></app-fee-rate>
               </div>
             </ng-template>
             <div [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-fee-span'" class="fee-span"
@@ -37,7 +37,7 @@
             </div>
             <ng-template #emptyfeespan>
               <div [attr.data-cy]="'bitcoin-block-offset=' + offset + '-index-' + i + '-fees'" class="fee-span">
-                &nbsp;
+                <app-fee-rate unitClass=""></app-fee-rate>
               </div>
             </ng-template>
             <div [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-total-fees'" *ngIf="showMiningInfo"

--- a/frontend/src/app/shared/components/fee-rate/fee-rate.component.html
+++ b/frontend/src/app/shared/components/fee-rate/fee-rate.component.html
@@ -1,4 +1,10 @@
 <ng-container *ngIf="rateUnits$ | async as units">
-  <ng-container *ngIf="units !== 'wu'">{{ fee / (weight / 4) | feeRounding:rounding }} <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></ng-container>
-  <ng-container *ngIf="units === 'wu'">{{ fee / weight | feeRounding:rounding }} <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-weight-units|sat/WU">sat/WU</span></ng-container>
+  <ng-container *ngIf="fee !== undefined; else noFee">
+    <ng-container *ngIf="units !== 'wu'">{{ fee / (weight / 4) | feeRounding:rounding }} <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></ng-container>
+    <ng-container *ngIf="units === 'wu'">{{ fee / weight | feeRounding:rounding }} <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-weight-units|sat/WU">sat/WU</span></ng-container>
+  </ng-container>
+  <ng-template #noFee>
+      <ng-container *ngIf="units !== 'wu'">- <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-vbyte|sat/vB">sat/vB</span></ng-container>
+      <ng-container *ngIf="units === 'wu'">- <span *ngIf="showUnit" [class]="unitClass" [style]="unitStyle" i18n="shared.sat-weight-units|sat/WU">sat/WU</span></ng-container>
+  </ng-template>
 </ng-container>

--- a/frontend/src/app/shared/components/fee-rate/fee-rate.component.ts
+++ b/frontend/src/app/shared/components/fee-rate/fee-rate.component.ts
@@ -8,7 +8,7 @@ import { StateService } from '../../../services/state.service';
   styleUrls: ['./fee-rate.component.scss']
 })
 export class FeeRateComponent implements OnInit {
-  @Input() fee: number;
+  @Input() fee: number | undefined;
   @Input() weight: number = 4;
   @Input() rounding: string = null;
   @Input() showUnit: boolean = true;


### PR DESCRIPTION
This PR adds a placeholder in the blockchain component in the case there is no fee data for the block (e.g. on Liquid).

Before: 

<img width="1087" alt="Screenshot 2024-02-07 at 11 34 52" src="https://github.com/mempool/mempool/assets/46578910/99124305-848b-4cdc-9e8e-c54ed537c0f2">


After: 

<img width="1085" alt="Screenshot 2024-02-07 at 11 33 49" src="https://github.com/mempool/mempool/assets/46578910/15968765-5cc4-4b8e-b500-1d6d34aa0bb8">
