### PR TITLE
Fix key navigation bug in accelerator dashboard

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input, ChangeDetectorRef, OnDestroy, Inject, LOCALE_ID } from '@angular/core';
-import { BehaviorSubject, Observable, Subscription, catchError, of, switchMap, tap, throttleTime } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription, catchError, filter, of, switchMap, tap, throttleTime } from 'rxjs';
 import { Acceleration, BlockExtended } from '../../../interfaces/node-api.interface';
 import { StateService } from '../../../services/state.service';
 import { WebsocketService } from '../../../services/websocket.service';
@@ -58,11 +58,12 @@ export class AccelerationsListComponent implements OnInit, OnDestroy {
         })
       ).subscribe();
 
+      const prevKey = this.dir === 'ltr' ? 'ArrowLeft' : 'ArrowRight';
+      const nextKey = this.dir === 'ltr' ? 'ArrowRight' : 'ArrowLeft';
 
       this.keyNavigationSubscription = this.stateService.keyNavigation$.pipe(
+        filter((event) => event.key === prevKey || event.key === nextKey),
         tap((event) => {
-          const prevKey = this.dir === 'ltr' ? 'ArrowLeft' : 'ArrowRight';
-          const nextKey = this.dir === 'ltr' ? 'ArrowRight' : 'ArrowLeft';
           if (event.key === prevKey && this.page > 1) {
             this.page--;
             this.isLoading = true;


### PR DESCRIPTION
This PR fixes an issue where typing a random key on the accelerator dashboard would inadvertently navigate to the accelerations list page: 

https://github.com/mempool/mempool/assets/46578910/4ed1e6dc-4261-46d1-a04c-119ef428354c

