### PR TITLE
[accelerator] error message after timeout

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -503,9 +503,12 @@
 
     <div class="row text-center mt-1">
       <div class="col-sm">
-        <div class="d-flex flex-row justify-content-center align-items-center">
+        <div class="d-flex flex-row flex-column justify-content-center align-items-center">
           <span i18n="accelerator.confirming-acceleration-with-miners">Confirming your acceleration with our mining pool partners...</span>
-          <div class="ml-2 spinner-border text-light" style="width: 25px; height: 25px"></div>
+          @if (timeSincePaid > 20000) {
+            <span i18n="accelerator.confirming-acceleration-with-miners">...sorry, this is taking longer than expected...</span>
+          }
+          <div class="m-2 spinner-border text-light" style="width: 25px; height: 25px"></div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -77,6 +77,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   private _step: CheckoutStep = 'summary';
   simpleMode: boolean = true;
   paymentMethod: 'cashapp' | 'btcpay';
+  timeoutTimer: any;
 
   authSubscription$: Subscription;
   auth: IAuth | null = null;
@@ -187,6 +188,9 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
 
   moveToStep(step: CheckoutStep) {
     this._step = step;
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer);
+    }
     if (!this.estimate && ['quote', 'summary', 'checkout'].includes(this.step)) {
       this.fetchEstimate();
     }
@@ -199,6 +203,13 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
       this.loadingCashapp = true;
       this.insertSquare();
       this.setupSquare();
+    } else if (this._step === 'paid') {
+      this.timePaid = Date.now();
+      this.timeoutTimer = setTimeout(() => {
+        if (this.step === 'paid') {
+          this.accelerateError = 'internal_server_error';
+        }
+      }, 120000)
     }
     this.hasDetails.emit(this._step === 'quote');
   }
@@ -593,6 +604,10 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
 
   get hasAccessToBalanceMode() {
     return this.isLoggedIn() && this.estimate?.hasAccess;
+  }
+
+  get timeSincePaid(): number {
+    return Date.now() - this.timePaid;
   }
 
   @HostListener('window:resize', ['$event'])


### PR DESCRIPTION
Shows an additional message if the user has been waiting for a transaction to be accelerated for >20 seconds.

<img width="1139" alt="Screenshot 2024-07-06 at 8 31 48 AM" src="https://github.com/mempool/mempool/assets/83316221/d9b1ac7f-08d2-4e4f-996d-2b102f766c0a">


Switches to the error screen after two minutes:

<img width="1139" alt="Screenshot 2024-07-06 at 8 15 00 AM" src="https://github.com/mempool/mempool/assets/83316221/3c14fad4-fa3a-410b-87da-e6be40187a28">
