### PR TITLE
Romanz support for address page

### DIFF
--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -26,11 +26,13 @@
               <tbody>
                 <tr><ng-container *ngTemplateOutlet="balanceRow"></ng-container></tr>
                 <tr><ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container></tr>
-                <tr><ng-container *ngTemplateOutlet="utxoRow"></ng-container></tr>
-                <tr><ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container></tr>
+                @if (!address.electrum) {
+                  <tr><ng-container *ngTemplateOutlet="utxoRow"></ng-container></tr>
+                  <tr><ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container></tr>
+                }
                 @if (network === 'liquid' || network === 'liquidtestnet') {
                   <tr><ng-container *ngTemplateOutlet="liquidRow"></ng-container></tr>
-                } @else {
+                } @else if (!address.electrum) {
                   <tr><ng-container *ngTemplateOutlet="volumeRow"></ng-container></tr>
                 }
                 <tr><ng-container *ngTemplateOutlet="typeRow"></ng-container></tr>
@@ -46,17 +48,21 @@
                   <ng-container *ngTemplateOutlet="spacerCell"></ng-container>
                   <ng-container *ngTemplateOutlet="pendingBalanceRow"></ng-container>
                 </tr>
+                @if (!address.electrum) {
                 <tr>
                   <ng-container *ngTemplateOutlet="utxoRow"></ng-container>
                   <ng-container *ngTemplateOutlet="spacerCell"></ng-container>
                   <ng-container *ngTemplateOutlet="pendingUtxoRow"></ng-container>
                 </tr>
+                }
                 <tr>
                   @if (network === 'liquid' || network === 'liquidtestnet') {
                     <ng-container *ngTemplateOutlet="liquidRow"></ng-container>
-                  } @else {
+                  } @else if (!address.electrum) {
                     <ng-container *ngTemplateOutlet="volumeRow"></ng-container>
-                  }
+                  } @else {
+                    <ng-container *ngTemplateOutlet="emptyTd"></ng-container>
+                  }                  
                   <ng-container *ngTemplateOutlet="spacerCell"></ng-container>
                   <ng-container *ngTemplateOutlet="typeRow"></ng-container>
                 </tr>
@@ -229,6 +235,11 @@
 </ng-template>
 
 <ng-template #spacerCell>
+  <td class="spacer"></td>
+</ng-template>
+
+<ng-template #emptyTd>
+  <td class="spacer"></td>
   <td class="spacer"></td>
 </ng-template>
 


### PR DESCRIPTION
Hiding the rows with data we don't have when running with `romanz/electrs`

Desktop
<img width="1186" alt="Screenshot 2024-06-24 at 16 25 32" src="https://github.com/mempool/mempool/assets/8561090/fdceb7a5-1ca5-49f8-bbba-369ee875a0aa">

Mobile
<img width="467" alt="Screenshot 2024-06-24 at 16 25 37" src="https://github.com/mempool/mempool/assets/8561090/9dfb2f6d-6d40-4341-91e6-c604fd7fe5c9">
