### PR TITLE
Switch success rate to total vsize

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.html
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.html
@@ -17,10 +17,10 @@
       </div>
     </div>
     <div class="item">
-      <h5 class="card-title" i18n="accelerator.success-rate">Success Rate</h5>
+      <h5 class="card-title" i18n="accelerator.total-vsize">Total vSize</h5>
       <div class="card-text">
-        <div>{{ stats.successRate.toFixed(2) }} %</div>
-        <div class="symbol" i18n="accelerator.mined-next-block">mined</div>
+        <div [innerHTML]="'&lrm;' + (stats.totalVsize | vbytes: 2)"></div>
+        <div class="symbol">{{ (stats.totalVsize / (1_000_000 * blocksInPeriod) * 100).toFixed(2) }}% <span i18n="accelerator.percent-of-blocks"> of blocks</span></div>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.html
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.html
@@ -43,7 +43,7 @@
       </div>
     </div>
     <div class="item">
-      <h5 class="card-title" i18n="accelerator.success-rate">Success Rate</h5>
+      <h5 class="card-title" i18n="accelerator.total-vsize">Total vSize</h5>
       <div class="card-text">
         <div class="skeleton-loader"></div>
         <div class="skeleton-loader"></div>

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.scss
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.scss
@@ -34,7 +34,7 @@
     @media (min-width: 376px) {
       margin: 0 auto 0px;
     }    
