### PR TITLE
[accelerator] set accel graph bar min height

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
@@ -247,6 +247,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnDestroy {
           type: 'bar',
           barWidth: '90%',
           large: true,
+          barMinHeight: 1,
         },
       ],
       dataZoom: (this.widget || data.length === 0 )? undefined : [{


### PR DESCRIPTION
<img width="418" alt="Screenshot 2024-03-09 at 09 23 19" src="https://github.com/mempool/mempool/assets/9780671/b960b2a2-c4ab-4434-b1b7-a198cdd712f3">

Make sure we always show something even if the value is really small in comparison to other bars

<img width="422" alt="Screenshot 2024-03-09 at 09 23 32" src="https://github.com/mempool/mempool/assets/9780671/39467c8e-e409-490b-8ddd-97de16db9cfe">
