### PR TITLE
Fix mining/liquid dashboard widget heights

### DIFF
--- a/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.scss
+++ b/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.scss
@@ -23,7 +23,7 @@
     height: 325px;
   }
   @media (min-width: 992px) {
-    height: 400px;
+    height: 409px;
   }
 }
 

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.scss
@@ -26,7 +26,7 @@
     height: 345px;
   }
   @media (min-width: 992px) {
-    height: 472px;
+    height: 440px;
   }
 }
 

--- a/frontend/src/app/components/mining-dashboard/mining-dashboard.component.ts
+++ b/frontend/src/app/components/mining-dashboard/mining-dashboard.component.ts
@@ -42,7 +42,7 @@ export class MiningDashboardComponent implements OnInit, AfterViewInit {
   @HostListener('window:resize', ['$event'])
   onResize(): void {
     if (window.innerWidth >= 992) {
-      this.graphHeight = 375;
+      this.graphHeight = 335;
     } else if (window.innerWidth >= 768) {
       this.graphHeight = 245;
     } else {

--- a/frontend/src/app/lightning/lightning-dashboard/lightning-dashboard.component.scss
+++ b/frontend/src/app/lightning/lightning-dashboard/lightning-dashboard.component.scss
@@ -29,7 +29,7 @@
     height: 345px;
   }
   @media (min-width: 992px) {
-    height: 442px;
+    height: 439px;
   }
 }
 


### PR DESCRIPTION
Fixes #4668

The second row of widgets on all dashboards should now be 508px tall.