-    &:first-child{
+    &:last-child{
       display: none;
       @media (min-width: 485px) {
         display: block;

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -6,6 +6,7 @@ export type AccelerationStats = {
   totalRequested: number;
   totalBidBoost: number;
   successRate: number;
+  totalVsize: number;
 }
 
 @Component({
@@ -17,16 +18,32 @@ export type AccelerationStats = {
 export class AccelerationStatsComponent implements OnInit, OnChanges {
   @Input() timespan: '3d' | '1w' | '1m' = '1w';
   accelerationStats$: Observable<AccelerationStats>;
+  blocksInPeriod: number = 7 * 144;
 
   constructor(
     private servicesApiService: ServicesApiServices
   ) { }
 
   ngOnInit(): void {
-    this.accelerationStats$ = this.servicesApiService.getAccelerationStats$({ timeframe: this.timespan });
+    this.updateStats();
   }
 
   ngOnChanges(): void {
+    this.updateStats();
+  }
+
+  updateStats(): void {
     this.accelerationStats$ = this.servicesApiService.getAccelerationStats$({ timeframe: this.timespan });
+    switch (this.timespan) {
+      case '3d':
+        this.blocksInPeriod = 3 * 144;
+        break;
+      case '1w':
+        this.blocksInPeriod = 7 * 144;
+        break;
+      case '1m':
+        this.blocksInPeriod = 30 * 144;
+        break;
+    }
   }
 }

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ServicesApiServices } from '../../../services/services-api.service';
 
@@ -14,7 +14,8 @@ export type AccelerationStats = {
   styleUrls: ['./acceleration-stats.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccelerationStatsComponent implements OnInit {
+export class AccelerationStatsComponent implements OnInit, OnChanges {
+  @Input() timespan: '3d' | '1w' | '1m' = '1w';
   accelerationStats$: Observable<AccelerationStats>;
 
   constructor(
@@ -22,6 +23,10 @@ export class AccelerationStatsComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.accelerationStats$ = this.servicesApiService.getAccelerationStats$();
+    this.accelerationStats$ = this.servicesApiService.getAccelerationStats$({ timeframe: this.timespan });
+  }
+
+  ngOnChanges(): void {
+    this.accelerationStats$ = this.servicesApiService.getAccelerationStats$({ timeframe: this.timespan });
   }
 }

--- a/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.html
+++ b/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.html
@@ -22,12 +22,26 @@
     <div class="col">
       <div class="main-title">
         <span [attr.data-cy]="'acceleration-stats'" i18n="accelerator.acceleration-stats">Acceleration stats</span>&nbsp;
-        <span style="font-size: xx-small" i18n="mining.3-months">(3 months)</span>
+        @switch (timespan) {
+          @case ('1w') {
+            <span style="font-size: xx-small" i18n="mining.1-week">(1 week)</span>
+          }
+          @case ('1m') {
+            <span style="font-size: xx-small" i18n="mining.1-month">(1 month)</span>
+          }
+        }
       </div>
       <div class="card-wrapper">
         <div class="card">
           <div class="card-body more-padding">
-            <app-acceleration-stats></app-acceleration-stats>
+            <app-acceleration-stats [timespan]="timespan"></app-acceleration-stats>
+            <div class="widget-toggler">
+              <a href="" (click)="setTimespan('1w')" class="toggler-option"
+                [ngClass]="{'inactive': timespan === '1w'}"><small>1w</small></a>
+              <span style="color: #ffffff66; font-size: 8px"> | </span>
+              <a href="" (click)="setTimespan('1m')" class="toggler-option"
+              [ngClass]="{'inactive': timespan === '1m'}"><small>1m</small></a>
+            </div>
           </div>
         </div>
       </div>
@@ -59,6 +73,7 @@
               [height]="graphHeight"
               [attr.data-cy]="'acceleration-fees'"
               [widget]=true
+              [period]="timespan"
             ></app-acceleration-fees-graph>
           </div>
           <div class="mt-1"><a [attr.data-cy]="'acceleration-fees-view-more'" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" i18n="dashboard.view-more">View more &raquo;</a></div>

--- a/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.scss
+++ b/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.scss
@@ -173,3 +173,19 @@
     max-width: 430px;
   }
 }
+
+.widget-toggler {
+  font-size: 12px;
+  position: absolute;
+  top: -20px;
+  right: 3px;
+  text-align: right;
+}
+
+.toggler-option {
+  text-decoration: none;
+}
+
+.inactive {
+  color: #ffffff66;
+}

--- a/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.ts
+++ b/frontend/src/app/components/acceleration/accelerator-dashboard/accelerator-dashboard.component.ts
@@ -37,6 +37,7 @@ export class AcceleratorDashboardComponent implements OnInit {
   webGlEnabled = true;
   seen: Set<string> = new Set();
   firstLoad = true;
+  timespan: '3d' | '1w' | '1m' = '1w';
 
   graphHeight: number = 300;
   theme: ThemeService;
@@ -146,6 +147,11 @@ export class AcceleratorDashboardComponent implements OnInit {
       const feeLevelIndex = feeLevels.findIndex((feeLvl) => Math.max(1, rate) < feeLvl) - 1;
       return this.theme.theme === 'contrast' ? contrastColors[feeLevelIndex] || contrastColors[contrastColors.length - 1] : normalColors[feeLevelIndex] || normalColors[normalColors.length - 1];
     }
+  }
+
+  setTimespan(timespan): boolean {
+    this.timespan = timespan;
+    return false;
   }
 
   @HostListener('window:resize', ['$event'])

--- a/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.html
+++ b/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.html
@@ -17,10 +17,10 @@
       </div>
     </div>
     <div class="item">
-      <h5 class="card-title" i18n="accelerator.total-vsize">Total Vsize</h5>
+      <h5 class="card-title" i18n="accelerator.total-vsize">Total vSize</h5>
       <div class="card-text">
-        <div [innerHTML]="'&lrm;' + (stats.totalVsize * 4 | vbytes: 2)"></div>
-        <div class="symbol">{{ (stats.totalVsize / 1_000_000 * 100).toFixed(2) }}% <span i18n="accelerator.percent-of-next-block"> of next block</span></div>
+        <div [innerHTML]="'&lrm;' + (stats.totalVsize | vbytes: 2)"></div>
+        <div class="symbol">{{ (stats.totalVsize / 1_000_000 * 100).toFixed(2) }}% <span i18n="accelerator.percent-of-block"> of block</span></div>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.html
+++ b/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.html
@@ -43,7 +43,7 @@
       </div>
     </div>
     <div class="item">
-      <h5 class="card-title" i18n="accelerator.total-vsize">Total Vsize</h5>
+      <h5 class="card-title" i18n="accelerator.total-vsize">Total vSize</h5>
       <div class="card-text">
         <div class="skeleton-loader"></div>
         <div class="skeleton-loader"></div>

--- a/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.scss
+++ b/frontend/src/app/components/acceleration/pending-stats/pending-stats.component.scss
@@ -34,7 +34,7 @@
     @media (min-width: 376px) {
       margin: 0 auto 0px;
     }    
-    &:first-child{
+    &:last-child{
       display: none;
       @media (min-width: 485px) {
         display: block;

--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -152,8 +152,8 @@ export class ServicesApiServices {
     return this.httpClient.get<any>(`${SERVICES_API_PREFIX}/accelerator/accelerations/history`, { params: { ...params }, observe: 'response'});
   }
 
-  getAccelerationStats$(): Observable<AccelerationStats> {
-    return this.httpClient.get<AccelerationStats>(`${SERVICES_API_PREFIX}/accelerator/accelerations/stats`);
+  getAccelerationStats$(params: AccelerationHistoryParams): Observable<AccelerationStats> {
+    return this.httpClient.get<AccelerationStats>(`${SERVICES_API_PREFIX}/accelerator/accelerations/stats`, { params: { ...params } });
   }
 
   setupSquare$(): Observable<{squareAppId: string, squareLocationId: string}> {


### PR DESCRIPTION
_(builds on #4945)_

Instead of showing the success rate on the acceleration dashboard, show the total vsize of successful accelerations.

<img width="1137" alt="Screenshot 2024-04-10 at 7 07 24 AM" src="https://github.com/mempool/mempool/assets/83316221/ebc3ec4e-d300-411e-9632-dad4bf4be36c">
