### PR TITLE
Fix address chart y-axis labels

### DIFF
--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -139,14 +139,16 @@ export class AddressGraphComponent implements OnInit, OnChanges {
           axisLabel: {
             color: 'rgb(110, 112, 121)',
             formatter: (val): string => {
-              if (maxValue > 100_000_000) {
+              if (maxValue > 1_000_000_000) {
                 return `${this.amountShortenerPipe.transform(Math.round(val / 100_000_000), 0)} BTC`;
+              } else if (maxValue > 100_000_000) {
+                return `${(val / 100_000_000).toFixed(1)} BTC`;
               } else if (maxValue > 10_000_000) {
-                return `${Math.round(val / 100_000_000)} BTC`;
-              } else if (maxValue > 100_000) {
                 return `${(val / 100_000_000).toFixed(2)} BTC`;
+              } else if (maxValue > 1_000_000) {
+                return `${(val / 100_000_000).toFixed(3)} BTC`;
               } else {
-                return `${this.amountShortenerPipe.transform(100_000_000, 0)} sats`;
+                return `${this.amountShortenerPipe.transform(val, 0)} sats`;
               }
             }
           },


### PR DESCRIPTION
Fixes bad rounding for y-axis tick labels on the new address balance chart:

| Before | After |
|-|-|
| <img width="285" alt="Screenshot 2024-03-21 at 2 58 06 AM" src="https://github.com/mempool/mempool/assets/83316221/6e31a11a-9c1d-4596-bd58-1eebfc9257e6"> | <img width="285" alt="Screenshot 2024-03-21 at 2 58 17 AM" src="https://github.com/mempool/mempool/assets/83316221/510cb6d9-ca78-40d9-b3f1-b05d3cd5a2a8"> |
| <img width="285" alt="Screenshot 2024-03-21 at 2 57 56 AM" src="https://github.com/mempool/mempool/assets/83316221/3498a288-1e54-4176-acf2-867a248c7daa"> | <img width="285" alt="Screenshot 2024-03-21 at 2 57 45 AM" src="https://github.com/mempool/mempool/assets/83316221/e10f49f6-ef4c-454b-9a88-e510bb3d214d"> |
