### PR TITLE
Fix stuck Goggles on websocket reconnect

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -3,7 +3,7 @@
   <div class="block-overview-graph">
     <canvas class="block-overview-canvas" [class.clickable]="!!hoverTx" #blockCanvas></canvas>
     <div class="loader-wrapper" [class.hidden]="(!isLoading || disableSpinner) && !unavailable">
-      <div *ngIf="isLoading" class="spinner-border ml-3 loading" role="status"></div>
+      <div *ngIf="!unavailable" class="spinner-border ml-3 loading" role="status"></div>
       <div *ngIf="!isLoading && unavailable" class="ml-3" i18n="block.not-available">not available</div>
     </div>
     <app-block-overview-tooltip

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.scss
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.scss
@@ -60,6 +60,5 @@
 
   &.hidden {
     opacity: 0;
-    transition: opacity 500ms;
   }
 }

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -234,7 +234,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
                   acc.unshift(stats);
                   acc = acc.slice(0, 120);
                   return acc;
-                }, mempoolStats)
+                }, (mempoolStats || []))
               ),
             of(mempoolStats)
           );

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -116,7 +116,7 @@ export class WebsocketService {
             this.startMultiTrackTransaction(this.trackingTxId);
           }
           if (this.isTrackingMempoolBlock) {
-            this.startTrackMempoolBlock(this.trackingMempoolBlock);
+            this.startTrackMempoolBlock(this.trackingMempoolBlock, true);
           }
           if (this.isTrackingRbf) {
             this.startTrackRbf(this.isTrackingRbf);
@@ -197,9 +197,9 @@ export class WebsocketService {
     this.websocketSubject.next({ 'track-asset': 'stop' });
   }
 
-  startTrackMempoolBlock(block: number) {
+  startTrackMempoolBlock(block: number, force: boolean = false) {
     // skip duplicate tracking requests
-    if (this.trackingMempoolBlock !== block) {
+    if (force || this.trackingMempoolBlock !== block) {
       this.websocketSubject.next({ 'track-mempool-block': block });
       this.isTrackingMempoolBlock = true;
       this.trackingMempoolBlock = block;


### PR DESCRIPTION
This PR fixes an issue where we could fail to resume the `track-mempool-block` subscription after a websocket reconnection.

The PR also adjusts the transition on the block visualization loading spinner, so that it stays visible for a bit longer until the transactions finish animating in.