### PR TITLE
Fix Liquid testnet broken blocks

### DIFF
--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -262,22 +262,10 @@ export class StateService {
     // /^\/                                         starts with a forward slash...
     // (?:[a-z]{2}(?:-[A-Z]{2})?\/)?                optional locale prefix (non-capturing)
     // (?:preview\/)?                               optional "preview" prefix (non-capturing)
-    // (testnet|liquidtestnet|liquid|signet)/  network string (captured as networkMatches[1])
+    // (testnet|signet)/                            network string (captured as networkMatches[1])
     // ($|\/)                                       network string must end or end with a slash
-    const networkMatches = url.match(/^\/(?:[a-z]{2}(?:-[A-Z]{2})?\/)?(?:preview\/)?(testnet|liquidtestnet|liquid|signet)($|\/)/);
+    const networkMatches = url.match(/^\/(?:[a-z]{2}(?:-[A-Z]{2})?\/)?(?:preview\/)?(testnet|signet)($|\/)/);
     switch (networkMatches && networkMatches[1]) {
-      case 'liquid':
-        if (this.network !== 'liquid') {
-          this.network = 'liquid';
-          this.networkChanged$.next('liquid');
-        }
-        return;
-      case 'liquidtestnet':
-        if (this.network !== 'liquidtestnet') {
-          this.network = 'liquidtestnet';
-          this.networkChanged$.next('liquidtestnet');
-        }
-        return;
       case 'signet':
         if (this.network !== 'signet') {
           this.network = 'signet';
@@ -285,7 +273,7 @@ export class StateService {
         }
         return;
       case 'testnet':
-        if (this.network !== 'testnet') {
+        if (this.network !== 'testnet' && this.network !== 'liquidtestnet') {
           if (this.env.BASE_MODULE === 'liquid') {
             this.network = 'liquidtestnet';
             this.networkChanged$.next('liquidtestnet');


### PR DESCRIPTION
Fixes #4797

The bug was due to the `networkChanged$` observable incorrectly emitting whenever the URL changed on Liquid testnet. This caused the blocks and transactions data to be reset, resulting in the blockchain disappearing and data on the main dashboard not loading anymore. 

https://github.com/mempool/mempool/assets/46578910/94ceeeec-4cda-45d6-a2b6-34624da08aff

