### PR TITLE
Make address chart prefer "recent" mode by default

### DIFF
--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -66,7 +66,7 @@
         </div>
         <div class="row">
           <div class="col-md">
-            <app-address-graph [address]="addressString" [isPubkey]="address?.is_pubkey" [stats]="address.chain_stats" [period]="balancePeriod" />
+            <app-address-graph [address]="addressString" [isPubkey]="address?.is_pubkey" [stats]="address.chain_stats" [period]="balancePeriod" left="80" />
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -182,6 +182,8 @@ export class AddressComponent implements OnInit, OnDestroy {
 
         if (!this.showBalancePeriod()) {
           this.setBalancePeriod('all');
+        } else {
+          this.setBalancePeriod('1m');
         }
       },
       (error) => {


### PR DESCRIPTION
Sets the address balance chart on the address page to "recent" if there are any recent transactions to show (within the last 30 days).

Also fixes cropped y-axis labels for some ranges.