### PR TITLE
Deprecate pool_unique_id, fixing accelerations sync

### DIFF
--- a/backend/src/api/services/acceleration.ts
+++ b/backend/src/api/services/acceleration.ts
@@ -31,10 +31,7 @@ export interface AccelerationHistory {
   feeDelta: number,
   blockHash: string,
   blockHeight: number,
-  pools: {
-    pool_unique_id: number,
-    username: string,
-  }[],
+  pools: number[];
 };
 
 class AccelerationApi {

--- a/backend/src/repositories/AccelerationRepository.ts
+++ b/backend/src/repositories/AccelerationRepository.ts
@@ -308,10 +308,10 @@ class AccelerationRepository {
         }
         const accelerationSummaries = accelerations.map(acc => ({
           ...acc,
-          pools: acc.pools.map(pool => pool.pool_unique_id),
+          pools: acc.pools,
         }))
         for (const acc of accelerations) {
-          if (blockTxs[acc.txid] && acc.pools.some(pool => pool.pool_unique_id === block.extras.pool.id)) {
+          if (blockTxs[acc.txid] && acc.pools.some(pool => pool === block.extras.pool.id)) {
             const tx = blockTxs[acc.txid];
             const accelerationInfo = accelerationCosts.getAccelerationInfo(tx, boostRate, transactions);
             accelerationInfo.cost = Math.max(0, Math.min(acc.feeDelta, accelerationInfo.cost));

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -313,7 +313,7 @@ export class BlockComponent implements OnInit, OnDestroy {
 
       const acceleratedInBlock = {};
       for (const acc of accelerations) {
-        if (acc.pools?.some(pool => pool === this.block?.extras?.pool.id || pool?.['pool_unique_id'] === this.block?.extras?.pool.id)) {
+        if (acc.pools?.some(pool => pool === this.block?.extras?.pool.id)) {
           acceleratedInBlock[acc.txid] = acc;
         }
       }

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -665,7 +665,7 @@ export class TrackerComponent implements OnInit, OnDestroy {
   }
 
   setIsAccelerated(initialState: boolean = false) {
-    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id || pool?.['pool_unique_id'] === this.pool.id))));
+    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id))));
   }
 
   dismissAccelAlert(): void {

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -726,7 +726,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   setIsAccelerated(initialState: boolean = false) {
-    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id || pool?.['pool_unique_id'] === this.pool.id))));
+    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id))));
     if (this.isAcceleration && initialState) {
       this.showAccelerationSummary = false;
     }

--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -9126,11 +9126,7 @@ export const restApiDocsData = [
     "blockHash": "00000000000000000000482f0746d62141694b9210a813b97eb8445780a32003",
     "blockHeight": 829559,
     "bidBoost": 6102,
-    "pools": [
-      {
-        "pool_unique_id": 111
-      }
-    ]
+    "pools": [111]
   }
 ]`,
         },


### PR DESCRIPTION
The acceleration history sync was broken, as the pool_unique_id had been migrated to pool number array.