### PR TITLE
Fix missing bare multisig labels

### DIFF
--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -33,6 +33,8 @@ export class AddressLabelsComponent implements OnChanges {
       this.handleAddress();
     } else if (this.vin) {
       this.handleVin();
+    } else if (this.vout) {
+      this.handleVout();
     }
   }
 
@@ -54,6 +56,16 @@ export class AddressLabelsComponent implements OnChanges {
 
   handleVin() {
     const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin])
+    if (address?.scripts.size) {
+      const script = address?.scripts.values().next().value;
+      if (script.template?.label) {
+        this.label = script.template.label;
+      }
+    }
+  }
+
+  handleVout() {
+    const address = new AddressTypeInfo(this.network || 'mainnet', this.vout.scriptpubkey_address, this.vout.scriptpubkey_type as AddressType, undefined, this.vout);
     if (address?.scripts.size) {
       const script = address?.scripts.values().next().value;
       if (script.template?.label) {


### PR DESCRIPTION
Since commit 7dfdb5553e5b06bf9c65add5cd8cada6c0d61790, bare multisig inputs and outputs have been missing the "Multisig m of n" label.

Happy to accept suggestions for a better approach, I'm not sure changing the interface of `AddressTypeInfo` this way is the best way to go about it.

Example transaction: https://mempool.space/tx/b10c0000004da5a9d1d9b4ae32e09f0b3e62d21a5cce5428d4ad714fb444eb5d

Current master:
![multisigbefore](https://github.com/mempool/mempool/assets/43024885/59c92b12-9aa0-4467-ba01-d979a6c36377)

This PR:
![multisigafter](https://github.com/mempool/mempool/assets/43024885/4c20aa71-def8-4b12-98bb-0eed39f59008)
