### PR TITLE
Fix block acceleration fees calculation & api bugs

### DIFF
--- a/backend/src/api/acceleration.ts
+++ b/backend/src/api/acceleration.ts
@@ -33,7 +33,7 @@ interface GraphTx {
   vsize: number;
   weight: number;
   fees: {
-    base: number;
+    base: number; // in sats
   };
   depends: string[];
   spentby: string[];
@@ -42,7 +42,7 @@ interface GraphTx {
 interface MempoolTx extends GraphTx {
   ancestorcount: number;
   ancestorsize: number;
-  fees: {
+  fees: { // in sats
     base: number;
     ancestor: number;
   };
@@ -317,7 +317,7 @@ class AccelerationCosts {
       throw new Error('invalid_tx_dependencies');
     }
 
-    let totalFee = Math.round(tx.fees.ancestor * 100_000_000);
+    let totalFee = tx.fees.ancestor;
 
     // transaction is already CPFP-d above the target rate by some descendant
     if (includedInCluster) {
@@ -325,7 +325,7 @@ class AccelerationCosts {
       let clusterFee = 0;
       includedInCluster.forEach(entry => {
         clusterSize += entry.vsize;
-        clusterFee += (entry.fees.base * 100_000_000);
+        clusterFee += entry.fees.base;
       });
       const clusterRate = clusterFee / clusterSize;
       totalFee = Math.ceil(tx.ancestorsize * clusterRate);
@@ -448,8 +448,8 @@ class AccelerationCosts {
    * @param tx 
    */
   private setAncestorScores(tx: MempoolTx): void {
-    tx.individualRate = (tx.fees.base * 100_000_000) / tx.vsize;
-    tx.ancestorRate = (tx.fees.ancestor * 100_000_000) / tx.ancestorsize;
+    tx.individualRate = tx.fees.base / tx.vsize;
+    tx.ancestorRate = tx.fees.ancestor / tx.ancestorsize;
     tx.score = Math.min(tx.individualRate, tx.ancestorRate);
   }
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 72;
+  private static currentVersion = 73;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -611,6 +611,13 @@ class DatabaseMigration {
       // reindex Goggles flags for mined block templates above height 833000
       await this.$executeQuery('UPDATE blocks_summaries SET version = 0 WHERE height >= 832000;');
       await this.updateToSchemaVersion(72);
+    }
+
+    if (databaseSchemaVersion < 73 && isBitcoin === true) {
+      // Clear bad data
+      await this.$executeQuery(`TRUNCATE accelerations`);
+      this.uniqueLog(logger.notice, `'accelerations' table has been truncated`);
+      await this.updateToSchemaVersion(73);
     }
   }
 

--- a/backend/src/repositories/AccelerationRepository.ts
+++ b/backend/src/repositories/AccelerationRepository.ts
@@ -73,7 +73,8 @@ class AccelerationRepository {
 
     if (interval) {
       query += ` WHERE accelerations.added BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW() `;
-    } else if (height != null) {
+    }
+    if (height != null) {
       query += ` WHERE accelerations.height = ? `;
       params.push(height);
     } else if (poolSlug != null) {


### PR DESCRIPTION
This PR should fix a bug in the accelerator audit calculation from https://github.com/mempool/mempool/pull/4718 which was interpreting transaction fees in the wrong units (BTC instead of sats).

Since the results so far are incorrect, **this PR includes a database migration to truncate the local accelerations table**.

The PR also fixes an issue with the `/api/v1/accelerations/pool/:slug` and `/api/v1/accelerations/block/:height` APIs which were mistakenly returning results for `/api/v1/accelerations/recent/24h`.