### PR TITLE
Fix bech32 regex and adapt tests

### DIFF
--- a/frontend/cypress/e2e/mainnet/mainnet.spec.ts
+++ b/frontend/cypress/e2e/mainnet/mainnet.spec.ts
@@ -144,13 +144,13 @@ describe('Mainnet', () => {
         });
       });
 
-      ['BC1PQYQSZQ', 'bc1PqYqSzQ'].forEach((searchTerm) => {
+      ['BC1PQYQS', 'bc1PqYqS'].forEach((searchTerm) => {
         it(`allows searching for partial case insensitive bech32m addresses: ${searchTerm}`, () => {
           cy.visit('/');
           cy.get('.search-box-container > .form-control').type(searchTerm).then(() => {
-            cy.get('app-search-results button.dropdown-item').should('have.length', 1);
+            cy.get('app-search-results button.dropdown-item').should('have.length', 10);
             cy.get('app-search-results button.dropdown-item.active').click().then(() => {
-              cy.url().should('include', '/address/bc1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9e');
+              cy.url().should('include', '/address/bc1pqyqs26fs4gnyw4aqttyjqa5ta7075zzfjftyz98qa8vdr49dh7fqm2zkv3');
               cy.waitForSkeletonGone();
               cy.get('.text-center').should('not.have.text', 'Invalid Bitcoin address');
             });
@@ -158,13 +158,13 @@ describe('Mainnet', () => {
         });
       });
 
-      ['BC1Q000375VXCU', 'bC1q000375vXcU'].forEach((searchTerm) => {
+      ['BC1Q0003', 'bC1q0003'].forEach((searchTerm) => {
         it(`allows searching for partial case insensitive bech32 addresses: ${searchTerm}`, () => {
           cy.visit('/');
           cy.get('.search-box-container > .form-control').type(searchTerm).then(() => {
-            cy.get('app-search-results button.dropdown-item').should('have.length', 1);
+            cy.get('app-search-results button.dropdown-item').should('have.length', 10);
             cy.get('app-search-results button.dropdown-item.active').click().then(() => {
-              cy.url().should('include', '/address/bc1q000375vxcuf5v04lmwy22vy2thvhqkxghgq7dy');
+              cy.url().should('include', '/address/bc1q000303cgr9zazthut63kdktwtatfe206um8nyh');
               cy.waitForSkeletonGone();
               cy.get('.text-center').should('not.have.text', 'Invalid Bitcoin address');
             });

--- a/frontend/src/app/shared/regex.utils.ts
+++ b/frontend/src/app/shared/regex.utils.ts
@@ -41,11 +41,11 @@ const ADDRESS_CHARS: {
     bech32: `(?:`
         + `bc1` // Starts with bc1
         + BECH32_CHARS_LW
-        + `{20,100}` // As per bech32, 6 char checksum is minimum
+        + `{6,100}` // As per bech32, 6 char checksum is minimum
       + `|`
         + `BC1` // All upper case version
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
   testnet: {
@@ -55,11 +55,11 @@ const ADDRESS_CHARS: {
     bech32: `(?:`
         + `tb1` // Starts with tb1
         + BECH32_CHARS_LW
-        + `{20,100}` // As per bech32, 6 char checksum is minimum
+        + `{6,100}` // As per bech32, 6 char checksum is minimum
       + `|`
         + `TB1` // All upper case version
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
   testnet4: {
@@ -69,11 +69,11 @@ const ADDRESS_CHARS: {
     bech32: `(?:`
         + `tb1` // Starts with tb1
         + BECH32_CHARS_LW
-        + `{20,100}` // As per bech32, 6 char checksum is minimum
+        + `{6,100}` // As per bech32, 6 char checksum is minimum
       + `|`
         + `TB1` // All upper case version
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
   signet: {
@@ -83,11 +83,11 @@ const ADDRESS_CHARS: {
     bech32: `(?:`
         + `tb1` // Starts with tb1
         + BECH32_CHARS_LW
-        + `{20,100}`
+        + `{6,100}`
       + `|`
         + `TB1` // All upper case version
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
   liquid: {
@@ -105,7 +105,7 @@ const ADDRESS_CHARS: {
           + `lq1`
         + `)`
         + BECH32_CHARS_LW // blech32 and bech32 are the same alphabet and protocol, different checksums.
-        + `{20,100}`
+        + `{6,100}`
       + `|`
         + `(?:` // Same as above but all upper case
           + `EX1`
@@ -113,7 +113,7 @@ const ADDRESS_CHARS: {
           + `LQ1`
         + `)`
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
   liquidtestnet: {
@@ -127,7 +127,7 @@ const ADDRESS_CHARS: {
           + `tlq1` // TODO: does this exist?
         + `)`
         + BECH32_CHARS_LW // blech32 and bech32 are the same alphabet and protocol, different checksums.
-        + `{20,100}`
+        + `{6,100}`
       + `|`
         + `(?:` // Same as above but all upper case
           + `TEX1`
@@ -135,7 +135,7 @@ const ADDRESS_CHARS: {
           + `TLQ1`
         + `)`
         + BECH32_CHARS_UP
-        + `{20,100}`
+        + `{6,100}`
       + `)`,
   },
 }


### PR DESCRIPTION
This PR fixes the regex detection for bech32 addresses ([minimum 6 characters of data](https://github.com/bitcoin/bips/blob/4f5a081d82323df5a7b0ff37e7e8d902837e2d13/bip-0173.mediawiki?plain=1#L89)) and adapts some of the frontend tests to accommodate this change.

<img width="449" alt="Screenshot 2024-07-02 at 13 11 44" src="https://github.com/mempool/mempool/assets/46578910/2305f839-d553-4d33-8603-6fd7cb83c7ec">
