### PR TITLE
Log mempool stats on new blocks

### DIFF
--- a/backend/src/api/statistics/statistics-api.ts
+++ b/backend/src/api/statistics/statistics-api.ts
@@ -285,7 +285,7 @@ class StatisticsApi {
 
   public async $list2H(): Promise<OptimizedStatistic[]> {
     try {
-      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 120`;
+      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics WHERE added BETWEEN DATE_SUB(NOW(), INTERVAL 2 HOUR) AND NOW() ORDER BY statistics.added DESC`;
       const [rows] = await DB.query({ sql: query, timeout: this.queryTimeout });
       return this.mapStatisticToOptimizedStatistic(rows as Statistic[]);
     } catch (e) {
@@ -296,7 +296,7 @@ class StatisticsApi {
 
   public async $list24H(): Promise<OptimizedStatistic[]> {
     try {
-      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics ORDER BY statistics.added DESC LIMIT 1440`;
+      const query = `SELECT *, UNIX_TIMESTAMP(added) as added FROM statistics WHERE added BETWEEN DATE_SUB(NOW(), INTERVAL 24 HOUR) AND NOW() ORDER BY statistics.added DESC`;
       const [rows] = await DB.query({ sql: query, timeout: this.queryTimeout });
       return this.mapStatisticToOptimizedStatistic(rows as Statistic[]);
     } catch (e) {

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -23,6 +23,7 @@ import priceUpdater from '../tasks/price-updater';
 import { ApiPrice } from '../repositories/PricesRepository';
 import accelerationApi from './services/acceleration';
 import mempool from './mempool';
+import statistics from './statistics/statistics';
 
 interface AddressTransactions {
   mempool: MempoolTransactionExtended[],
@@ -723,6 +724,7 @@ class WebsocketHandler {
     }
 
     this.printLogs();
+    await statistics.runStatistics();
 
     const _memPool = memPool.getMempool();
 
@@ -1014,6 +1016,8 @@ class WebsocketHandler {
         client.send(this.serializeResponse(response));
       }
     });
+
+    await statistics.runStatistics();
   }
 
   // takes a dictionary of JSON serialized values


### PR DESCRIPTION
With this PR, we run the mempool statistics log twice when a new block arrives to reflect in the graph what exactly happened to the mempool queue in the graph. The once a minute log is still in effect but it will skip if the last block was found within the last 30 seconds to reduce datapoints.

This will lead to up to 288 (+20%) more data points per day in the `statistics` table.

The result is this cleaner looking mempool graph, at least in the 2H view.

Before
<img width="363" alt="Screenshot 2024-02-10 at 20 51 19" src="https://github.com/mempool/mempool/assets/8561090/ecf31e66-1cc9-4318-ae52-1dd188de9319">

After
<img width="393" alt="Screenshot 2024-02-10 at 20 42 56" src="https://github.com/mempool/mempool/assets/8561090/e5790444-564c-4d5b-9a0f-79c5631a82b0">

Zoomed in / Filtered fee bands 
<img width="408" alt="Screenshot 2024-02-10 at 21 01 14" src="https://github.com/mempool/mempool/assets/8561090/be2efe9e-166f-4d05-bb18-45e7cdf4979c">
