### PR TITLE
Display basic mining info on transaction page

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -78,7 +78,8 @@
                       {{ pool.name }}
                     </a>
                     <ng-container *ngIf="auditStatus">
-                      <span *ngIf="auditStatus.expected; else seen" class="badge badge-success mr-1" i18n-ngbTooltip="Expected in block tooltip" ngbTooltip="This transaction was projected to be included in the block" placement="bottom" i18n="tx-features.tag.expected|Expected in Block">Expected in Block</span>
+                      <span *ngIf="auditStatus.coinbase; else expected" class="badge badge-primary mr-1" i18n="tx-features.tag.coinbase|Coinbase">Coinbase</span>
+                      <ng-template #expected><span *ngIf="auditStatus.expected; else seen" class="badge badge-success mr-1" i18n-ngbTooltip="Expected in block tooltip" ngbTooltip="This transaction was projected to be included in the block" placement="bottom" i18n="tx-features.tag.expected|Expected in Block">Expected in Block</span></ng-template>
                       <ng-template #seen><span *ngIf="auditStatus.seen; else notSeen" class="badge badge-success mr-1" i18n-ngbTooltip="Seen in mempool tooltip" ngbTooltip="This transaction was seen in the mempool prior to mining" placement="bottom" i18n="tx-features.tag.seen|Seen in Mempool">Seen in Mempool</span></ng-template>
                       <ng-template #notSeen><span class="badge badge-warning mr-1" i18n-ngbTooltip="Not seen in mempool tooltip" ngbTooltip="This transaction was missing from our mempool prior to mining" placement="bottom" i18n="tx-features.tag.not-seen|Not seen in Mempool">Not seen in Mempool</span></ng-template>
                       <span *ngIf="auditStatus.added" class="badge badge-primary mr-1" i18n-ngbTooltip="Added transaction tooltip" ngbTooltip="This transaction may have been added or prioritized out-of-band" placement="bottom" i18n="tx-features.tag.added|Added">Added</span>

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -70,6 +70,25 @@
                     <app-tx-features [tx]="tx"></app-tx-features>
                   </td>
                 </tr>
+                <tr *ngIf="network === ''">
+                  <td class="td-width" i18n="transaction.mining">Mining</td>
+                  <td *ngIf="pool" class="wrap-cell">
+                    <a placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, pool.slug]" class="badge mr-1"
+                      [class]="pool.name === 'Unknown' ? 'badge-secondary' : 'badge-primary'">
+                      {{ pool.name }}
+                    </a>
+                    <ng-container *ngIf="auditStatus">
+                      <span *ngIf="auditStatus.expected; else seen" class="badge badge-success mr-1" i18n-ngbTooltip="Expected in block tooltip" ngbTooltip="This transaction was projected to be included in the block" placement="bottom" i18n="tx-features.tag.expected|Expected in Block">Expected in Block</span>
+                      <ng-template #seen><span *ngIf="auditStatus.seen; else notSeen" class="badge badge-success mr-1" i18n-ngbTooltip="Seen in mempool tooltip" ngbTooltip="This transaction was seen in the mempool prior to mining" placement="bottom" i18n="tx-features.tag.seen|Seen in Mempool">Seen in Mempool</span></ng-template>
+                      <ng-template #notSeen><span class="badge badge-warning mr-1" i18n-ngbTooltip="Not seen in mempool tooltip" ngbTooltip="This transaction was missing from our mempool prior to mining" placement="bottom" i18n="tx-features.tag.not-seen|Not seen in Mempool">Not seen in Mempool</span></ng-template>
+                      <span *ngIf="auditStatus.added" class="badge badge-primary mr-1" i18n-ngbTooltip="Added transaction tooltip" ngbTooltip="This transaction may have been added or prioritized out-of-band" placement="bottom" i18n="tx-features.tag.added|Added">Added</span>
+                      <span *ngIf="auditStatus.conflict" class="badge badge-warning mr-1" i18n-ngbTooltip="Conflict in mempool tooltip" ngbTooltip="This transaction conflicted with another version in our mempool" placement="bottom" i18n="tx-features.tag.conflict|Conflict">Conflict</span>
+                    </ng-container>
+                  </td>
+                  <td *ngIf="!pool">
+                    <span class="skeleton-loader"></span>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -509,7 +528,7 @@
 <ng-template #feeTable>
   <table class="table table-borderless table-striped">
     <tbody>
-      <tr *ngIf="isMobile && (network === 'liquid' || network === 'liquidtestnet' || !featuresEnabled)"></tr>
+      <tr *ngIf="isMobile && (network === 'liquid' || network === 'liquidtestnet' || !featuresEnabled || network === '')"></tr>
       <tr>
         <td class="td-width" i18n="transaction.fee|Transaction fee">Fee</td>
         <td>{{ tx.fee | number }} <span class="symbol" i18n="shared.sat|sat">sat</span> <span class="fiat"><app-fiat [blockConversion]="blockConversion" [value]="tx.fee"></app-fiat></span></td>

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -149,6 +149,10 @@
 		.btn {
 			display: block;
 		}
+
+    &.wrap-cell {
+      white-space: normal;
+    }
 	}
 }
 


### PR DESCRIPTION
This PR is a partial implementation of the feature described in #4422.

It adds a new "mining" row to the details panel on the transaction page, which includes a miner tag and (if available) some other audit-related status badges.

This feature is only enabled on Bitcoin mainnet, and the audit-related functionality is further restricted to instances with the `AUDIT` and `MINING_DASHBOARD` settings enabled, and for blocks above the `MAINNET_BLOCK_AUDIT_START_HEIGHT`.

The audit-related badges all have mouse-over tooltips with more information.

<img width="1021" alt="Screenshot 2024-03-07 at 11 36 41 PM" src="https://github.com/mempool/mempool/assets/83316221/08c95cf7-0c75-4292-bf6f-59e94a1259e7">
<img width="1021" alt="Screenshot 2024-03-07 at 11 34 40 PM" src="https://github.com/mempool/mempool/assets/83316221/a6b481d8-7621-4d8a-9b96-1fa802550f26">
<img width="1021" alt="Screenshot 2024-03-07 at 11 35 30 PM" src="https://github.com/mempool/mempool/assets/83316221/99b93405-c6c6-427c-8933-1a907fc3abac">
<img width="1021" alt="Screenshot 2024-03-07 at 11 34 26 PM" src="https://github.com/mempool/mempool/assets/83316221/c8e313bc-3527-4076-816e-72c81a396ccf">

The audit status badges aren't an exact match for the functionality in #4422. Specifically:
 - No "Delayed" badge, since we don't currently have a good way to identify that case.
 - The "(Not) Seen in mempool" and "Added" badges have slightly different semantics:
    - "Added" matches the current usage in the block audit (either added out-of-band, or intentionally prioritized)
    - "Seen in mempool" is displayed if the transaction is neither "added" nor a "conflict", and the "Expected in Block" badge is not already displayed. This more or less matches the "Marginal fee rate" badge in the main block audit.
        - Since we don't currently record whether transactions were seen in the mempool or not, this is necessarily a bad heuristic.
 - Additional "Conflict" badge, with the same meaning as the main block audit.

When we overhaul the main block audit feature to disambiguate some of these cases, we can update these tags on the transaction page at the same time.