### PR TITLE
Display more accurate price data on tx bowtie tooltip

### DIFF
--- a/frontend/src/app/components/amount/amount.component.html
+++ b/frontend/src/app/components/amount/amount.component.html
@@ -8,8 +8,13 @@
     }}
   </span>
   <ng-template #noblockconversion>
-    <span class="fiat">{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ (conversions[currency] > -1 ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}
-    </span>
+    <ng-container *ngIf="!forceBlockConversion; else zeroValue">
+      <span class="fiat">{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ (conversions[currency] > -1 ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}
+      </span>
+    </ng-container>
+  </ng-template>
+  <ng-template #zeroValue>
+    <span class="fiat">{{ 0 | fiatCurrency : digitsInfo : currency }}</span>
   </ng-template>
 </ng-container>
 

--- a/frontend/src/app/components/amount/amount.component.html
+++ b/frontend/src/app/components/amount/amount.component.html
@@ -8,10 +8,8 @@
     }}
   </span>
   <ng-template #noblockconversion>
-    <ng-container *ngIf="!forceBlockConversion; else zeroValue">
-      <span class="fiat">{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ (conversions[currency] > -1 ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}
-      </span>
-    </ng-container>
+    <span class="fiat" *ngIf="!forceBlockConversion; else zeroValue">{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ (conversions[currency] > -1 ? conversions[currency] : 0) * satoshis / 100000000 | fiatCurrency : digitsInfo : currency }}
+    </span>
   </ng-template>
   <ng-template #zeroValue>
     <span class="fiat">{{ 0 | fiatCurrency : digitsInfo : currency }}</span>

--- a/frontend/src/app/components/amount/amount.component.ts
+++ b/frontend/src/app/components/amount/amount.component.ts
@@ -24,6 +24,7 @@ export class AmountComponent implements OnInit, OnDestroy {
   @Input() addPlus = false;
   @Input() blockConversion: Price;
   @Input() forceBtc: boolean = false;
+  @Input() forceBlockConversion: boolean = false; // true = displays fiat price as 0 if blockConversion is undefined instead of falling back to conversions
 
   constructor(
     private stateService: StateService,

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -44,6 +44,28 @@
           <span *ngSwitchCase="'fee'" i18n="transaction.fee|Transaction fee">Fee</span>
         </ng-container>
         <span *ngIf="line.type !== 'fee'"> #{{ line.index + 1 }}</span>
+        <ng-container [ngSwitch]="line.type">
+          <span *ngSwitchCase="'input'"> 
+            <ng-container *ngIf="line.status?.block_height">
+                <ng-container *ngIf="line.blockHeight; else noBlockHeight">
+                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: line.blockHeight - line?.status?.block_height, connector: false}"></ng-container>
+              </ng-container>
+              <ng-template #noBlockHeight>
+                <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: chainTip + 1 - line?.status?.block_height, connector: false}"></ng-container>
+              </ng-template>
+            </ng-container>
+          </span>
+          <span *ngSwitchCase="'output'">
+            <ng-container *ngIf="line.blockHeight && line?.spent">
+              <ng-container *ngIf="line?.status?.block_height; else noBlockHeight">
+                <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: line?.status?.block_height - line.blockHeight, connector: false}"></ng-container>
+              </ng-container>
+              <ng-template #noBlockHeight>
+                <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: chainTip + 1 - line.blockHeight, connector: false}"></ng-container>
+              </ng-template>
+            </ng-container>
+          </span>
+        </ng-container>
       </p>
       <ng-container *ngIf="isConnector && line.txid">
         <p>
@@ -51,8 +73,26 @@
           <app-truncate [text]="line.txid"></app-truncate>
         </p>
           <ng-container [ngSwitch]="line.type">
-            <p *ngSwitchCase="'input'"><span i18n="transaction.output">Output</span>&nbsp; #{{ line.vout + 1 }}</p>
-            <p *ngSwitchCase="'output'"><span i18n="transaction.input">Input</span>&nbsp; #{{ line.vin + 1 }}</p>
+            <p *ngSwitchCase="'input'"><span i18n="transaction.output">Output</span>&nbsp; #{{ line.vout + 1 }}
+              <ng-container *ngIf="line.status?.block_height">
+                <ng-container *ngIf="line.blockHeight; else noBlockHeight">
+                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: line.blockHeight - line?.status?.block_height, connector: true}"></ng-container>
+                </ng-container>
+                <ng-template #noBlockHeight>
+                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: chainTip + 1 - line?.status?.block_height, connector: true}"></ng-container>
+                </ng-template>
+              </ng-container>
+            </p>
+            <p *ngSwitchCase="'output'"><span i18n="transaction.input">Input</span>&nbsp; #{{ line.vin + 1 }}
+              <ng-container *ngIf="line.blockHeight">
+                <ng-container *ngIf="line?.status?.block_height; else noBlockHeight">
+                  <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: line?.status?.block_height - line.blockHeight, connector: true}"></ng-container>
+                </ng-container>
+                <ng-template #noBlockHeight>
+                  <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: chainTip + 1 - line.blockHeight, connector: true}"></ng-container>
+                </ng-template>
+              </ng-container>
+            </p>
           </ng-container>
       </ng-container>
       <p *ngIf="line.displayValue == null && line.confidential" i18n="shared.confidential">Confidential</p>
