### PR TITLE
Fix accelerated rate labels

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -976,6 +976,9 @@ class Blocks {
       if (this.blocks.length > config.MEMPOOL.INITIAL_BLOCKS_AMOUNT * 4) {
         this.blocks = this.blocks.slice(-config.MEMPOOL.INITIAL_BLOCKS_AMOUNT * 4);
       }
+      blockSummary.transactions.forEach(tx => {
+        delete tx.acc;
+      });
       this.blockSummaries.push(blockSummary);
       if (this.blockSummaries.length > config.MEMPOOL.INITIAL_BLOCKS_AMOUNT * 4) {
         this.blockSummaries = this.blockSummaries.slice(-config.MEMPOOL.INITIAL_BLOCKS_AMOUNT * 4);
@@ -1119,6 +1122,7 @@ class Blocks {
           }
           return {
             txid: tx.txid,
+            time: tx.firstSeen,
             fee: tx.fee || 0,
             vsize: tx.vsize,
             value: Math.round(tx.vout.reduce((acc, vout) => acc + (vout.value ? vout.value : 0), 0)),

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -561,13 +561,13 @@
 
 <ng-template #gogglesRow>
   @if (!isLoadingTx) {
-    @if (((auditStatus && auditStatus.accelerated) || accelerationInfo || (tx && tx.acceleration)) || filters.length) {
+    @if (isAcceleration || filters.length) {
       <tr>
         <td class="td-width">
           <span class="goggles-icon"><app-svg-images name="goggles" width="100%" height="100%"></app-svg-images></span>
         </td>
         <td class="wrap-cell">
-          @if ((auditStatus && auditStatus.accelerated) || accelerationInfo || (tx && tx.acceleration)) {
+          @if (isAcceleration) {
             <span class="badge badge-accelerated mr-1" i18n="transaction.audit.accelerated">Accelerated</span>
           }
           <ng-container *ngFor="let filter of filters;">

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -613,7 +613,7 @@
   @if (!isLoadingTx) {
     @if ((cpfpInfo && hasEffectiveFeeRate) || accelerationInfo) {
       <tr>
-        @if (tx.acceleration || accelerationInfo) {
+        @if (isAcceleration) {
           <td i18n="transaction.accelerated-fee-rate|Accelerated transaction fee rate">Accelerated fee rate</td>
         } @else {
           <td i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -93,6 +93,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   adjustedVsize: number | null;
   pool: Pool | null;
   auditStatus: AuditStatus | null;
+  isAcceleration: boolean = false;
   filters: Filter[] = [];
   showCpfpDetails = false;
   fetchCpfp$ = new Subject<string>();
@@ -287,6 +288,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       filter(() => this.stateService.env.ACCELERATOR === true),
       tap(() => {
         this.accelerationInfo = null;
+        this.setIsAccelerated();
       }),
       switchMap((blockHeight: number) => {
         return this.servicesApiService.getAccelerationHistory$({ blockHeight });
@@ -302,6 +304,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           acceleration.boost = boostCost;
 
           this.accelerationInfo = acceleration;
+          this.setIsAccelerated();
         }
       }
     });
@@ -354,6 +357,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     ).subscribe(([pool, auditStatus]) => {
       this.pool = pool;
       this.auditStatus = auditStatus;
+
+      this.setIsAccelerated();
     });
 
     this.mempoolPositionSubscription = this.stateService.mempoolTxPosition$.subscribe(txPosition => {
@@ -680,6 +685,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     if (cpfpInfo.acceleration) {
       this.tx.acceleration = cpfpInfo.acceleration;
+      this.setIsAccelerated();
     }
 
     this.cpfpInfo = cpfpInfo;
@@ -689,6 +695,11 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     this.hasCpfp =!!(this.cpfpInfo && (this.cpfpInfo.bestDescendant || this.cpfpInfo.descendants?.length || this.cpfpInfo.ancestors?.length));
     this.hasEffectiveFeeRate = hasRelatives || (this.tx.effectiveFeePerVsize && (Math.abs(this.tx.effectiveFeePerVsize - this.tx.feePerVsize) > 0.01));
+  }
+
+  setIsAccelerated() {
+    console.log(this.tx.acceleration, this.accelerationInfo, this.pool, this.accelerationInfo?.pools);
+    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id || pool?.['pool_unique_id'] === this.pool.id))));
   }
 
   setFeatures(): void {
@@ -757,6 +768,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pool = null;
     this.auditStatus = null;
     document.body.scrollTo(0, 0);
+    this.isAcceleration = false;
     this.leaveTransaction();
   }
 

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -9,7 +9,8 @@ import {
   delay,
   mergeMap,
   tap,
-  map
+  map,
+  retry
 } from 'rxjs/operators';
 import { Transaction } from '../../interfaces/electrs.interface';
 import { of, merge, Subscription, Observable, Subject, from, throwError, combineLatest } from 'rxjs';
@@ -325,6 +326,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
             map(block => {
               return block.extras.pool;
             }),
+            retry({ count: 3, delay: 2000 }),
             catchError(() => {
               return of(null);
             })
@@ -345,13 +347,14 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
                 accelerated: isAccelerated,
               };
             }),
+            retry({ count: 3, delay: 2000 }),
             catchError(() => {
               return of(null);
             })
           ) : of(isCoinbase ? { coinbase: true } : null)
         ]);
       }),
-      catchError(() => {
+      catchError((e) => {
         return of(null);
       })
     ).subscribe(([pool, auditStatus]) => {


### PR DESCRIPTION
Fix incorrect "Accelerated fee rate" labels on transaction which were accelerated, but mined by another pool (fixes #4927).

Also fixes a bug where "accelerated" status was saved to the cached block summaries, causing incorrect highlighting in the visualization.