### PR TITLE
Add an option to display values as sats

### DIFF
--- a/frontend/src/app/components/amount/amount.component.html
+++ b/frontend/src/app/components/amount/amount.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="!noFiat && (viewFiat$ | async) && (conversions$ | async) as conversions; else viewFiatVin">
+<ng-container *ngIf="!noFiat && (viewAmountMode$ | async) === 'fiat' && (conversions$ | async) as conversions; else viewFiatVin">
   <span class="fiat" *ngIf="blockConversion; else noblockconversion">
     {{ addPlus && satoshis >= 0 ? '+' : '' }}{{
       (
@@ -20,10 +20,28 @@
   <ng-template [ngIf]="(network === 'liquid' || network === 'liquidtestnet') && (satoshis === undefined || satoshis === null)" [ngIfElse]="default">
     <span i18n="shared.confidential">Confidential</span>
   </ng-template>
-  <ng-template #default>&lrm;{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ satoshis / 100000000 | number : digitsInfo }}
-    <span class="symbol"><ng-template [ngIf]="network === 'liquid' && !forceBtc">L-</ng-template>
-    <ng-template [ngIf]="network === 'liquidtestnet'">tL-</ng-template>
-    <ng-template [ngIf]="network === 'testnet'">t</ng-template>
-    <ng-template [ngIf]="network === 'signet'">s</ng-template>BTC</span>
+  <ng-template #default>
+    @if ((viewAmountMode$ | async) === 'btc' || (viewAmountMode$ | async) === 'fiat') {
+      &lrm;{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ satoshis / 100000000 | number : digitsInfo }}
+      <span class="symbol">
+        <ng-container *ngTemplateOutlet="prefix"></ng-container>BTC
+      </span>
+    } @else {
+      @if (digitsInfo === '1.8-8') {
+        &lrm;{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ satoshis | number }}
+      } @else { 
+        &lrm;{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ satoshis | amountShortener : satoshis < 1000 && satoshis > -1000 ? 0 : 1 }}
+      }
+      <span class="symbol">
+        <ng-container *ngTemplateOutlet="prefix"></ng-container>sats
+      </span>
+    }
   </ng-template>
+</ng-template>
+
+<ng-template #prefix>
+  <ng-template [ngIf]="network === 'liquid' && !forceBtc">L-</ng-template>
+  <ng-template [ngIf]="network === 'liquidtestnet'">tL-</ng-template>
+  <ng-template [ngIf]="network === 'testnet'">t</ng-template>
+  <ng-template [ngIf]="network === 'signet'">s</ng-template>
 </ng-template>

--- a/frontend/src/app/components/amount/amount.component.ts
+++ b/frontend/src/app/components/amount/amount.component.ts
@@ -12,7 +12,7 @@ import { Price } from '../../services/price.service';
 export class AmountComponent implements OnInit, OnDestroy {
   conversions$: Observable<any>;
   currency: string;
-  viewFiat$: Observable<boolean>;
+  viewAmountMode$: Observable<'btc' | 'sats' | 'fiat'>;
   network = '';
 
   stateSubscription: Subscription;
@@ -37,7 +37,7 @@ export class AmountComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.viewFiat$ = this.stateService.viewFiat$.asObservable();
+    this.viewAmountMode$ = this.stateService.viewAmountMode$.asObservable();
     this.conversions$ = this.stateService.conversions$.asObservable();
     this.stateSubscription = this.stateService.networkChanged$.subscribe((network) => this.network = network);
   }

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -10,6 +10,7 @@ import { filter, map, tap, switchMap, shareReplay, catchError } from 'rxjs/opera
 import { BlockExtended } from '../../interfaces/node-api.interface';
 import { ApiService } from '../../services/api.service';
 import { PriceService } from '../../services/price.service';
