### PR TITLE
Refactor "show all" toggle for long witnesses and witness scripts

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -114,22 +114,33 @@
                         <td i18n="transactions-list.witness">Witness</td>
                         <td style="text-align: left;">
                           <ng-container *ngFor="let witness of vin.witness; index as i">
-                            <input type="checkbox" [id]="'tx' + vindex + 'witness' + i" style="display: none;">
-                            <p class="witness-item" [class.accordioned]="witness.length > 1000">
-                              <ng-template [ngIf]="witness" [ngIfElse]="emptyWitnessItem">
+                            <p class="witness-item">
+                              @if (witness.length > 1000) {
+                                @if (!showFullWitness[vindex][i]) {
+                                  {{ witness | slice:0:1000 }}
+                                } @else {
+                                  {{ witness }}
+                                }
+                              } @else if (witness) {
                                 {{ witness }}
-                              </ng-template>
-                              <ng-template #emptyWitnessItem>
+                              } @else {
                                 &lt;empty&gt;
-                              </ng-template>
+                              }
                             </p>
-                            <div class="witness-toggle" *ngIf="witness.length > 1000">
-                              <span  class="ellipsis">...</span>
-                              <label [for]="'tx' + vindex + 'witness' + i" class="btn btn-sm btn-primary mt-2">
-                                <span class="show-all" i18n="show-all">Show all</span>
-                                <span class="show-less" i18n="show-less">Show less</span>
-                              </label>
-                            </div>
+                            @if (witness.length > 1000) {
+                              <div style="display: flex;">
+                                @if (!showFullWitness[vindex][i]) {
+                                  <span>...</span>
+                                }
+                                <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullWitness(vindex, i)" style="margin-left: auto;">
+                                  @if (!showFullWitness[vindex][i]) {
+                                    <span i18n="show-all">Show all</span>
+                                  } @else {
+                                    <span i18n="show-less">Show less</span>
+                                  }
+                                </label>
+                              </div>
+                            }
                           </ng-container>
                         </td>
                       </tr>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -142,7 +142,16 @@
                         <ng-template #p2wsh>
                           <td i18n="transactions-list.p2wsh-witness-script">P2WSH witness script</td>
                         </ng-template>
