### PR TITLE
Knorrium/increase language selector width

### DIFF
--- a/frontend/src/app/components/language-selector/language-selector.component.html
+++ b/frontend/src/app/components/language-selector/language-selector.component.html
@@ -1,5 +1,5 @@
-<div [formGroup]="languageForm" class="text-small text-center">
-    <select formControlName="language" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 95px;" (change)="changeLanguage()">
+<div [formGroup]="languageForm" class="text-small text-center" width="500px">
+    <select formControlName="language" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 120px;" (change)="changeLanguage()">
         <option *ngFor="let lang of languages" [value]="lang.code">{{ lang.name }}</option>
     </select>
 </div>

--- a/frontend/src/app/components/language-selector/language-selector.component.html
+++ b/frontend/src/app/components/language-selector/language-selector.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="languageForm" class="text-small text-center" width="500px">
+<div [formGroup]="languageForm" class="text-small text-center">
     <select formControlName="language" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 120px;" (change)="changeLanguage()">
         <option *ngFor="let lang of languages" [value]="lang.code">{{ lang.name }}</option>
     </select>


### PR DESCRIPTION
Some languages were getting cut off in the selector - increasing from 95px to 110px so they all fit:

<img width="336" alt="Screenshot 2024-04-21 at 6 47 56 PM" src="https://github.com/mempool/mempool/assets/100320/1cc5f290-6411-4807-8a01-737c58985ce2">
<img width="345" alt="Screenshot 2024-04-21 at 6 46 38 PM" src="https://github.com/mempool/mempool/assets/100320/c3b849bf-c019-440a-b579-ee68f93f8c2b">

<img width="343" alt="Screenshot 2024-04-21 at 6 47 40 PM" src="https://github.com/mempool/mempool/assets/100320/26bc91fa-8979-422d-9c5f-6881610640e4">

<img width="352" alt="Screenshot 2024-04-21 at 6 46 53 PM" src="https://github.com/mempool/mempool/assets/100320/c6a9a7aa-5916-4078-a752-963ff412a77a">


<img width="340" alt="Screenshot 2024-04-21 at 6 48 12 PM" src="https://github.com/mempool/mempool/assets/100320/bbb3b065-0b9e-46ef-86c2-e115e577651a">

<img width="332" alt="Screenshot 2024-04-21 at 6 47 12 PM" src="https://github.com/mempool/mempool/assets/100320/08cfd5f0-6846-4f4a-8c44-a3c4992f3702">

