### PR TITLE
Address page redesign phase 1

### DIFF
--- a/frontend/cypress/e2e/liquid/liquid.spec.ts
+++ b/frontend/cypress/e2e/liquid/liquid.spec.ts
@@ -72,20 +72,6 @@ describe('Liquid', () => {
       });
     });
 
-    it('renders unconfidential addresses correctly on mobile', () => {
-      cy.viewport('iphone-6');
-      cy.visit(`${basePath}/address/ex1qqmmjdwrlg59c8q4l75sj6wedjx57tj5grt8pat`);
-      cy.waitForSkeletonGone();
-      //TODO: Add proper IDs for these selectors
-      const firstRowSelector = '.container-xl > :nth-child(3) > div > :nth-child(1) > .table > tbody';
-      const thirdRowSelector = '.container-xl > :nth-child(3) > div > :nth-child(3)';
-      cy.get(firstRowSelector).invoke('css', 'width').then(firstRowWidth => {
-        cy.get(thirdRowSelector).invoke('css', 'width').then(thirdRowWidth => {
-          expect(parseInt(firstRowWidth)).to.be.lessThan(parseInt(thirdRowWidth));
-        });
-      });
-    });
-
     describe('peg in/peg out', () => {
       it('loads peg in addresses', () => {
         cy.visit(`${basePath}/tx/fe764f7bedfc2a37b29d9c8aef67d64a57d253a6b11c5a55555cfd5826483a58`);

--- a/frontend/src/app/components/address-labels/address-labels.component.html
+++ b/frontend/src/app/components/address-labels/address-labels.component.html
@@ -4,7 +4,7 @@
       <a [routerLink]="['/lightning/channel' | relativeUrl, channel.id]">
         <span 
           *ngIf="label"
-          class="badge badge-pill badge-warning"
+          class="badge badge-pill badge-warning {{ class }}"
         >{{ label }}</span>
       </a>
     </div>
@@ -15,6 +15,6 @@
 <ng-template #default>
   <span
     *ngIf="label"
-    class="badge badge-pill badge-warning"
+    class="badge badge-pill badge-warning {{ class }}"
   >{{ label }}</span>
 </ng-template>

--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, Input, OnChanges } from '@angular/core';
 import { Vin, Vout } from '../../interfaces/electrs.interface';
 import { StateService } from '../../services/state.service';
-import { parseMultisigScript } from '../../bitcoin.utils';
+import { AddressType, AddressTypeInfo } from '../../shared/address-utils';
 
 @Component({
   selector: 'app-address-labels',
@@ -12,6 +12,7 @@ import { parseMultisigScript } from '../../bitcoin.utils';
 export class AddressLabelsComponent implements OnChanges {
   network = '';
 
+  @Input() address: AddressTypeInfo;
   @Input() vin: Vin;
   @Input() vout: Vout;
   @Input() channel: any;
@@ -28,10 +29,10 @@ export class AddressLabelsComponent implements OnChanges {
   ngOnChanges() {
     if (this.channel) {
       this.handleChannel();
+    } else if (this.address) {
+      this.handleAddress();
     } else if (this.vin) {
       this.handleVin();
-    } else if (this.vout) {
-      this.handleVout();
     }
   }
 
@@ -42,74 +43,22 @@ export class AddressLabelsComponent implements OnChanges {
     this.label = `Channel ${type}: ${leftNodeName} <> ${rightNodeName}`;
   }
 
+  handleAddress() {
+    if (this.address?.scripts.size) {
+      const script = this.address?.scripts.values().next().value;
+      if (script.template?.label) {
+        this.label = script.template.label;
+      }
+    }
+  }
+
   handleVin() {
-    if (this.vin.inner_witnessscript_asm) {
-      if (this.vin.inner_witnessscript_asm.indexOf('OP_DEPTH OP_PUSHNUM_12 OP_EQUAL OP_IF OP_PUSHNUM_11') === 0 || this.vin.inner_witnessscript_asm.indexOf('OP_PUSHNUM_15 OP_CHECKMULTISIG OP_IFDUP OP_NOTIF OP_PUSHBYTES_2') === 1259) {
-        if (this.vin.witness.length > 11) {
-          this.label = 'Liquid Peg Out';
-        } else {
-          this.label = 'Emergency Liquid Peg Out';
-        }
-        return;
+    const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin])
+    if (address?.scripts.size) {
+      const script = address?.scripts.values().next().value;
+      if (script.template?.label) {
+        this.label = script.template.label;
       }
-
-      const topElement = this.vin.witness[this.vin.witness.length - 2];
-      if (/^OP_IF OP_PUSHBYTES_33 \w{66} OP_ELSE OP_PUSH(NUM_\d+|BYTES_(1 \w{2}|2 \w{4})) OP_CSV OP_DROP OP_PUSHBYTES_33 \w{66} OP_ENDIF OP_CHECKSIG$/.test(this.vin.inner_witnessscript_asm)) {
-        // https://github.com/lightning/bolts/blob/master/03-transactions.md#commitment-transaction-outputs
-        if (topElement === '01') {
-          // top element is '01' to get in the revocation path
-          this.label = 'Revoked Lightning Force Close';
-        } else {
-          // top element is '', this is a delayed to_local output
-          this.label = 'Lightning Force Close';
-        }
-        return;
-      } else if (
-        /^OP_DUP OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUAL OP_IF OP_CHECKSIG OP_ELSE OP_PUSHBYTES_33 \w{66} OP_SWAP OP_SIZE OP_PUSHBYTES_1 20 OP_EQUAL OP_NOTIF OP_DROP OP_PUSHNUM_2 OP_SWAP OP_PUSHBYTES_33 \w{66} OP_PUSHNUM_2 OP_CHECKMULTISIG OP_ELSE OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUALVERIFY OP_CHECKSIG OP_ENDIF (OP_PUSHNUM_1 OP_CSV OP_DROP |)OP_ENDIF$/.test(this.vin.inner_witnessscript_asm) ||
-        /^OP_DUP OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUAL OP_IF OP_CHECKSIG OP_ELSE OP_PUSHBYTES_33 \w{66} OP_SWAP OP_SIZE OP_PUSHBYTES_1 20 OP_EQUAL OP_IF OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUALVERIFY OP_PUSHNUM_2 OP_SWAP OP_PUSHBYTES_33 \w{66} OP_PUSHNUM_2 OP_CHECKMULTISIG OP_ELSE OP_DROP OP_PUSHBYTES_3 \w{6} OP_CLTV OP_DROP OP_CHECKSIG OP_ENDIF (OP_PUSHNUM_1 OP_CSV OP_DROP |)OP_ENDIF$/.test(this.vin.inner_witnessscript_asm)
-      ) {
-        // https://github.com/lightning/bolts/blob/master/03-transactions.md#offered-htlc-outputs
-        // https://github.com/lightning/bolts/blob/master/03-transactions.md#received-htlc-outputs
-        if (topElement.length === 66) {
-          // top element is a public key
-          this.label = 'Revoked Lightning HTLC';
-        } else if (topElement) {
-          // top element is a preimage
-          this.label = 'Lightning HTLC';
-        } else {
-          // top element is '' to get in the expiry of the script
-          this.label = 'Expired Lightning HTLC';
-        }
-        return;
-      } else if (/^OP_PUSHBYTES_33 \w{66} OP_CHECKSIG OP_IFDUP OP_NOTIF OP_PUSHNUM_16 OP_CSV OP_ENDIF$/.test(this.vin.inner_witnessscript_asm)) {
-        // https://github.com/lightning/bolts/blob/master/03-transactions.md#to_local_anchor-and-to_remote_anchor-output-option_anchors
-        if (topElement) {
-          // top element is a signature
-          this.label = 'Lightning Anchor';
-        } else {
-          // top element is '', it has been swept after 16 blocks
-          this.label = 'Swept Lightning Anchor';
-        }
-        return;
-      }
-
-      this.detectMultisig(this.vin.inner_witnessscript_asm);
     }
-
-    this.detectMultisig(this.vin.inner_redeemscript_asm);
-
-    this.detectMultisig(this.vin.prevout.scriptpubkey_asm);
-  }
-
-  detectMultisig(script: string) {
-    const ms = parseMultisigScript(script);
-
-    if (ms) {
-      this.label = $localize`:@@address-label.multisig:Multisig ${ms.m}:multisigM: of ${ms.n}:multisigN:`;
-    }
-  }
-
-  handleVout() {
-    this.detectMultisig(this.vout.scriptpubkey_asm);
   }
 }

--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -15,6 +15,7 @@ export class AddressLabelsComponent implements OnChanges {
   @Input() vin: Vin;
   @Input() vout: Vout;
   @Input() channel: any;
+  @Input() class: string = '';
 
   label?: string;
 

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -28,23 +28,31 @@
                 <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
                 <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>
-                <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+                @if (network === 'liquid' || network === 'liquidtestnet') {
+                  <ng-container *ngTemplateOutlet="liquidRow"></ng-container>
+                } @else {
+                  <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+                }
                 <ng-container *ngTemplateOutlet="typeRow"></ng-container>
               </tbody>
             </table>
           </div>
         } @else {
           <div class="col-sm">
-            <table class="table table-borderless table-striped">
+            <table class="table table-borderless table-striped table-fixed">
               <tbody>
                 <ng-container *ngTemplateOutlet="balanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
-                <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+                @if (network === 'liquid' || network === 'liquidtestnet') {
+                  <ng-container *ngTemplateOutlet="liquidRow"></ng-container>
+                } @else {
+                  <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+                }
               </tbody>
             </table>
           </div>
           <div class="col-sm">
-            <table class="table table-borderless table-striped">
+            <table class="table table-borderless table-striped table-fixed">
               <tbody>
                 <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>
@@ -227,7 +235,7 @@
 <ng-template #typeRow>
   <tr>
     <td i18n="address.type">Type</td>
-    <td><app-address-type [address]="addressTypeInfo"></app-address-type><app-address-labels [channel]="exampleChannel" [address]="addressTypeInfo" class="ml-1"></app-address-labels></td>
+    <td class="wrap-cell"><app-address-type [address]="addressTypeInfo"></app-address-type><app-address-labels [channel]="exampleChannel" [address]="addressTypeInfo" class="ml-1"></app-address-labels></td>
   </tr>
 </ng-template>
 
@@ -235,7 +243,7 @@
   <tr *ngIf="addressInfo && addressInfo.unconfidential">
     <td i18n="address.unconfidential">Unconfidential</td>
     <td>
-      <app-truncate [text]="addressInfo.unconfidential" [lastChars]="8" [link]="['/address/' | relativeUrl, addressInfo.unconfidential]">
+      <app-truncate [text]="addressInfo.unconfidential" [lastChars]="8" [textAlign]="isMobile ? 'end' : 'start'" [link]="['/address/' | relativeUrl, addressInfo.unconfidential]">
         <app-clipboard [text]="addressInfo.unconfidential"></app-clipboard>
       </app-truncate>
     </td>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -198,21 +198,21 @@
 
 <ng-template #pendingBalanceRow>
   <tr>
-    <td i18n="address.pending" class="font-italic">pending</td>
+    <td i18n="address.unconfirmed-balance" class="font-italic">unconfirmed balance</td>
     <td *ngIf="mempoolStats.funded_txo_sum !== undefined; else confidentialTd" class="font-italic"><app-amount [satoshis]="mempoolStats.balance" [noFiat]="true" [addPlus]="true"></app-amount> <span class="fiat"><app-fiat [value]="mempoolStats.balance"></app-fiat></span></td>
   </tr>
 </ng-template>
 
 <ng-template #utxoRow>
   <tr>
-    <td i18n="address.unspent_txos">Unspent TXOs</td>
+    <td i18n="address.utxos" i18n-ngbTooltip="unspent-transaction-outputs" ngbTooltip="unspent transaction outputs">UTXOs</td>
     <td>{{ chainStats.utxos }}</td>
   </tr>
 </ng-template>
 
 <ng-template #pendingUtxoRow>
   <tr>
-    <td i18n="address.pending" class="font-italic">pending</td>
+    <td i18n="address.unconfirmed-utxos" class="font-italic">unconfirmed UTXOs</td>
     <td class="font-italic">{{ mempoolStats.utxos > 0 ? '+' : ''}}{{ mempoolStats.utxos }}</td>
   </tr>
 </ng-template>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -14,40 +14,39 @@
     <div class="box">
 
       <div class="row">
-        <div class="col-md">
-          <table class="table table-borderless table-striped address-table">
-            <tbody>
-              <tr *ngIf="addressInfo && addressInfo.unconfidential">
-                <td i18n="address.unconfidential">Unconfidential</td>
-                <td>
-                  <app-truncate [text]="addressInfo.unconfidential" [lastChars]="8" [link]="['/address/' | relativeUrl, addressInfo.unconfidential]">
-                    <app-clipboard [text]="addressInfo.unconfidential"></app-clipboard>
-                  </app-truncate>
-                </td>
-              </tr>
-              <ng-template [ngIf]="!address.electrum">
-                <tr>
-                  <td i18n="address.total-received">Total received</td>
-                  <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.funded_txo_sum + mempoolStats.funded_txo_sum" [noFiat]="true"></app-amount></td>
-                </tr>
-                <tr>
-                  <td i18n="address.total-sent">Total sent</td>
-                  <td *ngIf="address.chain_stats.spent_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.spent_txo_sum + mempoolStats.spent_txo_sum" [noFiat]="true"></app-amount></td>
-                </tr>
-              </ng-template>
-              <tr>
-                <td i18n="address.balance">Balance</td>
-                <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.balance + mempoolStats.balance" [noFiat]="true"></app-amount> <span class="fiat"><app-fiat [value]="chainStats.balance + mempoolStats.balance"></app-fiat></span></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="w-100 d-block d-md-none"></div>
-        <div class="col-md qrcode-col">
-          <div class="qr-wrapper">
-            <app-qrcode [data]="address.address"></app-qrcode>
+        @if (isMobile) {
+          <div class="col-sm">
+            <table class="table table-borderless table-striped">
+              <tbody>
+                <ng-container *ngTemplateOutlet="balanceRow"></ng-container>
+                <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
+                <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
+                <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>
+                <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+                <ng-container *ngTemplateOutlet="typeRow"></ng-container>
+              </tbody>
+            </table>
           </div>
-        </div>
+        } @else {
+          <div class="col-sm">
+            <table class="table table-borderless table-striped">
+              <tbody>
+                <ng-container *ngTemplateOutlet="balanceRow"></ng-container>
+                <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
+                <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
+              </tbody>
+            </table>
+          </div>
+          <div class="col-sm">
+            <table class="table table-borderless table-striped">
+              <tbody>
+                <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
+                <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>
+                <ng-container *ngTemplateOutlet="typeRow"></ng-container>
+              </tbody>
+            </table>
+          </div>
+        }
       </div>
     </div>
 
@@ -181,4 +180,58 @@
   <div class="header-bg box" style="padding: 10px; margin-bottom: 10px;">
     <span class="skeleton-loader"></span>
   </div>
+</ng-template>
+
+
+<ng-template #balanceRow>
+  <tr>
+    <td i18n="address.balance">Balance</td>
+    <td *ngIf="chainStats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.balance" [noFiat]="true"></app-amount> <span class="fiat"><app-fiat [value]="chainStats.balance"></app-fiat></span></td>
+  </tr>
+</ng-template>
+
+<ng-template #pendingBalanceRow>
+  <tr>
+    <td i18n="address.pending" class="font-italic">pending</td>
+    <td *ngIf="mempoolStats.funded_txo_sum !== undefined; else confidentialTd" class="font-italic"><app-amount [satoshis]="mempoolStats.balance" [noFiat]="true" [addPlus]="true"></app-amount> <span class="fiat"><app-fiat [value]="mempoolStats.balance"></app-fiat></span></td>
+  </tr>
+</ng-template>
+
+<ng-template #utxoRow>
+  <tr>
+    <td i18n="address.unspent_txos">Unspent TXOs</td>
+    <td>{{ chainStats.utxos }}</td>
+  </tr>
+</ng-template>
+
+<ng-template #pendingUtxoRow>
+  <tr>
+    <td i18n="address.pending" class="font-italic">pending</td>
+    <td class="font-italic">{{ mempoolStats.utxos > 0 ? '+' : ''}}{{ mempoolStats.utxos }}</td>
+  </tr>
+</ng-template>
+
+<ng-template #volumeRow>
+  <tr>
+    <td i18n="address.volume">Volume</td>
+    <td><app-amount [satoshis]="chainStats.volume + mempoolStats.volume"></app-amount></td>
+  </tr>
+</ng-template>
+
+<ng-template #typeRow>
+  <tr>
+    <td i18n="address.type">Type</td>
+    <td><app-address-type [vout]="exampleVout || exampleVin?.prevout || null"></app-address-type><app-address-labels [channel]="exampleChannel" [vin]="exampleVin" [vout]="exampleVout" class="ml-1"></app-address-labels></td>
+  </tr>
+</ng-template>
+
+<ng-template #liquidRow>
+  <tr *ngIf="addressInfo && addressInfo.unconfidential">
+    <td i18n="address.unconfidential">Unconfidential</td>
+    <td>
+      <app-truncate [text]="addressInfo.unconfidential" [lastChars]="8" [link]="['/address/' | relativeUrl, addressInfo.unconfidential]">
+        <app-clipboard [text]="addressInfo.unconfidential"></app-clipboard>
+      </app-truncate>
+    </td>
+  </tr>
 </ng-template>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -4,6 +4,12 @@
     <div class="tx-link">
       <app-truncate [text]="addressString" [lastChars]="8" [link]="['/address/' | relativeUrl, addressString]">
         <app-clipboard [text]="addressString"></app-clipboard>
+        <span style="position: relative; cursor: pointer" (mouseover)="showQR = true" (mouseout)="showQR = false" (click)="showQR = !showQR">
+          <fa-icon [icon]="['fas', 'qrcode']" [fixedWidth]="true"></fa-icon>
+          <div class="qr-wrapper" [hidden]="!showQR">
+            <app-qrcode [size]="200" [data]="addressString"></app-qrcode>
+          </div>
+        </span>
       </app-truncate>
     </div>
   </div>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -22,7 +22,7 @@
       <div class="row">
         @if (isMobile) {
           <div class="col-sm">
-            <table class="table table-borderless table-striped">
+            <table class="table table-borderless table-striped address-table">
               <tbody>
                 <ng-container *ngTemplateOutlet="balanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
@@ -39,7 +39,7 @@
           </div>
         } @else {
           <div class="col-sm">
-            <table class="table table-borderless table-striped table-fixed">
+            <table class="table table-borderless table-striped table-fixed address-table">
               <tbody>
                 <ng-container *ngTemplateOutlet="balanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
@@ -52,7 +52,7 @@
             </table>
           </div>
           <div class="col-sm">
-            <table class="table table-borderless table-striped table-fixed">
+            <table class="table table-borderless table-striped table-fixed address-table">
               <tbody>
                 <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
                 <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -3,9 +3,9 @@
     <h1 i18n="shared.address">Address</h1>
     <div class="tx-link">
       <app-truncate [text]="addressString" [lastChars]="8" [link]="['/address/' | relativeUrl, addressString]">
-        <app-clipboard [text]="addressString"></app-clipboard>
-        <span style="position: relative; cursor: pointer" (mouseover)="showQR = true" (mouseout)="showQR = false" (click)="showQR = !showQR">
-          <fa-icon [icon]="['fas', 'qrcode']" [fixedWidth]="true"></fa-icon>
+        <app-clipboard [text]="addressString" [size]="isMobile ? 'large' : 'normal'"></app-clipboard>
+        <span style="position: relative; cursor: pointer" (mouseover)="showQR = true" (mouseout)="showQR = false" (pointerdown)="showQR = true">
+          <fa-icon [icon]="['fas', 'qrcode']" [fixedWidth]="true" [style.font-size]="isMobile ? '18px' : '12px'"></fa-icon>
           <div class="qr-wrapper" [hidden]="!showQR">
             <app-qrcode [size]="200" [data]="addressString"></app-qrcode>
           </div>

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -28,16 +28,16 @@
               <ng-template [ngIf]="!address.electrum">
                 <tr>
                   <td i18n="address.total-received">Total received</td>
-                  <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="received" [noFiat]="true"></app-amount></td>
+                  <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.funded_txo_sum + mempoolStats.funded_txo_sum" [noFiat]="true"></app-amount></td>
                 </tr>
                 <tr>
                   <td i18n="address.total-sent">Total sent</td>
-                  <td *ngIf="address.chain_stats.spent_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="sent" [noFiat]="true"></app-amount></td>
+                  <td *ngIf="address.chain_stats.spent_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.spent_txo_sum + mempoolStats.spent_txo_sum" [noFiat]="true"></app-amount></td>
                 </tr>
               </ng-template>
               <tr>
                 <td i18n="address.balance">Balance</td>
-                <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="received - sent" [noFiat]="true"></app-amount> <span class="fiat"><app-fiat [value]="received - sent"></app-fiat></span></td>
+                <td *ngIf="address.chain_stats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.balance + mempoolStats.balance" [noFiat]="true"></app-amount> <span class="fiat"><app-fiat [value]="chainStats.balance + mempoolStats.balance"></app-fiat></span></td>
               </tr>
             </tbody>
           </table>
@@ -76,8 +76,8 @@
     <div class="title-tx">
       <h2 class="text-left">
         <ng-template [ngIf]="!transactions?.length">&nbsp;</ng-template>
-        <ng-template i18n="X of X Address Transaction" [ngIf]="transactions?.length === 1">{{ (transactions?.length | number) || '?' }} of {{ txCount | number }} transaction</ng-template>
-        <ng-template i18n="X of X Address Transactions (Plural)" [ngIf]="transactions?.length > 1">{{ (transactions?.length | number) || '?' }} of {{ txCount | number }} transactions</ng-template>
+        <ng-template i18n="X of X Address Transaction" [ngIf]="transactions?.length === 1">{{ (transactions?.length | number) || '?' }} of {{ mempoolStats.tx_count + chainStats.tx_count | number }} transaction</ng-template>
+        <ng-template i18n="X of X Address Transactions (Plural)" [ngIf]="transactions?.length > 1">{{ (transactions?.length | number) || '?' }} of {{ mempoolStats.tx_count + chainStats.tx_count | number }} transactions</ng-template>
       </h2>
     </div>
 

--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -220,14 +220,14 @@
 <ng-template #volumeRow>
   <tr>
     <td i18n="address.volume">Volume</td>
-    <td><app-amount [satoshis]="chainStats.volume + mempoolStats.volume"></app-amount></td>
+    <td *ngIf="chainStats.funded_txo_sum !== undefined; else confidentialTd"><app-amount [satoshis]="chainStats.volume + mempoolStats.volume"></app-amount></td>
   </tr>
 </ng-template>
 
 <ng-template #typeRow>
   <tr>
     <td i18n="address.type">Type</td>
-    <td><app-address-type [vout]="exampleVout || exampleVin?.prevout || null"></app-address-type><app-address-labels [channel]="exampleChannel" [vin]="exampleVin" [vout]="exampleVout" class="ml-1"></app-address-labels></td>
+    <td><app-address-type [address]="addressTypeInfo"></app-address-type><app-address-labels [channel]="exampleChannel" [address]="addressTypeInfo" class="ml-1"></app-address-labels></td>
   </tr>
 </ng-template>
 

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -98,13 +98,6 @@ h1 {
 .liquid-address {
   .address-table {
     table-layout: fixed;
-
-    tr td:first-child {
-      width: 170px;
-    }
-    tr td:last-child {
-      width: 80%;
-    }
   }
 }
 

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -76,10 +76,10 @@ h1 {
   top: 9px;
   position: relative;
 	@media (min-width: 576px) {
+    max-width: calc(100% - 180px);
     top: 11px;
 	}
   @media (min-width: 768px) {
-    max-width: calc(100% - 180px);
     top: 17px;
   }
 }

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -25,7 +25,7 @@
   tr td {
     &:last-child {
       text-align: right;
-      @media (min-width: 576px) {
+      @media (min-width: 768px) {
         text-align: left;
       }
     }

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -1,16 +1,14 @@
 .qr-wrapper {
+  position: absolute;
+  top: 30px;
+  right: 0px;
+  border: solid 10px var(--active-bg);
+  border-radius: 5px;
   background-color: #fff;
   padding: 10px;
   padding-bottom: 5px;
-  display: inline-block;
-}
-
-.qrcode-col {
-  margin: 20px auto 10px;
-  text-align: center;
-  @media (min-width: 992px){
-    margin: 0px auto 0px;
-  }
+  display: block;
+  z-index: 99;
 }
 
 .fiat {
@@ -103,10 +101,6 @@ h1 {
     tr td:last-child {
       width: 80%;
     }
-  }
-
-  .qrcode-col {
-    flex-grow: 0.5;
   }
 }
 

--- a/frontend/src/app/components/address/address.component.scss
+++ b/frontend/src/app/components/address/address.component.scss
@@ -27,6 +27,10 @@
         text-align: left;
       }
     }
+
+    &.wrap-cell {
+      white-space: normal;
+    }
   }
 }
 

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -97,6 +97,7 @@ export class AddressComponent implements OnInit, OnDestroy {
   network = '';
 
   isMobile: boolean;
+  showQR: boolean = false;
 
   address: Address;
   addressString: string;
@@ -140,6 +141,8 @@ export class AddressComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.stateService.networkChanged$.subscribe((network) => this.network = network);
     this.websocketService.want(['blocks']);
+
+    this.onResize();
 
     this.addressLoadingStatus$ = this.route.paramMap
       .pipe(

--- a/frontend/src/app/components/clipboard/clipboard.component.html
+++ b/frontend/src/app/components/clipboard/clipboard.component.html
@@ -1,7 +1,7 @@
 <ng-template [ngIf]="button" [ngIfElse]="btnLink">
   <button #btn [attr.data-clipboard-text]="text" [class]="class" type="button" [disabled]="text === ''">
     <span #buttonWrapper [attr.data-tlite]="copiedMessage" style="position: relative;top: -2px;left: 1px;">
-      <app-svg-images name="clippy" [width]="size === 'small' ? '10' : '13'" viewBox="0 0 1000 1000"></app-svg-images>
+      <app-svg-images name="clippy" [width]="widths[size]" viewBox="0 0 1000 1000"></app-svg-images>
     </span>
   </button>
 </ng-template>
@@ -9,7 +9,7 @@
 <ng-template #btnLink>
   <span #buttonWrapper [attr.data-tlite]="copiedMessage" style="position: relative;">
     <button #btn class="btn btn-sm btn-link pt-0 {{ leftPadding ? 'padding' : '' }}" [attr.data-clipboard-text]="text"> 
-      <app-svg-images name="clippy" [width]="size === 'small' ? '10' : '13'" viewBox="0 0 1000 1000"></app-svg-images>
+      <app-svg-images name="clippy" [width]="widths[size]" viewBox="0 0 1000 1000"></app-svg-images>
     </button>
   </span>
 </ng-template>

--- a/frontend/src/app/components/clipboard/clipboard.component.ts
+++ b/frontend/src/app/components/clipboard/clipboard.component.ts
@@ -13,10 +13,16 @@ export class ClipboardComponent implements AfterViewInit {
   @ViewChild('buttonWrapper') buttonWrapper: ElementRef;
   @Input() button = false;
   @Input() class = 'btn btn-secondary ml-1';
-  @Input() size: 'small' | 'normal' = 'normal';
+  @Input() size: 'small' | 'normal' | 'large' = 'normal';
   @Input() text: string;
   @Input() leftPadding = true;
   copiedMessage: string = $localize`:@@clipboard.copied-message:Copied!`;
+
+  widths = {
+    small: '10',
+    normal: '13',
+    large: '18',
+  };
 
   clipboard: any;
 

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -75,7 +75,7 @@
                           {{ vin.prevout.scriptpubkey_type?.toUpperCase() }}
                         </ng-template>
                         <div>
-                          <app-address-labels [vin]="vin" [channel]="tx._channels && tx._channels.inputs[vindex] ? tx._channels.inputs[vindex] : null"></app-address-labels>
+                          <app-address-labels  [vin]="vin" [channel]="tx._channels && tx._channels.inputs[vindex] ? tx._channels.inputs[vindex] : null"></app-address-labels>
                         </div>
                       </ng-template>
                     </ng-container>

--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -1,0 +1,193 @@
+import '@angular/localize/init';
+import { ScriptInfo } from './script.utils';
+import { Vin } from '../interfaces/electrs.interface';
+import { BECH32_CHARS_LW, BASE58_CHARS, HEX_CHARS } from './regex.utils';
+
+export type AddressType = 'fee'
+  | 'empty'
+  | 'provably_unspendable'
+  | 'op_return'
+  | 'multisig'
+  | 'p2pk'
+  | 'p2pkh'
+  | 'p2sh'
+  | 'p2sh-p2wpkh'
+  | 'p2sh-p2wsh'
+  | 'v0_p2wpkh'
+  | 'v0_p2wsh'
+  | 'v1_p2tr'
+  | 'confidential'
+  | 'unknown'
+
+const ADDRESS_PREFIXES = {
+  mainnet: {
+    base58: {
+      pubkey: ['1'],
+      script: ['3'],
+    },
+    bech32: 'bc1',
+  },
+  testnet: {
+    base58: {
+      pubkey: ['m', 'n'],
+      script: '2',
+    },
+    bech32: 'tb1',
+  },
+  testnet4: {
+    base58: {
+      pubkey: ['m', 'n'],
+      script: '2',
+    },
+    bech32: 'tb1',
+  },
+  signet: {
+    base58: {
+      pubkey: ['m', 'n'],
+      script: '2',
+    },
+    bech32: 'tb1',
+  },
+  liquid: {
+    base58: {
+      pubkey: ['P','Q'],
+      script: ['G','H'],
+      confidential: ['V'],
+    },
+    bech32: 'ex1',
+    confidential: 'lq1',
+  },
+  liquidtestnet: {
+    base58: {
+      pubkey: ['F'],
+      script: ['8','9'],
+      confidential: ['V'], // TODO: check if this is actually correct
+    },
+    bech32: 'tex1',
+    confidential: 'tlq1',
+  },
+};
+
+// precompiled regexes for common address types (excluding prefixes)
+const base58Regex = RegExp('^' + BASE58_CHARS + '{26,34}$');
+const confidentialb58Regex = RegExp('^[TJ]' + BASE58_CHARS + '{78}$');
+const p2wpkhRegex = RegExp('^q' + BECH32_CHARS_LW + '{38}$');
+const p2wshRegex = RegExp('^q' + BECH32_CHARS_LW + '{58}$');
+const p2trRegex = RegExp('^p' + BECH32_CHARS_LW + '{58}$');
+const pubkeyRegex = RegExp('^' + `(04${HEX_CHARS}{128})|(0[23]${HEX_CHARS}{64})$`);
+
+export function detectAddressType(address: string, network: string): AddressType {
+  // normal address types
+  const firstChar = address.substring(0, 1);
+  if (ADDRESS_PREFIXES[network].base58.pubkey.includes(firstChar) && base58Regex.test(address.slice(1))) {
+    return 'p2pkh';
+  } else if (ADDRESS_PREFIXES[network].base58.script.includes(firstChar) && base58Regex.test(address.slice(1))) {
+    return 'p2sh';
+  } else if (address.startsWith(ADDRESS_PREFIXES[network].bech32)) {
+    const suffix = address.slice(ADDRESS_PREFIXES[network].bech32.length);
+    if (p2wpkhRegex.test(suffix)) {
+      return 'v0_p2wpkh';
+    } else if (p2wshRegex.test(suffix)) {
+      return 'v0_p2wsh';
+    } else if (p2trRegex.test(suffix)) {
+      return 'v1_p2tr';
+    }
+  }
+
+  // p2pk
+  if (pubkeyRegex.test(address)) {
+    return 'p2pk';
+  }
+
+  // liquid-specific types
+  if (network.startsWith('liquid')) {
+    if (ADDRESS_PREFIXES[network].base58.confidential.includes(firstChar) && confidentialb58Regex.test(address.slice(1))) {
+      return 'confidential';
+    } else if (address.startsWith(ADDRESS_PREFIXES[network].confidential)) {
+      return 'confidential';
+    }
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Parses & classifies address types + properties from address strings
+ *
+ * can optionally augment this data with examples of spends from the address,
+ * e.g. to classify revealed scripts for scripthash-type addresses.
+ */
+export class AddressTypeInfo {
+  network: string;
+  address: string;
+  type: AddressType;
+  // script data
+  scripts: Map<string, ScriptInfo>; // raw script
+  // flags
+  isMultisig?: { m: number, n: number };
+  tapscript?: boolean;
+
+  constructor (network: string, address: string, type?: AddressType, vin?: Vin[]) {
+    this.network = network;
+    this.address = address;
+    this.scripts = new Map();
+    if (type) {
+      this.type = type;
+    } else {
+      this.type = detectAddressType(address, network);
+    }
+    this.processInputs(vin);
+  }
+
+  public clone(): AddressTypeInfo {
+    const cloned = new AddressTypeInfo(this.network, this.address, this.type);
+    cloned.scripts = new Map(Array.from(this.scripts, ([key, value]) => [key, value?.clone()]));
+    cloned.isMultisig = this.isMultisig;
+    cloned.tapscript = this.tapscript;
+    return cloned;
+  }
+
+  public processInputs(vin: Vin[] = []): void {
+    // taproot can have multiple script paths
+    if (this.type === 'v1_p2tr') {
+      for (const v of vin) {
+        if (v.inner_witnessscript_asm) {
+          this.tapscript = true;
+          const controlBlock = v.witness[v.witness.length - 1].startsWith('50') ? v.witness[v.witness.length - 2] : v.witness[v.witness.length - 1];
+          this.processScript(new ScriptInfo('inner_witnessscript', undefined, v.inner_witnessscript_asm, v.witness, controlBlock));
+        }
+      }
+    // for single-script types, if we've seen one input we've seen them all
+    } else if (['p2sh', 'v0_p2wsh'].includes(this.type)) {
+      if (!this.scripts.size && vin.length) {
+        const v = vin[0];
+        // wrapped segwit
+        if (this.type === 'p2sh' && v.witness?.length) {
+          if (v.scriptsig.startsWith('160014')) {
+            this.type = 'p2sh-p2wpkh';
+          } else if (v.scriptsig.startsWith('220020')) {
+            this.type = 'p2sh-p2wsh';
+          }
+        }
+        // real script
+        if (this.type !== 'p2sh-p2wpkh') {
+          if (v.inner_witnessscript_asm) {
+            this.processScript(new ScriptInfo('inner_witnessscript', undefined, v.inner_witnessscript_asm, v.witness));
+          } else if (v.inner_redeemscript_asm) {
+            this.processScript(new ScriptInfo('inner_redeemscript', undefined, v.inner_redeemscript_asm, v.witness));
+          } else if (v.scriptsig || v.scriptsig_asm) {
+            this.processScript(new ScriptInfo('scriptsig', v.scriptsig, v.scriptsig_asm, v.witness));
+          }
+        }
+      }
+    }
+    // and there's nothing more to learn from processing inputs for non-scripthash types
+  }
+
+  private processScript(script: ScriptInfo): void {
+    this.scripts.set(script.key, script);
+    if (script.template?.type === 'multisig') {
+      this.isMultisig = { m: script.template['m'], n: script.template['n'] };
+    }
+  }
+}

--- a/frontend/src/app/shared/components/address-type/address-type.component.html
+++ b/frontend/src/app/shared/components/address-type/address-type.component.html
@@ -1,0 +1,29 @@
+@switch (vout?.scriptpubkey_type || null) {
+  @case ('fee') {
+    <span i18n="address.fee">fee</span>
+  }
+  @case ('empty') {
+    <span i18n="address.empty">empty</span>
+  }
+  @case ('v0_p2wpkh') {
+    <span>P2WPKH</span>
+  }
+  @case ('v0_p2wsh') {
+    <span>P2WSH</span>
+  }
+  @case ('v1_p2tr') {
+    <span>P2TR</span>
+  }
+  @case ('provably_unspendable') {
+    <span i18n="address.provably-unspendable">provably unspendable</span>
+  }
+  @case ('multisig') {
+    <span i18n="address.bare-multisig">bare multisig</span>
+  }
+  @case (null) {
+    <span>unknown</span>
+  }
+  @default {
+    <span>{{ vout.scriptpubkey_type.toUpperCase() }}</span>
+  }
+}

--- a/frontend/src/app/shared/components/address-type/address-type.component.html
+++ b/frontend/src/app/shared/components/address-type/address-type.component.html
@@ -1,4 +1,4 @@
-@switch (vout?.scriptpubkey_type || null) {
+@switch (address.type || null) {
   @case ('fee') {
     <span i18n="address.fee">fee</span>
   }
@@ -24,6 +24,6 @@
     <span>unknown</span>
   }
   @default {
-    <span>{{ vout.scriptpubkey_type.toUpperCase() }}</span>
+    <span>{{ address.type.toUpperCase() }}</span>
   }
 }

--- a/frontend/src/app/shared/components/address-type/address-type.component.ts
+++ b/frontend/src/app/shared/components/address-type/address-type.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Vout } from '../../../interfaces/electrs.interface';
+import { AddressTypeInfo } from '../../address-utils';
 
 @Component({
   selector: 'app-address-type',
@@ -7,5 +7,5 @@ import { Vout } from '../../../interfaces/electrs.interface';
   styleUrls: []
 })
 export class AddressTypeComponent {
-  @Input() vout: Vout;
+  @Input() address: AddressTypeInfo;
 }

--- a/frontend/src/app/shared/components/address-type/address-type.component.ts
+++ b/frontend/src/app/shared/components/address-type/address-type.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { Vout } from '../../../interfaces/electrs.interface';
+
+@Component({
+  selector: 'app-address-type',
+  templateUrl: './address-type.component.html',
+  styleUrls: []
+})
+export class AddressTypeComponent {
+  @Input() vout: Vout;
+}

--- a/frontend/src/app/shared/components/truncate/truncate.component.scss
+++ b/frontend/src/app/shared/components/truncate/truncate.component.scss
@@ -2,7 +2,7 @@
   text-overflow: unset;
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  align-items: start;
   position: relative;
 
   .truncate-link {

--- a/frontend/src/app/shared/regex.utils.ts
+++ b/frontend/src/app/shared/regex.utils.ts
@@ -1,14 +1,14 @@
 import { Env } from '../services/state.service';
 
 // all base58 characters
-const BASE58_CHARS = `[a-km-zA-HJ-NP-Z1-9]`;
+export const BASE58_CHARS = `[a-km-zA-HJ-NP-Z1-9]`;
 
 // all bech32 characters (after the separator)
-const BECH32_CHARS_LW = `[ac-hj-np-z02-9]`;
+export const BECH32_CHARS_LW = `[ac-hj-np-z02-9]`;
 const BECH32_CHARS_UP = `[AC-HJ-NP-Z02-9]`;
 
 // Hex characters
-const HEX_CHARS = `[a-fA-F0-9]`;
+export const HEX_CHARS = `[a-fA-F0-9]`;
 
 // A regex to say "A single 0 OR any number with no leading zeroes"
 // Capped at 9 digits so as to not be confused with lightning channel IDs (which are around 17 digits)

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -145,8 +145,116 @@ for (let i = 187; i <= 255; i++) {
 
 export { opcodes };
 
+export type ScriptType = 'scriptpubkey'
+  | 'scriptsig'
+  | 'inner_witnessscript'
+  | 'inner_redeemscript'
+
+export interface ScriptTemplate {
+  type: string;
+  label: string;
+}
+
+export const ScriptTemplates: { [type: string]: (...args: any) => ScriptTemplate } = {
+  liquid_peg_out: () => ({ type: 'liquid_peg_out', label: 'Liquid Peg Out' }),
+  liquid_peg_out_emergency: () => ({ type: 'liquid_peg_out_emergency', label: 'Emergency Liquid Peg Out' }),
+  ln_force_close: () => ({ type: 'ln_force_close', label: 'Lightning Force Close' }),
+  ln_force_close_revoked: () => ({ type: 'ln_force_close_revoked', label: 'Revoked Lightning Force Close' }),
+  ln_htlc: () => ({ type: 'ln_htlc', label: 'Lightning HTLC' }),
+  ln_htlc_revoked: () => ({ type: 'ln_htlc_revoked', label: 'Revoked Lightning HTLC' }),
+  ln_htlc_expired: () => ({ type: 'ln_htlc_expired', label: 'Expired Lightning HTLC' }),
+  ln_anchor: () => ({ type: 'ln_anchor', label: 'Lightning Anchor' }),
+  ln_anchor_swept: () => ({ type: 'ln_anchor_swept', label: 'Swept Lightning Anchor' }),
+  multisig: (m: number, n: number) => ({ type: 'multisig', m, n, label: $localize`:@@address-label.multisig:Multisig ${m}:multisigM: of ${n}:multisigN:` }),
+};
+
+export class ScriptInfo {
+  type: ScriptType;
+  scriptPath?: string;
+  hex?: string;
+  asm?: string;
+  template: ScriptTemplate;
+
+  constructor(type: ScriptType, hex?: string, asm?: string, witness?: string[], scriptPath?: string) {
+    this.type = type;
+    this.hex = hex;
+    this.asm = asm;
+    if (scriptPath) {
+      this.scriptPath = scriptPath;
+    }
+    if (this.asm) {
+      this.template = detectScriptTemplate(this.type, this.asm, witness);
+    }
+  }
+
+  public clone(): ScriptInfo {
+    return { ...this };
+  }
+
+  get key(): string {
+    return this.type + (this.scriptPath || '');
+  }
+}
+
+/** parses an inner_witnessscript + witness stack, and detects named script types */
+export function detectScriptTemplate(type: ScriptType, script_asm: string, witness?: string[]): ScriptTemplate | undefined {
+  if (type === 'inner_witnessscript' && witness?.length) {
+    if (script_asm.indexOf('OP_DEPTH OP_PUSHNUM_12 OP_EQUAL OP_IF OP_PUSHNUM_11') === 0 || script_asm.indexOf('OP_PUSHNUM_15 OP_CHECKMULTISIG OP_IFDUP OP_NOTIF OP_PUSHBYTES_2') === 1259) {
+      if (witness.length > 11) {
+        return ScriptTemplates.liquid_peg_out();
+      } else {
+        return ScriptTemplates.liquid_peg_out_emergency();
+      }
+    }
+
+    const topElement = witness[witness.length - 2];
+    if (/^OP_IF OP_PUSHBYTES_33 \w{66} OP_ELSE OP_PUSH(NUM_\d+|BYTES_(1 \w{2}|2 \w{4})) OP_CSV OP_DROP OP_PUSHBYTES_33 \w{66} OP_ENDIF OP_CHECKSIG$/.test(script_asm)) {
+      // https://github.com/lightning/bolts/blob/master/03-transactions.md#commitment-transaction-outputs
+      if (topElement === '01') {
+        // top element is '01' to get in the revocation path
+        return ScriptTemplates.ln_force_close_revoked();
+      } else {
+        // top element is '', this is a delayed to_local output
+        return ScriptTemplates.ln_force_close();
+      }
+    } else if (
+      /^OP_DUP OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUAL OP_IF OP_CHECKSIG OP_ELSE OP_PUSHBYTES_33 \w{66} OP_SWAP OP_SIZE OP_PUSHBYTES_1 20 OP_EQUAL OP_NOTIF OP_DROP OP_PUSHNUM_2 OP_SWAP OP_PUSHBYTES_33 \w{66} OP_PUSHNUM_2 OP_CHECKMULTISIG OP_ELSE OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUALVERIFY OP_CHECKSIG OP_ENDIF (OP_PUSHNUM_1 OP_CSV OP_DROP |)OP_ENDIF$/.test(script_asm) ||
+      /^OP_DUP OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUAL OP_IF OP_CHECKSIG OP_ELSE OP_PUSHBYTES_33 \w{66} OP_SWAP OP_SIZE OP_PUSHBYTES_1 20 OP_EQUAL OP_IF OP_HASH160 OP_PUSHBYTES_20 \w{40} OP_EQUALVERIFY OP_PUSHNUM_2 OP_SWAP OP_PUSHBYTES_33 \w{66} OP_PUSHNUM_2 OP_CHECKMULTISIG OP_ELSE OP_DROP OP_PUSHBYTES_3 \w{6} OP_CLTV OP_DROP OP_CHECKSIG OP_ENDIF (OP_PUSHNUM_1 OP_CSV OP_DROP |)OP_ENDIF$/.test(script_asm)
+    ) {
+      // https://github.com/lightning/bolts/blob/master/03-transactions.md#offered-htlc-outputs
+      // https://github.com/lightning/bolts/blob/master/03-transactions.md#received-htlc-outputs
+      if (topElement.length === 66) {
+        // top element is a public key
+        return ScriptTemplates.ln_htlc_revoked();
+      } else if (topElement) {
+        // top element is a preimage
+        return ScriptTemplates.ln_htlc();
+      } else {
+        // top element is '' to get in the expiry of the script
+        return ScriptTemplates.ln_htlc_expired();
+      }
+    } else if (/^OP_PUSHBYTES_33 \w{66} OP_CHECKSIG OP_IFDUP OP_NOTIF OP_PUSHNUM_16 OP_CSV OP_ENDIF$/.test(script_asm)) {
+      // https://github.com/lightning/bolts/blob/master/03-transactions.md#to_local_anchor-and-to_remote_anchor-output-option_anchors
+      if (topElement) {
+        // top element is a signature
+        return ScriptTemplates.ln_anchor();
+      } else {
+        // top element is '', it has been swept after 16 blocks
+        return ScriptTemplates.ln_anchor_swept();
+      }
+    }
+  }
+
+  const multisig = parseMultisigScript(script_asm);
+  if (multisig) {
+    return ScriptTemplates.multisig(multisig.m, multisig.n);
+  }
+
+  return;
+}
+
 /** extracts m and n from a multisig script (asm), returns nothing if it is not a multisig script */
-export function parseMultisigScript(script: string): void | { m: number, n: number } {
+export function parseMultisigScript(script: string): undefined | { m: number, n: number } {
   if (!script) {
     return;
   }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -87,6 +87,7 @@ import { ChangeComponent } from '../components/change/change.component';
 import { SatsComponent } from './components/sats/sats.component';
 import { BtcComponent } from './components/btc/btc.component';
 import { FeeRateComponent } from './components/fee-rate/fee-rate.component';
+import { AddressTypeComponent } from './components/address-type/address-type.component';
 import { TruncateComponent } from './components/truncate/truncate.component';
 import { SearchResultsComponent } from '../components/search-form/search-results/search-results.component';
 import { TimestampComponent } from './components/timestamp/timestamp.component';
@@ -202,6 +203,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     SatsComponent,
     BtcComponent,
     FeeRateComponent,
+    AddressTypeComponent,
     TruncateComponent,
     SearchResultsComponent,
     TimestampComponent,
@@ -343,6 +345,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     SatsComponent,
     BtcComponent,
     FeeRateComponent,
+    AddressTypeComponent,
     TruncateComponent,
     SearchResultsComponent,
     TimestampComponent,


### PR DESCRIPTION
_**(STATUS: ready for review)**_

This PR is the first in what I hope will be a series of changes and improvements to make the address page more useful.

This initial stage focuses on refactoring some of the underlying logic of the address page component, and redesigning the top details section to focus on more immediately relevant data, by:

 - making "Balance" the headline item
 - hiding the QR code behind a mouse-over icon/button
 - removing the "total received" and "total sent" items
 - adding items for the number of UTXOs and the address type (including special address labels where relevant).
 - splitting balance and utxo data into separate confirmed & pending fields, to emphasize that unconfirmed funds/utxos are not safe or guaranteed.
 
This refactor/redesign hasn't yet been polished to fully support Liquid, P2PK addresses, or non-esplora backends, so I'm leaving it in draft for now.

If the general idea gets a concept ACK, I'll finish up those parts and take the PR out of draft.

<img width="769" alt="Screenshot 2024-06-10 at 11 14 46 PM" src="https://github.com/mempool/mempool/assets/83316221/2fd00580-de44-4853-8dfc-6878fd87809b">

| Before | After |
|-|-|
| ![localhost_4200_address_bc1q5x9p784q6jkj4w3cw56h8vejz326yrf6u4tuksgg8kjnfkpg7l5qe8kpz6(iPhone SE) (1)](https://github.com/mempool/mempool/assets/83316221/6dea9d2f-2e6e-4ad0-9e73-3e9ff0fdd6f2) | ![localhost_4200_address_bc1q5x9p784q6jkj4w3cw56h8vejz326yrf6u4tuksgg8kjnfkpg7l5qe8kpz6(iPhone SE)](https://github.com/mempool/mempool/assets/83316221/b62d8b89-d598-4565-bf65-e14d7a4e8fb0) |


https://github.com/mempool/mempool/assets/83316221/fcfb132c-9ab7-4c54-8dfa-06e56d8133dc