### PR TITLE
Implement $getTxsForBlock for Core backends

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -107,8 +107,14 @@ class BitcoinApi implements AbstractBitcoinApi {
       .then((rpcBlock: IBitcoinApi.Block) => rpcBlock.tx);
   }
 
-  $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]> {
-    throw new Error('Method getTxsForBlock not supported by the Bitcoin RPC API.');
+  async $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]> {
+    const verboseBlock: IBitcoinApi.VerboseBlock = await this.bitcoindClient.getBlock(hash, 2);
+    const transactions: IEsploraApi.Transaction[] = [];
+    for (const tx of verboseBlock.tx) {
+      const converted = await this.$convertTransaction(tx, true);
+      transactions.push(converted);
+    }
+    return transactions;
   }
 
   $getRawBlock(hash: string): Promise<Buffer> {


### PR DESCRIPTION
Resolves #5166

This PR implements $getTxsForBlock for non-esplora backends, using the verbose block RPC and existing transaction conversion utility functions.

This is _**slow**_, and puts a bit of strain on the local core node, so we should avoid relying on it whenever possible.