### PR TITLE
Add audit=[bool] param to /block/[hash] url

### DIFF
--- a/contributors/russeree.txt
+++ b/contributors/russeree.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of March 8, 2024.
+
+Signed: PortlandHODL

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -127,7 +127,6 @@ export class BlockComponent implements OnInit, OnDestroy {
     if (this.auditSupported) {
       this.isAuditEnabledFromParam().subscribe(auditParam => {
         if (this.auditParamEnabled) {
-          console.log(`auditParamEnabled: ${auditParam}`);
           this.auditModeEnabled = auditParam;
         } else {
           this.auditPrefSubscription = this.stateService.hideAudit.subscribe(hide => {


### PR DESCRIPTION
**Request**

Currently the audit view of a block doesn't have a URL parameter to temporality disable/enable audit view when using a ```/block/<hash>```. This is because that parameter is stored in a session storage variable. This is opposed to when a user clicks on the details view of a block and mempool will add the URL parameters ```"showDetails=false&view=actual#block"``` which will activate a details view of the block when the url is passed to another device. This is useful for consistent visualizations or presentation. 

**Solution**
Add a check for a URL parameter ```audit=[true/false]``` being passed to a ```/block/<hash>``` url that will temporarily display the audit view based on that parameter. 

**Design Choices**

1.  URL Parameter is passed and the page will show the requested view audit [false/true]
2. This does not overwrite the users existing preference for their audit view, so even if they are sent a link to show a block without the audit view. As soon as they refresh the page without the URL param it displays their session saved version
3. Clicking the audit view on or/off while inside of a param'd url will modify the session storage object and be reflected on the the next non param visit of another block. 

 

<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