+import { StorageService } from '../../services/storage.service';
 
 @Component({
   selector: 'app-transactions-list',
@@ -56,6 +57,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
     private assetsService: AssetsService,
     private ref: ChangeDetectorRef,
     private priceService: PriceService,
+    private storageService: StorageService,
   ) { }
 
   ngOnInit(): void {
@@ -271,8 +273,11 @@ export class TransactionsListComponent implements OnInit, OnChanges {
     if (this.network === 'liquid' || this.network === 'liquidtestnet') {
       return;
     }
-    const oldvalue = !this.stateService.viewFiat$.value;
-    this.stateService.viewFiat$.next(oldvalue);
+    const modes = ['btc', 'sats', 'fiat'];
+    const oldIndex = modes.indexOf(this.stateService.viewAmountMode$.value);
+    const newIndex = (oldIndex + 1) % modes.length;
+    this.stateService.viewAmountMode$.next(modes[newIndex] as 'btc' | 'sats' | 'fiat');
+    this.storageService.setValue('view-amount-mode', modes[newIndex]);
   }
 
   trackByFn(index: number, tx: Transaction): string {

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
@@ -63,7 +63,7 @@ export class TxBowtieGraphTooltipComponent implements OnChanges {
       this.blockConversions = {};
       this.inputStatus = {};
     });
-    this.viewFiatSubscription = this.stateService.viewFiat$.subscribe(viewFiat => this.viewFiat = viewFiat);
+    this.viewFiatSubscription = this.stateService.viewAmountMode$.subscribe(viewFiat => this.viewFiat = viewFiat === 'fiat');
     this.chainTipSubscription = this.stateService.chainTip$.subscribe(tip => this.chainTip = tip);
   }
 

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -136,7 +136,7 @@ export class StateService {
 
   live2Chart$ = new Subject<OptimizedMempoolStats>();
 
-  viewFiat$ = new BehaviorSubject<boolean>(false);
+  viewAmountMode$: BehaviorSubject<'btc' | 'sats' | 'fiat'>;
   connectionState$ = new BehaviorSubject<0 | 1 | 2>(2);
   isTabHidden$: Observable<boolean>;
 
@@ -151,7 +151,7 @@ export class StateService {
   hideAudit: BehaviorSubject<boolean>;
   fiatCurrency$: BehaviorSubject<string>;
   rateUnits$: BehaviorSubject<string>;
-  blockDisplayMode$: BehaviorSubject<string> = new BehaviorSubject<string>('size');
+  blockDisplayMode$: BehaviorSubject<string>;
 
   searchFocus$: Subject<boolean> = new Subject<boolean>();
   menuOpen$: BehaviorSubject<boolean> = new BehaviorSubject(false);
@@ -261,6 +261,9 @@ export class StateService {
 
     const blockDisplayModePreference = this.storageService.getValue('block-display-mode-preference');
     this.blockDisplayMode$ = new BehaviorSubject<string>(blockDisplayModePreference || 'size');
+
+    const viewAmountModePreference = this.storageService.getValue('view-amount-mode') as 'btc' | 'sats' | 'fiat';
+    this.viewAmountMode$ = new BehaviorSubject<'btc' | 'sats' | 'fiat'>(viewAmountModePreference || 'btc');
 
     this.backend$.subscribe(backend => {
       this.backend = backend;


### PR DESCRIPTION
Closes #5000

This PR adds a toggle option when clicking on the value button. It also saves the user preference (`btc`, `sats` or `fiat`) in local storage. 
<img width="844" alt="Screenshot 2024-04-24 at 16 18 55" src="https://github.com/mempool/mempool/assets/46578910/ef08d66c-4692-4534-bcc9-ea1ad94516e5">
<img width="421" alt="Screenshot 2024-04-24 at 16 22 48" src="https://github.com/mempool/mempool/assets/46578910/db7c63c0-d413-4b87-9563-3cc51f65eccd">
<img width="520" alt="Screenshot 2024-04-24 at 16 29 27" src="https://github.com/mempool/mempool/assets/46578910/6625d652-6a43-40ef-8e6a-37f92876dd13">