@@ -66,7 +106,7 @@
           </ng-template>
         </ng-template>
         <ng-template #defaultOutput>
-          <app-amount [blockConversion]="blockConversion" [satoshis]="line.displayValue"></app-amount>
+          <app-amount [blockConversion]="isConnector ? blockConversions[line?.status?.block_time] : blockConversions[line?.timestamp]" [satoshis]="line.displayValue" [forceBlockConversion]="isConnector && line?.status?.block_time"></app-amount>
         </ng-template>
       </p>
       <p *ngIf="line.type !== 'fee' && line.address" class="address">
@@ -77,4 +117,42 @@
 
 <ng-template #assetBox let-item>
   {{ item.displayValue / pow(10, assetsMinimal[item.asset][3]) | number: '1.' + assetsMinimal[item.asset][3] + '-' + assetsMinimal[item.asset][3] }} <span class="symbol">{{ assetsMinimal[item.asset][1] }}</span>
+</ng-template>
+
+<ng-template #oneBlockAgo>
+  <span i18n="shared.one-block-ago">1 block ago</span>
+</ng-template>
+
+<ng-template #oneBlockLater>
+  <span i18n="shared.one-block-later">1 block later</span>
+</ng-template>
+
+<ng-template #inTheSameBlock>
+  <span i18n="shared.in-the-same-block">in the same block</span>
+</ng-template>
+
+<ng-template #nBlocksAgo let-n="n" let-connector="connector">
+  (<span *ngIf="!connector">prevout </span>
+  <ng-container *ngIf="n > 1">
+    <span>{{ n }} <ng-container i18n="shared.n-blocks-ago">blocks ago</ng-container>)</span>
+  </ng-container>
+  <ng-container *ngIf="n === 1">
+    <span><ng-container *ngTemplateOutlet="oneBlockAgo"></ng-container>)</span>
+  </ng-container>
+  <ng-container *ngIf="n === 0">
+    <span><ng-container *ngTemplateOutlet="inTheSameBlock"></ng-container>)</span>
+  </ng-container>
+</ng-template>
+
+<ng-template #nBlocksLater let-n="n" let-connector="connector">
+  (<span *ngIf="!connector" i18n="shared.spent">spent </span>
+  <ng-container *ngIf="n > 1">
+    <span>{{ n }} <ng-container i18n="shared.n-blocks-later">blocks later</ng-container>)</span>
+  </ng-container>
+  <ng-container *ngIf="n === 1">
+    <span><ng-container *ngTemplateOutlet="oneBlockLater"></ng-container>)</span>
+  </ng-container>
+  <ng-container *ngIf="n === 0">
+    <span><ng-container *ngTemplateOutlet="inTheSameBlock"></ng-container>)</span>
+  </ng-container>
 </ng-template>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -48,10 +48,10 @@
           <span *ngSwitchCase="'input'"> 
             <ng-container *ngIf="line.status?.block_height">
                 <ng-container *ngIf="line.blockHeight; else noBlockHeight">
-                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: line.blockHeight - line?.status?.block_height, connector: false}"></ng-container>
+                  <ng-container *ngTemplateOutlet="nBlocksEarlier; context:{n: line.blockHeight - line?.status?.block_height, connector: false}"></ng-container>
               </ng-container>
               <ng-template #noBlockHeight>
-                <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: chainTip + 1 - line?.status?.block_height, connector: false}"></ng-container>
+                <ng-container *ngTemplateOutlet="nBlocksEarlier; context:{n: chainTip + 1 - line?.status?.block_height, connector: false}"></ng-container>
               </ng-template>
             </ng-container>
           </span>
@@ -76,10 +76,10 @@
             <p *ngSwitchCase="'input'"><span i18n="transaction.output">Output</span>&nbsp; #{{ line.vout + 1 }}
               <ng-container *ngIf="line.status?.block_height">
                 <ng-container *ngIf="line.blockHeight; else noBlockHeight">
-                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: line.blockHeight - line?.status?.block_height, connector: true}"></ng-container>
+                  <ng-container *ngTemplateOutlet="nBlocksEarlier; context:{n: line.blockHeight - line?.status?.block_height, connector: true}"></ng-container>
                 </ng-container>
                 <ng-template #noBlockHeight>
