### PR TITLE
Improve deferred mempool visualization updates

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -238,7 +238,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
     }
   }
 
-  // collates non-urgent updates into a set of consistent pending changes
+  // collates deferred updates into a set of consistent pending changes
   queueUpdate(add: TransactionStripped[], remove: string[], change: { txid: string, rate: number | undefined, acc: boolean | undefined }[], direction: string = 'left'): void {
     for (const tx of add) {
       this.pendingUpdate.add[tx.txid] = tx;
@@ -262,9 +262,15 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
     this.pendingUpdate.count++;
   }
 
+  deferredUpdate(add: TransactionStripped[], remove: string[], change: { txid: string, rate: number | undefined, acc: boolean | undefined }[], direction: string = 'left'): void {
+    this.queueUpdate(add, remove, change, direction);
+    this.applyQueuedUpdates();
+  }
+
   applyQueuedUpdates(): void {
     if (this.pendingUpdate.count && performance.now() > (this.lastUpdate + this.animationDuration)) {
-      this.update([], [], [], this.pendingUpdate?.direction);
+      this.applyUpdate(Object.values(this.pendingUpdate.add), Object.values(this.pendingUpdate.remove), Object.values(this.pendingUpdate.change), this.pendingUpdate.direction);
+      this.clearUpdateQueue();
     }
   }
 

--- a/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
+++ b/frontend/src/app/components/mempool-block-overview/mempool-block-overview.component.ts
@@ -144,7 +144,7 @@ export class MempoolBlockOverviewComponent implements OnInit, OnDestroy, OnChang
       if (blockMined) {
         this.blockGraph.update(delta.added, delta.removed, delta.changed || [], blockMined ? this.chainDirection : this.poolDirection, blockMined);
       } else {
-        this.blockGraph.queueUpdate(delta.added, delta.removed, delta.changed || [], this.poolDirection);
+        this.blockGraph.deferredUpdate(delta.added, delta.removed, delta.changed || [], this.poolDirection);
       }
     }
 


### PR DESCRIPTION
A slight improvement to the new mempool animation pipeline from #5032, to continue to apply layout updates incrementally while the tab is backgrounded (and therefore requestAnimationFrame is paused).

Before (changes accumulate into one big update applied when the tab is returned to the foreground):

https://github.com/mempool/mempool/assets/83316221/c307b037-c305-4afa-9575-11bba024feca

After (the layout is kept up-to-date while the tab is in the background):

https://github.com/mempool/mempool/assets/83316221/878520aa-6a58-4ea8-82db-453914ee1728
