### PR TITLE
Add non-standard Goggles filter

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -7,6 +7,24 @@ import { isIP } from 'net';
 import transactionUtils from './transaction-utils';
 import { isPoint } from '../utils/secp256k1';
 import logger from '../logger';
+import { getVarIntLength, opcodes, parseMultisigScript } from '../utils/bitcoin-script';
+
+// Bitcoin Core default policy settings
+const TX_MAX_STANDARD_VERSION = 2;
+const MAX_STANDARD_TX_WEIGHT = 400_000;
+const MAX_BLOCK_SIGOPS_COST = 80_000;
+const MAX_STANDARD_TX_SIGOPS_COST = (MAX_BLOCK_SIGOPS_COST / 5);
+const MIN_STANDARD_TX_NONWITNESS_SIZE = 65;
+const MAX_P2SH_SIGOPS = 15;
+const MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
+const MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
+const MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE = 80;
+const MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
+const MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
+const DUST_RELAY_TX_FEE = 3;
+const MAX_OP_RETURN_RELAY = 83;
+const DEFAULT_PERMIT_BAREMULTISIG = true;
+
 export class Common {
   static nativeAssetId = config.MEMPOOL.NETWORK === 'liquidtestnet' ?
     '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49'
@@ -175,6 +193,141 @@ export class Common {
       && ['01', '02', '03', '81', '82', '83'].includes(w.slice(-2)) // signature must end with a valid sighash flag
       && (w.length === (2 * parseInt(w.slice(2, 4), 16)) + 6) // second byte encodes the combined length of the R and S components
     );
+  }
+
+  /**
+   * Validates most standardness rules
+   *
+   * returns true early if any standardness rule is violated, otherwise false
+   * (except for non-mandatory-script-verify-flag and p2sh script evaluation rules which are *not* enforced)
+   */
+  static isNonStandard(tx: TransactionExtended): boolean {
+    // version
+    if (tx.version > TX_MAX_STANDARD_VERSION) {
+      return true;
+    }
+
+    // tx-size
+    if (tx.weight > MAX_STANDARD_TX_WEIGHT) {
+      return true;
+    }
+
+    // tx-size-small
+    if (this.getNonWitnessSize(tx) < MIN_STANDARD_TX_NONWITNESS_SIZE) {
+      return true;
+    }
+
+    // bad-txns-too-many-sigops
+    if (tx.sigops && tx.sigops > MAX_STANDARD_TX_SIGOPS_COST) {
+      return true;
+    }
+
+    // input validation
+    for (const vin of tx.vin) {
+      if (vin.is_coinbase) {
+        // standardness rules don't apply to coinbase transactions
+        return false;
+      }
+      // scriptsig-size
+      if ((vin.scriptsig.length / 2) > MAX_STANDARD_SCRIPTSIG_SIZE) {
+        return true;
+      }
+      // scriptsig-not-pushonly
+      if (vin.scriptsig_asm) {
+        for (const op of vin.scriptsig_asm.split(' ')) {
+          if (opcodes[op] && opcodes[op] > opcodes['OP_16']) {
+            return true;
+          }
+        }
+      }
+      // bad-txns-nonstandard-inputs
+      if (vin.prevout?.scriptpubkey_type === 'p2sh') {
+        // TODO: evaluate script (https://github.com/bitcoin/bitcoin/blob/1ac627c485a43e50a9a49baddce186ee3ad4daad/src/policy/policy.cpp#L177)
+        // countScriptSigops returns the witness-scaled sigops, so divide by 4 before comparison with MAX_P2SH_SIGOPS
+        const sigops = (transactionUtils.countScriptSigops(vin.inner_redeemscript_asm) / 4);
+        if (sigops > MAX_P2SH_SIGOPS) {
+          return true;
+        }
+      } else if (['unknown', 'provably_unspendable', 'empty'].includes(vin.prevout?.scriptpubkey_type || '')) {
+        return true;
+      }
+      // TODO: bad-witness-nonstandard
+    }
+
+    // output validation
+    let opreturnCount = 0;
+    for (const vout of tx.vout) {
+      // scriptpubkey
+      if (['unknown', 'provably_unspendable', 'empty'].includes(vout.scriptpubkey_type)) {
+        // (non-standard output type)
+        return true;
+      } else if (vout.scriptpubkey_type === 'multisig') {
+        if (!DEFAULT_PERMIT_BAREMULTISIG) {
+          // bare-multisig
+          return true;
+        }
+        const mOfN = parseMultisigScript(vout.scriptpubkey_asm);
+        if (!mOfN || mOfN.n < 1 || mOfN.n > 3 || mOfN.m < 1 || mOfN.m > mOfN.n) {
+          // (non-standard bare multisig threshold)
+          return true;
+        }
+      } else if (vout.scriptpubkey_type === 'op_return') {
+        opreturnCount++;
+        if ((vout.scriptpubkey.length / 2) > MAX_OP_RETURN_RELAY) {
+          // over default datacarrier limit
+          return true;
+        }
+      }
+      // dust
+      // (we could probably hardcode this for the different output types...)
+      if (vout.scriptpubkey_type !== 'op_return') {
+        let dustSize = (vout.scriptpubkey.length / 2);
+        // add varint length overhead
+        dustSize += getVarIntLength(dustSize);
+        // add value size
+        dustSize += 8;
+        if (['v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(vout.scriptpubkey_type)) {
+          dustSize += 67;
+        } else {
+          dustSize += 148;
+        }
+        if (vout.value < (dustSize * DUST_RELAY_TX_FEE)) {
+          // under minimum output size
+          console.log(`NON-STANDARD | dust | ${vout.value} | ${dustSize} ${dustSize * DUST_RELAY_TX_FEE} `, tx.txid);
+          return true;
+        }
+      }
+    }
+
+    // multi-op-return
+    if (opreturnCount > 1) {
+      return true;
+    }
+
+    // TODO: non-mandatory-script-verify-flag
+
+    return false;
+  }
+
+  static getNonWitnessSize(tx: TransactionExtended): number {
+    let weight = tx.weight;
+    let hasWitness = false;
+    for (const vin of tx.vin) {
+      if (vin.witness?.length) {
+        hasWitness = true;
+        // witness count
+        weight -= getVarIntLength(vin.witness.length);
+        for (const witness of vin.witness) {
+          // witness item size + content
+          weight -= getVarIntLength(witness.length / 2) + (witness.length / 2);
+        }
+      }
+    }
+    if (hasWitness) {
+      // marker & segwit flag
+      weight -= 2;
+    }
+    return Math.ceil(weight / 4);
   }
 
   static setSegwitSighashFlags(flags: bigint, witness: string[]): bigint {
@@ -349,6 +502,10 @@ export class Common {
     // less than 1:5 input:output ratio
     if (tx.vin.length / tx.vout.length <= 0.2) {
       flags |= TransactionFlags.batch_payout;
+    }
+
+    if (this.isNonStandard(tx)) {
+      flags |= TransactionFlags.nonstandard;
     }
 
     return Number(flags);

--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -145,6 +145,10 @@ class TransactionUtils {
   }
 
   public countScriptSigops(script: string, isRawScript: boolean = false, witness: boolean = false): number {
+    if (!script?.length) {
+      return 0;
+    }
+
     let sigops = 0;
     // count OP_CHECKSIG and OP_CHECKSIGVERIFY
     sigops += (script.match(/OP_CHECKSIG/g)?.length || 0);

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -209,6 +209,7 @@ export const TransactionFlags = {
   v1:                                                          0b00000100n,
   v2:                                                          0b00001000n,
   v3:                                                          0b00010000n,
+  nonstandard:                                                 0b00100000n,
   // address types
   p2pk:                                               0b00000001_00000000n,
   p2ms:                                               0b00000010_00000000n,

--- a/backend/src/utils/bitcoin-script.ts
+++ b/backend/src/utils/bitcoin-script.ts
@@ -1,0 +1,203 @@
+const opcodes = {
+  OP_FALSE: 0,
+  OP_0: 0,
+  OP_PUSHDATA1: 76,
+  OP_PUSHDATA2: 77,
+  OP_PUSHDATA4: 78,
+  OP_1NEGATE: 79,
+  OP_PUSHNUM_NEG1: 79,
+  OP_RESERVED: 80,
+  OP_TRUE: 81,
+  OP_1: 81,
+  OP_2: 82,
+  OP_3: 83,
+  OP_4: 84,
+  OP_5: 85,
+  OP_6: 86,
+  OP_7: 87,
+  OP_8: 88,
+  OP_9: 89,
+  OP_10: 90,
+  OP_11: 91,
+  OP_12: 92,
+  OP_13: 93,
+  OP_14: 94,
+  OP_15: 95,
+  OP_16: 96,
+  OP_PUSHNUM_1: 81,
+  OP_PUSHNUM_2: 82,
+  OP_PUSHNUM_3: 83,
+  OP_PUSHNUM_4: 84,
+  OP_PUSHNUM_5: 85,
+  OP_PUSHNUM_6: 86,
+  OP_PUSHNUM_7: 87,
+  OP_PUSHNUM_8: 88,
+  OP_PUSHNUM_9: 89,
+  OP_PUSHNUM_10: 90,
+  OP_PUSHNUM_11: 91,
+  OP_PUSHNUM_12: 92,
+  OP_PUSHNUM_13: 93,
+  OP_PUSHNUM_14: 94,
+  OP_PUSHNUM_15: 95,
+  OP_PUSHNUM_16: 96,
+  OP_NOP: 97,
+  OP_VER: 98,
+  OP_IF: 99,
+  OP_NOTIF: 100,
+  OP_VERIF: 101,
+  OP_VERNOTIF: 102,
+  OP_ELSE: 103,
+  OP_ENDIF: 104,
+  OP_VERIFY: 105,
+  OP_RETURN: 106,
+  OP_TOALTSTACK: 107,
+  OP_FROMALTSTACK: 108,
+  OP_2DROP: 109,
+  OP_2DUP: 110,
+  OP_3DUP: 111,
+  OP_2OVER: 112,
+  OP_2ROT: 113,
+  OP_2SWAP: 114,
+  OP_IFDUP: 115,
+  OP_DEPTH: 116,
+  OP_DROP: 117,
+  OP_DUP: 118,
+  OP_NIP: 119,
+  OP_OVER: 120,
+  OP_PICK: 121,
+  OP_ROLL: 122,
+  OP_ROT: 123,
+  OP_SWAP: 124,
+  OP_TUCK: 125,
+  OP_CAT: 126,
+  OP_SUBSTR: 127,
+  OP_LEFT: 128,
+  OP_RIGHT: 129,
+  OP_SIZE: 130,
+  OP_INVERT: 131,
+  OP_AND: 132,
+  OP_OR: 133,
+  OP_XOR: 134,
+  OP_EQUAL: 135,
+  OP_EQUALVERIFY: 136,
+  OP_RESERVED1: 137,
+  OP_RESERVED2: 138,
+  OP_1ADD: 139,
+  OP_1SUB: 140,
+  OP_2MUL: 141,
+  OP_2DIV: 142,
+  OP_NEGATE: 143,
+  OP_ABS: 144,
+  OP_NOT: 145,
+  OP_0NOTEQUAL: 146,
+  OP_ADD: 147,
+  OP_SUB: 148,
+  OP_MUL: 149,
+  OP_DIV: 150,
+  OP_MOD: 151,
+  OP_LSHIFT: 152,
+  OP_RSHIFT: 153,
+  OP_BOOLAND: 154,
+  OP_BOOLOR: 155,
+  OP_NUMEQUAL: 156,
+  OP_NUMEQUALVERIFY: 157,
+  OP_NUMNOTEQUAL: 158,
+  OP_LESSTHAN: 159,
+  OP_GREATERTHAN: 160,
+  OP_LESSTHANOREQUAL: 161,
+  OP_GREATERTHANOREQUAL: 162,
+  OP_MIN: 163,
+  OP_MAX: 164,
+  OP_WITHIN: 165,
+  OP_RIPEMD160: 166,
+  OP_SHA1: 167,
+  OP_SHA256: 168,
+  OP_HASH160: 169,
+  OP_HASH256: 170,
+  OP_CODESEPARATOR: 171,
+  OP_CHECKSIG: 172,
+  OP_CHECKSIGVERIFY: 173,
+  OP_CHECKMULTISIG: 174,
+  OP_CHECKMULTISIGVERIFY: 175,
+  OP_NOP1: 176,
+  OP_NOP2: 177,
+  OP_CHECKLOCKTIMEVERIFY: 177,
+  OP_CLTV: 177,
+  OP_NOP3: 178,
+  OP_CHECKSEQUENCEVERIFY: 178,
+  OP_CSV: 178,
+  OP_NOP4: 179,
+  OP_NOP5: 180,
+  OP_NOP6: 181,
+  OP_NOP7: 182,
+  OP_NOP8: 183,
+  OP_NOP9: 184,
+  OP_NOP10: 185,
+  OP_CHECKSIGADD: 186,
+  OP_PUBKEYHASH: 253,
+  OP_PUBKEY: 254,
+  OP_INVALIDOPCODE: 255,
+};
+// add unused opcodes
+for (let i = 187; i <= 255; i++) {
+  opcodes[`OP_RETURN_${i}`] = i;
+}
+
+export { opcodes };
+
+/** extracts m and n from a multisig script (asm), returns nothing if it is not a multisig script */
+export function parseMultisigScript(script: string): void | { m: number, n: number } {
+  if (!script) {
+    return;
+  }
+  const ops = script.split(' ');
+  if (ops.length < 3 || ops.pop() !== 'OP_CHECKMULTISIG') {
+    return;
+  }
+  const opN = ops.pop();
+  if (!opN) {
+    return;
+  }
+  if (!opN.startsWith('OP_PUSHNUM_')) {
+    return;
+  }
+  const n = parseInt(opN.match(/[0-9]+/)?.[0] || '', 10);
+  if (ops.length < n * 2 + 1) {
+    return;
+  }
+  // pop n public keys
+  for (let i = 0; i < n; i++) {
+    if (!/^0((2|3)\w{64}|4\w{128})$/.test(ops.pop() || '')) {
+      return;
+    }
+    if (!/^OP_PUSHBYTES_(33|65)$/.test(ops.pop() || '')) {
+      return;
+    }
+  }
+  const opM = ops.pop();
+  if (!opM) {
+    return;
+  }
+  if (!opM.startsWith('OP_PUSHNUM_')) {
+    return;
+  }
+  const m = parseInt(opM.match(/[0-9]+/)?.[0] || '', 10);
+
+  if (ops.length) {
+    return;
+  }
+
+  return { m, n };
+}
+
+export function getVarIntLength(n: number): number {
+  if (n < 0xfd) {
+    return 1;
+  } else if (n <= 0xffff) {
+    return 3;
+  } else if (n <= 0xffffffff) {
+    return 5;
+  } else {
+    return 9;
+  }
+}

--- a/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.html
+++ b/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.html
@@ -8,6 +8,7 @@
   [showFilters]="showFilters"
   [filterFlags]="filterFlags"
   [filterMode]="filterMode"
+  [excludeFilters]="['nonstandard']"
   [overrideColors]="overrideColors"
   (txClickEvent)="onTxClick($event)"
 ></app-block-overview-graph>

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -22,6 +22,7 @@ export const TransactionFlags = {
   v1:                                                          0b00000100n,
   v2:                                                          0b00001000n,
   v3:                                                          0b00010000n,
+  nonstandard:                                                 0b00100000n,
   // address types
   p2pk:                                               0b00000001_00000000n,
   p2ms:                                               0b00000010_00000000n,
@@ -66,6 +67,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     v1: { key: 'v1', label: 'Version 1', flag: TransactionFlags.v1, toggle: 'version' },
     v2: { key: 'v2', label: 'Version 2', flag: TransactionFlags.v2, toggle: 'version' },
     v3: { key: 'v3', label: 'Version 3', flag: TransactionFlags.v3, toggle: 'version' },
+    nonstandard: { key: 'nonstandard', label: 'Non-Standard', flag: TransactionFlags.nonstandard, important: true },
     /* address types */
     p2pk: { key: 'p2pk', label: 'P2PK', flag: TransactionFlags.p2pk, important: true },
     p2ms: { key: 'p2ms', label: 'Bare multisig', flag: TransactionFlags.p2ms, important: true },
@@ -96,7 +98,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
 };
 
 export const FilterGroups: { label: string, filters: Filter[]}[] = [
-  { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3'] },
+  { label: 'Features', filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3', 'nonstandard'] },
   { label: 'Address Types', filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
   { label: 'Behavior', filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration'] },
   { label: 'Data', filters: ['op_return', 'fake_pubkey', 'inscription'] },


### PR DESCRIPTION
This PR adds a new Goggles filter for non-standard transactions.

This PR does **not** bump the block template version, so the new filter will not apply to blocks mined before deployment without manually triggering a re-index (e.g. by resetting the version column to zero in `blocks_summaries`).

<img width="535" alt="Screenshot 2024-02-26 at 1 51 32 AM" src="https://github.com/mempool/mempool/assets/83316221/c74b5669-46dd-4f58-af7d-6ae04d6d8d59">

Once this is deployed, most non-standard transactions will be detected and filterable in mined blocks.

The PR detects the following kinds of non-standardness
 - version > 2
 - `tx-size` (more than 100kvb)
 - `tx-size-small` (non-witness size < 65 bytes)
 - `bad-txns-too-many-sigops`
 - `scriptsig-size` (scriptsig > 1650 bytes)
 - `scriptsig-not-pushonly` non-push opcodes in scriptsig
 - `bad-txns-nonstandard-inputs` due to excessive P2SH sigops or non-standard type
 - `scriptpubkey`
     - unknown output type
     - bare multisig with non-standard threshold
     - op_return over default 83 byte datacarriersize limit
 - `dust`
 - `multi-op-return`

But does not yet implement
 - `bad-txns-nonstandard-inputs` due to failed P2SH script evaluation
 - `bad-witness-nonstandard` (witness script resource usage limits)
 - `non-mandatory-script-verify-flag` (non-standard DER encodings or non-null dummy arguments)

The filter is currently hidden/disabled on projected blocks (since we're running default mempool policy).

---

### TODO

I suspect people will want to know *why* a given transaction is non-standard. Perhaps we could record the reason in a new transaction flag field, or re-run the standardness tests client-side to identify and display the specific reasons on the transaction page.

If Libre Relay gains more traction among miners, it might be worth switching our nodes over too to get the widest possible view of pending transactions. In that case, we should enable the non-standard filter on projected blocks too.