### PR TITLE
Clear cpfp dirty status

### DIFF
--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -334,6 +334,11 @@ class MempoolBlocks {
   }
 
   private processBlockTemplates(mempool: { [txid: string]: MempoolTransactionExtended }, blocks: string[][], blockWeights: number[] | null, rates: [string, number][], clusters: string[][], candidates: GbtCandidates | undefined, accelerations, accelerationPool, saveResults): MempoolBlockWithTransactions[] {
+    for (const txid of Object.keys(candidates?.txs ?? mempool)) {
+      if (txid in mempool) {
+        mempool[txid].cpfpDirty = false;
+      }
+    }
     for (const [txid, rate] of rates) {
       if (txid in mempool) {
         mempool[txid].cpfpDirty = (rate !== mempool[txid].effectiveFeePerVsize);


### PR DESCRIPTION
Fixes a bug (possibly introduced in the Limited GBT PR (#4555)) where the `cpfpDirty` flag would not get properly cleared, leading to unnecessary websocket messages and on-demand CPFP re-calculations.