### PR TITLE
Experimental auto-push URL support

### DIFF
--- a/frontend/src/app/components/push-transaction/push-transaction.component.ts
+++ b/frontend/src/app/components/push-transaction/push-transaction.component.ts
@@ -5,6 +5,8 @@ import { StateService } from '../../services/state.service';
 import { SeoService } from '../../services/seo.service';
 import { OpenGraphService } from '../../services/opengraph.service';
 import { seoDescriptionNetwork } from '../../shared/common.utils';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RelativeUrlPipe } from '../../shared/pipes/relative-url/relative-url.pipe';
 
 @Component({
   selector: 'app-push-transaction',
@@ -23,6 +25,9 @@ export class PushTransactionComponent implements OnInit {
     public stateService: StateService,
     private seoService: SeoService,
     private ogService: OpenGraphService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private relativeUrlPipe: RelativeUrlPipe,
   ) { }
 
   ngOnInit(): void {
@@ -33,27 +38,100 @@ export class PushTransactionComponent implements OnInit {
     this.seoService.setTitle($localize`:@@meta.title.push-tx:Broadcast Transaction`);
     this.seoService.setDescription($localize`:@@meta.description.push-tx:Broadcast a transaction to the ${this.stateService.network==='liquid'||this.stateService.network==='liquidtestnet'?'Liquid':'Bitcoin'}${seoDescriptionNetwork(this.stateService.network)} network using the transaction's hash.`);
     this.ogService.setManualOgImage('tx-push.jpg');
+
+    this.route.fragment.subscribe(async (fragment) => {
+      const fragmentParams = new URLSearchParams(fragment || '');
+      return this.handleColdcardPushTx(fragmentParams);
+    });
   }
 
-  postTx() {
+  async postTx(hex?: string): Promise<string> {
     this.isLoading = true;
     this.error = '';
     this.txId = '';
-    this.apiService.postTransaction$(this.pushTxForm.get('txHash').value)
+    return new Promise((resolve, reject) => {
+      this.apiService.postTransaction$(hex || this.pushTxForm.get('txHash').value)
       .subscribe((result) => {
         this.isLoading = false;
         this.txId = result;
         this.pushTxForm.reset();
+        resolve(this.txId);
       },
       (error) => {
         if (typeof error.error === 'string') {
           const matchText = error.error.match('"message":"(.*?)"');
-          this.error = matchText && matchText[1] || error.error;
+          this.error = 'Failed to broadcast transaction, reason: ' + (matchText && matchText[1] || error.error);
         } else if (error.message) {
-          this.error = error.message;
+          this.error = 'Failed to broadcast transaction, reason: ' + error.message;
         }
         this.isLoading = false;
+        reject(this.error);
       });
+    });
   }
 
+  private async handleColdcardPushTx(fragmentParams: URLSearchParams): Promise<boolean> {
+    // maybe conforms to Coldcard nfc-pushtx spec
+    if (fragmentParams && fragmentParams.get('t')) {
+      try {
+        const pushNetwork = fragmentParams.get('n');
+
+        // Redirect to the appropriate network-specific URL
+        if (this.stateService.network !== '' && !pushNetwork) {
+          this.router.navigateByUrl(`/pushtx#${fragmentParams.toString()}`);
+          return false;
+        } else if (this.stateService.network !== 'testnet' && pushNetwork === 'XTN') {
+          this.router.navigateByUrl(`/testnet/pushtx#${fragmentParams.toString()}`);
+          return false;
+        } else if (pushNetwork === 'XRT') {
+          this.error = 'Regtest is not supported';
+          return false;
+        } else if (pushNetwork && !['XTN', 'XRT'].includes(pushNetwork)) {
+          this.error = 'Invalid network';
+          return false;
+        }
+
+        const rawTx = this.base64UrlToU8Array(fragmentParams.get('t'));
+        if (!fragmentParams.get('c')) {
+          this.error = 'Missing checksum, URL is probably truncated';
+          return false;
+        }
+        const rawCheck = this.base64UrlToU8Array(fragmentParams.get('c'));
+        
+
+        // check checksum
+        const hashTx = await crypto.subtle.digest('SHA-256', rawTx);
+        if (this.u8ArrayToHex(new Uint8Array(hashTx.slice(24))) !== this.u8ArrayToHex(rawCheck)) {
+          this.error = 'Bad checksum, URL is probably truncated';
+          return false;
+        }
+
+        const hexTx = this.u8ArrayToHex(rawTx);
+        this.pushTxForm.get('txHash').setValue(hexTx);
+
+        try {
+          const txid = await this.postTx(hexTx);
+          this.router.navigate([this.relativeUrlPipe.transform('/tx'), txid]);
+        } catch (e) {
+          // error already handled
+          return false;
+        }
+
+        return true;
+      } catch (e) {
+        this.error = 'Failed to decode transaction';
+        return false;
+      }
+    }
+  }
+
+  private base64UrlToU8Array(base64Url: string): Uint8Array {
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/').padEnd(base64Url.length + (4 - base64Url.length % 4) % 4, '=');
+    const binaryString = atob(base64);
+    return new Uint8Array([...binaryString].map(char => char.charCodeAt(0)));
+  }
+
+  private u8ArrayToHex(arr: Uint8Array): string {
+    return Array.from(arr).map(byte => byte.toString(16).padStart(2, '0')).join('');
+  }
 }

--- a/frontend/src/app/master-page.module.ts
+++ b/frontend/src/app/master-page.module.ts
@@ -33,6 +33,10 @@ const routes: Routes = [
         component: PushTransactionComponent,
       },
       {
+        path: 'pushtx',
+        component: PushTransactionComponent,
+      },
+      {
         path: 'tx/test',
         component: TestTransactionsComponent,
       },


### PR DESCRIPTION
Experimental support for auto-broadcasting transactions via URL, (attempts to) conform to Coldcard NFC Push Tx spec.

Adds a new route `/pushtx` for the broadcast transaction page (in case we want to add some special UX later, separate from the manual `/tx/push` page), which accepts the following fragment-encoded parameters:
 - `t`: base64Url encoded raw transaction bytes
 - `c`: base64Url encoded checksum, consisting of the rightmost 8 bytes of the sha256 hash of the raw transaction bytes from `t`
 - `n`: optional network selector, either `XTN` for testnet or `XRT` for regtest (not supported)
     - the user is automatically redirected to the appropriate network-specific `/pushtx` page, determined by the value (or absence of) this parameter.
     
If the provided parameters pass validation & the checksum is correct, the decoded transaction is immediately submitted for broadcast via the `POST /tx` API.

On success, we automatically redirect to the Transaction page for the resulting TXID.

On failure, the error response is displayed inline, and the decoded transaction is shown (in hex) in the manual form input on the Broadcast Transaction page.
 
The spec permits either query string `?` or fragment-encoded `#` params, but this implementation opts for the `#t=...&c=...` fragment encoding to maximize privacy.
 
Example URLs:
https://mempool.space/pushtx#t=AQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP____9NBP__AB0BBEVUaGUgVGltZXMgMDMvSmFuLzIwMDkgQ2hhbmNlbGxvciBvbiBicmluayBvZiBzZWNvbmQgYmFpbG91dCBmb3IgYmFua3P_____AQDyBSoBAAAAQ0EEZ4r9sP5VSCcZZ_GmcTC3EFzWqCjgOQmmeWLg6h9h3rZJ9rw_TO84xPNVBOUewRLeXDhN97oLjVeKTHAra_EdX6wAAAAA&c=uwSvoYoxxr8

(this is the genesis coinbase transaction, so it'll pass client-side validation but then fail to actually broadcast)

<img width="773" alt="Screenshot 2024-06-03 at 9 45 14 PM" src="https://github.com/mempool/mempool/assets/83316221/b868660c-e813-4cd0-91a4-faacb7ee5fc9">


https://mempool.space/pushtx#t=AQAAAAABAXgtw8GUD4FzETIvl3uAWtQZHrjj5huqW-3yGRINQz8wywEAAAD_____ARoDAAAAAAAAGXapFESf-cFM95FfPH-YZLA1ddIKMLUKiKwCRzBEAiBtKsKWDHJMrdP8x3l6OVxo-oyL2sxuNsrl-NxARxD8ZAIgaN3j2igO6A47BmTsnBhTtFrMe6IqH81gU3dcufzfms4BIQKUGzP_tcjOSJ26oVwfQS4kP1Fq3oKPSpAqCaqqMi20pQAAAAA&c=tAWqjtypsww

https://github.com/mempool/mempool/assets/83316221/dfcec068-1b7d-4a5f-94e9-8defd7a4bf69
