### PR TITLE
Filter accelerations for matching pool

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -358,11 +358,15 @@ export class BlockComponent implements OnInit, OnDestroy {
 
       const acceleratedInBlock = {};
       for (const acc of accelerations) {
-        acceleratedInBlock[acc.txid] = acc;
+        if (acc.pools?.some(pool => pool === this.block?.extras?.pool.id || pool?.['pool_unique_id'] === this.block?.extras?.pool.id)) {
+          acceleratedInBlock[acc.txid] = acc;
+        }
       }
       for (const tx of transactions) {
         if (acceleratedInBlock[tx.txid]) {
           tx.acc = true;
+        } else {
+          tx.acc = false;
         }
       }
 


### PR DESCRIPTION
Second part of #4929, filtering accelerations by pool at the block level to fix any remaining cases of incorrect highlighting in the mined block visualization.

**Test procedure:**
 - Navigate to block 00000000000000000002f3a330d44ad274ac55409a47ebebf31c3599ec04d8a7
 - Confirm there are no purple transactions in the mined template.