### PR TITLE
hide empty audit row in tx page details panel

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -70,10 +70,10 @@
                     <app-tx-features [tx]="tx"></app-tx-features>
                   </td>
                 </tr>
-                <tr *ngIf="network === ''">
+                <tr *ngIf="network === '' && auditStatus">
                   <td class="td-width" i18n="transaction.audit">Audit</td>
                   <td *ngIf="pool" class="wrap-cell">
-                    <ng-container *ngIf="auditStatus">
+                    <ng-container>
                       <span *ngIf="auditStatus.coinbase; else expected" class="badge badge-primary mr-1" i18n="tx-features.tag.coinbase|Coinbase">Coinbase</span>
                       <ng-template #expected><span *ngIf="auditStatus.expected; else seen" class="badge badge-success mr-1" i18n-ngbTooltip="Expected in block tooltip" ngbTooltip="This transaction was projected to be included in the block" placement="bottom" i18n="tx-features.tag.expected|Expected in Block">Expected in Block</span></ng-template>
                       <ng-template #seen><span *ngIf="auditStatus.seen; else notSeen" class="badge badge-success mr-1" i18n-ngbTooltip="Seen in mempool tooltip" ngbTooltip="This transaction was seen in the mempool prior to mining" placement="bottom" i18n="tx-features.tag.seen|Seen in Mempool">Seen in Mempool</span></ng-template>


### PR DESCRIPTION
Before:
<img width="1136" alt="Screenshot 2024-03-29 at 6 52 50 AM" src="https://github.com/mempool/mempool/assets/83316221/81151890-4dd0-45e9-84ab-13b1f885851a">


After:
<img width="1136" alt="Screenshot 2024-03-29 at 6 52 40 AM" src="https://github.com/mempool/mempool/assets/83316221/7b9d24e4-53c9-4043-84d2-a5313d9fc6f5">
