### PR TITLE
Searchbar: wait for 3 characters before requesting lightning data

### DIFF
--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -403,9 +403,13 @@ export class ApiService {
     return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/channels/txids/', { params });
   }
 
-  lightningSearch$(searchText: string): Observable<any[]> {
+  lightningSearch$(searchText: string): Observable<{ nodes: any[], channels: any[] }> {
     let params = new HttpParams().set('searchText', searchText);
-    return this.httpClient.get<any[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/search', { params });
+    // Don't request the backend if searchText is less than 3 characters
+    if (searchText.length < 3) {
+      return of({ nodes: [], channels: [] });
+    }
+    return this.httpClient.get<{ nodes: any[], channels: any[] }>(this.apiBaseUrl + this.apiBasePath + '/api/v1/lightning/search', { params });
   }
 
   getNodesPerIsp(): Observable<any> {


### PR DESCRIPTION
Builds on #5117

The lightning search API frequently times out when the search text is only one or two characters long. This causes all results to take several seconds to appear even if the address prefix and the mining pools queries returned almost instantly. 
To mitigate this issue, this PR makes the frontend only query lightning nodes and channels if the search text is 3 or more characters. 