### PR TITLE
Add more context to error messages

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -364,7 +364,7 @@
   </ng-template>
   <ng-template [ngIf]="error">
     <app-http-error [error]="error">
-      <span i18n="error.general-loading-data">Error loading data.</span>
+      <span i18n="block.error.loading-block-data">Error loading block data.</span>
     </app-http-error>
   </ng-template>
 

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,6 +1,6 @@
 <app-indexing-progress></app-indexing-progress>
 
-<div class="container-xl">
+<div class="container-xl" *ngIf="!error; else errorTemplate">
 
   <!-- Pool overview -->
   <div *ngIf="poolStats$ | async as poolStats; else loadingMain">
@@ -459,4 +459,11 @@
 
 <ng-template #emptyTd>
   <td class="text-center"></td>
+</ng-template>
+
+<ng-template #errorTemplate>
+  <br>
+  <app-http-error [error]="error">
+    <span i18n="pool.error.loading-pool-data">Error loading pool data.</span>
+  </app-http-error>
 </ng-template>

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -9,6 +9,7 @@ import { StateService } from '../../services/state.service';
 import { selectPowerOfTen } from '../../bitcoin.utils';
 import { formatNumber } from '@angular/common';
 import { SeoService } from '../../services/seo.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 interface AccelerationTotal {
   cost: number,
@@ -33,6 +34,7 @@ export class PoolComponent implements OnInit {
   blocks$: Observable<BlockExtended[]>;
   oobFees$: Observable<AccelerationTotal[]>;
   isLoading = true;
+  error: HttpErrorResponse | null = null;
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
@@ -104,6 +106,10 @@ export class PoolComponent implements OnInit {
             return [];
           }
           return this.apiService.getPoolBlocks$(this.slug, this.blocks[this.blocks.length - 1]?.height);
+        }),
+        catchError((err) => {
+          this.error = err;
+          return of([]);
         }),
         tap((newBlocks) => {
           this.blocks = this.blocks.concat(newBlocks);

--- a/frontend/src/app/shared/pipes/http-error-pipe/http-error.pipe.ts
+++ b/frontend/src/app/shared/pipes/http-error-pipe/http-error.pipe.ts
@@ -4,6 +4,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({ name: 'httpErrorMsg' })
 export class HttpErrorPipe implements PipeTransform {
   transform(e: HttpErrorResponse | null): string {
-    return e ? `${e.status}: ${e.statusText}` : '';
+    return e ? `${e.status} ${e.statusText}: ${e.error}` : '';
   }
 }


### PR DESCRIPTION
Before: 
<img width="573" alt="Screenshot 2024-07-04 at 19 48 38" src="https://github.com/mempool/mempool/assets/46578910/0786b24c-9395-4dd2-be47-6963a4e38d80">

After: 
<img width="573" alt="Screenshot 2024-07-04 at 19 44 57" src="https://github.com/mempool/mempool/assets/46578910/141e33d8-bfca-4cec-99dd-57a29c1953a9">
<img width="580" alt="Screenshot 2024-07-04 at 19 45 09" src="https://github.com/mempool/mempool/assets/46578910/511748f2-b6ba-4081-b05b-4e839ac595e4">


Also added an error message to the pool page which would load indefinitely if an error occurred:

<img width="361" alt="Screenshot 2024-07-04 at 19 45 25" src="https://github.com/mempool/mempool/assets/46578910/75d5a473-1f25-4634-b35e-e0cefa38467b">
