### PR TITLE
Fix nginx caching for customize.js resource

### DIFF
--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -27,6 +27,11 @@
 		try_files $uri =404;
 		expires 5m;
 	}
+	# only cache /resources/customize.* for 5 minutes since it changes often
+	location /resources/customize. {
+		try_files $uri =404;
+		expires 5m;
+	}
 
 	location @index-redirect {
 		rewrite (.*) /$lang/index.html;

--- a/production/nginx/server-common.conf
+++ b/production/nginx/server-common.conf
@@ -90,6 +90,11 @@ location /resources/config. {
 	try_files $uri =404;
 	expires 5m;
 }
+# only cache /resources/customize.* for 5 minutes since it changes often
+location /resources/customize. {
+	try_files $uri =404;
+	expires 5m;
+}
 
 # cache /main.f40e91d908a068a2.js forever since they never change
 location ~* ^/.+\..+\.(js|css)$ {


### PR DESCRIPTION
Updates the foss build nginx caching for `/resources/customize.js` to match the existing rules for `/resources/config.js`