-                  <ng-container *ngTemplateOutlet="nBlocksAgo; context:{n: chainTip + 1 - line?.status?.block_height, connector: true}"></ng-container>
+                  <ng-container *ngTemplateOutlet="nBlocksEarlier; context:{n: chainTip + 1 - line?.status?.block_height, connector: true}"></ng-container>
                 </ng-template>
               </ng-container>
             </p>
@@ -119,8 +119,8 @@
   {{ item.displayValue / pow(10, assetsMinimal[item.asset][3]) | number: '1.' + assetsMinimal[item.asset][3] + '-' + assetsMinimal[item.asset][3] }} <span class="symbol">{{ assetsMinimal[item.asset][1] }}</span>
 </ng-template>
 
-<ng-template #oneBlockAgo>
-  <span i18n="shared.one-block-ago">1 block ago</span>
+<ng-template #oneBlockEarlier>
+  <span i18n="shared.one-block-earlier">1 block earlier</span>
 </ng-template>
 
 <ng-template #oneBlockLater>
@@ -131,13 +131,13 @@
   <span i18n="shared.in-the-same-block">in the same block</span>
 </ng-template>
 
-<ng-template #nBlocksAgo let-n="n" let-connector="connector">
+<ng-template #nBlocksEarlier let-n="n" let-connector="connector">
   (<span *ngIf="!connector">prevout </span>
   <ng-container *ngIf="n > 1">
-    <span>{{ n }} <ng-container i18n="shared.n-blocks-ago">blocks ago</ng-container>)</span>
+    <span>{{ n }} <ng-container i18n="shared.n-blocks-earlier">blocks earlier</ng-container>)</span>
   </ng-container>
   <ng-container *ngIf="n === 1">
-    <span><ng-container *ngTemplateOutlet="oneBlockAgo"></ng-container>)</span>
+    <span><ng-container *ngTemplateOutlet="oneBlockEarlier"></ng-container>)</span>
   </ng-container>
   <ng-container *ngIf="n === 0">
     <span><ng-container *ngTemplateOutlet="inTheSameBlock"></ng-container>)</span>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.scss
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.scss
@@ -7,7 +7,7 @@
   padding: 10px 15px;
   text-align: left;
   pointer-events: none;
-  max-width: 300px;
+  max-width: 350px;
 
   p {
     margin: 0;

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -34,6 +34,7 @@ interface Xput {
   pegout?: string;
   confidential?: boolean;
   timestamp?: number;
+  blockHeight?: number;
   asset?: string;
 }
 
@@ -178,6 +179,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
         pegout: v?.pegout?.scriptpubkey_address,
         confidential: (this.isLiquid && v?.value === undefined),
         timestamp: this.tx.status.block_time,
+        blockHeight: this.tx.status.block_height,
         asset: v?.asset,
       } as Xput;
     });
@@ -200,6 +202,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
         pegin: v?.is_pegin,
         confidential: (this.isLiquid && v?.prevout?.value === undefined),
         timestamp: this.tx.status.block_time,
+        blockHeight: this.tx.status.block_height,
         asset: v?.prevout?.asset,
       } as Xput;
     });

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -240,6 +240,10 @@ export class ApiService {
     return this.httpClient.post<any>(this.apiBaseUrl + this.apiBasePath + '/api/tx', hexPayload, { responseType: 'text' as 'json'});
   }
 
+  getTransactionStatus$(txid: string): Observable<any> {
+    return this.httpClient.get<any>(this.apiBaseUrl + this.apiBasePath + '/api/tx/' + txid + '/status');
+  }
+
   listPools$(interval: string | undefined) : Observable<any> {
     return this.httpClient.get<any>(
       this.apiBaseUrl + this.apiBasePath + `/api/v1/mining/pools` +


### PR DESCRIPTION
This PR adds some data on the tx bowtie tooltip: 
- the number of blocks elapsed between the input and prevout or the output and the input spending it (if exists)
- if the user chooses to view fiat instead of btc value, the value displayed in the tooltip uses the BTC price at the time of the corresponding transaction (price data queried on hover)

*********************


- Prevout: 
<img width="249" alt="Screenshot 2024-03-17 at 16 55 48" src="https://github.com/mempool/mempool/assets/46578910/c633fdc7-5499-431d-937c-f7904729dbb5">

- Input: 
<img width="247" alt="Screenshot 2024-03-17 at 16 55 41" src="https://github.com/mempool/mempool/assets/46578910/050fe2f2-b51b-4d14-ada0-ec9d87d10ce4">

- Output: 
<img width="250" alt="Screenshot 2024-03-17 at 16 55 33" src="https://github.com/mempool/mempool/assets/46578910/6b8bbac5-a622-4596-b7bf-b22dba741738">

- Next input spending the output: 
<img width="249" alt="Screenshot 2024-03-17 at 16 55 25" src="https://github.com/mempool/mempool/assets/46578910/166e90f8-b084-41d4-b9df-9f984b979a55">
