### PR TITLE
Minor changes on Liquid frontend

### DIFF
--- a/frontend/src/app/components/liquid-reserves-audit/federation-utxos-list/federation-utxos-list.component.ts
+++ b/frontend/src/app/components/liquid-reserves-audit/federation-utxos-list/federation-utxos-list.component.ts
@@ -122,8 +122,8 @@ export class FederationUtxosListComponent implements OnInit {
 
   getGradientColor(value: number): string {
     const distanceToGreen = Math.abs(4032 - value);
-    const green = 'var(--green)';
-    const red = 'var(--red)';
+    const green = '#3bcc49';
+    const red = '#dc3545';
   
     if (value < 0) {
       return red;

--- a/frontend/src/app/components/liquid-reserves-audit/reserves-ratio-stats/reserves-ratio-stats.component.html
+++ b/frontend/src/app/components/liquid-reserves-audit/reserves-ratio-stats/reserves-ratio-stats.component.html
@@ -3,7 +3,7 @@
     <h5 class="card-title" i18n="liquid.unpeg">Unpeg</h5> 
     <div *ngIf="(unbackedMonths$ | async) as unbackedMonths; else loadingData" class="card-text">
       <ng-container *ngIf="unbackedMonths.historyComplete; else loadingData">
-        <div class="fee-text" [ngClass]="{'danger' : unbackedMonths.total > 0, 'correct': unbackedMonths.total === 0}">
+        <div class="fee-text" [ngClass]="{'danger' : unbackedMonths.total > 0, 'correct': unbackedMonths.total === 0}" i18n-ngbTooltip="liquid.unpeg-info" ngbTooltip="Number of times that the Federation's BTC holdings fall below 95% of the total L-BTC supply">
           {{ unbackedMonths.total }} <span i18n="liquid.unpeg-event">Unpeg Event</span>
         </div>
       </ng-container>

--- a/frontend/src/app/components/liquid-reserves-audit/reserves-ratio-stats/reserves-ratio-stats.component.ts
+++ b/frontend/src/app/components/liquid-reserves-audit/reserves-ratio-stats/reserves-ratio-stats.component.ts
@@ -34,7 +34,7 @@ export class ReservesRatioStatsComponent implements OnInit {
           let avg = 0;
           for (let i = 0; i < ratioSeries.length; i++) {
             avg += ratioSeries[i];
-            if (ratioSeries[i] < 1) {
+            if (ratioSeries[i] < 0.95) {
               total++;
             }
           }

--- a/frontend/src/app/components/liquid-reserves-audit/reserves-ratio/reserves-ratio.component.ts
+++ b/frontend/src/app/components/liquid-reserves-audit/reserves-ratio/reserves-ratio.component.ts
@@ -85,6 +85,7 @@ export class ReservesRatioComponent implements OnInit, OnChanges {
         {
           type: 'gauge',
           startAngle: 180,
+          silent: true,
           endAngle: 0,
           center: ['50%', '75%'],
           radius: '100%',


### PR DESCRIPTION
This PR brings minor changes to the Liquid audit. 

Until now, the frontend claims a `unpeg event` as soon as the Federation's holdings are 1 sat lower than the L-BTC supply, which is a little dramatic imo:
<img width="373" alt="Screenshot 2024-04-24 at 14 27 23" src="https://github.com/mempool/mempool/assets/46578910/f550ab5b-01b4-466b-b7a6-c81b03baea6c">
To fix this we add a 5% tolerance to the trigger, meaning that the the Federation's holdings needs to be less than `0.95 * L-BTC supply` to announce an `unpeg event`. 

This PR also fixes some color issues in the Federation UTXOs table, and an issue where the gauge pointer disappears on hover. 