### PR TITLE
Fix the Docker workflow for the new Rust steps

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -101,5 +101,7 @@ jobs:
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
+          --build-context rustgbt=./rust \
+          --build-context backend=./backend \
           --output "type=registry" ./${{ matrix.service }}/ \
           --build-arg commitHash=$SHORT_SHA

--- a/backend/npm_package_rm_build_deps.sh
+++ b/backend/npm_package_rm_build_deps.sh
@@ -3,7 +3,7 @@ set -e
 
 # Cleaning up inside the node_modules folder
 cd package/node_modules
-rm -r \
+rm -rf \
   typescript \
   @typescript-eslint \
   @napi-rs

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -11,10 +11,17 @@ RUN apt-get install -y build-essential python3 pkg-config curl ca-certificates
 
 # Install Rust via rustup
 RUN CPU_ARCH=$(uname -m); if [ "$CPU_ARCH" = "armv7l" ]; then c_rehash; fi
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+#RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+#Workaround to run on github actions from https://github.com/rust-lang/rustup/issues/2700#issuecomment-1367488985
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sed 's#/proc/self/exe#\/bin\/sh#g' | sh -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:$PATH"
 
+COPY --from=backend . .
+COPY --from=rustgbt . ../rust/
+ENV FD=/build/rust-gbt
 RUN npm install --omit=dev --omit=optional
+
+WORKDIR /build
 RUN npm run package
 
 FROM node:20.12.0-buster-slim

--- a/rust/gbt/package.json
+++ b/rust/gbt/package.json
@@ -11,7 +11,7 @@
     "build-release": "npm run build -- --release --strip",
     "check-cargo-version": "VER=$(cat rust-toolchain) ; if ! cargo version | grep \"cargo $VER\" >/dev/null ; then echo -e \"\\033[1;35m[[[[WARNING]]]]: cargo version mismatch with ./rust-toolchain version ($VER)!!!\\033[0m\" >&2; fi",
     "clean": "rm -rf ./target/ ./node_modules/ *.node package-lock.json",
-    "to-backend": "FD=../../backend/rust-gbt/ ; rm -rf $FD && mkdir $FD && cp index.js index.d.ts package.json *.node $FD",
+    "to-backend": "FD=${FD:-../../backend/rust-gbt/} ; rm -rf $FD && mkdir $FD && cp index.js index.d.ts package.json *.node $FD",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "cargo test"
   },


### PR DESCRIPTION
We are using relative paths and changing directories when building the backend now, so that broke the current Docker tagging workflow.

I tried to keep the changes at a minimum to get a working build again so we can test on Umbrel again.