### PR TITLE
Correctly expand environment variables in the config files in the docker images.

### DIFF
--- a/contributors/danrmiller.txt
+++ b/contributors/danrmiller.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of June 3, 2024.
+
+Signed: danrmiller

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -13,8 +13,8 @@ localhostIP="127.0.0.1"
 cp ./docker/frontend/* ./frontend
 cp ./nginx.conf ./frontend/
 cp ./nginx-mempool.conf ./frontend/
-sed -i"" -e "s/${localhostIP}:80/0.0.0.0:__MEMPOOL_FRONTEND_HTTP_PORT__/g" ./frontend/nginx.conf
+sed -i"" -e "s/${localhostIP}:80/0.0.0.0:${MEMPOOL_FRONTEND_HTTP_PORT}/g" ./frontend/nginx.conf
 sed -i"" -e "s/${localhostIP}/0.0.0.0/g" ./frontend/nginx.conf
 sed -i"" -e "s/user nobody;//g" ./frontend/nginx.conf
 sed -i"" -e "s!/etc/nginx/nginx-mempool.conf!/etc/nginx/conf.d/nginx-mempool.conf!g" ./frontend/nginx.conf
-sed -i"" -e "s/${localhostIP}:8999/__MEMPOOL_BACKEND_MAINNET_HTTP_HOST__:__MEMPOOL_BACKEND_MAINNET_HTTP_PORT__/g" ./frontend/nginx-mempool.conf
+sed -i"" -e "s/${localhostIP}:8999/${BACKEND_MAINNET_HTTP_HOST}:${BACKEND_HTTP_PORT}/g" ./frontend/nginx-mempool.conf


### PR DESCRIPTION
The docker images that get uploaded to dockerhub under mempool/frontend don't accept environment variables for FRONTEND_HTTP_PORT, BACKEND_MAINNET_HTTP_HOST, and BACKEND_MAINNET_HTTP_PORT and instead just contain the placeholder string.