### PR TITLE
Hide effective rate on tooltip where irrelevant

### DIFF
--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -59,7 +59,7 @@ export default class TxView implements TransactionStripped {
     this.acc = tx.acc;
     this.rate = tx.rate;
     this.status = tx.status;
-    this.bigintFlags = tx.flags ? (BigInt(tx.flags) ^ (this.acc ? TransactionFlags.acceleration : 0n)): 0n;
+    this.bigintFlags = tx.flags ? (BigInt(tx.flags) | (this.acc ? TransactionFlags.acceleration : 0n)): 0n;
     this.initialised = false;
     this.vertexArray = scene.vertexArray;
 

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -28,7 +28,7 @@
           <app-fee-rate [fee]="feeRate"></app-fee-rate>
         </td>
       </tr>
-      <tr *ngIf="effectiveRate && effectiveRate !== feeRate">
+      <tr *ngIf="hasEffectiveRate && effectiveRate != null">
         <td *ngIf="!this.acceleration" class="td-width" i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>
         <td *ngIf="this.acceleration" class="td-width" i18n="transaction.effective-fee-rate|Effective transaction fee rate">Accelerated fee rate</td>
         <td>

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, ViewChild, Input, OnChanges, ChangeDetectionStra
 import { Position } from '../../components/block-overview-graph/sprite-types.js';
 import { Price } from '../../services/price.service';
 import { TransactionStripped } from '../../interfaces/node-api.interface.js';
+import { TransactionFlags } from '../../shared/filters.utils';
 
 @Component({
   selector: 'app-block-overview-tooltip',
@@ -22,6 +23,7 @@ export class BlockOverviewTooltipComponent implements OnChanges {
   feeRate = 0;
   effectiveRate;
   acceleration;
+  hasEffectiveRate: boolean = false;
 
   tooltipPosition: Position = { x: 0, y: 0 };
 
@@ -55,6 +57,8 @@ export class BlockOverviewTooltipComponent implements OnChanges {
       this.feeRate = this.fee / this.vsize;
       this.effectiveRate = tx.rate;
       this.acceleration = tx.acc;
+      this.hasEffectiveRate = Math.abs((this.fee / this.vsize) - this.effectiveRate) > 0.05
+        || (tx.bigintFlags && (tx.bigintFlags & (TransactionFlags.cpfp_child | TransactionFlags.cpfp_parent)) > 0n);
     }
   }
 }


### PR DESCRIPTION
PR #4670 rounded the `rate` field in mempool block websocket updates to 2 decimal places, which broke some naive logic in the tooltip component for detecting whether the "effective fee rate" ought to be displayed.

This PR adds a bit of tolerance to that condition, and then also checks the CPFP goggles flags to correct any false negatives.

| Before | After |
|-|-|
| <img width="537" alt="Screenshot 2024-03-03 at 4 49 23 PM" src="https://github.com/mempool/mempool/assets/83316221/4fc2dd9d-7341-402a-a756-8a253a7c0a17"> | <img width="537" alt="Screenshot 2024-03-03 at 4 49 09 PM" src="https://github.com/mempool/mempool/assets/83316221/d1bb2d1c-857d-4973-b551-c66f4e8d07e1"> |
