### PR TITLE
Set coherent units for hashrate and difficulty units on hashrate graph

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -339,6 +339,9 @@ export class HashrateChartComponent implements OnInit {
             const newMin = Math.floor(value.min / selectedPowerOfTen.divider / 10);
             return newMin * selectedPowerOfTen.divider * 10;
           },
+          max: (value) => {
+            return value.max;
+          },
           type: 'value',
           axisLabel: {
             color: 'rgb(110, 112, 121)',
@@ -357,11 +360,18 @@ export class HashrateChartComponent implements OnInit {
           },
         },
         {
-          min: (value) => {
-            return value.min * 0.9;
-          },
           type: 'value',
           position: 'right',
+          min: (_) => {
+            const firstYAxisMin = this.chartInstance.getModel().getComponent('yAxis', 0).axis.scale.getExtent()[0];
+            const selectedPowerOfTen: any = selectPowerOfTen(firstYAxisMin);
+            const newMin = Math.floor(firstYAxisMin / selectedPowerOfTen.divider / 10)
+            return 600 / 2 ** 32 * newMin * selectedPowerOfTen.divider * 10;
+          },
+          max: (_) => {
+            const firstYAxisMax = this.chartInstance.getModel().getComponent('yAxis', 0).axis.scale.getExtent()[1];
+            return 600 / 2 ** 32 * firstYAxisMax;
+          },
           axisLabel: {
             color: 'rgb(110, 112, 121)',
             formatter: (val): string => {


### PR DESCRIPTION
Fixes #2491

| Before  | After |
| ------------- | ------------- |
| <img width="502" alt="Screenshot 2024-03-26 at 16 58 36" src="https://github.com/mempool/mempool/assets/46578910/4241fe6a-3d06-4169-aefc-fb94f76f97ae"> | <img width="497" alt="Screenshot 2024-03-26 at 16 58 59" src="https://github.com/mempool/mempool/assets/46578910/6938472b-a9d9-43d7-a410-96dc23787c67"> |
| <img width="1662" alt="Screenshot 2024-03-26 at 16 59 52" src="https://github.com/mempool/mempool/assets/46578910/38a33e75-073d-497c-8f85-8d1840f9d165"> | <img width="1648" alt="Screenshot 2024-03-26 at 17 00 16" src="https://github.com/mempool/mempool/assets/46578910/069003a2-ed0b-4810-b3ac-d1640a55f4fa"> |