### PR TITLE
simple acceleration mode on main tx page

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -18,7 +18,7 @@
       <div class="row">
         <div class="col-md">
           <div class="form-group form-check mb-2">
-            <input type="radio" [checked]="choosenOption === 'wait'"  class="form-check-input" id="wait" name="accelerate" (change)="selectedOptionChanged($event)">
+            <input type="radio" [checked]="choosenOption === 'wait'"  class="form-check-input" id="wait" name="accel" (change)="selectedOptionChanged($event)">
             <label class="form-check-label d-flex flex-column" for="wait">
               <span class="font-weight-bold">Wait</span>
               @if (eta.blocks < 7) {
@@ -33,8 +33,8 @@
         </div>
         <div class="col-md">
           <div class="form-group form-check mb-2">
-            <input type="radio" [checked]="choosenOption === 'accelerate'" class="form-check-input" id="accelerate" name="accelerate" (change)="selectedOptionChanged($event)">
-            <label class="form-check-label d-flex flex-column" for="accelerate">
+            <input type="radio" [checked]="choosenOption === 'accel'" class="form-check-input" id="accel" name="accel" (change)="selectedOptionChanged($event)">
+            <label class="form-check-label d-flex flex-column" for="accel">
               <span class="font-weight-bold">Accelerate</span>
               <span style="color: rgb(186, 186, 186); font-size: 14px;" *ngIf="(etaInfo$ | async) as etaInfo">Confirmation expected <app-time kind="within" [time]="etaInfo.acceleratedETA" [fastRender]="false" [fixedRender]="true"></app-time><br>
                 @if (!calculating) {
@@ -51,7 +51,7 @@
           <app-active-acceleration-box [miningStats]="miningStats" [pools]="estimate.pools" [chartOnly]="true"></app-active-acceleration-box>
         </div>
       </div>
-      <div class="row mt-2 mb-2" [style]="(choosenOption !== 'accelerate' || calculating) ? 'opacity: 0.25; pointer-events: none' : ''">
+      <div class="row mt-2 mb-2" [style]="(choosenOption !== 'accel' || calculating) ? 'opacity: 0.25; pointer-events: none' : ''">
         <div class="col-sm d-flex flex-row justify-content-center">
           <button type="button" class="mt-1 btn btn-purple rounded-pill align-self-center d-flex flex-row justify-content-center align-items-center" style="width: 200px" (click)="enableCheckoutPage()">
             <img src="/resources/mempool-accelerator-sparkles-light.svg" height="20" class="mr-2" style="margin-left: -10px">

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -1,4 +1,4 @@
-<div class="container-md card w-100" style="padding: 1em; background: var(--box-bg)" id=acceleratePreviewAnchor>
+<div class="box card w-100" style="padding: 1em; background: var(--box-bg)" id=acceleratePreviewAnchor>
 
   @if (error) {
     <div class="mt-2">
@@ -10,18 +10,33 @@
     <!-- Show A/B CTAs -->
     <div class="row mb-1">
       <div class="col-sm">
-        <h1 style="font-size: larger;">Accelerate your Bitcoin transaction?</h1>
+        <h1 style="font-size: larger;"><ng-content select="[slot='cta-title']"></ng-content><span class="default-slot">Accelerate your Bitcoin transaction?</span></h1>
       </div>
     </div>
 
     <form>
-      <div class="row">
-        <div class="col-sm">
+      <div class="row" *ngIf="(etaInfo$ | async) as etaInfo">
+        <div class="col-md">
+          <div class="form-group form-check mb-2">
+            <input type="radio" class="form-check-input" id="wait" name="accelerate" (change)="selectedOptionChanged($event)">
+            <label class="form-check-label d-flex flex-column" for="wait">
+              <span class="font-weight-bold">Wait</span>
+              @if (eta.blocks < 7) {
+                <span style="color: rgb(186, 186, 186); font-size: 14px;">Confirmation expected <app-time kind="within" [time]="eta.time" [fastRender]="false" [fixedRender]="true"></app-time></span>
+              } @else {
+                <span style="color: rgb(186, 186, 186); font-size: 14px;">
+                  <span>Confirmation expected within several hours</span>
+                </span>
+              }
+            </label>
+          </div>
+        </div>
+        <div class="col-md">
           <div class="form-group form-check mb-2">
             <input type="radio" class="form-check-input" id="accelerate" name="accelerate" (change)="selectedOptionChanged($event)">
             <label class="form-check-label d-flex flex-column" for="accelerate">
               <span class="font-weight-bold">Accelerate</span>
-              <span style="color: rgb(186, 186, 186); font-size: 14px;" *ngIf="(etaInfo$ | async) as etaInfo">Confirmation expected <app-time kind="within" [time]="etaInfo.acceleratedETA" [fastRender]="false" [fixedRender]="true"></app-time><br>
+              <span style="color: rgb(186, 186, 186); font-size: 14px;">Confirmation expected <app-time kind="within" [time]="etaInfo.acceleratedETA" [fastRender]="false" [fixedRender]="true"></app-time><br>
                 @if (!calculating) {
                   <app-fiat [value]="cost"></app-fiat>fee (<span><small style="font-family: monospace;">{{ cost | number }}</small>&nbsp;<span class="symbol" i18n="shared.sats">sats</span></span>)
                 } @else {
@@ -31,22 +46,9 @@
             </label>
           </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm">
-          <div class="form-group form-check mb-2">
-            <input type="radio" class="form-check-input" id="wait" name="accelerate" (change)="selectedOptionChanged($event)">
-            <label class="form-check-label d-flex flex-column" for="wait">
-              <span class="font-weight-bold">Wait</span>
-              @if (eta) {
-                <span style="color: rgb(186, 186, 186); font-size: 14px;">Confirmation expected <app-time kind="within" [time]="eta" [fastRender]="false" [fixedRender]="true"></app-time></span>
-              } @else {
-                <span style="color: rgb(186, 186, 186); font-size: 14px;">
-                  <span>Settlement expected within several hours</span>
-                </span>
-              }
-            </label>
-          </div>
+        <div class="col-md pie d-none d-lg-flex" *ngIf="estimate && !isTracker">
+          <small class="form-text text-muted mb-2" i18n="accelerator.hashrate-percentage-description">Your transaction will be prioritized by up to {{ etaInfo.hashratePercentage | number : '1.1-1' }}% of miners.</small>
+          <app-active-acceleration-box [miningStats]="miningStats" [pools]="estimate.pools" [chartOnly]="true"></app-active-acceleration-box>
         </div>
       </div>
       <div class="row mt-2 mb-2" [style]="(choosenOption === 'wait' || calculating) ? 'opacity: 0.25; pointer-events: none' : ''">
@@ -62,7 +64,7 @@
   } @else if (step === 'paymentMethod') {
     <div class="row mb-md-1 text-center">
       <div class="col-sm">
-        <h1 style="font-size: larger;">Select your payment method</h1>
+        <h1 style="font-size: larger;"><ng-content select="[slot='payment-title']"></ng-content><span class="default-slot">Select your payment method</span></h1>
       </div>
     </div>
     <div class="pt-2 d-flex justify-content-around">
@@ -76,14 +78,14 @@
     <!-- Show checkout page -->
     <div class="row mb-md-1 text-center">
       <div class="col-sm" id="confirm-payment-title">
-        <h1 style="font-size: larger;">Confirm your payment</h1>
+        <h1 style="font-size: larger;"><ng-content select="[slot='checkout-title']"></ng-content><span class="default-slot">Confirm your payment</span></h1>
       </div>
     </div>
 
     <div class="row text-center">
       <div class="col-sm">
         <div class="form-group w-100" style="font-size: 14px">
-          Payment to mempool.space for acceleration of txid <a [routerLink]="'/tx/' + txid" target="_blank">{{ txid.substr(0, 10) }}..{{ txid.substr(-10) }}</a>
+          Payment to mempool.space for acceleration of txid <a [routerLink]="'/tx/' + tx.txid" target="_blank">{{ tx.txid.substr(0, 10) }}..{{ tx.txid.substr(-10) }}</a>
         </div>
       </div>
     </div>
@@ -134,7 +136,7 @@
   @else if (step === 'processing') {
     <div class="row mb-1 text-center">
       <div class="col-sm">
-        <h1 style="font-size: larger;">Confirming your payment</h1>
+        <h1 style="font-size: larger;"><ng-content select="[slot='processing-title']"></ng-content><span class="default-slot">Confirming your payment</span></h1>
       </div>
     </div>
 

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -15,10 +15,10 @@
     </div>
 
     <form>
-      <div class="row" *ngIf="(etaInfo$ | async) as etaInfo">
+      <div class="row">
         <div class="col-md">
           <div class="form-group form-check mb-2">
-            <input type="radio" class="form-check-input" id="wait" name="accelerate" (change)="selectedOptionChanged($event)">
+            <input type="radio" [checked]="choosenOption === 'wait'"  class="form-check-input" id="wait" name="accelerate" (change)="selectedOptionChanged($event)">
             <label class="form-check-label d-flex flex-column" for="wait">
               <span class="font-weight-bold">Wait</span>
               @if (eta.blocks < 7) {
@@ -33,10 +33,10 @@
         </div>
         <div class="col-md">
           <div class="form-group form-check mb-2">
-            <input type="radio" class="form-check-input" id="accelerate" name="accelerate" (change)="selectedOptionChanged($event)">
+            <input type="radio" [checked]="choosenOption === 'accelerate'" class="form-check-input" id="accelerate" name="accelerate" (change)="selectedOptionChanged($event)">
             <label class="form-check-label d-flex flex-column" for="accelerate">
               <span class="font-weight-bold">Accelerate</span>
-              <span style="color: rgb(186, 186, 186); font-size: 14px;">Confirmation expected <app-time kind="within" [time]="etaInfo.acceleratedETA" [fastRender]="false" [fixedRender]="true"></app-time><br>
+              <span style="color: rgb(186, 186, 186); font-size: 14px;" *ngIf="(etaInfo$ | async) as etaInfo">Confirmation expected <app-time kind="within" [time]="etaInfo.acceleratedETA" [fastRender]="false" [fixedRender]="true"></app-time><br>
                 @if (!calculating) {
                   <app-fiat [value]="cost"></app-fiat>fee (<span><small style="font-family: monospace;">{{ cost | number }}</small>&nbsp;<span class="symbol" i18n="shared.sats">sats</span></span>)
                 } @else {
@@ -47,11 +47,11 @@
           </div>
         </div>
         <div class="col-md pie d-none d-lg-flex" *ngIf="estimate && !isTracker">
-          <small class="form-text text-muted mb-2" i18n="accelerator.hashrate-percentage-description">Your transaction will be prioritized by up to {{ etaInfo.hashratePercentage | number : '1.1-1' }}% of miners.</small>
+          <small class="form-text text-muted mb-2" i18n="accelerator.hashrate-percentage-description" *ngIf="(etaInfo$ | async) as etaInfo">Your transaction will be prioritized by up to {{ etaInfo.hashratePercentage | number : '1.1-1' }}% of miners.</small>
           <app-active-acceleration-box [miningStats]="miningStats" [pools]="estimate.pools" [chartOnly]="true"></app-active-acceleration-box>
         </div>
       </div>
-      <div class="row mt-2 mb-2" [style]="(choosenOption === 'wait' || calculating) ? 'opacity: 0.25; pointer-events: none' : ''">
+      <div class="row mt-2 mb-2" [style]="(choosenOption !== 'accelerate' || calculating) ? 'opacity: 0.25; pointer-events: none' : ''">
         <div class="col-sm d-flex flex-row justify-content-center">
           <button type="button" class="mt-1 btn btn-purple rounded-pill align-self-center d-flex flex-row justify-content-center align-items-center" style="width: 200px" (click)="enableCheckoutPage()">
             <img src="/resources/mempool-accelerator-sparkles-light.svg" height="20" class="mr-2" style="margin-left: -10px">
@@ -62,16 +62,28 @@
     </form>
   
   } @else if (step === 'paymentMethod') {
-    <div class="row mb-md-1 text-center">
+    <div class="row text-center">
       <div class="col-sm">
-        <h1 style="font-size: larger;"><ng-content select="[slot='payment-title']"></ng-content><span class="default-slot">Select your payment method</span></h1>
+        <h1 class="mb-2" style="font-size: larger;"><ng-content select="[slot='payment-title']"></ng-content><span class="default-slot">Select your payment method</span></h1>
       </div>
     </div>
-    <div class="pt-2 d-flex justify-content-around">
+    <div class="row text-center">
+      <div class="col-sm">
+        <app-fiat [value]="cost"></app-fiat> (<span><small style="font-family: monospace;">{{ cost | number }}</small>&nbsp;<span class="symbol" i18n="shared.sats">sats</span></span>)
+      </div>
+    </div>
+    <div class="pt-2 d-flex justify-content-center position-relative">
       @if (cashappEnabled) {
-        <img class="paymentMethod" src="/resources/cash-app.svg" height=55 (click)="selectPaymentMethod('cashapp')">
+        <img class="paymentMethod mx-2" src="/resources/cash-app.svg" height=55 (click)="selectPaymentMethod('cashapp')">
       }
-      <img class="paymentMethod" src="/resources/btcpay.svg" height=55 (click)="selectPaymentMethod('btcpay')">
+      <img class="paymentMethod mx-2" src="/resources/btcpay.svg" height=55 (click)="selectPaymentMethod('btcpay')">
+    </div>
+
+    <hr>
+    <div class="row mt-2 mb-2 text-center">
+      <div class="col-sm d-flex flex-column">
+        <button type="button" class="mt-1 btn btn-secondary btn-sm rounded-pill align-self-center" style="width: 200px" (click)="step = 'cta'">Go Back</button>
+      </div>
     </div>
 
   } @else if (step === 'checkout') {
@@ -127,8 +139,7 @@
     <hr>
     <div class="row mt-2 mb-2 text-center">
       <div class="col-sm d-flex flex-column">
-        <small>Changed your mind?</small>
-        <button type="button" class="mt-1 btn btn-secondary btn-sm rounded-pill align-self-center" style="width: 200px" (click)="step = 'cta'">Go Back</button>
+        <button type="button" class="mt-1 btn btn-secondary btn-sm rounded-pill align-self-center" style="width: 200px" (click)="step = 'paymentMethod'">Go Back</button>
       </div>
     </div>
   }

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
@@ -15,3 +15,13 @@
   border: 2px solid var(--bg);
   cursor: pointer;
 }
+
+.default-slot:not(:only-child) {
+  display: none;
+}
+
+.pie {
+  display: flex;
+  align-items: center;
+  max-width: 330px;
+}

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -24,7 +24,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   @Output() close = new EventEmitter<null>();
 
   calculating = true;
-  choosenOption: 'wait' | 'accelerate';
+  choosenOption: 'wait' | 'accel';
   error = '';
 
   step: 'paymentMethod' | 'cta' | 'checkout' | 'processing' = 'cta';

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -24,7 +24,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   @Output() close = new EventEmitter<null>();
 
   calculating = true;
-  choosenOption: 'wait' | 'accelerate' = 'wait';
+  choosenOption: 'wait' | 'accelerate';
   error = '';
 
   step: 'paymentMethod' | 'cta' | 'checkout' | 'processing' = 'cta';

--- a/frontend/src/app/components/bitcoin-invoice/bitcoin-invoice.component.html
+++ b/frontend/src/app/components/bitcoin-invoice/bitcoin-invoice.component.html
@@ -46,7 +46,7 @@
 
     </ng-template>
 
-    <ng-template [ngIf]="paymentForm.get('method')?.value === 'lightning' && invoice">
+    <ng-template [ngIf]="paymentForm.get('method')?.value === 'lightning' && invoice && invoice.addresses.BTC_LightningLike">
 
         <div class="qr-wrapper">
           <a [href]="bypassSecurityTrustUrl('lightning:' + invoice.addresses.BTC_LightningLike)" target="_blank">

--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -116,7 +116,9 @@
 
     <div class="bottom-panel">
       @if (showAccelerationSummary && !accelerationFlowCompleted) {
-        <app-accelerate-checkout *ngIf="(da$ | async) as da;" [cashappEnabled]="accelerationEligible" [txid]="tx.txid" [eta]="mempoolPosition?.block >= 7 ? null : da.adjustedTimeAvg * (mempoolPosition.block + 1) + now + da.timeOffset" (close)="accelerationFlowCompleted = true" [scrollEvent]="scrollIntoAccelPreview" class="h-100 w-100"></app-accelerate-checkout>
+        <ng-container *ngIf="(ETA$ | async) as eta;">
+          <app-accelerate-checkout *ngIf="(da$ | async) as da;" [cashappEnabled]="accelerationEligible" [tx]="tx" [miningStats]="miningStats" [eta]="eta" [isTracker]="true" (close)="accelerationFlowCompleted = true" [scrollEvent]="scrollIntoAccelPreview" class="h-100 w-100"></app-accelerate-checkout>
+        </ng-container>
       } @else {
         @if (tx?.acceleration && !tx.status?.confirmed) {
           <div class="progress-icon">

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -82,9 +82,17 @@
       </div>
       <div class="clearfix"></div>
 
-      <div class="box">
-        <app-accelerate-preview [tx]="tx" [miningStats]="miningStats" [scrollEvent]="scrollIntoAccelPreview"></app-accelerate-preview>
-      </div>
+      @if (isLoggedIn()) {
+        <div class="box">
+          <app-accelerate-preview [tx]="tx" [miningStats]="miningStats" [scrollEvent]="scrollIntoAccelPreview"></app-accelerate-preview>
+        </div>
+      } @else {
+        <ng-container *ngIf="(ETA$ | async) as eta;">
+          <app-accelerate-checkout *ngIf="(da$ | async) as da;" [cashappEnabled]="accelerationEligible" [tx]="tx" [eta]="eta" [miningStats]="miningStats" (close)="showAccelerationSummary = false" [scrollEvent]="scrollIntoAccelPreview" class="h-100 w-100">
+            <span slot="cta-title">Urgent transaction? Get it confirmed faster.</span>
+          </app-accelerate-checkout>
+        </ng-container>
+      }
     </ng-container>
 
     <ng-template [ngIf]="showCpfpDetails">

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -139,6 +139,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   acceleratorAvailable: boolean = this.stateService.env.OFFICIAL_MEMPOOL_SPACE && this.stateService.env.ACCELERATOR && this.stateService.network === '';
   showAccelerationSummary = false;
   scrollIntoAccelPreview = false;
+  accelerationEligible = false;
   auditEnabled: boolean = this.stateService.env.AUDIT && this.stateService.env.BASE_MODULE === 'mempool' && this.stateService.env.MINING_DASHBOARD === true;
 
   @ViewChild('graphContainer')
@@ -398,6 +399,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           } else if ((this.tx?.acceleration && txPosition.position.acceleratedBy)) {
             this.tx.acceleratedBy = txPosition.position.acceleratedBy;
           }
+          this.accelerationEligible = txPosition?.position?.block > 0 && this.tx?.weight < 4000;
         }
       } else {
         this.mempoolPosition = null;
@@ -909,6 +911,11 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       }, 1);
     }
+  }
+
+  isLoggedIn(): boolean {
+    const auth = this.storageService.getAuth();
+    return auth !== null;
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/components/transaction/transaction.module.ts
+++ b/frontend/src/app/components/transaction/transaction.module.ts
@@ -6,7 +6,10 @@ import { SharedModule } from '../../shared/shared.module';
 import { TxBowtieModule } from '../tx-bowtie-graph/tx-bowtie.module';
 import { GraphsModule } from '../../graphs/graphs.module';
 import { AcceleratePreviewComponent } from '../accelerate-preview/accelerate-preview.component';
+import { AccelerateCheckout } from '../accelerate-checkout/accelerate-checkout.component';
 import { AccelerateFeeGraphComponent } from '../accelerate-preview/accelerate-fee-graph.component';
+import { TrackerComponent } from '../tracker/tracker.component';
+import { TrackerBarComponent } from '../tracker/tracker-bar.component';
 
 const routes: Routes = [
   {
@@ -38,7 +41,10 @@ export class TransactionRoutingModule { }
   ],
   declarations: [
     TransactionComponent,
+    TrackerComponent,
+    TrackerBarComponent,
     AcceleratePreviewComponent,
+    AccelerateCheckout,
     AccelerateFeeGraphComponent,
   ]
 })

--- a/frontend/src/app/services/eta.service.ts
+++ b/frontend/src/app/services/eta.service.ts
@@ -6,7 +6,7 @@ import { Transaction } from '../interfaces/electrs.interface';
 import { MiningService, MiningStats } from './mining.service';
 import { getUnacceleratedFeeRate } from '../shared/transaction.utils';
 import { AccelerationEstimate } from '../components/accelerate-preview/accelerate-preview.component';
-import { Observable, combineLatest, map, of } from 'rxjs';
+import { Observable, combineLatest, map, of, share, shareReplay, tap } from 'rxjs';
 
 export interface ETA {
   now: number, // time at which calculation performed
@@ -61,7 +61,8 @@ export class EtaService {
             { block: 0, hashrateShare: acceleratingHashrateFraction },
           ], da).time,
         };
