### PR TITLE
Fix footer position

### DIFF
--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -84,7 +84,7 @@
 </header>
 
 <div class="d-flex" style="overflow: clip">
-  <div *ngIf="!servicesEnabled" class="empty-sidenav"><!-- empty sidenav needed to push footer down the screen --></div>
+  <div class="empty-sidenav"><!-- empty sidenav needed to push footer down the screen --></div>
 
   <div class="flex-grow-1 d-flex flex-column">
     <app-testnet-alert *ngIf="network.val === 'testnet' || network.val === 'signet'"></app-testnet-alert>


### PR DESCRIPTION
Fixes #4867

The footer is incorrectly positioned on frontends with services enabled (official instance and accelerator set to true). This PR fixes this by always displaying the `empty-sidenav` element, instead of only when the services are disabled. 