### PR TITLE
fix: set http protocol

### DIFF
--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -60,9 +60,11 @@
 	}
 	location /api/v1 {
 		proxy_pass http://127.0.0.1:8999/api/v1;
+		proxy_http_version 1.1;
 	}
 	location /api/ {
 		proxy_pass http://127.0.0.1:8999/api/v1/;
+		proxy_http_version 1.1;
 	}
 
 	# mainnet API


### PR DESCRIPTION
Sets the HTTP protocol in Nginx for /api paths. Without this, the very old HTTP 1.0 protocol is used and may cause HTTP 426 errors in service meshes.
Tested and verified working locally.