-      })
+      }),
+      shareReplay()
     );
   }
 

--- a/frontend/src/app/shared/components/mempool-error/mempool-error.component.ts
+++ b/frontend/src/app/shared/components/mempool-error/mempool-error.component.ts
@@ -29,6 +29,7 @@ const MempoolErrors = {
   'faucet_address_not_allowed': `You cannot use this address`,
   'faucet_below_minimum': `Requested amount is too small`,
   'faucet_above_maximum': `Requested amount is too high`,
+  'payment_method_not_allowed': `You are not allowed to use this payment method`,
 } as { [error: string]: string };
 
 export function isMempoolError(error: string) {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -50,8 +50,6 @@ import { BlockOverviewGraphComponent } from '../components/block-overview-graph/
 import { BlockOverviewTooltipComponent } from '../components/block-overview-tooltip/block-overview-tooltip.component';
 import { BlockFiltersComponent } from '../components/block-filters/block-filters.component';
 import { AddressGroupComponent } from '../components/address-group/address-group.component';
-import { TrackerComponent } from '../components/tracker/tracker.component';
-import { TrackerBarComponent } from '../components/tracker/tracker-bar.component';
 import { SearchFormComponent } from '../components/search-form/search-form.component';
 import { AddressLabelsComponent } from '../components/address-labels/address-labels.component';
 import { FooterComponent } from '../components/footer/footer.component';
@@ -100,7 +98,6 @@ import { MempoolErrorComponent } from './components/mempool-error/mempool-error.
 import { AccelerationsListComponent } from '../components/acceleration/accelerations-list/accelerations-list.component';
 import { PendingStatsComponent } from '../components/acceleration/pending-stats/pending-stats.component';
 import { AccelerationStatsComponent } from '../components/acceleration/acceleration-stats/acceleration-stats.component';
-import { AccelerateCheckout } from '../components/accelerate-checkout/accelerate-checkout.component';
 
 import { BlockViewComponent } from '../components/block-view/block-view.component';
 import { EightBlocksComponent } from '../components/eight-blocks/eight-blocks.component';
@@ -165,8 +162,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     BlockFiltersComponent,
     TransactionsListComponent,
     AddressGroupComponent,
-    TrackerComponent,
-    TrackerBarComponent,
     SearchFormComponent,
     AddressLabelsComponent,
     FooterComponent,
@@ -225,7 +220,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     MempoolErrorComponent,
     AccelerationsListComponent,
     AccelerationStatsComponent,
-    AccelerateCheckout,
     PendingStatsComponent,
     HttpErrorComponent,
     TwitterWidgetComponent,
@@ -307,8 +301,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     BlockFiltersComponent,
     TransactionsListComponent,
     AddressGroupComponent,
-    TrackerComponent,
-    TrackerBarComponent,
     SearchFormComponent,
     AddressLabelsComponent,
     FooterComponent,
@@ -356,7 +348,6 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     MempoolErrorComponent,
     AccelerationsListComponent,
     AccelerationStatsComponent,
-    AccelerateCheckout,
     PendingStatsComponent,
     HttpErrorComponent,
     TwitterWidgetComponent,


### PR DESCRIPTION
_(PR onto #5218 branch)_

refactors the accelerate checkout slightly, and integrates it into the main tx page for non-logged-in users.

<img width="1134" alt="Screenshot 2024-06-27 at 2 03 56 AM" src="https://github.com/mempool/mempool/assets/83316221/3d5b6d80-3d7f-40e0-b29e-7162a2e4145d">

the `/tracker` page implementation should be unchanged.
<img src="https://github.com/mempool/mempool/assets/83316221/6ecf9741-88ee-4d65-9ad6-895be3104468" width="400">
