### PR TITLE
disable accelerate button after submission

### DIFF
--- a/frontend/src/app/components/accelerate-preview/accelerate-preview.component.html
+++ b/frontend/src/app/components/accelerate-preview/accelerate-preview.component.html
@@ -26,7 +26,7 @@
   </ng-container>
 
   <ng-container *ngIf="estimate else loadingEstimate">
-    <div [class]="{estimateDisabled: error}">
+    <div [class]="{estimateDisabled: error || processing || showSuccess }">
 
       <div *ngIf="user && !estimate.hasAccess">
         <div class="alert alert-mempool">You are currently on the waitlist</div>
@@ -286,7 +286,7 @@
         </div>
       </div>
 
-      @if (!hideCashApp && paymentType === 'cashapp') {
+      @if (!hideCashApp && !(error || processing || showSuccess) && paymentType === 'cashapp') {
         <div #cashappCTA class="cashapp-placeholder {{ stickyCTA }}"></div>
         <div class="d-flex justify-content-center align-items-center cashapp-cta {{ stickyCTA }}" (click)="submitCashappPay()">
           <div [style]="showSpinner ? 'opacity: 0' : 'opacity: 1'" class="p-2">Accelerate for <app-fiat [value]="maxCost" [colorClass]="estimate.userBalance < maxCost ? 'red-color' : 'green-color'"></app-fiat> with</div>

--- a/frontend/src/app/components/accelerate-preview/accelerate-preview.component.ts
+++ b/frontend/src/app/components/accelerate-preview/accelerate-preview.component.ts
@@ -48,6 +48,7 @@ export class AcceleratePreviewComponent implements OnInit, OnDestroy, OnChanges 
 
   math = Math;
   error = '';
+  processing = false;
   showSuccess = false;
   estimateSubscription: Subscription;
   accelerationSubscription: Subscription;
@@ -245,18 +246,21 @@ export class AcceleratePreviewComponent implements OnInit, OnDestroy, OnChanges 
     if (this.accelerationSubscription) {
       this.accelerationSubscription.unsubscribe();
     }
+    this.processing = true;
     this.accelerationSubscription = this.servicesApiService.accelerate$(
       this.tx.txid,
       this.userBid,
       this.accelerationUUID
     ).subscribe({
       next: () => {
+        this.processing = false;
         this.audioService.playSound('ascend-chime-cartoon');
         this.showSuccess = true;
         this.scrollToPreviewWithTimeout('successAlert', 'center');
         this.estimateSubscription.unsubscribe();
       },
       error: (response) => {
+        this.processing = false;
         if (response.status === 403 && response.error === 'not_available') {
           this.error = 'waitlisted';
         } else {
@@ -359,12 +363,14 @@ export class AcceleratePreviewComponent implements OnInit, OnDestroy, OnChanges 
               that.accelerationUUID
             ).subscribe({
               next: () => {
+                this.processing = false;
                 that.audioService.playSound('ascend-chime-cartoon');
                 that.showSuccess = true;
                 that.scrollToPreviewWithTimeout('successAlert', 'center');
                 that.estimateSubscription.unsubscribe();
               },
               error: (response) => {
+                this.processing = false;
                 if (response.status === 403 && response.error === 'not_available') {
                   that.error = 'waitlisted';
                 } else {
@@ -401,6 +407,7 @@ export class AcceleratePreviewComponent implements OnInit, OnDestroy, OnChanges 
   submitCashappPay(): void {
     if (this.cashappSubmit) {
       this.cashappSubmit?.begin();
+      this.processing = true;
     }
   }
 


### PR DESCRIPTION
gray out the acceleration panel and hide the sticky button after submitting an acceleration to avoid duplicate requests