-                        <td style="text-align: left;" [innerHTML]="vin.inner_witnessscript_asm | asmStyler"></td>
+                        <td style="text-align: left;">
+                          <div [innerHTML]="vin.inner_witnessscript_asm | asmStyler:showFullScript[vindex]"></div>
+                          <div *ngIf="vin.inner_witnessscript_asm.length > 1000" style="display: flex;">
+                            <span *ngIf="!showFullScript[vindex]">...</span>
+                            <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullScript(vindex)" style="margin-left: auto;">
+                              <span *ngIf="!showFullScript[vindex]" i18n="show-all">Show all</span>
+                              <span *ngIf="showFullScript[vindex]" i18n="show-less">Show less</span>
+                            </label>
+                          </div>
+                        </td>
                       </tr>
                       <tr>
                         <td i18n="transactions-list.nsequence">nSequence</td>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -172,42 +172,7 @@ h2 {
 }
 
 .vin-witness {
-	.witness-item.accordioned {
-		max-height: 300px;
-		overflow: hidden;
-	}
-
-	input:checked + .witness-item.accordioned {
-		max-height: none;
-	}
-
-	.witness-toggle {
-		display: flex;
-		flex-direction: row;
-		align-items: flex-start;
-		justify-content: space-between;
-		margin-bottom: 1em;
-
-		.show-all {
-			display: inline;
-		}
-		.show-less {
-			display: none;
-		}
-		.ellipsis {
-			visibility: visible;
-		}
-	}
-
-	input:checked ~ .witness-toggle {
-		.show-all {
-			display: none;
-		}
-		.show-less {
-			display: inline;
-		}
-		.ellipsis {
-			visibility: hidden;
-		}
+	.witness-item {
+		overflow: hidden;	
 	}
 }

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -48,6 +48,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   transactionsLength: number = 0;
   inputRowLimit: number = 12;
   outputRowLimit: number = 12;
+  showFullScript: { [vinIndex: number]: boolean } = {};
 
   constructor(
     public stateService: StateService,
@@ -300,7 +301,9 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   toggleDetails(): void {
     if (this.showDetails$.value === true) {
       this.showDetails$.next(false);
+      this.showFullScript = {};
     } else {
+      this.showFullScript = this.transactions[0] ? this.transactions[0].vin.reduce((acc, _, i) => ({...acc, [i]: false}), {}) : {};
       this.showDetails$.next(true);
     }
   }
@@ -350,6 +353,10 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       limit = tx.vout.length;
     }
     return limit;
+  }
+
+  toggleShowFullScript(vinIndex: number): void {
+    this.showFullScript[vinIndex] = !this.showFullScript[vinIndex];
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -49,6 +49,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   inputRowLimit: number = 12;
   outputRowLimit: number = 12;
   showFullScript: { [vinIndex: number]: boolean } = {};
+  showFullWitness: { [vinIndex: number]: { [witnessIndex: number]: boolean } } = {};
 
   constructor(
     public stateService: StateService,
@@ -302,8 +303,16 @@ export class TransactionsListComponent implements OnInit, OnChanges {
     if (this.showDetails$.value === true) {
       this.showDetails$.next(false);
       this.showFullScript = {};
+      this.showFullWitness = {};
     } else {
       this.showFullScript = this.transactions[0] ? this.transactions[0].vin.reduce((acc, _, i) => ({...acc, [i]: false}), {}) : {};
+      this.showFullWitness = this.transactions[0] ? this.transactions[0].vin.reduce((acc, vin, vinIndex) => {
+        acc[vinIndex] = vin.witness ? vin.witness.reduce((witnessAcc, _, witnessIndex) => {
+          witnessAcc[witnessIndex] = false;
+          return witnessAcc;
+        }, {}) : {};
+        return acc;
+      }, {}) : {};
       this.showDetails$.next(true);
     }
   }
@@ -357,6 +366,10 @@ export class TransactionsListComponent implements OnInit, OnChanges {
 
   toggleShowFullScript(vinIndex: number): void {
     this.showFullScript[vinIndex] = !this.showFullScript[vinIndex];
+  }
+
+  toggleShowFullWitness(vinIndex: number, witnessIndex: number): void {
+    this.showFullWitness[vinIndex][witnessIndex] = !this.showFullWitness[vinIndex][witnessIndex];
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/shared/pipes/asm-styler/asm-styler.pipe.ts
+++ b/frontend/src/app/shared/pipes/asm-styler/asm-styler.pipe.ts
@@ -5,13 +5,18 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class AsmStylerPipe implements PipeTransform {
 
-  transform(asm: string): string {
+  transform(asm: string, showAll = true): string {
     const instructions = asm.split('OP_');
     let out = '';
+    let chars = -3;
     for (const instruction of instructions) {
       if (instruction === '') {
         continue;
       }
+      if (!showAll && chars > 1000) {
+        break;
+      }
+      chars += instruction.length + 3;
       out += this.addStyling(instruction);
     }
     return out;


### PR DESCRIPTION
Fixes #4994

This PR fixes an issue where, for transactions with very large witness data, the page would freeze when toggling transactions details. 

To do so: 
- instead of hiding the full input's witness data behind CSS, we don't render it until the user clicks on "Show all"
- we apply the same mechanism to P2WSH redeem scripts and taproot script path spends

Example P2WSH transaction: https://mempool.space/tx/c5cd415fa48d3907080d76788b2c4bae3298d14d47b0f7b8c57f609ec6ae8dc3

Example taproot script path spend: https://mempool.space/tx/0301e0480b374b32851a9462db29dc19fe830a7f7d7a88b81612b9d42099c0ae 