### PR TITLE
Add sequence number to mempool block updates

### DIFF
--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -96,6 +96,7 @@ export class StateService {
   env: Env;
   latestBlockHeight = -1;
   blocks: BlockExtended[] = [];
+  mempoolSequence: number;
 
   backend$ = new BehaviorSubject<'esplora' | 'electrum' | 'none'>('esplora');
   networkChanged$ = new ReplaySubject<string>(1);

--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -400,9 +400,16 @@ export class WebsocketService {
     if (response['projected-block-transactions']) {
       if (response['projected-block-transactions'].index == this.trackingMempoolBlock) {
         if (response['projected-block-transactions'].blockTransactions) {
+          this.stateService.mempoolSequence = response['projected-block-transactions'].sequence;
           this.stateService.mempoolBlockTransactions$.next(response['projected-block-transactions'].blockTransactions.map(uncompressTx));
         } else if (response['projected-block-transactions'].delta) {
-          this.stateService.mempoolBlockDelta$.next(uncompressDeltaChange(response['projected-block-transactions'].delta));
+          if (this.stateService.mempoolSequence && response['projected-block-transactions'].sequence !== this.stateService.mempoolSequence + 1) {
+            this.stateService.mempoolSequence = 0;
+            this.startTrackMempoolBlock(this.trackingMempoolBlock, true);
+          } else {
+            this.stateService.mempoolSequence = response['projected-block-transactions'].sequence;
+            this.stateService.mempoolBlockDelta$.next(uncompressDeltaChange(response['projected-block-transactions'].delta));
+          }
         }
       }
     }


### PR DESCRIPTION
In some browsers, when mempool is running in a background tab the process can get put to sleep and silently drop websocket messages.

Since our mempool block visualization subscription assumes reliable transport and only sends deltas most of the time, this can cause the visualization to get stuck showing stale transactions.

This PR adds a sequence number to the websocket `projected-block-transactions` messages, so that the frontend can detect when we've missed websocket updates and trigger a resync.