### PR TITLE
Fix broken load more for P2PK address page

### DIFF
--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -253,7 +253,9 @@ export class AddressComponent implements OnInit, OnDestroy {
     }
     this.isLoadingTransactions = true;
     this.retryLoadMore = false;
-    this.electrsApiService.getAddressTransactions$(this.address.address, this.lastTransactionTxId)
+    (this.address.is_pubkey
+    ? this.electrsApiService.getScriptHashTransactions$((this.address.address.length === 66 ? '21' : '41') + this.address.address + 'ac', this.lastTransactionTxId)
+    : this.electrsApiService.getAddressTransactions$(this.address.address, this.lastTransactionTxId))
       .subscribe((transactions: Transaction[]) => {
         if (transactions && transactions.length) {
           this.lastTransactionTxId = transactions[transactions.length - 1].txid;


### PR DESCRIPTION
This PR fixes the infinite load on P2PK addresses: 

<img width="1025" alt="Screenshot 2024-03-17 at 18 02 05" src="https://github.com/mempool/mempool/assets/46578910/e0f99560-3e91-4cec-a421-2b7b7ee6b013">

https://mempool.space/address/0441e923f9c56c8315925d5d782007a1e7fbdf90cc72a27e0c354e31fde724e2da44dff65161903fafa5c9e723f1eeb0a12bc86ccf2c26473e7ffda79e7aa62163