### PR TITLE
Fix accelerated fee rate in mined block tooltips

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -68,7 +68,7 @@ export class BlockOverviewTooltipComponent implements OnChanges {
       this.effectiveRate = this.tx.rate;
       const txFlags = BigInt(this.tx.flags) || 0n;
       this.acceleration = this.tx.acc || (txFlags & TransactionFlags.acceleration);
-      this.hasEffectiveRate = Math.abs((this.fee / this.vsize) - this.effectiveRate) > 0.05
+      this.hasEffectiveRate = this.tx.acc || Math.abs((this.fee / this.vsize) - this.effectiveRate) > 0.05
         || (txFlags && (txFlags & (TransactionFlags.cpfp_child | TransactionFlags.cpfp_parent)) > 0n);
       this.filters = this.tx.flags ? toFilters(txFlags).filter(f => f.tooltip) : [];
       this.activeFilters = {}

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -365,6 +365,12 @@ export class BlockComponent implements OnInit, OnDestroy {
       for (const tx of transactions) {
         if (acceleratedInBlock[tx.txid]) {
           tx.acc = true;
+          const acceleration = acceleratedInBlock[tx.txid];
+          const boostCost = acceleration.boostCost || (acceleration.feePaid - acceleration.baseFee - acceleration.vsizeFee);
+          const acceleratedFeeRate = Math.max(acceleration.effectiveFee, acceleration.effectiveFee + boostCost) / acceleration.effectiveVsize;
+          if (acceleratedFeeRate > tx.rate) {
+            tx.rate = acceleratedFeeRate;
+          }
         } else {
           tx.acc = false;
         }


### PR DESCRIPTION
Fixes an issue where the wrong rate would be displayed in the block visualization tooltip for some accelerated transactions.