### PR TITLE
Fix missing mempool blocks

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="(loadingBlocks$ | async) === false; else loadingBlocks" [class.minimal]="minimal">
   <div class="mempool-blocks-container" [class.time-ltr]="timeLtr" [style.--block-size]="blockWidth+'px'" *ngIf="(difficultyAdjustments$ | async) as da;">
-    <div class="flashing">
-      <ng-template ngFor let-projectedBlock [ngForOf]="mempoolBlocks$ | async" let-i="index" [ngForTrackBy]="trackByFn">
+    <div class="flashing" *ngIf="(mempoolBlocks$ | async) as mempoolBlocks">
+      <ng-template ngFor let-projectedBlock [ngForOf]="mempoolBlocks" let-i="index" [ngForTrackBy]="trackByFn">
         <div
           *ngIf="minimal && spotlight > 0 && spotlight === i + 1"
           class="spotlight-bottom"


### PR DESCRIPTION
This PR works around an Angular bug which can cause the mempool blocks component to fail to render in certain conditions.

That happens most often after switching to the block page when there is only one block pending and relatively little mempool activity (which is most of the time on e.g. signet and liquid).

The bug seems to be caused by buggy change detection when using `async` pipes inside the `ngForOf` directive, so the workaround is to subscribe to the observable in an `ngIf` instead, one level higher.

The change to the `mempoolBlocks$` observable isn't as substantial as it looks from the diff - it just removes the `merge(
      of(true),
      fromEvent(window, 'resize')
    )` part, which doesn't really do anything right now, removes the superfluous `markForCheck()` call from the end, and then fixes the indentation.
    
Before:

https://github.com/mempool/mempool/assets/83316221/0d5d2898-411a-405d-a0f4-91a342c1f16a

After:

https://github.com/mempool/mempool/assets/83316221/ae1d5f81-f740-48ec-97e5-b69059049b69

