### PR TITLE
fix hex2ascii.pipe

### DIFF
--- a/frontend/src/app/shared/pipes/hex2ascii/hex2ascii.pipe.ts
+++ b/frontend/src/app/shared/pipes/hex2ascii/hex2ascii.pipe.ts
@@ -6,6 +6,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class Hex2asciiPipe implements PipeTransform {
 
   transform(hex: string): string {
+    
+    if (!hex) {
+      return '';
+    }
+    
     const opPush = hex.split(' ').filter((_, i, a) => i > 0 && /^OP_PUSH/.test(a[i - 1]));
 
     if (opPush[0]) {


### PR DESCRIPTION
Early exit if `hex` is undefined. 
In rare cases `undefined` gets into the pipe, and unessary errors appear in the dev tools.

<img width="707" alt="Screenshot 2024-06-18 at 23 12 41" src="https://github.com/mempool/mempool/assets/108269257/9b83bcfb-f7b4-47f4-8fc1-8cb4def217c7">
