### PR TITLE
Fix local acceleration filter & reindex

### DIFF
--- a/backend/src/repositories/AccelerationRepository.ts
+++ b/backend/src/repositories/AccelerationRepository.ts
@@ -244,6 +244,8 @@ class AccelerationRepository {
     let count = 0;
     try {
       while (!done) {
+        // don't DDoS the services backend
+        Common.sleep$(500 + (Math.random() * 1000));
         const accelerations = await accelerationApi.$fetchAccelerationHistory(page);
         page++;
         if (!accelerations?.length) {
@@ -309,7 +311,7 @@ class AccelerationRepository {
           pools: acc.pools.map(pool => pool.pool_unique_id),
         }))
         for (const acc of accelerations) {
-          if (blockTxs[acc.txid]) {
+          if (blockTxs[acc.txid] && acc.pools.some(pool => pool.pool_unique_id === block.extras.pool.id)) {
             const tx = blockTxs[acc.txid];
             const accelerationInfo = accelerationCosts.getAccelerationInfo(tx, boostRate, transactions);
             accelerationInfo.cost = Math.max(0, Math.min(acc.feeDelta, accelerationInfo.cost));


### PR DESCRIPTION
Fixes a missing pool filter in the local indexing of historic accelerations, and truncates the local accelerations table to trigger a reindex of this data.

The re-indexing process may take several minutes to complete.

Before:
<img width="1386" alt="Screenshot 2024-05-21 at 9 49 51 PM" src="https://github.com/mempool/mempool/assets/83316221/771746bd-36d0-4595-a9c5-6beb76fbc054">

After:
<img width="1386" alt="Screenshot 2024-05-21 at 9 50 05 PM" src="https://github.com/mempool/mempool/assets/83316221/c60f234a-f046-4eeb-b89d-8b199f3b9190">
