### PR TITLE
[auth] properly refresh user when `auth` object changes

### DIFF
--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { StateService } from './state.service';
 import { StorageService } from './storage.service';
 import { MenuGroup } from '../interfaces/services.interface';
-import { Observable, of, ReplaySubject, tap, catchError, share } from 'rxjs';
+import { Observable, of, ReplaySubject, tap, catchError, share, filter, switchMap } from 'rxjs';
 import { IBackendInfo } from '../interfaces/websocket.interface';
 import { Acceleration, AccelerationHistoryParams } from '../interfaces/node-api.interface';
 
@@ -64,13 +64,10 @@ export class ServicesApiServices {
     }
 
     this.getUserInfo$().subscribe();
-    this.router.events.subscribe((event) => {
-      if (event instanceof NavigationStart) {
-        if (this.currentAuth !== localStorage.getItem('auth')) {
-          this.getUserInfo$().subscribe();
-        }
-      }
-    });
+    this.router.events.pipe(
+      filter((event) => event instanceof NavigationStart && this.currentAuth !== localStorage.getItem('auth')),
+      switchMap(() => this.getUserInfo$()),
+    ).subscribe();
   }
 
   /**

--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -64,11 +64,9 @@ export class ServicesApiServices {
     }
 
     this.getUserInfo$().subscribe();
-    console.log('refresh user');
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationStart) {
         if (this.currentAuth !== localStorage.getItem('auth')) {
-          console.log('refresh user');
           this.getUserInfo$().subscribe();
         }
       }


### PR DESCRIPTION
This PR aims to fix the following bug. You can easily reproduce it locally as well.

### Repro the bug

- Go to mempool.space
- Make sure you are logged out
- Open https://mempool.space/login
- Login with Twitter or your credentials

Result: user name and subscription level badge is not showing, a page refresh is required

<img width="252" alt="image" src="https://github.com/mempool/mempool/assets/9780671/dde79d27-6872-4bc7-88f3-9178acfd97e4">