### PR TITLE
Fix query parameter label in tx history api doc

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -1017,7 +1017,7 @@ export const restApiDocsData = [
     fragment: "get-address-transactions",
     title: "GET Address Transactions",
     description: {
-      default: "Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using <code>:last_seen_txid</code> (see below)."
+      default: "Get transaction history for the specified address/scripthash, sorted with newest first. Returns up to 50 mempool transactions plus the first 25 confirmed transactions. You can request more confirmed transactions using an <code>after_txid</code> query parameter."
     },
     urlString: "/address/:address/txs",
     showConditions: bitcoinNetworks.concat(liquidNetworks),


### PR DESCRIPTION
Fixes #4705.

Can test with:
- `/api/address/15sECDEYuvUWGKk6dC4sWAHpMVonV5VUiJ/txs`
- `/api/address/15sECDEYuvUWGKk6dC4sWAHpMVonV5VUiJ/txs?after_txid=53cf48d87731e6cbb11d0b7a46fa4e3535748e765d9aead0d3ded9373fe8114c`