### PR TITLE
Fix dropdown menu position in Liquid

### DIFF
--- a/frontend/src/app/components/liquid-master-page/liquid-master-page.component.scss
+++ b/frontend/src/app/components/liquid-master-page/liquid-master-page.component.scss
@@ -91,6 +91,10 @@ li.nav-item {
   }
 }
 
+.dropdown-container {
+  margin-top: 4px;
+}
+
 nav {
   box-shadow: 0px 0px 15px 0px #000;
 }

--- a/frontend/src/app/components/liquid-master-page/liquid-master-page.component.scss
+++ b/frontend/src/app/components/liquid-master-page/liquid-master-page.component.scss
@@ -92,7 +92,7 @@ li.nav-item {
 }
 
 .dropdown-container {
-  margin-top: 4px;
+  margin-top: 5px;
 }
 
 nav {


### PR DESCRIPTION
The dropdown menu was slightly mispositioned on Liquid:

Before: 
<img width="541" alt="Screenshot 2024-04-08 at 15 56 52" src="https://github.com/mempool/mempool/assets/46578910/4675f4fb-e867-493d-b6b3-3138970ced8d">
After: 
<img width="549" alt="Screenshot 2024-04-08 at 15 57 13" src="https://github.com/mempool/mempool/assets/46578910/20938ba8-d628-47a2-8ef2-ed03e02680cc">
