### PR TITLE
Refactor block transactions

### DIFF
--- a/frontend/cypress/e2e/liquid/liquid.spec.ts
+++ b/frontend/cypress/e2e/liquid/liquid.spec.ts
@@ -45,6 +45,7 @@ describe('Liquid', () => {
 
     it('loads a specific block page', () => {
       cy.visit(`${basePath}/block/7e1369a23a5ab861e7bdede2aadcccae4ea873ffd9caf11c7c5541eb5bcdff54`);
+      cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
       cy.waitForSkeletonGone();
     });
 

--- a/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
+++ b/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
@@ -47,6 +47,7 @@ describe('Liquid Testnet', () => {
 
     it('loads a specific block page', () => {
       cy.visit(`${basePath}/block/7e1369a23a5ab861e7bdede2aadcccae4ea873ffd9caf11c7c5541eb5bcdff54`);
+      cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
       cy.waitForSkeletonGone();
     });
 

--- a/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
+++ b/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
@@ -46,7 +46,7 @@ describe('Liquid Testnet', () => {
     });
 
     it('loads a specific block page', () => {
-      cy.visit(`${basePath}/block/7e1369a23a5ab861e7bdede2aadcccae4ea873ffd9caf11c7c5541eb5bcdff54`);
+      cy.visit(`${basePath}/block/fb4cbcbff3993ca4bf8caf657d55a23db5ed4ab1cfa33c489303c2e04e1c38e0`);
       cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
       cy.waitForSkeletonGone();
     });

--- a/frontend/cypress/e2e/mainnet/mainnet.spec.ts
+++ b/frontend/cypress/e2e/mainnet/mainnet.spec.ts
@@ -103,6 +103,7 @@ describe('Mainnet', () => {
 
     it('check op_return tx tooltip', () => {
       cy.visit('/block/00000000000000000003c5f542bed265319c6cf64238cf1f1bb9bca3ebf686d2');
+      cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
       cy.waitForSkeletonGone();
       cy.get('tbody > :nth-child(2) > :nth-child(1) > a').first().trigger('onmouseover');
       cy.get('tbody > :nth-child(2) > :nth-child(1) > a').first().trigger('mouseenter');
@@ -111,6 +112,7 @@ describe('Mainnet', () => {
 
     it('check op_return coinbase tooltip', () => {
       cy.visit('/block/00000000000000000003c5f542bed265319c6cf64238cf1f1bb9bca3ebf686d2');
+      cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
       cy.waitForSkeletonGone();
       cy.get('tbody > :nth-child(2) > :nth-child(1) > a').first().trigger('onmouseover');
       cy.get('tbody > :nth-child(2) > :nth-child(1) > a').first().trigger('mouseenter');
@@ -283,6 +285,7 @@ describe('Mainnet', () => {
         it('loads genesis block and keypress arrow right', () => {
           cy.viewport('macbook-16');
           cy.visit('/block/0');
+          cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
           cy.waitForSkeletonGone();
           cy.waitForPageIdle();
 
@@ -295,6 +298,7 @@ describe('Mainnet', () => {
         it('loads genesis block and keypress arrow left', () => {
           cy.viewport('macbook-16');
           cy.visit('/block/0');
+          cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
           cy.waitForSkeletonGone();
           cy.waitForPageIdle();
 
@@ -323,6 +327,7 @@ describe('Mainnet', () => {
         it('loads genesis block and click on the arrow left', () => {
           cy.viewport('macbook-16');
           cy.visit('/block/0');
+          cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
           cy.waitForSkeletonGone();
           cy.waitForPageIdle();
           cy.get('[ngbtooltip="Next Block"] > .ng-fa-icon > .svg-inline--fa').should('be.visible');
@@ -439,6 +444,7 @@ describe('Mainnet', () => {
     describe('blocks', () => {
       it('shows empty blocks properly', () => {
         cy.visit('/block/0000000000000000000bd14f744ef2e006e61c32214670de7eb891a5732ee775');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.waitForPageIdle();
         cy.get('h2').invoke('text').should('equal', '1 transaction');
@@ -446,6 +452,7 @@ describe('Mainnet', () => {
 
       it('expands and collapses the block details', () => {
         cy.visit('/block/0');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.waitForPageIdle();
         cy.get('.btn.btn-outline-info').click().then(() => {
@@ -458,6 +465,7 @@ describe('Mainnet', () => {
       });
       it('shows blocks with no pagination', () => {
         cy.visit('/block/00000000000000000001ba40caf1ad4cec0ceb77692662315c151953bfd7c4c4');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.waitForPageIdle();
         cy.get('.block-tx-title h2').invoke('text').should('equal', '19 transactions');
@@ -467,6 +475,7 @@ describe('Mainnet', () => {
       it('supports pagination on the block screen', () => {
         // 41 txs
         cy.visit('/block/00000000000000000009f9b7b0f63ad50053ad12ec3b7f5ca951332f134f83d8');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('.pagination-container a').invoke('text').then((text1) => {
           cy.get('.active + li').first().click().then(() => {
@@ -482,6 +491,7 @@ describe('Mainnet', () => {
       it('shows blocks pagination with 5 pages (desktop)', () => {
         cy.viewport(760, 800);
         cy.visit('/block/000000000000000000049281946d26fcba7d99fdabc1feac524bc3a7003d69b3').then(() => {
+          cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
           cy.waitForSkeletonGone();
           cy.waitForPageIdle();
         });
@@ -493,6 +503,7 @@ describe('Mainnet', () => {
       it('shows blocks pagination with 3 pages (mobile)', () => {
         cy.viewport(669, 800);
         cy.visit('/block/000000000000000000049281946d26fcba7d99fdabc1feac524bc3a7003d69b3').then(() => {
+          cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
           cy.waitForSkeletonGone();
           cy.waitForPageIdle();
         });

--- a/frontend/cypress/e2e/signet/signet.spec.ts
+++ b/frontend/cypress/e2e/signet/signet.spec.ts
@@ -95,12 +95,14 @@ describe('Signet', () => {
     describe('blocks', () => {
       it('shows empty blocks properly', () => {
         cy.visit('/signet/block/00000133d54e4589f6436703b067ec23209e0a21b8a9b12f57d0592fd85f7a42');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('h2').invoke('text').should('equal', '1 transaction');
       });
 
       it('expands and collapses the block details', () => {
         cy.visit('/signet/block/0');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('.btn.btn-outline-info').click().then(() => {
           cy.get('#details').should('be.visible');
@@ -113,6 +115,7 @@ describe('Signet', () => {
 
       it('shows blocks with no pagination', () => {
         cy.visit('/signet/block/00000078f920a96a69089877b934ce7fd009ab55e3170920a021262cb258e7cc');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('h2').invoke('text').should('equal', '13 transactions');
         cy.get('ul.pagination').first().children().should('have.length', 5);
@@ -121,6 +124,7 @@ describe('Signet', () => {
       it('supports pagination on the block screen', () => {
         // 43 txs
         cy.visit('/signet/block/00000094bd52f73bdbfc4bece3a94c21fec2dc968cd54210496e69e4059d66a6');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('.header-bg.box > a').invoke('text').then((text1) => {
           cy.get('.active + li').first().click().then(() => {

--- a/frontend/cypress/e2e/testnet4/testnet4.spec.ts
+++ b/frontend/cypress/e2e/testnet4/testnet4.spec.ts
@@ -95,12 +95,14 @@ describe('Testnet4', () => {
     describe('blocks', () => {
       it('shows empty blocks properly', () => {
         cy.visit('/testnet4/block/0');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('h2').invoke('text').should('equal', '1 transaction');
       });
 
       it('expands and collapses the block details', () => {
         cy.visit('/testnet4/block/0');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('.btn.btn-outline-info').click().then(() => {
           cy.get('#details').should('be.visible');
@@ -113,6 +115,7 @@ describe('Testnet4', () => {
 
       it('shows blocks with no pagination', () => {
         cy.visit('/testnet4/block/000000000066e8b6cc78a93f8989587f5819624bae2eb1c05f535cadded19f99');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('h2').invoke('text').should('equal', '18 transactions');
         cy.get('ul.pagination').first().children().should('have.length', 5);
@@ -121,6 +124,7 @@ describe('Testnet4', () => {
       it('supports pagination on the block screen', () => {
         // 48 txs
         cy.visit('/testnet4/block/000000000000006982d53f8273bdff21dafc380c292eabc669b5ab6d732311c3');
+        cy.get('.pagination').scrollIntoView({ offset: { top: 200, left: 0 } });
         cy.waitForSkeletonGone();
         cy.get('.header-bg.box > a').invoke('text').then((text1) => {
           cy.get('.active + li').first().click().then(() => {

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { PriceService } from './services/price.service';
 import { EnterpriseService } from './services/enterprise.service';
 import { WebsocketService } from './services/websocket.service';
 import { AudioService } from './services/audio.service';
+import { PreloadService } from './services/preload.service';
 import { SeoService } from './services/seo.service';
 import { OpenGraphService } from './services/opengraph.service';
 import { ZoneService } from './services/zone-shim.service';
@@ -46,6 +47,7 @@ const providers = [
   CapAddressPipe,
   AppPreloadingStrategy,
   ServicesApiServices,
+  PreloadService,
   { provide: HTTP_INTERCEPTORS, useClass: HttpCacheInterceptor, multi: true },
   { provide: ZONE_SERVICE, useClass: ZoneService },
 ];

--- a/frontend/src/app/components/block/block-transactions.component.html
+++ b/frontend/src/app/components/block/block-transactions.component.html
@@ -1,0 +1,53 @@
+<div #blockTxTitle id="block-tx-title" class="block-tx-title">
+  <h2 class="text-left">
+    <ng-container *ngTemplateOutlet="txCount === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: txCount | number}"></ng-container>
+    <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
+    <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
+  </h2>
+  <ngb-pagination class="pagination-container float-right" [collectionSize]="txCount" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination>
+</div>
+<div class="clearfix"></div>
+
+<app-transactions-list *ngIf="transactions$ | async as transactions; else loading" [transactions]="transactions" [paginated]="true" [blockTime]="timestamp"></app-transactions-list>
+
+<ng-template [ngIf]="transactionsError">
+  <br>
+  <app-http-error [error]="transactionsError">
+    <span i18n="error.general-loading-data">Error loading data.</span>
+  </app-http-error>
+  <br>
+  <br>
+</ng-template>
+
+<ng-template #loading>
+  <div class="text-center mb-4" class="tx-skeleton">
+    <ng-container *ngIf="(txsLoadingStatus$ | async) as txsLoadingStatus; else headerLoader">
+      <div class="header-bg box">
+        <div class="progress progress-dark" style="margin: 4px; height: 14px;">
+          <div class="progress-bar progress-light" role="progressbar" [ngStyle]="{'width': txsLoadingStatus + '%' }"></div>
+        </div>
+      </div>
+    </ng-container>
+
+    <div class="header-bg box">
+      <div class="row">
+        <div class="col-sm">
+          <span class="skeleton-loader"></span>
+        </div>
+        <div class="col-sm">
+          <span class="skeleton-loader"></span>
+          <span class="skeleton-loader"></span>
+          <span class="skeleton-loader"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #headerLoader>
+  <div class="header-bg box">
+    <span class="skeleton-loader"></span>
+  </div>
+</ng-template>
+
+<ngb-pagination class="pagination-container float-right" [collectionSize]="txCount" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination>

--- a/frontend/src/app/components/block/block-transactions.component.scss
+++ b/frontend/src/app/components/block/block-transactions.component.scss
@@ -1,0 +1,37 @@
+.block-tx-title {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  margin-top: -15px;
+  position: relative;
+  @media (min-width: 550px) {
+    margin-top: 1rem;
+    flex-direction: row;
+  }
+  h2 {
+    line-height: 1;
+    margin: 0;
+    position: relative;
+    padding-bottom: 10px;
+    @media (min-width: 550px) {
+      padding-bottom: 0px;
+      align-self: end;
+    }
+  }
+}
+
+.tx-skeleton {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  .header-bg {
+    &:first-child {
+      padding: 10px;
+      margin-bottom: 10px;
+    }
+    &:nth-child(2) {
+      .row {
+        height: 107px;
+      }
+    }
+  }
+}

--- a/frontend/src/app/components/block/block-transactions.component.ts
+++ b/frontend/src/app/components/block/block-transactions.component.ts
@@ -58,9 +58,11 @@ export class BlockTransactionsComponent implements OnInit, OnDestroy {
           this.blockReward.emit(blockReward);
         }
         this.unsubscribeNextBlockSubscriptions();
-        setTimeout(() => {
-          this.nextBlockTxListSubscription = this.electrsApiService.getBlockTransactions$(this.previousBlockHash).subscribe();
-        }, 100);
+        if (this.previousBlockHash) {
+          setTimeout(() => {
+            this.nextBlockTxListSubscription = this.electrsApiService.getBlockTransactions$(this.previousBlockHash).subscribe();
+          }, 100);
+        }
       })
     );
 

--- a/frontend/src/app/components/block/block-transactions.component.ts
+++ b/frontend/src/app/components/block/block-transactions.component.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { StateService } from '../../services/state.service';
+import { Transaction, Vout } from '../../interfaces/electrs.interface';
+import { Observable, Subscription, catchError, combineLatest, map, of, startWith, switchMap, tap } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ElectrsApiService } from '../../services/electrs-api.service';
+
+@Component({
+  selector: 'app-block-transactions',
+  templateUrl: './block-transactions.component.html',
+  styleUrl: './block-transactions.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BlockTransactionsComponent implements OnInit, OnDestroy {
+  @Input() txCount: number;
+  @Input() timestamp: number;
+  @Input() blockHash: string;
+  @Input() previousBlockHash: string;
+  @Input() block$: Observable<any>;
+  @Input() paginationMaxSize: number;
+  @Output() blockReward = new EventEmitter<number>();
+
+  itemsPerPage = this.stateService.env.ITEMS_PER_PAGE;
+  page = 1;
+
+  transactions$: Observable<Transaction[]>;
+  isLoadingTransactions = true;
+  transactionsError: any = null;
+  transactionSubscription: Subscription;
+  txsLoadingStatus$: Observable<number>;
+  nextBlockTxListSubscription: Subscription;
+
+  constructor(
+    private stateService: StateService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private electrsApiService: ElectrsApiService,
+  ) { }
+
+  ngOnInit(): void {
+    this.transactions$ = combineLatest([this.block$, this.route.queryParams]).pipe(
+      tap(([_, queryParams]) => {
+        this.page = +queryParams['page'] || 1;
+      }),
+      switchMap(([block, _]) => this.electrsApiService.getBlockTransactions$(block.id, (this.page - 1) * this.itemsPerPage)
+        .pipe(
+          startWith(null),
+          catchError((err) => {
+            this.transactionsError = err;
+            return of([]);
+        }))
+      ),
+    )
+    .pipe(
+      tap((transactions: Transaction[]) => {
+        if (transactions && transactions[0] && transactions[0].vin[0].is_coinbase) {
+          const blockReward = transactions[0].vout.reduce((acc: number, curr: Vout) => acc + curr.value, 0) / 100000000;
+          this.blockReward.emit(blockReward);
+        }
+        this.unsubscribeNextBlockSubscriptions();
+        setTimeout(() => {
+          this.nextBlockTxListSubscription = this.electrsApiService.getBlockTransactions$(this.previousBlockHash).subscribe();
+        }, 100);
+      })
+    );
+
+    this.txsLoadingStatus$ = this.route.paramMap
+      .pipe(
+        switchMap(() => this.stateService.loadingIndicators$),
+        map((indicators) => indicators['blocktxs-' + this.blockHash] !== undefined ? indicators['blocktxs-' + this.blockHash] : 0)
+      );
+  }
+
+  pageChange(page: number, target: HTMLElement): void {
+    target.scrollIntoView(); // works for chrome
+    this.router.navigate([], { queryParams: { page: page }, queryParamsHandling: 'merge' });
+  }
+
+  unsubscribeNextBlockSubscriptions(): void {
+    if (this.nextBlockTxListSubscription !== undefined) {
+      this.nextBlockTxListSubscription.unsubscribe();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribeNextBlockSubscriptions();
+  }
+}

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -325,53 +325,39 @@
       >Details</button>
     </div>
 
-    <div #blockTxTitle id="block-tx-title" class="block-tx-title">
-      <h2 class="text-left">
-        <ng-container *ngTemplateOutlet="block.tx_count === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: block.tx_count | number}"></ng-container>
-        <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
-        <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
-      </h2>
-
-      <ngb-pagination class="pagination-container float-right" [collectionSize]="block.tx_count" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination>
-    </div>
-    <div class="clearfix"></div>
-
-    <app-transactions-list [transactions]="transactions" [paginated]="true" [blockTime]="block.timestamp"></app-transactions-list>
-
-    <ng-template [ngIf]="transactionsError">
-      <br>
-      <app-http-error [error]="transactionsError">
-        <span i18n="error.general-loading-data">Error loading data.</span>
-      </app-http-error>
-      <br>
-      <br>
-    </ng-template>
-
-    <ng-template [ngIf]="isLoadingTransactions && !transactionsError">
-      <div class="text-center mb-4" class="tx-skeleton">
-
-        <ng-container *ngIf="(txsLoadingStatus$ | async) as txsLoadingStatus; else headerLoader">
+    @defer (on viewport) {
+      <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash" (blockReward)="updateBlockReward($event)"></app-block-transactions>
+    } @placeholder {
+      <div>
+        <div class="block-tx-title">
+          <h2 class="text-left">
+            <ng-container *ngTemplateOutlet="block.tx_count === 1 ? transactionsSingular : transactionsPlural; context: {$implicit: block.tx_count | number}"></ng-container>
+            <ng-template #transactionsSingular let-i i18n="shared.transaction-count.singular">{{ i }} transaction</ng-template>
+            <ng-template #transactionsPlural let-i i18n="shared.transaction-count.plural">{{ i }} transactions</ng-template>
+          </h2>
+          <ngb-pagination class="pagination-container float-right" [disabled]="true" [collectionSize]="block.tx_count" [rotate]="true" [pageSize]="stateService.env.ITEMS_PER_PAGE" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination>
+        </div>
+        <div class="clearfix"></div>
+        <div class="text-center mb-4" class="tx-skeleton">
+  
           <div class="header-bg box">
-            <div class="progress progress-dark" style="margin: 4px; height: 14px;">
-              <div class="progress-bar progress-light" role="progressbar" [ngStyle]="{'width': txsLoadingStatus + '%' }"></div>
-            </div>
+            <span class="skeleton-loader"></span>
           </div>
-        </ng-container>
-
-        <div class="header-bg box">
-          <div class="row">
-            <div class="col-sm">
-              <span class="skeleton-loader"></span>
-              <span class="skeleton-loader"></span>
-            </div>
-            <div class="col-sm">
-              <span class="skeleton-loader"></span>
+          <div class="header-bg box">
+            <div class="row">
+              <div class="col-sm">
+                <span class="skeleton-loader"></span>
+              </div>
+              <div class="col-sm">
+                <span class="skeleton-loader"></span>
+                <span class="skeleton-loader"></span>
+                <span class="skeleton-loader"></span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </ng-template>
-    <ngb-pagination class="pagination-container float-right" [collectionSize]="block.tx_count" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page, blockTxTitle)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="false"></ngb-pagination>
+    }
 
     <div class="clearfix"></div>
     <br>
@@ -380,12 +366,6 @@
     <app-http-error [error]="error">
       <span i18n="error.general-loading-data">Error loading data.</span>
     </app-http-error>
-  </ng-template>
-
-  <ng-template #headerLoader>
-    <div class="header-bg box">
-      <span class="skeleton-loader"></span>
-    </div>
   </ng-template>
 
 </div>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -326,7 +326,7 @@
     </div>
 
     @defer (on viewport) {
-      <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash" (blockReward)="updateBlockReward($event)"></app-block-transactions>
+      <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash"></app-block-transactions>
     } @placeholder {
       <div>
         <div class="block-tx-title">

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -326,7 +326,7 @@
     </div>
 
     @defer (on viewport) {
-      <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash"></app-block-transactions>
+      <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash" (blockReward)="updateBlockReward($event)"></app-block-transactions>
     } @placeholder {
       <div>
         <div class="block-tx-title">

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -21,25 +21,6 @@
   }
 }
 
-.qr-wrapper {
-  background-color: var(--fg);
-  padding: 10px;
-  padding-bottom: 5px;
-  display: inline-block;
-}
-
-.qrcode-col {
-  text-align: center;
-}
-
-.qrcode-col > div {
-  margin: 20px auto 5px;
-  @media (min-width: 768px) {
-    text-align: center;
-    margin: auto;
-  }
-}
-
 .fiat {
   display: block;
   font-size: 13px;
@@ -100,19 +81,7 @@ h1 {
   }
 }
 
-.address-link {
-  line-height: 26px;
-  margin-left: 0px;
-  top: 14px;
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  @media (min-width: 768px) {
-    line-height: 38px;
-  }
-}
-
-.row{
+.row {
 	flex-direction: column;
 	@media (min-width: 768px) {
 		flex-direction: row;
@@ -138,28 +107,6 @@ h1 {
 
 .btn-audit {
   margin-right: .5em;
-}
-
-.block-tx-title {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-  margin-top: -15px;
-  position: relative;
-  @media (min-width: 550px) {
-    margin-top: 1rem;
-    flex-direction: row;
-  }
-  h2 {
-    line-height: 1;
-    margin: 0;
-    position: relative;
-    padding-bottom: 10px;
-    @media (min-width: 550px) {
-      padding-bottom: 0px;
-      align-self: end;
-    }
-  }
 }
 
 .grow {
@@ -201,22 +148,6 @@ h1 {
   color: #393e5c73;
   @media (min-width: 768px) {
     font-size: 36px;
-  }
-}
-
-.tx-skeleton {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  .header-bg {
-    &:first-child {
-      padding: 10px;
-      margin-bottom: 10px;
-    }
-    &:nth-child(2) {
-      .row {
-        height: 107px;
-      }
-    }
   }
 }
 
@@ -302,4 +233,42 @@ h1 {
 
 .graph-col {
   flex-grow: 1.11;
+}
+
+.block-tx-title {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  margin-top: -15px;
+  position: relative;
+  @media (min-width: 550px) {
+    margin-top: 1rem;
+    flex-direction: row;
+  }
+  h2 {
+    line-height: 1;
+    margin: 0;
+    position: relative;
+    padding-bottom: 10px;
+    @media (min-width: 550px) {
+      padding-bottom: 0px;
+      align-self: end;
+    }
+  }
+}
+
+.tx-skeleton {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  .header-bg {
+    &:first-child {
+      padding: 10px;
+      margin-bottom: 10px;
+    }
+    &:nth-child(2) {
+      .row {
+        height: 107px;
+      }
+    }
+  }
 }

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -755,4 +755,10 @@ export class BlockComponent implements OnInit, OnDestroy {
       this.block.canonical = block.id;
     }
   }
+
+  updateBlockReward(blockReward: number): void {
+    if (this.fees === undefined) {
+       this.fees = blockReward;
+    }
+  }
 }

--- a/frontend/src/app/components/block/block.module.ts
+++ b/frontend/src/app/components/block/block.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Routes, RouterModule } from '@angular/router';
 import { BlockComponent } from './block.component';
+import { BlockTransactionsComponent } from './block-transactions.component';
 import { SharedModule } from '../../shared/shared.module';
 
 const routes: Routes = [
@@ -32,6 +33,7 @@ export class BlockRoutingModule { }
   ],
   declarations: [
     BlockComponent,
+    BlockTransactionsComponent,
   ]
 })
 export class BlockModule { }

--- a/frontend/src/app/services/preload.service.ts
+++ b/frontend/src/app/services/preload.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { ElectrsApiService } from '../services/electrs-api.service';
+import { Subject, debounceTime, switchMap } from 'rxjs';
+import { ApiService } from './api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PreloadService {
+  block$ = new Subject<string>;
+  blockAudit$ = new Subject<string>;
+  debounceTime = 250;
+
+  constructor(
+    private electrsApiService: ElectrsApiService,
+    private apiService: ApiService,
+  ) {
+    this.block$
+      .pipe(
+        debounceTime(this.debounceTime),
+        switchMap((blockHash) => this.electrsApiService.getBlockTransactions$(blockHash))
+      )
+      .subscribe();
+
+    this.blockAudit$
+      .pipe(
+        debounceTime(this.debounceTime),
+        switchMap((blockHash) => this.apiService.getBlockAudit$(blockHash))
+      )
+      .subscribe();
+  }
+
+}


### PR DESCRIPTION
What this PR / Refactor does:

1. The Transactions list on the Block page is now it's own separate component reducing the complexity of Block component slightly.
2. The new Angular defer view feature is utilized. So only when the Transactions list on the block page is visible in the viewport, it will render and load the transactions saving rendering time and server traffic, that commonly isn't required as mobile phones need to scroll down to view transactions. As soon as the transactions list is in view, the old behaviour of loading the transactions and lazy-loading the previous block kicks in, so people with long screens shouldn't notice any difference.

Opening a new Block page (on a default screen where the transactions list isn't visible), 6 API requests are now being triggered, instead of 10 currently!