### PR TITLE
Fix hardcoded hashrate unit in pool ranking graph

### DIFF
--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -163,7 +163,7 @@ export class PoolRankingComponent implements OnInit {
             const i = pool.blockCount.toString();
             if (this.miningWindowPreference === '24h') {
               return `<b style="color: white">${pool.name} (${pool.share}%)</b><br>` +
-                pool.lastEstimatedHashrate.toString() + ' PH/s' +
+                pool.lastEstimatedHashrate.toString() + ' ' + miningStats.miningUnits.hashrateUnit +
                 `<br>` + $localize`${ i }:INTERPOLATION: blocks`;
             } else {
               return `<b style="color: white">${pool.name} (${pool.share}%)</b><br>` +
@@ -201,7 +201,7 @@ export class PoolRankingComponent implements OnInit {
           const i = totalBlockOther.toString();
           if (this.miningWindowPreference === '24h') {
             return `<b style="color: white">` + $localize`Other (${percentage})` + `</b><br>` +
-              totalEstimatedHashrateOther.toString() + ' PH/s' +
+              totalEstimatedHashrateOther.toString() + ' ' + miningStats.miningUnits.hashrateUnit +
               `<br>` + $localize`${ i }:INTERPOLATION: blocks`;
           } else {
             return `<b style="color: white">` + $localize`Other (${percentage})` + `</b><br>` +


### PR DESCRIPTION
This PR fixes the hardcoded `PH/s` unit in the pool ranking graph.

- Before: 
<img width="600" alt="Screenshot 2024-02-16 at 10 05 51" src="https://github.com/mempool/mempool/assets/46578910/ea4d7b97-423e-44d5-82ff-defc57fcc561">

- Now: 
<img width="600" alt="Screenshot 2024-02-16 at 10 06 45" src="https://github.com/mempool/mempool/assets/46578910/5304f0ce-8913-4b4f-abee-59ebad1d4308">
