### PR TITLE
Accelerated badge fixes

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -61,10 +61,10 @@
         </td>
       </tr>
       {{ activeFilters.rbf }}
-      <tr *ngIf="(!auditEnabled && tx && tx.status === 'accelerated') || filters.length">
+      <tr *ngIf="(!auditEnabled && tx && (tx.status === 'accelerated' || tx.acc || acceleration)) || filters.length">
         <td colspan="2">
           <div class="tags mt-2" [class.any-mode]="filterMode === 'or'">
-            <span *ngIf="!auditEnabled && tx && tx.status === 'accelerated'" class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span>
+            <span *ngIf="!auditEnabled && tx && (tx.status === 'accelerated' || tx.acc || acceleration)" class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span>
             <ng-container *ngFor="let filter of filters;">
               <span class="btn badge filter-tag" [class.matching]="activeFilters[filter.key]">{{ filter.label }}</span>
             </ng-container>

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
@@ -9,8 +9,8 @@
   justify-content: space-between;
   padding: 10px 15px;
   text-align: left;
-  min-width: 320px;
-  max-width: 320px;
+  min-width: 340px;
+  max-width: 340px;
   pointer-events: none;
   z-index: 11;
 

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -61,8 +61,8 @@ export class BlockOverviewTooltipComponent implements OnChanges {
       this.vsize = this.tx.vsize || 1;
       this.feeRate = this.fee / this.vsize;
       this.effectiveRate = this.tx.rate;
-      this.acceleration = this.tx.acc;
       const txFlags = BigInt(this.tx.flags) || 0n;
+      this.acceleration = this.tx.acc || (txFlags & TransactionFlags.acceleration);
       this.hasEffectiveRate = Math.abs((this.fee / this.vsize) - this.effectiveRate) > 0.05
         || (txFlags && (txFlags & (TransactionFlags.cpfp_child | TransactionFlags.cpfp_parent)) > 0n);
       this.filters = this.tx.flags ? toFilters(txFlags).filter(f => f.tooltip) : [];

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -74,8 +74,7 @@
                   <td class="td-width" i18n="transaction.audit">Audit</td>
                   <td *ngIf="pool" class="wrap-cell">
                     <ng-container *ngIf="auditStatus">
-                      <span *ngIf="auditStatus.coinbase; else accelerated" class="badge badge-primary mr-1" i18n="tx-features.tag.coinbase|Coinbase">Coinbase</span>
-                      <ng-template #accelerated><span *ngIf="auditStatus.accelerated || accelerationInfo || (tx && tx.acceleration) ; else expected" class="badge badge-accelerated mr-1" i18n="transaction.audit.accelerated">Accelerated</span></ng-template>
+                      <span *ngIf="auditStatus.coinbase; else expected" class="badge badge-primary mr-1" i18n="tx-features.tag.coinbase|Coinbase">Coinbase</span>
                       <ng-template #expected><span *ngIf="auditStatus.expected; else seen" class="badge badge-success mr-1" i18n-ngbTooltip="Expected in block tooltip" ngbTooltip="This transaction was projected to be included in the block" placement="bottom" i18n="tx-features.tag.expected|Expected in Block">Expected in Block</span></ng-template>
                       <ng-template #seen><span *ngIf="auditStatus.seen; else notSeen" class="badge badge-success mr-1" i18n-ngbTooltip="Seen in mempool tooltip" ngbTooltip="This transaction was seen in the mempool prior to mining" placement="bottom" i18n="tx-features.tag.seen|Seen in Mempool">Seen in Mempool</span></ng-template>
                       <ng-template #notSeen><span class="badge badge-warning mr-1" i18n-ngbTooltip="Not seen in mempool tooltip" ngbTooltip="This transaction was missing from our mempool prior to mining" placement="bottom" i18n="tx-features.tag.not-seen|Not seen in Mempool">Not seen in Mempool</span></ng-template>


### PR DESCRIPTION
Fixes some minor UI issues related to the accelerated tx badges in the Goggles tooltip and on the transaction page:

Before:
<img width="536" alt="Screenshot 2024-03-26 at 2 34 41 AM" src="https://github.com/mempool/mempool/assets/83316221/e3898426-7ffa-49f5-9e6c-690f2caf3233">

After:
<img width="539" alt="Screenshot 2024-03-26 at 2 28 24 AM" src="https://github.com/mempool/mempool/assets/83316221/a9e5ecab-6f6a-4229-8e52-0670f9ccc1e7">

Unchanged (audit mode):
<img width="534" alt="Screenshot 2024-03-26 at 2 32 43 AM" src="https://github.com/mempool/mempool/assets/83316221/44e9ef2d-c1c8-4b0b-a0e9-0b375188184b">

Before:
<img width="1159" alt="Screenshot 2024-03-26 at 2 30 34 AM" src="https://github.com/mempool/mempool/assets/83316221/93071df3-0a15-4225-8d5b-c077c08951d2">

After:
<img width="1159" alt="Screenshot 2024-03-26 at 2 32 15 AM" src="https://github.com/mempool/mempool/assets/83316221/f9febb08-5944-41bf-9378-d005d390621e">
