### PR TITLE
Fix cropped transaction tooltip in block overview on mobile

### DIFF
--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -3,7 +3,7 @@
   class="block-overview-tooltip"
   [class.clickable]="clickable"
   [style.visibility]="tx ? 'visible' : 'hidden'"
-  [style.left]="tooltipPosition.x + 'px'"
+  [style.left]="getTooltipLeftPosition()"
   [style.top]="tooltipPosition.y + 'px'"
 >
   <table class="table-fixed">

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.scss
@@ -10,7 +10,7 @@
   padding: 10px 15px;
   text-align: left;
   min-width: 340px;
-  max-width: 340px;
+  max-width: 400px;
   pointer-events: none;
   z-index: 11;
 
@@ -41,7 +41,7 @@ th, td {
   flex-wrap: wrap;
   row-gap: 0.25em;
   margin-top: 0.2em;
-  max-width: 100%;
+  max-width: 310px;
 
   .badge {
     border-radius: 0.2rem;

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -98,6 +98,6 @@ export class BlockOverviewTooltipComponent implements OnChanges {
   }
 
   getTooltipLeftPosition(): string {
-    return window.innerWidth < 392 ? '-40px' : this.tooltipPosition.x + 'px';
+    return window.innerWidth < 392 ? '-50px' : this.tooltipPosition.x + 'px';
   }
 }

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.ts
@@ -96,4 +96,8 @@ export class BlockOverviewTooltipComponent implements OnChanges {
       this.cd.markForCheck();
     }
   }
+
+  getTooltipLeftPosition(): string {
+    return window.innerWidth < 392 ? '-40px' : this.tooltipPosition.x + 'px';
+  }
 }


### PR DESCRIPTION
This PR allows block overview tooltip not to be cropped on mobile.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/mempool/mempool/assets/46578910/4a35c46e-dac3-42de-b271-f540559cec17" width="300"> | <img src="https://github.com/mempool/mempool/assets/46578910/7f4fc685-f7c7-4c81-bf1d-3c2abb5a7b92" width="300">
