### PR TITLE
Continue other indexing tasks while Goggles classification runs

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -40,6 +40,7 @@ class Blocks {
   private quarterEpochBlockTime: number | null = null;
   private newBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: TransactionExtended[]) => void)[] = [];
   private newAsyncBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: MempoolTransactionExtended[]) => Promise<void>)[] = [];
+  private classifyingBlocks: boolean = false;
 
   private mainLoopTimeout: number = 120000;
 
@@ -568,6 +569,11 @@ class Blocks {
    * [INDEXING] Index transaction classification flags for Goggles
    */
   public async $classifyBlocks(): Promise<void> {
+    if (this.classifyingBlocks) {
+      return;
+    }
+    this.classifyingBlocks = true;
+
     // classification requires an esplora backend
     if (!Common.gogglesIndexingEnabled() || config.MEMPOOL.BACKEND !== 'esplora') {
       return;
@@ -679,6 +685,8 @@ class Blocks {
         indexedThisRun = 0;
       }
     }
+
+    this.classifyingBlocks = false;
   }
 
   /**

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -185,7 +185,8 @@ class Indexer {
       await blocks.$generateCPFPDatabase();
       await blocks.$generateAuditStats();
       await auditReplicator.$sync();
-      await blocks.$classifyBlocks();
+      // do not wait for classify blocks to finish
+      blocks.$classifyBlocks();
     } catch (e) {
       this.indexerRunning = false;
       logger.err(`Indexer failed, trying again in 10 seconds. Reason: ` + (e instanceof Error ? e.message : e));


### PR DESCRIPTION
Currently other indexing tasks (hashrates etc) are prevented from making progress until Goggles classification completes.

This PR runs the Goggles indexing in the background instead so that other tasks can continue to run every hour.