### PR TITLE
fix(address): Clicking Balance History chart under testnet now navigates to /testnet/tx/:tx instead of /tx/:tx.

### DIFF
--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -6,6 +6,7 @@ import { ChainStats } from '../../interfaces/electrs.interface';
 import { ElectrsApiService } from '../../services/electrs-api.service';
 import { AmountShortenerPipe } from '../../shared/pipes/amount-shortener.pipe';
 import { Router } from '@angular/router';
+import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
 
 @Component({
   selector: 'app-address-graph',
@@ -46,6 +47,7 @@ export class AddressGraphComponent implements OnChanges {
     private router: Router,
     private amountShortenerPipe: AmountShortenerPipe,
     private cd: ChangeDetectorRef,
+    private relativeUrlPipe: RelativeUrlPipe,
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -122,7 +124,7 @@ export class AddressGraphComponent implements OnChanges {
               </div>
               <span>${date}</span>
             </div>
-          `; 
+          `;
         }.bind(this)
       },
       xAxis: {
@@ -178,7 +180,7 @@ export class AddressGraphComponent implements OnChanges {
 
   onChartClick(e) {
     if (this.hoverData?.length && this.hoverData[0]?.[2]?.txid) {
-      this.router.navigate(['/tx/', this.hoverData[0][2].txid]);
+      this.router.navigate([this.relativeUrlPipe.transform('/tx/'), this.hoverData[0][2].txid]);
     }
   }
 


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->

# What :computer: 
* This PR fix a bug which is clicking on the Balance History chart within the /testnet/address/:id page under testnet now navigates to /testnet/tx/:tx instead of /tx/:tx.


# Evidence :camera:
* Before (online)
<img width="1233" alt="image" src="https://github.com/mempool/mempool/assets/7405300/a6130482-d413-453c-b0ba-91c26dc78d2e">
<img width="1227" alt="image" src="https://github.com/mempool/mempool/assets/7405300/3dac8b09-cceb-44f3-ae4f-00fd7cd536d9">

*After (my local branch)
<img width="1246" alt="image" src="https://github.com/mempool/mempool/assets/7405300/554e13f4-72e6-4254-a4cb-9085ebbfb895">
<img width="1286" alt="image" src="https://github.com/mempool/mempool/assets/7405300/4dbef1d2-30b1-4acc-b491-d9e6bf7f7331">


