### PR TITLE
configurable block size & count in rust gbt

### DIFF
--- a/backend/src/__tests__/gbt/gbt-tests.ts
+++ b/backend/src/__tests__/gbt/gbt-tests.ts
@@ -13,7 +13,7 @@ const vectorBuffer: Buffer = fs.readFileSync(path.join(__dirname, './', './test-
 
 describe('Rust GBT', () => {
   test('should produce the same template as getBlockTemplate from Bitcoin Core', async () => {
-    const rustGbt = new GbtGenerator();
+    const rustGbt = new GbtGenerator(4_000_000, 8);
     const { mempool, maxUid } = mempoolFromArrayBuffer(vectorBuffer.buffer);
     const result = await rustGbt.make(mempool, [], maxUid);
 

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -16,7 +16,7 @@ class MempoolBlocks {
   private mempoolBlockDeltas: MempoolBlockDelta[] = [];
   private txSelectionWorker: Worker | null = null;
   private rustInitialized: boolean = false;
-  private rustGbtGenerator: GbtGenerator = new GbtGenerator();
+  private rustGbtGenerator: GbtGenerator = new GbtGenerator(config.MEMPOOL.BLOCK_WEIGHT_UNITS, config.MEMPOOL.MEMPOOL_BLOCKS_AMOUNT);
 
   private nextUid: number = 1;
   private uidMap: Map<number, string> = new Map(); // map short numerical uids to full txids
@@ -230,7 +230,7 @@ class MempoolBlocks {
 
   private resetRustGbt(): void {
     this.rustInitialized = false;
-    this.rustGbtGenerator = new GbtGenerator();
+    this.rustGbtGenerator = new GbtGenerator(config.MEMPOOL.BLOCK_WEIGHT_UNITS, config.MEMPOOL.MEMPOOL_BLOCKS_AMOUNT);
   }
 
   public async $rustMakeBlockTemplates(txids: string[], newMempool: { [txid: string]: MempoolTransactionExtended }, candidates: GbtCandidates | undefined, saveResults: boolean = false, useAccelerations: boolean = false, accelerationPool?: number): Promise<MempoolBlockWithTransactions[]> {
@@ -262,7 +262,7 @@ class MempoolBlocks {
     });
 
     // run the block construction algorithm in a separate thread, and wait for a result
-    const rustGbt = saveResults ? this.rustGbtGenerator : new GbtGenerator();
+    const rustGbt = saveResults ? this.rustGbtGenerator : new GbtGenerator(config.MEMPOOL.BLOCK_WEIGHT_UNITS, config.MEMPOOL.MEMPOOL_BLOCKS_AMOUNT);
     try {
       const { blocks, blockWeights, rates, clusters, overflow } = this.convertNapiResultTxids(
         await rustGbt.make(transactions as RustThreadTransaction[], convertedAccelerations as RustThreadAcceleration[], this.nextUid),

--- a/rust/gbt/src/gbt.rs
+++ b/rust/gbt/src/gbt.rs
@@ -8,11 +8,9 @@ use crate::{
     GbtResult, ThreadTransactionsMap, thread_acceleration::ThreadAcceleration,
 };
 
-const MAX_BLOCK_WEIGHT_UNITS: u32 = 4_000_000 - 4_000;
 const BLOCK_SIGOPS: u32 = 80_000;
 const BLOCK_RESERVED_WEIGHT: u32 = 4_000;
 const BLOCK_RESERVED_SIGOPS: u32 = 400;
-const MAX_BLOCKS: usize = 8;
 
 type AuditPool = Vec<Option<ManuallyDrop<AuditTransaction>>>;
 type ModifiedQueue = PriorityQueue<u32, TxPriority, U32HasherState>;
@@ -53,7 +51,13 @@ impl Ord for TxPriority {
 // TODO: Make gbt smaller to fix these lints.
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::cognitive_complexity)]
-pub fn gbt(mempool: &mut ThreadTransactionsMap, accelerations: &[ThreadAcceleration], max_uid: usize) -> GbtResult {
+pub fn gbt(
+    mempool: &mut ThreadTransactionsMap,
+    accelerations: &[ThreadAcceleration],
+    max_uid: usize,
+    max_block_weight: u32,
+    max_blocks: usize,
+) -> GbtResult {
     let mut indexed_accelerations = Vec::with_capacity(max_uid + 1);
     indexed_accelerations.resize(max_uid + 1, None);
     for acceleration in accelerations {
@@ -146,9 +150,9 @@ pub fn gbt(mempool: &mut ThreadTransactionsMap, accelerations: &[ThreadAccelerat
                 modified.pop();
             }
 
-            if blocks.len() < (MAX_BLOCKS - 1)
+            if blocks.len() < (max_blocks - 1)
                 && ((block_weight + (4 * next_tx.ancestor_sigop_adjusted_vsize())
-                    >= MAX_BLOCK_WEIGHT_UNITS)
+                    >= max_block_weight)
                     || (block_sigops + next_tx.ancestor_sigops() > BLOCK_SIGOPS))
             {
                 // hold this package in an overflow list while we check for smaller options
@@ -201,9 +205,9 @@ pub fn gbt(mempool: &mut ThreadTransactionsMap, accelerations: &[ThreadAccelerat
 
         // this block is full
         let exceeded_package_tries =
-            failures > 1000 && block_weight > (MAX_BLOCK_WEIGHT_UNITS - BLOCK_RESERVED_WEIGHT);
+            failures > 1000 && block_weight > (max_block_weight - BLOCK_RESERVED_WEIGHT);
         let queue_is_empty = mempool_stack.is_empty() && modified.is_empty();
-        if (exceeded_package_tries || queue_is_empty) && blocks.len() < (MAX_BLOCKS - 1) {
+        if (exceeded_package_tries || queue_is_empty) && blocks.len() < (max_blocks - 1) {
             // finalize this block
             if transactions.is_empty() {
                 info!("trying to push an empty block! breaking loop! mempool {:#?} | modified {:#?} | overflow {:#?}", mempool_stack.len(), modified.len(), overflow.len());

--- a/rust/gbt/src/gbt.rs
+++ b/rust/gbt/src/gbt.rs
@@ -152,7 +152,7 @@ pub fn gbt(
 
             if blocks.len() < (max_blocks - 1)
                 && ((block_weight + (4 * next_tx.ancestor_sigop_adjusted_vsize())
-                    >= max_block_weight)
+                    >= max_block_weight - 4_000)
                     || (block_sigops + next_tx.ancestor_sigops() > BLOCK_SIGOPS))
             {
                 // hold this package in an overflow list while we check for smaller options
@@ -205,7 +205,7 @@ pub fn gbt(
 
         // this block is full
         let exceeded_package_tries =
-            failures > 1000 && block_weight > (max_block_weight - BLOCK_RESERVED_WEIGHT);
+            failures > 1000 && block_weight > (max_block_weight - 4_000 - BLOCK_RESERVED_WEIGHT);
         let queue_is_empty = mempool_stack.is_empty() && modified.is_empty();
         if (exceeded_package_tries || queue_is_empty) && blocks.len() < (max_blocks - 1) {
             // finalize this block


### PR DESCRIPTION
use `config.MEMPOOL.BLOCK_WEIGHT_UNITS` and `config.MEMPOOL.MEMPOOL_BLOCKS_AMOUNT` config settings in rust gbt instead of hardcoded constants.