### PR TITLE
Add Acceleration Goggles

### DIFF
--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -4,6 +4,7 @@ import { SpriteUpdateParams, Square, Color, ViewUpdateParams } from './sprite-ty
 import { hexToColor } from './utils';
 import BlockScene from './block-scene';
 import { TransactionStripped } from '../../interfaces/node-api.interface';
+import { TransactionFlags } from '../../shared/filters.utils';
 
 const hoverTransitionTime = 300;
 const defaultHoverColor = hexToColor('1bd8f4');
@@ -58,7 +59,7 @@ export default class TxView implements TransactionStripped {
     this.acc = tx.acc;
     this.rate = tx.rate;
     this.status = tx.status;
-    this.bigintFlags = tx.flags ? BigInt(tx.flags) : 0n;
+    this.bigintFlags = tx.flags ? (BigInt(tx.flags) ^ (this.acc ? TransactionFlags.acceleration : 0n)): 0n;
     this.initialised = false;
     this.vertexArray = scene.vertexArray;
 

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -34,6 +34,7 @@ export const TransactionFlags = {
   cpfp_parent:                               0b00000001_00000000_00000000n,
   cpfp_child:                                0b00000010_00000000_00000000n,
   replacement:                               0b00000100_00000000_00000000n,
+  acceleration:                              0b00001000_00000000_00000000n,
   // data
   op_return:                        0b00000001_00000000_00000000_00000000n,
   fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
@@ -77,6 +78,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent, important: true },
     cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child, important: true },
     replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement, important: true },
+    acceleration: window?.['__env']?.ACCELERATOR ? { key: 'acceleration', label: 'Accelerated', flag: TransactionFlags.acceleration, important: false } : undefined,
     /* data */
     op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return, important: true },
     fake_pubkey: { key: 'fake_pubkey', label: 'Fake pubkey', flag: TransactionFlags.fake_pubkey },
@@ -96,7 +98,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
 export const FilterGroups: { label: string, filters: Filter[]}[] = [
   { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'multisig'] },
   { label: 'Address Types', filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
-  { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement'] },
+  { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration'] },
   { label: 'Data', filters: ['op_return', 'fake_pubkey', 'inscription'] },
   { label: 'Heuristics', filters: ['coinjoin', 'consolidation', 'batch_payout'] },
   { label: 'Sighash Flags', filters: ['sighash_all', 'sighash_none', 'sighash_single', 'sighash_default', 'sighash_acp'] },


### PR DESCRIPTION
This PR adds a new Goggles filter for accelerated transactions.

<img width="533" alt="Screenshot 2024-02-24 at 8 28 04 PM" src="https://github.com/mempool/mempool/assets/83316221/32f7c329-0319-4525-b028-7a8e48de035c">

This doesn't change the backend classification, but rather incorporates our existing acceleration data into the frontend filters.

If the `ACCELERATOR` setting is disabled in the frontend, then the filter will not appear.