### PR TITLE
Fix disappearing effective/accelerated fee rates

### DIFF
--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -343,7 +343,7 @@ class MempoolBlocks {
       if (txid in mempool) {
         mempool[txid].cpfpDirty = (rate !== mempool[txid].effectiveFeePerVsize);
         mempool[txid].effectiveFeePerVsize = rate;
-        mempool[txid].cpfpChecked = false;
+        mempool[txid].cpfpChecked = true;
       }
     }
 

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -739,7 +739,7 @@ class WebsocketHandler {
               accelerated: mempoolTx.acceleration || undefined,
             }
           };
-          if (!mempoolTx.cpfpChecked) {
+          if (!mempoolTx.cpfpChecked && !mempoolTx.acceleration) {
             calculateCpfp(mempoolTx, newMempool);
           }
           if (mempoolTx.cpfpDirty) {


### PR DESCRIPTION
Fixes an issue where outdated CPFP information could be send over the websocket, replacing the latest correct effective fee rate on the transaction page (esp. on accelerated transactions).