### PR TITLE
Fix rbf autoscroll bug on mobile

### DIFF
--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
@@ -51,7 +51,7 @@ export class RbfTimelineComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes): void {
     this.rows = this.buildTimelines(this.replacements);
-    if (changes.txid &&!changes.txid.firstChange && changes.txid.previousVaue !== changes.txid.currentValue) {
+    if (changes.txid && !changes.txid.firstChange && changes.txid.previousValue !== changes.txid.currentValue) {
       setTimeout(() => { this.scrollToSelected(); });
     }
   }

--- a/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
+++ b/frontend/src/app/components/rbf-timeline/rbf-timeline.component.ts
@@ -51,7 +51,7 @@ export class RbfTimelineComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes): void {
     this.rows = this.buildTimelines(this.replacements);
-    if (changes.txid) {
+    if (changes.txid &&!changes.txid.firstChange && changes.txid.previousVaue !== changes.txid.currentValue) {
       setTimeout(() => { this.scrollToSelected(); });
     }
   }


### PR DESCRIPTION
Fixes a bug where transactions with an RBF history would autoscroll to the RBF timeline on page load on mobile.