### PR TITLE
Audit past acceleration fees

### DIFF
--- a/backend/src/api/acceleration.ts
+++ b/backend/src/api/acceleration.ts
@@ -238,7 +238,7 @@ class AccelerationCosts {
   private convertToGraphTx(tx: MempoolTransactionExtended): GraphTx {
     return {
       txid: tx.txid,
-      vsize: tx.vsize,
+      vsize: Math.ceil(tx.weight / 4),
       weight: tx.weight,
       fees: {
         base: 0, // dummy
@@ -256,7 +256,7 @@ class AccelerationCosts {
         ancestor: tx.fees.base,
       },
       ancestorcount: 1,
-      ancestorsize: tx.vsize,
+      ancestorsize: Math.ceil(tx.weight / 4),
       ancestors: new Map<string, MempoolTx>(),
       ancestorRate: 0,
       individualRate: 0,
@@ -493,7 +493,7 @@ interface MinerTransaction extends TemplateTransaction {
 * Build a block using an approximation of the transaction selection algorithm from Bitcoin Core
 * (see BlockAssembler in https://github.com/bitcoin/bitcoin/blob/master/src/node/miner.cpp)
 */
-function makeBlockTemplate(candidates: IEsploraApi.Transaction[], accelerations: Acceleration[], maxBlocks: number = 8, weightLimit: number = BLOCK_WEIGHT_UNITS, sigopLimit: number = BLOCK_SIGOPS): TemplateTransaction[] {
+export function makeBlockTemplate(candidates: IEsploraApi.Transaction[], accelerations: Acceleration[], maxBlocks: number = 8, weightLimit: number = BLOCK_WEIGHT_UNITS, sigopLimit: number = BLOCK_SIGOPS): TemplateTransaction[] {
   const auditPool: Map<string, MinerTransaction> = new Map();
   const mempoolArray: MinerTransaction[] = [];
   

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 73;
+  private static currentVersion = 74;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -618,6 +618,11 @@ class DatabaseMigration {
       await this.$executeQuery(`TRUNCATE accelerations`);
       this.uniqueLog(logger.notice, `'accelerations' table has been truncated`);
       await this.updateToSchemaVersion(73);
+    }
+
+    if (databaseSchemaVersion < 74 && config.MEMPOOL.NETWORK === 'mainnet') {
+      await this.$executeQuery(`INSERT INTO state(name, number) VALUE ('last_acceleration_block', 0);`);
+      await this.updateToSchemaVersion(74);
     }
   }
 

--- a/backend/src/api/services/acceleration.ts
+++ b/backend/src/api/services/acceleration.ts
@@ -7,7 +7,26 @@ export interface Acceleration {
   txid: string,
   feeDelta: number,
   pools: number[],
-}
+};
+
+export interface AccelerationHistory {
+  txid: string,
+  status: string,
+  feePaid: number,
+  added: number,
+  lastUpdated: number,
+  baseFee: number,
+  vsizeFee: number,
+  effectiveFee: number,
+  effectiveVsize: number,
+  feeDelta: number,
+  blockHash: string,
+  blockHeight: number,
+  pools: {
+    pool_unique_id: number,
+    username: string,
+  }[],
+};
 
 class AccelerationApi {
   public async $fetchAccelerations(): Promise<Acceleration[] | null> {
@@ -17,6 +36,27 @@ class AccelerationApi {
         return response.data as Acceleration[];
       } catch (e) {
         logger.warn('Failed to fetch current accelerations from the mempool services backend: ' + (e instanceof Error ? e.message : e));
+        return null;
+      }
+    } else {
+      return [];
+    }
+  }
+
+  public async $fetchAccelerationHistory(page?: number, status?: string): Promise<AccelerationHistory[] | null> {
+    if (config.MEMPOOL_SERVICES.ACCELERATIONS) {
+      try {
+        const response = await axios.get(`${config.MEMPOOL_SERVICES.API}/accelerator/accelerations/history`, {
+          responseType: 'json',
+          timeout: 10000,
+          params: {
+            page,
+            status,
+          }
+        });
+        return response.data as AccelerationHistory[];
+      } catch (e) {
+        logger.warn('Failed to fetch acceleration history from the mempool services backend: ' + (e instanceof Error ? e.message : e));
         return null;
       }
     } else {

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -8,6 +8,7 @@ import priceUpdater from './tasks/price-updater';
 import PricesRepository from './repositories/PricesRepository';
 import config from './config';
 import auditReplicator from './replication/AuditReplication';
+import AccelerationRepository from './repositories/AccelerationRepository';
 
 export interface CoreIndex {
   name: string;
@@ -185,6 +186,7 @@ class Indexer {
       await blocks.$generateCPFPDatabase();
       await blocks.$generateAuditStats();
       await auditReplicator.$sync();
+      await AccelerationRepository.$indexPastAccelerations();
       // do not wait for classify blocks to finish
       blocks.$classifyBlocks();
     } catch (e) {

--- a/backend/src/repositories/AccelerationRepository.ts
+++ b/backend/src/repositories/AccelerationRepository.ts
@@ -1,10 +1,16 @@
-import { AccelerationInfo } from '../api/acceleration';
-import { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { AccelerationInfo, makeBlockTemplate } from '../api/acceleration';
+import { RowDataPacket } from 'mysql2';
 import DB from '../database';
 import logger from '../logger';
 import { IEsploraApi } from '../api/bitcoin/esplora-api.interface';
 import { Common } from '../api/common';
 import config from '../config';
+import blocks from '../api/blocks';
+import accelerationApi, { Acceleration } from '../api/services/acceleration';
+import accelerationCosts from '../api/acceleration';
+import bitcoinApi from '../api/bitcoin/bitcoin-api-factory';
+import transactionUtils from '../api/transaction-utils';
+import { BlockExtended, MempoolTransactionExtended } from '../mempool.interfaces';
 
 export interface PublicAcceleration {
   txid: string,
@@ -21,19 +27,15 @@ export interface PublicAcceleration {
 }
 
 class AccelerationRepository {
+  private bidBoostV2Activated = 831580;
+
   public async $saveAcceleration(acceleration: AccelerationInfo, block: IEsploraApi.Block, pool_id: number): Promise<void> {
     try {
       await DB.query(`
         INSERT INTO accelerations(txid, added, height, pool, effective_vsize, effective_fee, boost_rate, boost_cost)
         VALUE (?, FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
-          added = FROM_UNIXTIME(?),
-          height = ?,
-          pool = ?,
-          effective_vsize = ?,
-          effective_fee = ?,
-          boost_rate = ?,
-          boost_cost = ?
+          height = ?
       `, [
         acceleration.txSummary.txid,
         block.timestamp,
@@ -41,13 +43,9 @@ class AccelerationRepository {
         pool_id,
         acceleration.txSummary.effectiveVsize,
         acceleration.txSummary.effectiveFee,
-        acceleration.targetFeeRate, acceleration.cost,
-        block.timestamp,
+        acceleration.targetFeeRate,
+        acceleration.cost,
         block.height,
-        pool_id,
-        acceleration.txSummary.effectiveVsize,
-        acceleration.txSummary.effectiveFee,
-        acceleration.targetFeeRate, acceleration.cost,
       ]);
     } catch (e: any) {
       logger.err(`Cannot save acceleration (${acceleration.txSummary.txid}) into db. Reason: ` + (e instanceof Error ? e.message : e));
@@ -118,6 +116,167 @@ class AccelerationRepository {
       logger.err(`Cannot query acceleration info. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
+  }
+
+  public async $getLastSyncedHeight(): Promise<number> {
+    try {
+      const [rows] = await DB.query(`
+        SELECT * FROM state
+        WHERE name = 'last_acceleration_block'
+      `);
+      if (rows?.['length']) {
+        return rows[0].number;
+      }
+    } catch (e: any) {
+      logger.err(`Cannot find last acceleration sync height. Reason: ` + (e instanceof Error ? e.message : e));
+    }
+    return 0;
+  }
+
+  private async $setLastSyncedHeight(height: number): Promise<void> {
+    try {
+      await DB.query(`
+        UPDATE state
+        SET number = ?
+        WHERE name = 'last_acceleration_block'
+      `, [height]);
+    } catch (e: any) {
+      logger.err(`Cannot update last acceleration sync height. Reason: ` + (e instanceof Error ? e.message : e));
+    }
+  }
+
+  public async $indexAccelerationsForBlock(block: BlockExtended, accelerations: Acceleration[], transactions: MempoolTransactionExtended[]): Promise<void> {
+    const blockTxs: { [txid: string]: MempoolTransactionExtended } = {};
+    for (const tx of transactions) {
+      blockTxs[tx.txid] = tx;
+    }
+    const successfulAccelerations = accelerations.filter(acc => acc.pools.includes(block.extras.pool.id));
+    let boostRate: number | null = null;
+    for (const acc of successfulAccelerations) {
+      if (boostRate === null) {
+        boostRate = accelerationCosts.calculateBoostRate(
+          accelerations.map(acc => ({ txid: acc.txid, max_bid: acc.feeDelta })),
+          transactions
+        );
+      }
+      if (blockTxs[acc.txid]) {
+        const tx = blockTxs[acc.txid];
+        const accelerationInfo = accelerationCosts.getAccelerationInfo(tx, boostRate, transactions);
+        accelerationInfo.cost = Math.max(0, Math.min(acc.feeDelta, accelerationInfo.cost));
+        this.$saveAcceleration(accelerationInfo, block, block.extras.pool.id);
+      }
+    }
+    const lastSyncedHeight = await this.$getLastSyncedHeight();
+    // if we've missed any blocks, let the indexer catch up from the last synced height on the next run
+    if (block.height === lastSyncedHeight + 1) {
+      await this.$setLastSyncedHeight(block.height);
+    }
+  }
+
+  /**
+   * [INDEXING] Backfill missing acceleration data
+   */
+  async $indexPastAccelerations(): Promise<void> {
+    if (config.MEMPOOL.NETWORK !== 'mainnet' || !config.MEMPOOL_SERVICES.ACCELERATIONS) {
+      // acceleration history disabled
+      return;
+    }
+    const lastSyncedHeight = await this.$getLastSyncedHeight();
+    const currentHeight = blocks.getCurrentBlockHeight();
+    if (currentHeight <= lastSyncedHeight) {
+      // already in sync
+      return;
+    }
+
+    logger.debug(`Fetching accelerations between block ${lastSyncedHeight} and ${currentHeight}`);
+
+    // Fetch accelerations from mempool.space since the last synced block;
+    const accelerationsByBlock = {};
+    const blockHashes = {};
+    let done = false;
+    let page = 1;
+    let count = 0;
+    try {
+      while (!done) {
+        const accelerations = await accelerationApi.$fetchAccelerationHistory(page);
+        page++;
+        if (!accelerations?.length) {
+          done = true;
+          break;
+        }
+        for (const acc of accelerations) {
+          if (acc.status !== 'mined' && acc.status !== 'completed') {
+            continue;
+          }
+          if (!lastSyncedHeight || acc.blockHeight > lastSyncedHeight) {
+            if (!accelerationsByBlock[acc.blockHeight]) {
+              accelerationsByBlock[acc.blockHeight] = [];
+              blockHashes[acc.blockHeight] = acc.blockHash;
+            }
+            accelerationsByBlock[acc.blockHeight].push(acc);
+            count++;
+          } else {
+            done = true;
+          }
+        }
+      }
+    } catch (e) {
+      logger.err(`Failed to fetch full acceleration history. Reason: ` + (e instanceof Error ? e.message : e));
+    }
+
+    logger.debug(`Indexing ${count} accelerations between block ${lastSyncedHeight} and ${currentHeight}`);
+
+    // process accelerated blocks in order
+    const heights = Object.keys(accelerationsByBlock).map(key => parseInt(key)).sort((a,b) => a - b);
+    for (const height of heights) {
+      const accelerations = accelerationsByBlock[height];
+      try {
+        const block = await blocks.$getBlock(blockHashes[height]) as BlockExtended;
+        const transactions = (await bitcoinApi.$getTxsForBlock(blockHashes[height])).map(tx => transactionUtils.extendMempoolTransaction(tx));
+
+        const blockTxs = {};
+        for (const tx of transactions) {
+          blockTxs[tx.txid] = tx;
+        }
+
+        let boostRate = 0;
+        // use Bid Boost V2 if active
+        if (height > this.bidBoostV2Activated) {
+          boostRate = accelerationCosts.calculateBoostRate(
+            accelerations.map(acc => ({ txid: acc.txid, max_bid: acc.feeDelta })),
+            transactions
+          );
+        } else {
+          // default to Bid Boost V1 (median block fee rate)
+          const template = makeBlockTemplate(
+            transactions,
+            accelerations.map(acc => ({ txid: acc.txid, max_bid: acc.feeDelta })),
+            1,
+            Infinity,
+            Infinity
+          );
+          const feeStats = Common.calcEffectiveFeeStatistics(template);
+          boostRate = feeStats.medianFee;
+        }
+        for (const acc of accelerations) {
+          if (blockTxs[acc.txid]) {
+            const tx = blockTxs[acc.txid];
+            const accelerationInfo = accelerationCosts.getAccelerationInfo(tx, boostRate, transactions);
+            accelerationInfo.cost = Math.max(0, Math.min(acc.feeDelta, accelerationInfo.cost));
+            await this.$saveAcceleration(accelerationInfo, block, block.extras.pool.id);
+          }
+        }
+        await this.$setLastSyncedHeight(height);
+      } catch (e) {
+        logger.err(`Failed to process accelerations for block ${height}. Reason: ` + (e instanceof Error ? e.message : e));
+        return;
+      }
+      logger.debug(`Indexed ${accelerations.length} accelerations in block  ${height}`);
+    }
+
+    await this.$setLastSyncedHeight(currentHeight);
+
+    logger.debug(`Indexing accelerations completed`);
   }
 }
 


### PR DESCRIPTION
This PR uses the paginated mempool services backend API to fetch past accelerations, and independently calculate the expected Bid Boost fees paid for each.

The task runs as part of the regular indexing, and so will also catch up on accelerations mined while the backend was offline or missed for other reasons.

Accelerations are processed block-by-block, oldest first, with progress tracked in a "last_acceleration_block" row in the `mempool.state` db table. If you need to reindex the acceleration data for any reason, truncate the `mempool.accelerations` table (or drop the relevant rows) and reset the "last_acceleration_block" to 0 (or some other starting height) in the `mempool.state` table.

The implementation supports both Bid Boost V1 and V2 calculations, with a hardcoded switch-over at block height 831580.

The PR also includes a small bugfix for the existing V2 calculation related to vsize rounding, which could sometimes cause results to be off by a few sats.

Note that due to variability in the median fee rate used for the V1 calculation, the fees calculated for these older accelerations may differ slightly from the amounts actually charged (as reported by the services backend public APIs).