### PR TITLE
Transparently redirect direct mobile tx visits to pizza tracker

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -215,10 +215,6 @@ let routes: Routes = [
     loadChildren: () => import('./bitcoin-graphs.module').then(m => m.BitcoinGraphsModule),
     data: { preload: true },
   },
-  {
-    path: '**',
-    redirectTo: ''
-  },
 ];
 
 if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
@@ -303,11 +299,14 @@ if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
       loadChildren: () => import('./liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
       data: { preload: true },
     },
-    {
-      path: '**',
-      redirectTo: ''
-    },
   ];
+}
+
+if (!window['isMempoolSpaceBuild']) {
+  routes.push({
+    path: '**',
+    redirectTo: ''
+  });
 }
 
 @NgModule({

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -142,10 +142,10 @@ let routes: Routes = [
     data: { preload: true },
   },
   {
-    path: 'tx/:id',
+    path: 'tx',
     canMatch: [TrackerGuard],
     runGuardsAndResolvers: 'always',
-    component: TrackerComponent,
+    loadChildren: () => import('./components/tracker/tracker.module').then(m => m.TrackerModule),
   },
   {
     path: '',

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -9,6 +9,7 @@ import { StatusViewComponent } from './components/status-view/status-view.compon
 import { AddressGroupComponent } from './components/address-group/address-group.component';
 import { TrackerComponent } from './components/tracker/tracker.component';
 import { AccelerateCheckout } from './components/accelerate-checkout/accelerate-checkout.component';
+import { TrackerGuard } from './route-guards';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -141,14 +142,15 @@ let routes: Routes = [
     data: { preload: true },
   },
   {
+    path: 'tx/:id',
+    canMatch: [TrackerGuard],
+    runGuardsAndResolvers: 'always',
+    component: TrackerComponent,
+  },
+  {
     path: '',
     loadChildren: () => import('./master-page.module').then(m => m.MasterPageModule),
     data: { preload: true },
-  },
-  {
-    path: 'tracker',
-    data: { networkSpecific: true },
-    loadChildren: () => import('./components/tracker/tracker.module').then(m => m.TrackerModule),
   },
   {
     path: 'wallet',

--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -185,7 +185,11 @@
       }
     </div>
 
-    <div class="footer-link" [routerLink]="['/tx' | relativeUrl, tx?.txid]">
+    <div class="footer-link"
+      [routerLink]="['/tx' | relativeUrl, tx?.txid]"
+      [queryParams]="{ mode: 'details' }"
+      queryParamsHandling="merge"
+    >
       <span><ng-container i18n="accelerator.show-more-details">See more details</ng-container>&nbsp;<fa-icon [icon]="['fas', 'arrow-alt-circle-right']"></fa-icon></span>
     </div>
   </div>

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -140,6 +140,7 @@ export class TrackerComponent implements OnInit, OnDestroy {
     private priceService: PriceService,
     private enterpriseService: EnterpriseService,
     private miningService: MiningService,
+    private router: Router,
     private cd: ChangeDetectorRef,
     private zone: NgZone,
     @Inject(ZONE_SERVICE) private zoneService: any,

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -31,6 +31,8 @@ import { TrackerStage } from './tracker-bar.component';
 import { MiningService, MiningStats } from '../../services/mining.service';
 import { ETA, EtaService } from '../../services/eta.service';
 import { getTransactionFlags, getUnacceleratedFeeRate } from '../../shared/transaction.utils';
+import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
+
 
 interface Pool {
   id: number;

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -518,6 +518,13 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
               });
             }
           }
+          if (window.innerWidth <= 767.98) {
+            this.router.navigate([this.relativeUrlPipe.transform('/tx'), this.txId], {
+              queryParamsHandling: 'merge',
+              preserveFragment: true,
+              queryParams: { mode: 'details' },
+            });
+          }
           this.seoService.setTitle(
             $localize`:@@bisq.transaction.browser-title:Transaction: ${this.txId}:INTERPOLATION:`
           );

--- a/frontend/src/app/route-guards.ts
+++ b/frontend/src/app/route-guards.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject } from '@angular/core';
+import { CanMatchFn, Route, Router, UrlSegment } from '@angular/router';
+import { NavigationService } from './services/navigation.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+class GuardService {
+  constructor(
+    private router: Router,
+    private navigationService: NavigationService,
+  ) {}
+
+  trackerGuard(route: Route, segments: UrlSegment[]): boolean {
+    const preferredRoute = this.router.getCurrentNavigation()?.extractedUrl.queryParams?.mode;
+    return preferredRoute !== 'details' && this.navigationService.isInitialLoad() && window.innerWidth <= 767.98;
+  }
+}
+
+export const TrackerGuard: CanMatchFn = (route: Route, segments: UrlSegment[]): boolean => {
+  return inject(GuardService).trackerGuard(route, segments);
+};

--- a/frontend/src/app/services/navigation.service.ts
+++ b/frontend/src/app/services/navigation.service.ts
@@ -27,6 +27,7 @@ export class NavigationService {
     }
   };
   networks = Object.keys(this.networkModules);
+  initialLoad = true;
 
   constructor(
     private stateService: StateService,
@@ -40,6 +41,10 @@ export class NavigationService {
       if (this.enforceSubnetRestrictions(state)) {
         this.updateSubnetPaths(state);
       }
+      if (this.initialLoad) {
+        this.initialLoad = false;
+      }
+      this.updateSubnetPaths(state);
     });
   }
 
@@ -97,5 +102,9 @@ export class NavigationService {
       });
     });
     this.subnetPaths.next(subnetPaths);
+  }
+
+  isInitialLoad(): boolean {
+    return this.initialLoad;
   }
 }


### PR DESCRIPTION
_(requires https://github.com/mempool/mempool.space/pull/1205)_

This PR moves the new "Pizza Tracker" page under the same `/tx/:txid` route path as the main transaction page, and adds a `canMatch` route guard to selectively render the pizza tracker component if all of the following conditions are met:
 - Initial page load (i.e. not an internal navigation)
 - On mobile (`window.innerWidth <= 767.98`)
 - *NOT* overridden by query parameter `?mode=details`
 
If the mode=details query parameter is set in the URL, then the full transaction page will always be displayed, so this can be used to explicitly link to the main page instead of the pizza tracker.

When navigating to a /tx page internally on mobile, `?mode=details` is automatically added to prevent forcing the user back to the tracker view on page reload/refresh.

~~Leaving in draft for now because the tracker page needs some more polish before we funnel all of our `/tx/` traffic there.~~