### PR TITLE
Minor style & layout tweaks for the acceleration preview

### DIFF
--- a/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.scss
+++ b/frontend/src/app/components/accelerate-preview/accelerate-fee-graph.component.scss
@@ -4,7 +4,6 @@
   width: 120px;
   margin-left: 4em;
   margin-right: 1.5em;
-  padding-bottom: 17px;
 
   .column {
     width: 100%;

--- a/frontend/src/app/components/accelerate-preview/accelerate-preview.component.html
+++ b/frontend/src/app/components/accelerate-preview/accelerate-preview.component.html
@@ -98,7 +98,7 @@
       </div>
   
       <h5>Summary</h5>
-      <div class="row mb-3">
+      <div class="row">
         <div class="col">
           <table class="table table-borderless table-border table-dark table-background table-accelerator">
             <tbody>
@@ -128,7 +128,7 @@
                 <tr>
                   <td class="item" i18n="accelerator.mempool-accelerator-fees">Mempool Accelerator™ fees</td>
                 </tr>
-                <tr class="info">
+                <tr class="info" [class.group-last]="!estimate.vsizeFee" [class.dashed-bottom]="!estimate.vsizeFee">
                   <td class="info">
                     <i><small i18n="accelerator.service-fee">Accelerator Service Fee</small></i>
                   </td>
@@ -140,7 +140,7 @@
                     <span class="fiat ml-1"><app-fiat [value]="estimate.mempoolBaseFee"></app-fiat></span>
                   </td>
                 </tr>
-              <tr class="info group-last" *ngIf="estimate.vsizeFee">
+              <tr class="info group-last dashed-bottom" *ngIf="estimate.vsizeFee">
                 <td class="info">
                   <i><small i18n="accelerator.tx-size-surcharge">Transaction Size Surcharge</small></i>
                 </td>
@@ -174,7 +174,7 @@
 
               <!-- MAX COST -->
               <ng-container>
-                <tr class="group-first">
+                <tr class="group-first" [class.group-last]="!isLoggedIn() || estimate.userBalance >= maxCost">
                   <td class="item">
                     <b style="background-color: var(--primary);" class="p-1 pl-0" i18n="accelerator.maximum-cost">Maximum acceleration cost</b> 
                   </td>
@@ -186,7 +186,7 @@
                   <td class="units">
                     <span class="symbol" i18n="shared.sats">sats</span>
                     <span class="fiat ml-1">
-                      <app-fiat [value]="maxCost" [colorClass]="estimate.userBalance < maxCost ? 'red-color' : 'green-color'"></app-fiat>
+                      <app-fiat [value]="maxCost" [colorClass]="isLoggedIn() && estimate.userBalance < maxCost ? 'red-color' : 'green-color'"></app-fiat>
                     </span>
                   </td>
                 </tr>
@@ -194,7 +194,7 @@
   
               <!-- USER BALANCE -->
               <ng-container *ngIf="isLoggedIn() && estimate.userBalance < maxCost">
-                <tr class="group-first group-last" style="border-top: 1px dashed grey">
+                <tr class="group-first group-last dashed-top">
                   <td class="item" i18n="accelerator.available-balance">Available balance</td>
                   <td class="amt">
                     {{ estimate.userBalance | number }}
@@ -207,27 +207,21 @@
                   </td>
                 </tr>
               </ng-container>
-              <tr>
-                <td colspan="3">
-                  <div style="border-top: 1px dashed grey; margin-top: 10px;"></div>
-                </td>
-              </tr>
-              <!-- LOGIN CTA -->
-              <ng-container *ngIf="stateService.isMempoolSpaceBuild && !isLoggedIn()">
+              <ng-container *ngIf="user && estimate?.hasAccess || !isLoggedIn()">
                 <tr class="group-first group-last" style="border-top: 1px dashed grey">
                   <td class="item"></td>
-                  <td class="amt"></td>
-                  <td class="units d-flex">
-                    <a [routerLink]="['/login']" [queryParams]="{redirectTo: '/tx/' + tx.txid + '#accelerate'}" class="btn btn-purple flex-grow-1" i18n="shared.sign-in">Sign In</a>
-                  </td>
-                </tr>
-              </ng-container>
-              <ng-container *ngIf="!stateService.isMempoolSpaceBuild">
-                <tr class="group-first group-last">
-                  <td class="item"></td>
-                  <td class="amt"></td>
-                  <td class="units d-flex">
-                    <a [href]="'https://mempool.space/tx/' + tx.txid + '#accelerate'" class="btn btn-purple flex-grow-1" i18n="accelerator.accelerate-on-mempoolspace">Accelerate on mempool.space</a>
+                  <td colspan="2">
+                    <div class="d-flex">
+                      @if (isLoggedIn()) {
+                        @if (user && estimate.hasAccess) {
+                          <button class="btn btn-sm btn-primary btn-success flex-grow-1" style="width: 150px" (click)="accelerate()" i18n="transaction.accelerate|Accelerate button label">Accelerate</button>
+                        }
+                      } @else if (stateService.isMempoolSpaceBuild) {
+                        <a [routerLink]="['/login']" [queryParams]="{redirectTo: '/tx/' + tx.txid + '#accelerate'}" class="btn btn-purple flex-grow-1" i18n="shared.sign-in">Sign In</a>
+                      } @else {
+                        <a [href]="'https://mempool.space/tx/' + tx.txid + '#accelerate'" class="btn btn-purple flex-grow-1" i18n="accelerator.accelerate-on-mempoolspace">Accelerate on mempool.space</a>
+                      }
+                    </div>
                   </td>
                 </tr>
               </ng-container>
@@ -235,15 +229,6 @@
           </table>
         </div>
       </div>
-  
-      <div class="row mb-3" *ngIf="isLoggedIn()">
-        <div class="col">
-          <div class="d-flex justify-content-end" *ngIf="user && estimate.hasAccess">
-            <button class="btn btn-sm btn-primary btn-success" style="width: 150px" (click)="accelerate()" i18n="transaction.accelerate|Accelerate button label">Accelerate</button>
-          </div>
-        </div>
-      </div>
-  
     </div>
   </ng-container>
 </div>

--- a/frontend/src/app/components/accelerate-preview/accelerate-preview.component.scss
+++ b/frontend/src/app/components/accelerate-preview/accelerate-preview.component.scss
@@ -72,10 +72,16 @@
         padding-top: 0.75rem;
       }
     }
