### PR TITLE
Missing difficulty adjustment causes invalid json response

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -1300,7 +1300,7 @@ class WebsocketHandler {
   // and zips it together into a valid JSON object
   private serializeResponse(response): string {
     return '{'
-        + Object.keys(response).map(key => `"${key}": ${response[key]}`).join(', ')
+        + Object.keys(response).filter(key => response[key] != null).map(key => `"${key}": ${response[key]}`).join(', ')
         + '}';
   }
 


### PR DESCRIPTION
When a node is still syncing, and we don't have the Difficulty Adjustment data yet.

The websocket is returning invalid data _undefined_.

Returning an empty string instead that should be falsy for the frontend.