### PR TITLE
Don't get stuck fetching orphans

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -839,8 +839,11 @@ class Blocks {
       } else {
         this.currentBlockHeight++;
         logger.debug(`New block found (#${this.currentBlockHeight})!`);
-        this.updateTimerProgress(timer, `getting orphaned blocks for ${this.currentBlockHeight}`);
-        await chainTips.updateOrphanedBlocks();
+        // skip updating the orphan block cache if we've fallen behind the chain tip
+        if (this.currentBlockHeight >= blockHeightTip - 2) {
+          this.updateTimerProgress(timer, `getting orphaned blocks for ${this.currentBlockHeight}`);
+          await chainTips.updateOrphanedBlocks();
+        }
       }
 
       this.updateTimerProgress(timer, `getting block data for ${this.currentBlockHeight}`);


### PR DESCRIPTION
The current implementation of `chain-tips.ts` may struggle to handle a very large numbers of forks and orphan blocks because:
 - it runs on every new block, even if we've fallen behind the chain tip.
 - it fetches every block in every valid fork returned by `getChainTips()` every time.
 
This PR optimizes the process by:
 - skipping `updateOrphanedBlocks()` until we catch up with the chain tip.
 - holding an in-memory cache of orphaned block data, and only fetching blocks we don't already have.
 - bailing out of `updateOrphanedBlocks()` and resuming on the next loop if it's taking too long (more than 10 seconds).
     - (note that this timer only applies to fetching the data for the individual orphan blocks, and starts after the unavoidable initial call to `bitcoinClient.getChainTips()`)