### PR TITLE
Increase precision of out-of-band fees on the block page

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -226,7 +226,7 @@
         fragment="actual" (click)="changeMode('actual')">Actual</a>
     </div>
     <div class="row">
-      <div class="col-sm">
+      <div class="col-sm audit-col" [class.mobile]="isMobile">
         <h3 class="block-subtitle" *ngIf="!isMobile"><ng-container i18n="block.expected-block">Expected Block</ng-container></h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="isLoadingOverview" [resolution]="86"
@@ -241,7 +241,7 @@
           </ng-template>
         </ng-container>
       </div>
-      <div class="col-sm" *ngIf="!isMobile">
+      <div class="col-sm audit-col" *ngIf="!isMobile">
         <h3 class="block-subtitle actual" *ngIf="!isMobile"><ng-container i18n="block.actual-block">Actual Block</ng-container><a class="info-link" [routerLink]="['/docs/faq' | relativeUrl ]" fragment="how-do-block-audits-work"><fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></a></h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphActual [isLoading]="isLoadingOverview" [resolution]="86"
@@ -431,10 +431,10 @@
     <tbody>
       <tr>
         <td i18n="block.total-fees|Total fees in a block">Total fees</td>
-        <td>
+        <td class="text-wrap">
           <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
           <span *ngIf="oobFees" class="oobFees" i18n-ngbTooltip="Acceleration Fees" ngbTooltip="Acceleration fees paid out-of-band">
-             +<app-amount [satoshis]="oobFees" digitsInfo="1.2-4" [noFiat]="true"></app-amount>
+             +<app-amount [satoshis]="oobFees" digitsInfo="1.2-8" [noFiat]="true"></app-amount>
           </span>
           <span *ngIf="blockAudit.feeDelta" class="difference" [class.positive]="blockAudit.feeDelta <= 0" [class.negative]="blockAudit.feeDelta > 0">
             {{ blockAudit.feeDelta < 0 ? '+' : '' }}{{ (-blockAudit.feeDelta * 100) | amountShortener: 2 }}%

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -70,6 +70,14 @@
   }
 }
 
+.audit-col {
+  max-width: 50%;
+
+  &.mobile {
+    max-width: 100%;
+  }
+}
+
 .block-subtitle.actual a {
   position: absolute;
   top: -3px;


### PR DESCRIPTION
Increases the maximum precision of the out-of-band fees on the block page from 4 to 8 decimal places.

Before:
<img width="535" alt="Screenshot 2024-03-15 at 7 47 55 AM" src="https://github.com/mempool/mempool/assets/83316221/83881123-a73e-4439-9c7f-483f2a4127ff">

After:
<img width="535" alt="Screenshot 2024-03-15 at 7 47 36 AM" src="https://github.com/mempool/mempool/assets/83316221/1fa966fc-46cd-4d5d-8d46-1aef636302e9">
