### PR TITLE
Fix dropdown menu navigation with arrow keys

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1268,7 +1268,7 @@ app-global-footer {
 
 .dropdown-menu {
   background-color: var(--bg);
-  .dropdown-item:hover {
+  .dropdown-item:hover, .dropdown-item:focus { 
     background-color: var(--active-bg);
   }
 }


### PR DESCRIPTION
This PR fixes a small issue where the dropdown menu would not highlight the selected item when using arrow keys on contrast themes. 