### PR TITLE
Add first seen data to confirmed transactions

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -51,6 +51,7 @@ interface AuditStatus {
   accelerated?: boolean;
   conflict?: boolean;
   coinbase?: boolean;
+  firstSeen?: number;
 }
 
 @Component({
@@ -368,6 +369,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
             const isAccelerated = audit.acceleratedTxs.includes(txid);
             const isConflict = audit.fullrbfTxs.includes(txid);
             const isExpected = audit.template.some(tx => tx.txid === txid);
+            const firstSeen = audit.template.find(tx => tx.txid === txid)?.time;
             return {
               seen: isExpected || isPrioritized || isAccelerated,
               expected: isExpected,
@@ -375,6 +377,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
               prioritized: isPrioritized,
               conflict: isConflict,
               accelerated: isAccelerated,
+              firstSeen,
             };
           }),
           retry({ count: 3, delay: 2000 }),
@@ -388,6 +391,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       })
     ).subscribe(auditStatus => {
       this.auditStatus = auditStatus;
+      if (this.auditStatus?.firstSeen) {
+        this.transactionTime = this.auditStatus.firstSeen;
+      }
       this.setIsAccelerated();
     });
 


### PR DESCRIPTION
This PR adds first seen data to mined transactions, retrieved from the fetched block audit: 

<img width="1019" alt="Screenshot 2024-07-05 at 11 47 00" src="https://github.com/mempool/mempool/assets/46578910/bf17c1ac-4859-4e5d-8227-9180551bb4a7">
