### PR TITLE
Add Public-Pool to pools.json

### DIFF
--- a/contributors/benjamin-wilson.txt
+++ b/contributors/benjamin-wilson.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of February 17, 2024.
+
+Signed: benjamin-wilson

--- a/frontend/cypress/fixtures/pools.json
+++ b/frontend/cypress/fixtures/pools.json
@@ -555,6 +555,10 @@
         "Entrustus" : {
             "name": "Entrust Charity Pool",
             "link": "pool.entustus.org"
+        },
+        "Public-Pool" :{
+            "name": "Public-Pool",
+            "link": "https://web.public-pool.io"
         }
     },
     "payout_addresses" : {


### PR DESCRIPTION
Added public-pool to pools.json. 

Is there anything else to be done so the pool can be queried like https://mempool.space/mining/pool/FoundryUSA ? 