-    &.group-last {
+    &.group-last, &:last-child {
       td {
         padding-bottom: 0.75rem;
       }
+    }
+    &.dashed-top {
+      border-top: 1px dashed grey;
+    }
+    &.dashed-bottom {
+      border-bottom: 1px dashed grey
     }
   }
   td {


### PR DESCRIPTION
cleans up a few small remaining visual issues:
 - misplaced divider lines in the summary table
 - max cost fiat value shown in red when not logged in
 - inconsistent padding & spacing
 - inconsistent CTA placement (inside vs outside of summary table)

| Before | After |
|-|-|
| <img width="1134" alt="Screenshot 2024-06-26 at 8 22 25 AM" src="https://github.com/mempool/mempool/assets/83316221/8c4e64d7-a852-4bea-9c6a-4e726e75c290"> | <img width="1134" alt="Screenshot 2024-06-26 at 8 22 56 AM" src="https://github.com/mempool/mempool/assets/83316221/549bae86-73e9-472b-848b-101be86e2e42"> |
| <img width="1134" alt="Screenshot 2024-06-26 at 8 22 33 AM" src="https://github.com/mempool/mempool/assets/83316221/8687a91b-4d29-41b6-9a71-cb77e40f01ca"> | <img width="1134" alt="Screenshot 2024-06-26 at 8 22 49 AM" src="https://github.com/mempool/mempool/assets/83316221/0d4670a4-4065-4af5-964e-89b74bd7eb60"> |
| <img width="1134" alt="Screenshot 2024-06-26 at 8 29 32 AM" src="https://github.com/mempool/mempool/assets/83316221/5a4cba15-38d5-4e90-a116-86dae4e97cdc"> | <img width="1134" alt="Screenshot 2024-06-26 at 8 29 46 AM" src="https://github.com/mempool/mempool/assets/83316221/1950e866-ef3b-4e49-b079-539aa9849824"> |
| <img width="1134" alt="Screenshot 2024-06-26 at 8 29 24 AM" src="https://github.com/mempool/mempool/assets/83316221/1ed509d9-e02f-4680-9a81-e5d9f9263683"> | <img width="1134" alt="Screenshot 2024-06-26 at 8 29 56 AM" src="https://github.com/mempool/mempool/assets/83316221/d9f8b157-df1a-4738-8e60-c467943b8062"> |
