### PR TITLE
Temporarily disable tagging images as latest

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -100,6 +100,5 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache" \
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
-          --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
           --output "type=registry" ./${{ matrix.service }}/ \
           --build-arg commitHash=$SHORT_SHA


### PR DESCRIPTION
Temporary workaround to skip tagging images as `latest`, in preparation for a patch release.

I'll submit a follow up PR to rebuild the image and tag as `latest` with a release workflow soon (tm).