### PR TITLE
Fix first seen loading time in tx tracker

### DIFF
--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -32,10 +32,10 @@
           <div class="field">
             <div class="label" i18n="transaction.first-seen|Transaction first seen">First seen</div>
             <div class="value">
-              @if (transactionTime) {
+              @if (transactionTime > 0) {
                 <i><app-time kind="since" [time]="transactionTime" [fastRender]="true"></app-time></i>
               } @else {
-                <span class="skeleton-loader"></span>
+                <span class="skeleton-loader" style="max-width: 50%;"></span>
               }
             </div>
           </div>


### PR DESCRIPTION
Fix broken skeleton loader logic in the first seen time on the tx tracker page:
| Before | After |
|-|-|
| <img width="365" alt="Screenshot 2024-04-14 at 3 51 09 AM" src="https://github.com/mempool/mempool/assets/83316221/c4106d0e-769e-450a-9c6c-8e47e504afd9"> | <img width="365" alt="Screenshot 2024-04-14 at 3 50 52 AM" src="https://github.com/mempool/mempool/assets/83316221/39e4ef20-3ef5-40ea-89c5-d0438f7331b5"> |
