### PR TITLE
Fix new acceleration visualization color change

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-scene.ts
+++ b/frontend/src/app/components/block-overview-graph/block-scene.ts
@@ -197,6 +197,7 @@ export default class BlockScene {
           this.txs[tx.txid].feerate = tx.rate || (this.txs[tx.txid].fee / this.txs[tx.txid].vsize);
           this.txs[tx.txid].rate = tx.rate;
           this.txs[tx.txid].dirty = true;
+          this.updateColor(this.txs[tx.txid], startTime, 50, true);
         }
       });
 


### PR DESCRIPTION
Fixes a bug where newly accelerated transactions would not be highlighted if they were already in the block visualization.