### PR TITLE
Simplify recent transactions observable

### DIFF
--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -189,17 +189,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
         })
       );
 
-    this.transactions$ = this.stateService.transactions$
-      .pipe(
-        scan((acc, tx) => {
-          if (acc.find((t) => t.txid == tx.txid)) {
-            return acc;
-          }
-          acc.unshift(tx);
-          acc = acc.slice(0, 6);
-          return acc;
-        }, []),
-      );
+    this.transactions$ = this.stateService.transactions$;
 
     this.blocks$ = this.stateService.blocks$
       .pipe(

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -101,7 +101,7 @@ export class StateService {
   lightningChanged$ = new ReplaySubject<boolean>(1);
   blocksSubject$ = new BehaviorSubject<BlockExtended[]>([]);
   blocks$: Observable<BlockExtended[]>;
-  transactions$ = new ReplaySubject<TransactionStripped>(6);
+  transactions$ = new BehaviorSubject<TransactionStripped[]>(null);
   conversions$ = new ReplaySubject<any>(1);
   bsqPrice$ = new ReplaySubject<number>(1);
   mempoolInfo$ = new ReplaySubject<MempoolInfo>(1);
@@ -217,7 +217,7 @@ export class StateService {
     }
 
     this.networkChanged$.subscribe((network) => {
-      this.transactions$ = new ReplaySubject<TransactionStripped>(6);
+      this.transactions$ = new BehaviorSubject<TransactionStripped[]>(null);
       this.blocksSubject$.next([]);
     });
 

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -343,7 +343,7 @@ export class WebsocketService {
     }
 
     if (response.transactions) {
-      response.transactions.forEach((tx) => this.stateService.transactions$.next(tx));
+      this.stateService.transactions$.next(response.transactions.slice(0, 6));
     }
 
     if (response['bsq-price']) {


### PR DESCRIPTION
This PR simplifies the `stateService.transactions$` observable used for the Recent Transactions widget, and also fixes the ordering of transactions there (so that new transactions enter from the top, not the bottom).

Before:

https://github.com/mempool/mempool/assets/83316221/0a1d3c25-2042-4d6a-a6c7-d91fa30f08b8

After:

https://github.com/mempool/mempool/assets/83316221/c0d40fc9-91ac-4dca-ac95-ba58480a7367


