### PR TITLE
Add pool dominance data to mining pool page

### DIFF
--- a/frontend/src/app/components/pool/pool.component.scss
+++ b/frontend/src/app/components/pool/pool.component.scss
@@ -32,6 +32,7 @@
 }
 
 .chart {
+  margin-top: 10px;
   margin-bottom: 20px;
   @media (max-width: 768px) {
     margin-bottom: 10px;


### PR DESCRIPTION
This PR adds pool's dominance to the hashrate graph on the pool page:

<img width="1248" alt="Screenshot 2024-03-26 at 14 11 38" src="https://github.com/mempool/mempool/assets/46578910/8a874257-7122-4774-8e18-534dde2e82ea">
