### PR TITLE
Fix stale cpfp bug

### DIFF
--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -353,6 +353,9 @@ class MempoolBlocks {
     for (const txid of Object.keys(candidates?.txs ?? mempool)) {
       if (txid in mempool) {
         mempool[txid].cpfpDirty = false;
+        mempool[txid].ancestors = [];
+        mempool[txid].descendants = [];
+        mempool[txid].bestDescendant = null;
       }
     }
     for (const [txid, rate] of rates) {


### PR DESCRIPTION
Fixes an issue where stale CPFP ancestor & descendant info might not be correctly reset/updated for some transactions.

e.g. https://mempool.space/tx/eab2f16c89a47fbfd4f6cfb1a5e2fe83ae703034e84e9cec2818c341cab45566 shows two lower-fee-rate CPFP ancestors, which have actually already been confirmed.
<img width="974" alt="Screenshot 2024-07-04 at 8 54 56 AM" src="https://github.com/mempool/mempool/assets/83316221/919d5f99-eb1f-4bcf-8832-8ae946d3fdc7">
<img width="974" alt="Screenshot 2024-07-04 at 8 55 10 AM" src="https://github.com/mempool/mempool/assets/83316221/984ce476-5573-42d6-88f4-e6258a95920d">

