### PR TITLE
Pizza tracker RBF support

### DIFF
--- a/frontend/src/app/components/tracker/tracker-bar.component.ts
+++ b/frontend/src/app/components/tracker/tracker-bar.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
-export type TrackerStage = 'waiting' | 'pending' | 'soon' | 'next' | 'confirmed';
+export type TrackerStage = 'waiting' | 'pending' | 'soon' | 'next' | 'confirmed' | 'replaced';
 
 @Component({
   selector: 'app-tracker-bar',

--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -43,9 +43,16 @@
         <app-clockchain [height]="blockchainHeight" [width]="blockchainWidth" mode="none"></app-clockchain>
       </div>
     <div class="panel">
-      <div class="tracker-bar">
-        <app-tracker-bar [stage]="trackerStage"></app-tracker-bar>
-      </div>
+      @if (replaced) {
+        <div class="alert-replaced" role="alert">
+          <span i18n="transaction.rbf.replacement|RBF replacement">This transaction has been replaced by:</span>
+          <app-truncate [text]="latestReplacement" [lastChars]="12" [link]="['/tracker/' | relativeUrl, latestReplacement]"></app-truncate>
+        </div>
+      } @else {
+        <div class="tracker-bar">
+          <app-tracker-bar [stage]="trackerStage"></app-tracker-bar>
+        </div>
+      }
       <div class="data">
         @if (tx && !tx.status?.confirmed && mempoolPosition?.block != null) {
           <div class="field narrower mt-2">
@@ -142,6 +149,12 @@
                 <fa-icon [icon]="['fas', 'circle-check']" [fixedWidth]="true"></fa-icon>
               </div>
               <span class="explainer" i18n="tracker.explain.confirmed">Your transaction is confirmed!</span>
+            }
+            @case ('replaced') {
+              <div class="progress-icon">
+                <fa-icon [icon]="['fas', 'timeline']" [fixedWidth]="true"></fa-icon>
+              </div>
+              <span class="explainer" i18n="tracker.explain.replaced">Your transaction has been replaced by a newer version!</span>
             }
           }
         }

--- a/frontend/src/app/components/tracker/tracker.component.scss
+++ b/frontend/src/app/components/tracker/tracker.component.scss
@@ -187,4 +187,12 @@
   padding: 0.5em;
   background: var(--primary);
   color: white;
+  cursor: pointer;
+}
+
+.alert-replaced {
+  background: var(--danger);
+  margin: 1em 0.5em;
+  padding: 0.5em;
+  border-radius: 0.5em;
 }

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -220,7 +220,23 @@ export class TrackerComponent implements OnInit, OnDestroy {
       this.rbfInfo = rbfResponse?.replacements;
       this.rbfReplaces = rbfResponse?.replaces || null;
       if (this.rbfInfo) {
+        // link to the latest pending version
         this.latestReplacement = this.rbfInfo.tx.txid;
+        // or traverse the rbf tree to find a confirmed version
+        if (this.rbfInfo.mined) {
+          const stack = [this.rbfInfo];
+          let found = false;
+          while (stack.length && !found) {
+            const top = stack.pop();
+            if (top?.tx.mined) {
+              found = true;
+              this.latestReplacement = top.tx.txid;
+              break;
+            } else {
+              stack.push(...top.replaces);
+            }
+          }
+        }
       }
     });
 

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -4,7 +4,7 @@ import { NgbCollapseModule, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstra
 import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, faChartArea, faCogs, faCubes, faHammer, faDatabase, faExchangeAlt, faInfoCircle,
   faLink, faList, faSearch, faCaretUp, faCaretDown, faTachometerAlt, faThList, faTint, faTv, faClock, faAngleDoubleDown, faSortUp, faAngleDoubleUp, faChevronDown,
-  faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl, faDownload, faQrcode, faArrowRightArrowLeft, faArrowsRotate, faCircleLeft, faFastForward, faWallet, faUserClock, faWrench, faUserFriends, faQuestionCircle, faHistory, faSignOutAlt, faKey, faSuitcase, faIdCardAlt, faNetworkWired, faUserCheck, faCircleCheck, faUserCircle, faCheck, faRocket, faScaleBalanced, faHourglassStart, faHourglassHalf, faHourglassEnd, faWandMagicSparkles, faFaucetDrip } from '@fortawesome/free-solid-svg-icons';
+  faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl, faDownload, faQrcode, faArrowRightArrowLeft, faArrowsRotate, faCircleLeft, faFastForward, faWallet, faUserClock, faWrench, faUserFriends, faQuestionCircle, faHistory, faSignOutAlt, faKey, faSuitcase, faIdCardAlt, faNetworkWired, faUserCheck, faCircleCheck, faUserCircle, faCheck, faRocket, faScaleBalanced, faHourglassStart, faHourglassHalf, faHourglassEnd, faWandMagicSparkles, faFaucetDrip, faTimeline } from '@fortawesome/free-solid-svg-icons';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { MenuComponent } from '../components/menu/menu.component';
 import { PreviewTitleComponent } from '../components/master-page-preview/preview-title.component';
@@ -438,5 +438,6 @@ export class SharedModule {
     library.addIcons(faHourglassEnd);
     library.addIcons(faWandMagicSparkles);
     library.addIcons(faFaucetDrip);
+    library.addIcons(faTimeline);
   }
 }


### PR DESCRIPTION
Adds UX support for replaced transactions to the pizza tracker:

| ![localhost_4200_tracker_86e408c4bb441e4a1d827b6a1b8cd943a387c78660a2c8fb5631005f2db9d1fc(iPhone SE)](https://github.com/mempool/mempool/assets/83316221/700db0af-0acb-4908-8349-bfc4f32dad81) | unlike the main transaction page, the "replaced by ..." alert here links directly to the most relevant transaction (either the latest pending replacement, or whichever version actually got confirmed), rather than the "next" transaction in the sequence of replacements.|
|-|-|
