### PR TITLE
Add Goggles filter for nVersion=3

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -245,6 +245,8 @@ export class Common {
       flags |= TransactionFlags.v1;
     } else if (tx.version === 2) {
       flags |= TransactionFlags.v2;
+    } else if (tx.version === 3) {
+      flags |= TransactionFlags.v3;
     }
     const reusedInputAddresses: { [address: string ]: number } = {};
     const reusedOutputAddresses: { [address: string ]: number } = {};

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -208,6 +208,7 @@ export const TransactionFlags = {
   no_rbf:                                                      0b00000010n,
   v1:                                                          0b00000100n,
   v2:                                                          0b00001000n,
+  v3:                                                          0b00010000n,
   // address types
   p2pk:                                               0b00000001_00000000n,
   p2ms:                                               0b00000010_00000000n,

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -21,7 +21,7 @@ export const TransactionFlags = {
   no_rbf:                                                      0b00000010n,
   v1:                                                          0b00000100n,
   v2:                                                          0b00001000n,
-  multisig:                                                    0b00010000n,
+  v3:                                                          0b00010000n,
   // address types
   p2pk:                                               0b00000001_00000000n,
   p2ms:                                               0b00000010_00000000n,
@@ -64,7 +64,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     no_rbf: { key: 'no_rbf', label: 'RBF disabled', flag: TransactionFlags.no_rbf, toggle: 'rbf', important: true },
     v1: { key: 'v1', label: 'Version 1', flag: TransactionFlags.v1, toggle: 'version' },
     v2: { key: 'v2', label: 'Version 2', flag: TransactionFlags.v2, toggle: 'version' },
-    // multisig: { key: 'multisig', label: 'Multisig', flag: TransactionFlags.multisig },
+    v3: { key: 'v3', label: 'Version 3', flag: TransactionFlags.v3, toggle: 'version' },
     /* address types */
     p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk, important: true },
     p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms, important: true },
@@ -94,7 +94,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
 };
 
 export const FilterGroups: { label: string, filters: Filter[]}[] = [
-  { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'multisig'] },
+  { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3'] },
   { label: 'Address Types', filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
   { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement'] },
   { label: 'Data', filters: ['op_return', 'fake_pubkey', 'inscription'] },


### PR DESCRIPTION
Adds a Goggles filter toggle for v3 transactions.

<img width="531" alt="Screenshot 2024-02-12 at 8 08 25 PM" src="https://github.com/mempool/mempool/assets/83316221/a26747fd-41eb-4758-816b-6cbb86c10185">

Now that v3 transaction policy has been merged into Bitcoin Core, we may start to see version 3 transactions appear on testnet and signet.

The feature isn't yet included in any tagged releases, and I understand nVersion=3 transactions will remain non-standard for now, so it may be a while yet before any v3 transactions hit mainnet, but it doesn't hurt to be prepared.