### PR TITLE
Slightly lift up blockchain toggle button

### DIFF
--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -71,7 +71,7 @@
   color: var(--fg);
   font-size: 0.8rem;
   position: absolute;
-  bottom: 15.8em;
+  bottom: 16.1em;
   left: 1px;
   transform: translateX(-50%) rotate(90deg);
   background: none;


### PR DESCRIPTION
This PR slightly lifts up the blockchain upper toggle button so that it is not cropped on screenshots: 

<img width="785" alt="Screenshot 2024-05-28 at 16 17 53" src="https://github.com/mempool/mempool/assets/46578910/a9490344-3860-4033-b286-60dd38fb5138">
