### PR TITLE
Sort currency by ticker in fiat selector

### DIFF
--- a/frontend/src/app/components/fiat-selector/fiat-selector.component.ts
+++ b/frontend/src/app/components/fiat-selector/fiat-selector.component.ts
@@ -13,10 +13,10 @@ import { StateService } from '../../services/state.service';
 export class FiatSelectorComponent implements OnInit {
   fiatForm: UntypedFormGroup;
   currencies = Object.entries(fiatCurrencies).sort((a: any, b: any) => {
-    if (a[1].name < b[1].name) {
+    if (a[1].code < b[1].code) {
       return -1;
     }
-    if (a[1].name > b[1].name) {
+    if (a[1].code > b[1].code) {
       return 1;
     }
     return 0;


### PR DESCRIPTION
Right now currencies are sorted by name which can be confusing since only the ticker is displayed.

<img width="92" alt="Screenshot 2024-04-03 at 16 36 45" src="https://github.com/mempool/mempool/assets/46578910/b2ef7202-5f85-4cf2-87f1-e5f6c3fb6602">

This PR sorts the currencies by ticker, which can be useful for when all the other currencies get added. 