### PR TITLE
Fix missing accelerated fee rate again

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -615,7 +615,7 @@
         }
         <td>
           <div class="effective-fee-container">
-            @if (accelerationInfo && (accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize)) {
+            @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize)) {
               <app-fee-rate [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
             } @else {
               <app-fee-rate [fee]="tx.effectiveFeePerVsize"></app-fee-rate>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -673,7 +673,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         relatives.reduce((prev, val) => prev + val.fee, 0);
       this.tx.effectiveFeePerVsize = totalFees / (totalWeight / 4);
     } else {
-      this.tx.effectiveFeePerVsize = cpfpInfo.effectiveFeePerVsize;
+      this.tx.effectiveFeePerVsize = cpfpInfo.effectiveFeePerVsize || this.tx.effectiveFeePerVsize || this.tx.feePerVsize || (this.tx.fee / (this.tx.weight / 4));
     }
     if (cpfpInfo.acceleration) {
       this.tx.acceleration = cpfpInfo.acceleration;


### PR DESCRIPTION
Fixes blank accelerated fee rate on mined transaction:

| Before | After |
|-|-|
| <img width="405" alt="Screenshot 2024-04-08 at 11 38 22 AM" src="https://github.com/mempool/mempool/assets/83316221/3bc66488-409b-41ca-8b1d-ae528653ae3b"> | <img width="405" alt="Screenshot 2024-04-08 at 11 37 54 AM" src="https://github.com/mempool/mempool/assets/83316221/76846934-9c06-43cd-aef8-074a105c94f1"> |
