### PR TITLE
Fix block visualisation tooltip z-index

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
@@ -11,6 +11,7 @@
   text-align: left;
   min-width: 320px;
   pointer-events: none;
+  z-index: 11;
 
   &.clickable {
     pointer-events: all;


### PR DESCRIPTION
This PR adds z-index to the block visualisation tooltip:

| Before  | After |
| ------------- | ------------- |
| <img width="384" alt="Screenshot 2024-02-17 at 18 04 41" src="https://github.com/mempool/mempool/assets/46578910/23ebb081-1447-4627-9bd1-fc9e604d9980"> |  <img width="382" alt="Screenshot 2024-02-17 at 18 06 59" src="https://github.com/mempool/mempool/assets/46578910/bc759eb2-0523-4bbe-bbbb-eea1fcd8dcdf">|
| <img width="374" alt="Screenshot 2024-02-17 at 18 05 03" src="https://github.com/mempool/mempool/assets/46578910/1d603987-6faa-4c81-8b3e-a77524870d9f">| <img width="372" alt="Screenshot 2024-02-17 at 18 15 19" src="https://github.com/mempool/mempool/assets/46578910/b8221d05-11c8-4fed-b41e-0117f3cbe9f2"> |
