### PR TITLE
New ETA label

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -284,7 +284,7 @@
                     <span class="checkout-text"><ng-container i18n="accelerator.confirmation-expected">Confirmation expected</ng-container>&nbsp;<app-time kind="within" [time]="eta.time" [fastRender]="false" [fixedRender]="true"></app-time></span>
                   } @else {
                     <span class="checkout-text">
-                      <span i18n="accelerator.confirmation-expected-within-hours">Confirmation expected within several hours</span>
+                      <span i18n="accelerator.confirmation-not-expected-soon">Confirmation not expected any time soon</span>
                     </span>
                   }
                 </label>

--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -71,7 +71,7 @@
               <ng-container *ngIf="(ETA$ | async) as eta; else etaSkeleton">
                 <span class="justify-content-end d-flex align-items-center">
                   @if (eta.blocks >= 7) {
-                    <span i18n="transaction.eta.in-several-hours|Transaction ETA in several hours or more">In several hours (or more)</span>
+                    <span i18n="transaction.eta.not-any-time-soon|Transaction ETA mot any time soon">Not any time soon</span>
                   } @else {
                     <app-time kind="until" [time]="eta.time" [fastRender]="false" [fixedRender]="true"></app-time>
                   }

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -552,7 +552,7 @@
           <ng-container *ngIf="(ETA$ | async) as eta; else etaSkeleton">
             @if (eta.blocks >= 7) {
               <span [class]="(!tx?.acceleration && acceleratorAvailable && accelerateCtaType === 'button' && !showAccelerationSummary && eligibleForAcceleration) ? 'etaDeepMempool d-flex justify-content-end align-items-center' : ''">
-                <span i18n="transaction.eta.in-several-hours|Transaction ETA in several hours or more">In several hours (or more)</span>
+                <span i18n="transaction.eta.not-any-time-soon|Transaction ETA mot any time soon">Not any time soon</span>
                 @if (!tx?.acceleration && acceleratorAvailable && accelerateCtaType === 'button' && !showAccelerationSummary && eligibleForAcceleration) {
                   <a class="btn btn-sm accelerateDeepMempool btn-small-height" i18n="transaction.accelerate|Accelerate button label" (click)="onAccelerateClicked()">Accelerate</a>
                 }


### PR DESCRIPTION
Displayed when transaction is at the 8th block or more.

<img width="574" alt="Screenshot 2024-07-03 at 15 56 31" src="https://github.com/mempool/mempool/assets/8561090/3dac92ec-6ac0-414c-b322-200634ebc456">

<img width="622" alt="Screenshot 2024-07-03 at 15 56 41" src="https://github.com/mempool/mempool/assets/8561090/62da705e-1ba2-407c-9a49-88988f13e411">
