### PR TITLE
Update lightning-api.service.ts - fix typo

### DIFF
--- a/contributors/hans-crypto.txt
+++ b/contributors/hans-crypto.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of May 17, 2025.
+
+Signed: hans-crypto

--- a/frontend/src/app/lightning/lightning-api.service.ts
+++ b/frontend/src/app/lightning/lightning-api.service.ts
@@ -21,7 +21,6 @@ export class LightningApiService {
     if (!stateService.isBrowser) { // except when inside AU SSR process
       this.apiBaseUrl = this.stateService.env.NGINX_PROTOCOL + '://' + this.stateService.env.NGINX_HOSTNAME + ':' + this.stateService.env.NGINX_PORT;
     }
-    this.apiBasePath = ''; // assume mainnet by default
     this.stateService.networkChanged$.subscribe((network) => {
       this.apiBasePath = network ? '/' + network : '';
     });


### PR DESCRIPTION
You have this line twice in the file:

```
LINE 20: this.apiBaseUrl = ''; // use relative URL by default

LINE 24: this.apiBaseUrl = ''; // use relative URL by default
```

line 24 should be removed