### PR TITLE
Fix liquid dashboard css

### DIFF
--- a/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.html
+++ b/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{'widget': widget}">
+<div [ngClass]="{'widget': widget, 'extra-margin-right': widget}">
 
   <div class="clearfix"></div>
 

--- a/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.scss
+++ b/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.scss
@@ -4,6 +4,12 @@
   margin-top: 13px;
 }
 
+.extra-margin-right {
+  @media (max-width: 380px) {
+    margin-left: -10px;
+  }
+}
+
 tr, td, th {
   border: 0px;
   padding-top: 0.65rem;

--- a/frontend/src/app/components/liquid-reserves-audit/recent-pegs-list/recent-pegs-list.component.scss
+++ b/frontend/src/app/components/liquid-reserves-audit/recent-pegs-list/recent-pegs-list.component.scss
@@ -31,7 +31,7 @@ tr, td, th {
 }
 
 .transaction {
-  width: 20%;
+  width: 65%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -57,7 +57,7 @@ tr, td, th {
 }
 
 .output {
-  width: 20%;
+  width: 50%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -427,6 +427,7 @@
 
 .card-title-liquid {
   padding-top: 20px;
+  margin-left: 10px;
 }
 
 .in-progress-message {


### PR DESCRIPTION
This PR fixes some css issues that happened on Safari and / or small screens (Liquid dashboard): 

| Before  | After |
| ------------- | ------------- |
| <img width="250" alt="Screenshot 2024-02-22 at 15 18 56" src="https://github.com/mempool/mempool/assets/46578910/6acbfb63-362d-487c-b685-c2597a0ca313"> | <img width="250" alt="Screenshot 2024-02-22 at 15 22 29" src="https://github.com/mempool/mempool/assets/46578910/c88bc0c0-8c10-4e4f-a7c8-e5c5ebaad487"> |
| <img width="250" alt="Screenshot 2024-02-22 at 15 19 03" src="https://github.com/mempool/mempool/assets/46578910/27988a6c-655e-48b6-b07c-59a7d1f02a90"> | <img width="250" alt="Screenshot 2024-02-22 at 15 22 37" src="https://github.com/mempool/mempool/assets/46578910/debfce0f-079f-4850-a9cf-bacfd11be176"> |
| <img width="250" alt="Screenshot 2024-02-22 at 15 22 03" src="https://github.com/mempool/mempool/assets/46578910/23c47d1c-a772-4e08-beea-45fccc2cc47b"> | <img width="250" alt="Screenshot 2024-02-22 at 15 22 13" src="https://github.com/mempool/mempool/assets/46578910/43fca4eb-f6fc-43eb-9822-ec14d25130ab"> |