### PR TITLE
Acceleration timeline polishing

### DIFF
--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -1,3 +1,4 @@
+@if (tx.status.confirmed) {
 <div class="acceleration-timeline box">
   <div class="timeline-wrapper">
     <div class="timeline">
@@ -11,68 +12,225 @@
         <div class="node-spacer"></div>
         <div class="interval">
           <div class="interval-time">
-            @if (eta) {
-            ~<app-time [time]="eta?.wait / 1000"></app-time>
-            } @else if (tx.status.block_time) {
             <app-time [time]="tx.status.block_time - acceleratedAt"></app-time>
-            }
           </div>
         </div>
         <div class="node-spacer"></div>
       </div>
-
-    </div>
-    <div class="nodes">
-      <div class="node" [id]="'first-seen'">
-        <div class="seen-to-acc right" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.sent-selected]="!tx.status.confirmed && !isAcceleration">
-          <div class="shape"></div>
-        </a>
-        <div class="status"><span class="badge badge-primary" i18n="accelerator.sent-state">Sent</span></div>
-        <div class="time">
-          <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
+      <div class="nodes">
+        <div class="node" [id]="'first-seen'">
+          <div class="seen-to-acc right"></div>
+          <a class="shape-border">
+            <div class="shape"></div>
+          </a>
+          <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
+          <div class="time">
+            <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
+          </div>
         </div>
-      </div>
-      <div class="interval-spacer">
-        <div class="seen-to-acc" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
-      </div>
-      <div class="node" [id]="'accelerated'">
-        <div class="seen-to-acc left" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
-        <div class="acc-to-confirmed right" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.accelerated-selected]="isAcceleration && !tx.status.confirmed" [class.waiting]="!isAcceleration && !tx.status.confirmed">
-          <div class="shape"></div>
-        </a>
-        <div class="status"><span class="badge" [class]="tx.status.confirmed || isAcceleration ? 'badge-accelerated' : 'badge-waiting'" i18n="transaction.audit.accelerated">Accelerated</span></div>
-        <div class="time">
-          <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
+        <div class="interval-spacer">
+          <div class="seen-to-acc"></div>
         </div>
-      </div>
-      <div class="interval-spacer">
-        <div class="acc-to-confirmed" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
-      </div>
-      <div class="node" [id]="'confirmed'" [class.mined]="tx.status.confirmed">
-        <div class="acc-to-confirmed left" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.mined-selected]="tx.status.confirmed" [class.waiting]="!tx.status.confirmed">
-          <div class="shape"></div>
-        </a>
-        <div class="status"><span class="badge" [class]="tx.status.confirmed ? 'badge-success' : 'badge-waiting'" i18n="transaction.rbf.mined">Mined</span></div>
-        <div class="time">
-          @if (tx.status.block_time) {
+        <div class="node" [id]="'accelerated'">
+          <div class="seen-to-acc left"></div>
+          <div class="acc-to-confirmed right"></div>
+          <a class="shape-border">
+            <div class="shape"></div>
+          </a>
+          <div class="status"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></div>
+          <div class="time">
+            <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
+          </div>
+        </div>
+        <div class="interval-spacer">
+          <div class="acc-to-confirmed"></div>
+        </div>
+        <div class="node mined" [id]="'confirmed'" >
+          <div class="acc-to-confirmed left" ></div>
+          <a class="shape-border mined-selected">
+            <div class="shape"></div>
+          </a>
+          <div class="status"><span class="badge badge-success" i18n="transaction.rbf.mined">Mined</span></div>
+          <div class="time">
             <app-time kind="since" [time]="tx.status.block_time"></app-time>
-          } @else if (eta) {
-            <app-time kind="until" [time]="eta?.time"></app-time>
-          }
+          </div>
+        </div>
+      </div>  
+    </div>
+  </div>
+</div>
+} @else if (acceleratedETA) { <!-- Not yet accelerated; to be shown only in acceleration checkout -->
+<div class="acceleration-timeline">
+  <div class="timeline-wrapper">
+    <div class="timeline">
+      <div class="intervals">
+        <div class="node-spacer"></div>
+        <div class="interval">
+          <div class="interval-time">
+            <app-time [time]="now - transactionTime"></app-time>
+          </div>
+        </div>
+        <div class="node-spacer"></div>
+        <div class="interval">
+          <div class="interval-time">
+            ~<app-time [time]="acceleratedETA / 1000 - now"></app-time>
+          </div>
+        </div>
+        <div class="node-spacer"></div>
+      </div>
+      <div class="nodes">
+        <div class="node" [id]="'first-seen'">
+          <div class="seen-to-acc right"></div>
+          <a class="shape-border">
+            <div class="shape"></div>
+          </a>
+          <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
+          <div class="time">
+            <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
+          </div>
+        </div>
+        <div class="interval-spacer">
+          <div class="seen-to-acc"></div>
+        </div>
+        <div class="node" [id]="'accelerated'">
+          <div class="seen-to-acc left"></div>
+          <div class="acc-to-confirmed right"></div>
+          <a class="shape-border waiting">
+            <div class="shape accelerating"></div>
+          </a>
+          <div class="status"><span class="badge badge-waiting" i18n="transaction.audit.accelerated">Accelerated</span></div>
+          <div class="time">
+            <span i18n="date.now">Now</span>
+          </div>
+        </div>
+        <div class="interval-spacer">
+          <div class="acc-to-confirmed"></div>
+        </div>
+        <div class="node" [id]="'confirmed'">
+          <div class="acc-to-confirmed left"></div>
+          <div class="corner-up"></div>
+          <a class="shape-border waiting">
+            <div class="shape"></div>
+          </a>
+          <div class="status"><span class="badge badge-waiting" i18n="transaction.rbf.mined">Mined</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="timeline">
+      <div class="intervals">
+        <div class="node-spacer"></div>
+        <div class="interval-spacer"></div>
+        <div class="node-spacer"></div>
+        <div class="interval">
+          <div class="interval-time">
+            ~<app-time [time]="eta.time / 1000 - now"></app-time> <span *ngIf="accelerateRatio > 1" style="font-style: italic; color: var(--transparent-fg);"> ({{ accelerateRatio }}x slower)</span>
+          </div>
+        </div>
+        <div class="node-spacer"></div>
+      </div>
+      <div class="nodes">
+        <div class="node-spacer"></div>
+        <div class="interval-spacer"></div>
+        <div class="node-spacer">
+          <div class="connector"><div class="corner-down"></div></div>
+          <div class="seen-to-acc right"></div>
+        </div>
+        <div class="interval-spacer">
+          <div class="seen-to-acc"></div>
+        </div>
+        <div class="node" [id]="'confirmed'">
+          <div class="seen-to-acc left"></div>
         </div>
       </div>
     </div>
   </div>
-
-  <ng-template #nodeSpacer>
-    <div class="node-spacer"></div>
-  </ng-template>
-
-  <ng-template #intervalSpacer>
-    <div class="interval-spacer"></div>
-  </ng-template>
-
 </div>
+} @else if (standardETA) { <!-- Accelerated, to be mined -->
+  <div class="acceleration-timeline box">
+    <div class="timeline-wrapper">
+      <div class="timeline">
+        <div class="intervals">
+          <div class="node-spacer"></div>
+          <div class="interval">
+            <div class="interval-time">
+              <app-time [time]="acceleratedAt - transactionTime"></app-time>
+            </div>
+          </div>
+          <div class="node-spacer"></div>
+          <div class="interval">
+            <div class="interval-time">
+              @if (eta) {
+                ~<app-time [time]="eta?.wait / 1000"></app-time>
+                }
+            </div>
+          </div>
+          <div class="node-spacer"></div>
+        </div>
+        <div class="nodes">
+          <div class="node" [id]="'first-seen'">
+            <div class="seen-to-acc right"></div>
+            <a class="shape-border">
+              <div class="shape"></div>
+            </a>
+            <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
+            <div class="time">
+              <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
+            </div>
+          </div>
+          <div class="interval-spacer">
+            <div class="seen-to-acc"></div>
+          </div>
+          <div class="node" [id]="'accelerated'">
+            <div class="seen-to-acc left"></div>
+            <div class="acc-to-confirmed right loading"></div>
+            <a class="shape-border accelerated-selected">
+              <div class="shape accelerating"></div>
+            </a>
+            <div class="status"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></div>
+            <div class="time sm-margin">
+              <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
+            </div>
+          </div>
+          <div class="interval-spacer">
+            <div class="acc-to-confirmed loading"></div>
+          </div>
+          <div class="node" [id]="'confirmed'">
+            <div class="acc-to-confirmed left loading"></div>
+            <div class="corner-up"></div>
+            <a class="shape-border waiting">
+              <div class="shape"></div>
+            </a>
+            <div class="status"><span class="badge badge-waiting" i18n="transaction.rbf.mined">Mined</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="timeline">
+        <div class="intervals">
+          <div class="node-spacer"></div>
+          <div class="interval-spacer"></div>
+          <div class="node-spacer"></div>
+          <div class="interval">
+            <div class="interval-time">
+              ~<app-time [time]="standardETA / 1000 - now"></app-time> <span *ngIf="accelerateRatio > 1" style="font-style: italic; color: var(--transparent-fg);"> ({{ accelerateRatio }}x slower)</span>
+            </div>
+          </div>
+          <div class="node-spacer"></div>
+        </div>
+        <div class="nodes">
+          <div class="node-spacer"></div>
+          <div class="interval-spacer"></div>
+          <div class="node-spacer">
+            <div class="connector"><div class="corner-down"></div></div>
+            <div class="seen-to-acc right"></div>
+          </div>
+          <div class="interval-spacer">
+            <div class="seen-to-acc"></div>
+          </div>
+          <div class="node" [id]="'confirmed'">
+            <div class="seen-to-acc left"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -39,10 +39,10 @@
       <div class="node" [id]="'accelerated'">
         <div class="seen-to-acc left" [class.loading]="!tx.acceleration && !tx.status.confirmed"></div>
         <div class="acc-to-confirmed right" [class.loading]="tx.acceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.accelerated-selected]="tx.acceleration && !tx.status.confirmed">
+        <a class="shape-border" [class.accelerated-selected]="tx.acceleration && !tx.status.confirmed" [class.waiting]="!tx.acceleration && !tx.status.confirmed ? 'waiting' : ''">
           <div class="shape"></div>
         </a>
-        <div class="status" [style]="!tx.acceleration && !tx.status.confirmed ? 'opacity: 0.5' : ''"><span class="badge badge-accelerated">Accelerated</span></div>
+        <div class="status"><span class="badge" [class]="tx.status.confirmed || tx.acceleration ? 'badge-accelerated' : 'badge-waiting'">Accelerated</span></div>
         <div class="time">
           <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
         </div>
@@ -52,10 +52,10 @@
       </div>
       <div class="node" [id]="'confirmed'" [class.mined]="tx.status.confirmed">
         <div class="acc-to-confirmed left" [class.loading]="tx.acceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.mined-selected]="tx.status.confirmed">
+        <a class="shape-border" [class.mined-selected]="tx.status.confirmed" [class.waiting]="!tx.status.confirmed ? 'waiting' : ''">
           <div class="shape"></div>
         </a>
-        <div class="status" [style]="!tx.status.confirmed ? 'opacity: 0.5' : ''"><span class="badge badge-success">Mined</span></div>
+        <div class="status"><span class="badge" [class]="tx.status.confirmed ? 'badge-success' : 'badge-waiting'">Mined</span></div>
         <div class="time">
           @if (tx.status.block_time) {
             <app-time kind="since" [time]="tx.status.block_time"></app-time>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -20,9 +20,9 @@
       <div class="nodes">
         <div class="node" [id]="'first-seen'">
           <div class="seen-to-acc right"></div>
-          <a class="shape-border">
+          <div class="shape-border">
             <div class="shape"></div>
-          </a>
+          </div>
           <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
           <div class="time">
             <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
@@ -34,9 +34,9 @@
         <div class="node" [id]="'accelerated'">
           <div class="seen-to-acc left"></div>
           <div class="acc-to-confirmed right"></div>
-          <a class="shape-border">
+          <div class="shape-border">
             <div class="shape"></div>
-          </a>
+          </div>
           <div class="status"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></div>
           <div class="time">
             <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
@@ -47,10 +47,9 @@
         </div>
         <div class="node mined" [id]="'confirmed'" >
           <div class="acc-to-confirmed left" ></div>
-          <a class="shape-border mined-selected">
+          <div class="shape-border mined-selected">
             <div class="shape"></div>
-          </a>
-          <div class="status"><span class="badge badge-success" i18n="transaction.rbf.mined">Mined</span></div>
+          </div>
           <div class="time">
             <app-time kind="since" [time]="tx.status.block_time"></app-time>
           </div>
@@ -60,94 +59,41 @@
   </div>
 </div>
 } @else if (acceleratedETA) { <!-- Not yet accelerated; to be shown only in acceleration checkout -->
-<div class="acceleration-timeline">
-  <div class="timeline-wrapper">
-    <div class="timeline">
-      <div class="intervals">
-        <div class="node-spacer"></div>
-        <div class="interval">
-          <div class="interval-time">
-            <app-time [time]="now - transactionTime"></app-time>
-          </div>
-        </div>
-        <div class="node-spacer"></div>
-        <div class="interval">
-          <div class="interval-time">
-            ~<app-time [time]="acceleratedETA / 1000 - now"></app-time>
-          </div>
-        </div>
-        <div class="node-spacer"></div>
-      </div>
-      <div class="nodes">
-        <div class="node" [id]="'first-seen'">
-          <div class="seen-to-acc right"></div>
-          <a class="shape-border">
-            <div class="shape"></div>
-          </a>
-          <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
-          <div class="time">
-            <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
-          </div>
-        </div>
-        <div class="interval-spacer">
-          <div class="seen-to-acc"></div>
-        </div>
-        <div class="node" [id]="'accelerated'">
-          <div class="seen-to-acc left"></div>
-          <div class="acc-to-confirmed right"></div>
-          <a class="shape-border waiting">
-            <div class="shape accelerating"></div>
-          </a>
-          <div class="status"><span class="badge badge-waiting" i18n="transaction.audit.accelerated">Accelerated</span></div>
-          <div class="time">
-            <span i18n="date.now">Now</span>
-          </div>
-        </div>
-        <div class="interval-spacer">
-          <div class="acc-to-confirmed"></div>
-        </div>
-        <div class="node" [id]="'confirmed'">
-          <div class="acc-to-confirmed left"></div>
-          <div class="corner-up"></div>
-          <a class="shape-border waiting">
-            <div class="shape"></div>
-          </a>
-          <div class="status"><span class="badge badge-waiting" i18n="transaction.rbf.mined">Mined</span></div>
-        </div>
-      </div>
-    </div>
-    <div class="timeline">
-      <div class="intervals">
-        <div class="node-spacer"></div>
-        <div class="interval-spacer"></div>
-        <div class="node-spacer"></div>
-        <div class="interval">
-          <div class="interval-time">
-            ~<app-time [time]="eta.time / 1000 - now"></app-time> <span *ngIf="accelerateRatio > 1" style="font-style: italic; color: var(--transparent-fg);"> ({{ accelerateRatio }}x slower)</span>
-          </div>
-        </div>
-        <div class="node-spacer"></div>
-      </div>
-      <div class="nodes">
-        <div class="node-spacer"></div>
-        <div class="interval-spacer"></div>
-        <div class="node-spacer">
-          <div class="connector"><div class="corner-down"></div></div>
-          <div class="seen-to-acc right"></div>
-        </div>
-        <div class="interval-spacer">
-          <div class="seen-to-acc"></div>
-        </div>
-        <div class="node" [id]="'confirmed'">
-          <div class="seen-to-acc left"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-} @else if (standardETA) { <!-- Accelerated, to be mined -->
+} @else if (standardETA) { <!-- Accelerated -->
   <div class="acceleration-timeline box">
     <div class="timeline-wrapper">
+      <div class="timeline">
+        <div class="intervals">
+          <div class="node-spacer"></div>
+          <div class="interval-spacer"></div>
+          <div class="node-spacer"></div>
+          <div class="interval">
+            <div class="interval-time">
+              @if (eta) {
+                ~<app-time [time]="eta?.wait / 1000"></app-time> <span *ngIf="accelerateRatio > 1" class="compare"> ({{ accelerateRatio }}x faster)</span>
+                }
+            </div>
+          </div>
+          <div class="node-spacer"></div>
+        </div>
+        <div class="nodes">
+          <div class="node-spacer"></div>
+          <div class="interval-spacer"></div>
+          <div class="node">
+            <div class="acc-to-confirmed loading right"></div>
+          </div>
+          <div class="interval-spacer">
+            <div class="acc-to-confirmed loading"></div>
+          </div>
+          <div class="node" [id]="'confirmed'">
+            <div class="acc-to-confirmed loading left"></div>
+            <div class="shape-border waiting">
+              <div class="shape animate"></div>
+            </div>
+            <div class="status"><span class="badge badge-waiting" i18n="transaction.rbf.mined">Mined</span></div>
+          </div>
+        </div>
+      </div>
       <div class="timeline">
         <div class="intervals">
           <div class="node-spacer"></div>
@@ -159,9 +105,7 @@
           <div class="node-spacer"></div>
           <div class="interval">
             <div class="interval-time">
-              @if (eta) {
-                ~<app-time [time]="eta?.wait / 1000"></app-time>
-                }
+                ~<app-time [time]="standardETA / 1000 - now"></app-time>
             </div>
           </div>
           <div class="node-spacer"></div>
@@ -169,9 +113,9 @@
         <div class="nodes">
           <div class="node" [id]="'first-seen'">
             <div class="seen-to-acc right"></div>
-            <a class="shape-border">
+            <div class="shape-border">
               <div class="shape"></div>
-            </a>
+            </div>
             <div class="status"><span class="badge badge-primary" i18n="transaction.first-seen|Transaction first seen">First seen</span></div>
             <div class="time">
               <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
@@ -182,52 +126,23 @@
           </div>
           <div class="node" [id]="'accelerated'">
             <div class="seen-to-acc left"></div>
-            <div class="acc-to-confirmed right loading"></div>
-            <a class="shape-border accelerated-selected">
-              <div class="shape accelerating"></div>
-            </a>
-            <div class="status"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></div>
-            <div class="time sm-margin">
-              <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
-            </div>
-          </div>
-          <div class="interval-spacer">
-            <div class="acc-to-confirmed loading"></div>
-          </div>
-          <div class="node" [id]="'confirmed'">
-            <div class="acc-to-confirmed left loading"></div>
-            <div class="corner-up"></div>
-            <a class="shape-border waiting">
-              <div class="shape"></div>
-            </a>
-            <div class="status"><span class="badge badge-waiting" i18n="transaction.rbf.mined">Mined</span></div>
-          </div>
-        </div>
-      </div>
-      <div class="timeline">
-        <div class="intervals">
-          <div class="node-spacer"></div>
-          <div class="interval-spacer"></div>
-          <div class="node-spacer"></div>
-          <div class="interval">
-            <div class="interval-time">
-              ~<app-time [time]="standardETA / 1000 - now"></app-time> <span *ngIf="accelerateRatio > 1" style="font-style: italic; color: var(--transparent-fg);"> ({{ accelerateRatio }}x slower)</span>
-            </div>
-          </div>
-          <div class="node-spacer"></div>
-        </div>
-        <div class="nodes">
-          <div class="node-spacer"></div>
-          <div class="interval-spacer"></div>
-          <div class="node-spacer">
-            <div class="connector"><div class="corner-down"></div></div>
             <div class="seen-to-acc right"></div>
+            <div  class="shape-border accelerated-selected">
+              <div class="shape accelerating"></div>
+              <div class="connector down loading"></div>
+            </div>
+            <div class="time" style="margin-top: 3px;">
+              <span i18n="transaction.audit.accelerated">Accelerated</span>&nbsp;<app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
+            </div>
           </div>
           <div class="interval-spacer">
             <div class="seen-to-acc"></div>
           </div>
           <div class="node" [id]="'confirmed'">
             <div class="seen-to-acc left"></div>
+            <div class="shape-border waiting">
+              <div class="shape"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -28,7 +28,7 @@
         <a class="shape-border" [class.sent-selected]="!tx.status.confirmed && !tx.acceleration">
           <div class="shape"></div>
         </a>
-        <div class="status"><span class="badge badge-primary">Sent</span></div>
+        <div class="status"><span class="badge badge-primary" i18n="accelerator.sent-state">Sent</span></div>
         <div class="time">
           <app-time *ngIf="transactionTime > 0" kind="since" [time]="transactionTime"></app-time>
         </div>
@@ -42,7 +42,7 @@
         <a class="shape-border" [class.accelerated-selected]="tx.acceleration && !tx.status.confirmed" [class.waiting]="!tx.acceleration && !tx.status.confirmed ? 'waiting' : ''">
           <div class="shape"></div>
         </a>
-        <div class="status"><span class="badge" [class]="tx.status.confirmed || tx.acceleration ? 'badge-accelerated' : 'badge-waiting'">Accelerated</span></div>
+        <div class="status"><span class="badge" [class]="tx.status.confirmed || tx.acceleration ? 'badge-accelerated' : 'badge-waiting'" i18n="transaction.audit.accelerated">Accelerated</span></div>
         <div class="time">
           <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
         </div>
@@ -55,7 +55,7 @@
         <a class="shape-border" [class.mined-selected]="tx.status.confirmed" [class.waiting]="!tx.status.confirmed ? 'waiting' : ''">
           <div class="shape"></div>
         </a>
-        <div class="status"><span class="badge" [class]="tx.status.confirmed ? 'badge-success' : 'badge-waiting'">Mined</span></div>
+        <div class="status"><span class="badge" [class]="tx.status.confirmed ? 'badge-success' : 'badge-waiting'" i18n="transaction.rbf.mined">Mined</span></div>
         <div class="time">
           @if (tx.status.block_time) {
             <app-time kind="since" [time]="tx.status.block_time"></app-time>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -50,6 +50,7 @@
           <div class="shape-border mined-selected">
             <div class="shape"></div>
           </div>
+          <div class="status"><span class="badge badge-success" i18n="transaction.rbf.mined">Mined</span></div>
           <div class="time">
             <app-time kind="since" [time]="tx.status.block_time"></app-time>
           </div>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -12,9 +12,9 @@
         <div class="interval">
           <div class="interval-time">
             @if (eta) {
-            ~<app-time kind="plain" [time]="eta?.wait / 1000"></app-time>
+            ~<app-time [time]="eta?.wait / 1000"></app-time>
             } @else if (tx.status.block_time) {
-            <app-time kind="plain" [time]="tx.status.block_time - acceleratedAt"></app-time>
+            <app-time [time]="tx.status.block_time - acceleratedAt"></app-time>
             }
           </div>
         </div>
@@ -24,8 +24,8 @@
     </div>
     <div class="nodes">
       <div class="node" [id]="'first-seen'">
-        <div class="seen-to-acc right" [class.loading]="!tx.acceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.sent-selected]="!tx.status.confirmed && !tx.acceleration">
+        <div class="seen-to-acc right" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
+        <a class="shape-border" [class.sent-selected]="!tx.status.confirmed && !isAcceleration">
           <div class="shape"></div>
         </a>
         <div class="status"><span class="badge badge-primary" i18n="accelerator.sent-state">Sent</span></div>
@@ -34,25 +34,25 @@
         </div>
       </div>
       <div class="interval-spacer">
-        <div class="seen-to-acc" [class.loading]="!tx.acceleration && !tx.status.confirmed"></div>
+        <div class="seen-to-acc" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
       </div>
       <div class="node" [id]="'accelerated'">
-        <div class="seen-to-acc left" [class.loading]="!tx.acceleration && !tx.status.confirmed"></div>
-        <div class="acc-to-confirmed right" [class.loading]="tx.acceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.accelerated-selected]="tx.acceleration && !tx.status.confirmed" [class.waiting]="!tx.acceleration && !tx.status.confirmed ? 'waiting' : ''">
+        <div class="seen-to-acc left" [class.loading]="!isAcceleration && !tx.status.confirmed"></div>
+        <div class="acc-to-confirmed right" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
+        <a class="shape-border" [class.accelerated-selected]="isAcceleration && !tx.status.confirmed" [class.waiting]="!isAcceleration && !tx.status.confirmed">
           <div class="shape"></div>
         </a>
-        <div class="status"><span class="badge" [class]="tx.status.confirmed || tx.acceleration ? 'badge-accelerated' : 'badge-waiting'" i18n="transaction.audit.accelerated">Accelerated</span></div>
+        <div class="status"><span class="badge" [class]="tx.status.confirmed || isAcceleration ? 'badge-accelerated' : 'badge-waiting'" i18n="transaction.audit.accelerated">Accelerated</span></div>
         <div class="time">
           <app-time *ngIf="acceleratedAt" kind="since" [time]="acceleratedAt"></app-time>
         </div>
       </div>
       <div class="interval-spacer">
-        <div class="acc-to-confirmed" [class.loading]="tx.acceleration && !tx.status.confirmed"></div>
+        <div class="acc-to-confirmed" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
       </div>
       <div class="node" [id]="'confirmed'" [class.mined]="tx.status.confirmed">
-        <div class="acc-to-confirmed left" [class.loading]="tx.acceleration && !tx.status.confirmed"></div>
-        <a class="shape-border" [class.mined-selected]="tx.status.confirmed" [class.waiting]="!tx.status.confirmed ? 'waiting' : ''">
+        <div class="acc-to-confirmed left" [class.loading]="isAcceleration && !tx.status.confirmed"></div>
+        <a class="shape-border" [class.mined-selected]="tx.status.confirmed" [class.waiting]="!tx.status.confirmed">
           <div class="shape"></div>
         </a>
         <div class="status"><span class="badge" [class]="tx.status.confirmed ? 'badge-success' : 'badge-waiting'" i18n="transaction.rbf.mined">Mined</span></div>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
@@ -1,7 +1,7 @@
 .acceleration-timeline {
   position: relative;
   width: 100%;
-  padding: 1em 0;
+  padding: 0.5em 0 1em;
 
   &::after, &::before {
     content: '';
@@ -69,6 +69,15 @@
       font-size: 12px;
       line-height: 16px;
       white-space: nowrap;
+
+      .compare {
+        font-style: italic;
+        color: var(--mainnet-alt);
+        font-weight: 600;
+        @media (max-width: 600px) {
+          display: none;
+        }
+      }
     }
   }
 
@@ -115,26 +124,27 @@
       }
     }
 
-    .corner-up {
+    .connector {
       position: absolute;
+      height: 88px;
+      width: 10px;
       left: -5px;
-      left: 48.5%;
-      height: 86px;
-      border-left: solid 10px var(--primary);
-      border-bottom: solid 10px var(--primary);
-      border-bottom-right-radius: 10px;
-      // horrible css:
-      @media (max-width: 1030px) {
-        left: 48%; 
+      top: -73px;
+      transform: translateX(120%);
+      background: var(--tertiary);
+
+      &.down {
+        border-top-left-radius: 10px; 
       }
-      @media (max-width: 850px) {
-        left: 47%;
+
+      &.up {
+        border-top-right-radius: 10px; 
       }
-      @media (max-width: 700px) {
-        left: 46%;
+
+      &.loading {
+        animation: acceleratePulse 1s infinite;
       }
     }
-    
   }
 
   .nodes {
@@ -150,8 +160,6 @@
         transform: translateY(-50%);
         border-radius: 50%;
         padding: 2px;
-        background: transparent;
-        transition: background-color 300ms, padding 300ms;
 
         .shape {
           width: 100%;
@@ -161,7 +169,6 @@
           &.accelerating {
             animation: acceleratePulse 1s infinite;
           }
-          transition: background-color 300ms, border 300ms;
         }
 
         &.waiting {
@@ -203,30 +210,6 @@
         font-size: 12px;
         line-height: 16px;
         white-space: nowrap;
-
-        &.sm-margin {
-          @media (max-width: 650px) {
-            margin-left: 20px;
-          }
-        }
-      }
-    }
-
-    .connector {
-      position: relative;
-      height: 10px;
-    
-      .corner-down {
-        position: absolute;
-        @media (max-width: 650px) {
-          width: 223px;
-        }
-        width: 290px;
-        height: 90px;
-        bottom: 50%;
-        border-left: solid 10px var(--primary);
-        border-bottom: solid 10px var(--primary);
-        border-bottom-left-radius: 10px;
       }
     }
   }
@@ -236,10 +219,4 @@
   0% { background-color: var(--tertiary) }
   50% { background-color: var(--mainnet-alt) }
   100% { background-color: var(--tertiary) }
-}
-
-@keyframes textPulse {
-  0% { color: var(--tertiary) }
-  50% { color: var(--mainnet-alt) }
-  100% { color: var(--tertiary) }
 }

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
@@ -145,6 +145,12 @@
           transition: background-color 300ms, border 300ms;
         }
 
+        &.waiting {
+          .shape {
+            background: var(--grey);
+          }
+        }
+
         &.sent-selected {
           .shape {
             background: var(--primary);
@@ -166,6 +172,12 @@
 
       .status {
         margin-top: -64px;
+
+        .badge.badge-waiting {
+          opacity: 0.5;
+          background-color: var(--grey);
+          color: white;
+        }
         
         .badge.badge-accelerated {
           background-color: var(--tertiary);

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.scss
@@ -84,10 +84,6 @@
       background: var(--primary);
       border-radius: 5px;
 
-      &.loading {
-        animation: standardPulse 1s infinite;
-      }
-
       &.left {
         right: 50%;
       }
@@ -118,6 +114,26 @@
         left: 50%;
       }
     }
+
+    .corner-up {
+      position: absolute;
+      left: -5px;
+      left: 48.5%;
+      height: 86px;
+      border-left: solid 10px var(--primary);
+      border-bottom: solid 10px var(--primary);
+      border-bottom-right-radius: 10px;
+      // horrible css:
+      @media (max-width: 1030px) {
+        left: 48%; 
+      }
+      @media (max-width: 850px) {
+        left: 47%;
+      }
+      @media (max-width: 700px) {
+        left: 46%;
+      }
+    }
     
   }
 
@@ -142,18 +158,15 @@
           height: 100%;
           border-radius: 50%;
           background: white;
+          &.accelerating {
+            animation: acceleratePulse 1s infinite;
+          }
           transition: background-color 300ms, border 300ms;
         }
 
         &.waiting {
           .shape {
             background: var(--grey);
-          }
-        }
-
-        &.sent-selected {
-          .shape {
-            background: var(--primary);
           }
         }
 
@@ -190,6 +203,30 @@
         font-size: 12px;
         line-height: 16px;
         white-space: nowrap;
+
+        &.sm-margin {
+          @media (max-width: 650px) {
+            margin-left: 20px;
+          }
+        }
+      }
+    }
+
+    .connector {
+      position: relative;
+      height: 10px;
+    
+      .corner-down {
+        position: absolute;
+        @media (max-width: 650px) {
+          width: 223px;
+        }
+        width: 290px;
+        height: 90px;
+        bottom: 50%;
+        border-left: solid 10px var(--primary);
+        border-bottom: solid 10px var(--primary);
+        border-bottom-left-radius: 10px;
       }
     }
   }
@@ -201,9 +238,8 @@
   100% { background-color: var(--tertiary) }
 }
 
-@keyframes standardPulse {
-  0% { background-color: var(--primary) }
-  50% { background-color: var(--secondary) }
-  100% { background-color: var(--primary) }
-  
+@keyframes textPulse {
+  0% { color: var(--tertiary) }
+  50% { color: var(--mainnet-alt) }
+  100% { color: var(--tertiary) }
 }

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
@@ -11,9 +11,14 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
   @Input() transactionTime: number;
   @Input() tx: Transaction;
   @Input() eta: ETA;
-  @Input() isAcceleration: boolean;
+  // A mined transaction has standard ETA and accelerated ETA undefined
+  // A transaction in mempool has either standardETA defined (if accelerated) or acceleratedETA defined (if not accelerated yet)
+  @Input() standardETA: number;
+  @Input() acceleratedETA: number;
 
   acceleratedAt: number;
+  now: number;
+  accelerateRatio: number;
 
   constructor() {}
 
@@ -22,6 +27,15 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes): void {
+    this.now = Math.floor(new Date().getTime() / 1000);
+    if (changes?.eta?.currentValue || changes?.standardETA?.currentValue || changes?.acceleratedETA?.currentValue) {
+      if (changes?.eta?.currentValue) {
+        if (changes?.acceleratedETA?.currentValue) {
+          this.accelerateRatio = Math.floor((Math.floor(changes.eta.currentValue.time / 1000) - this.now) / (Math.floor(changes.acceleratedETA.currentValue / 1000) - this.now));
+        } else if (changes?.standardETA?.currentValue) {
+          this.accelerateRatio = Math.floor((Math.floor(changes.standardETA.currentValue / 1000) - this.now) / (Math.floor(changes.eta.currentValue.time / 1000) - this.now));
+        }
+      }
+    }
   }
-
 }

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
@@ -11,6 +11,7 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
   @Input() transactionTime: number;
   @Input() tx: Transaction;
   @Input() eta: ETA;
+  @Input() isAcceleration: boolean;
 
   acceleratedAt: number;
 

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, Inject, LOCALE_ID } from '@angular/core';
+import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import { ETA } from '../../services/eta.service';
 import { Transaction } from '../../interfaces/electrs.interface';
 
@@ -13,15 +13,8 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
   @Input() eta: ETA;
 
   acceleratedAt: number;
-  dir: 'rtl' | 'ltr' = 'ltr';
 
-  constructor(
-    @Inject(LOCALE_ID) private locale: string,
-  ) {
-    if (this.locale.startsWith('ar') || this.locale.startsWith('fa') || this.locale.startsWith('he')) {
-      this.dir = 'rtl';
-    }
-  }
+  constructor() {}
 
   ngOnInit(): void {
     this.acceleratedAt = this.tx.acceleratedAt ?? new Date().getTime() / 1000;

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -152,12 +152,12 @@
 
     <br>
 
-    <ng-container *ngIf="transactionTime && (tx.acceleration || isAcceleration)">
+    <ng-container *ngIf="transactionTime && isAcceleration">
       <div class="title float-left">
         <h2 id="acceleration-timeline" i18n="transaction.acceleration-timeline|Acceleration Timeline">Acceleration Timeline</h2>
       </div>
       <div class="clearfix"></div>
-      <app-acceleration-timeline [transactionTime]="transactionTime" [tx]="tx" [eta]="(ETA$ | async)"></app-acceleration-timeline>
+      <app-acceleration-timeline [transactionTime]="transactionTime" [tx]="tx" [eta]="(ETA$ | async)" [isAcceleration]="isAcceleration"></app-acceleration-timeline>
       <br>
     </ng-container>
 

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -152,21 +152,21 @@
 
     <br>
 
-    <ng-container *ngIf="transactionTime && isAcceleration">
-      <div class="title float-left">
-        <h2 id="acceleration-timeline" i18n="transaction.acceleration-timeline|Acceleration Timeline">Acceleration Timeline</h2>
-      </div>
-      <div class="clearfix"></div>
-      <app-acceleration-timeline [transactionTime]="transactionTime" [tx]="tx" [eta]="(ETA$ | async)" [isAcceleration]="isAcceleration"></app-acceleration-timeline>
-      <br>
-    </ng-container>
-
     <ng-container *ngIf="rbfInfo">
       <div class="title float-left">
         <h2 id="rbf" i18n="transaction.rbf-history|RBF Timeline">RBF Timeline</h2>
       </div>
       <div class="clearfix"></div>
       <app-rbf-timeline [txid]="txId" [replacements]="rbfInfo"></app-rbf-timeline>
+      <br>
+    </ng-container>
+
+    <ng-container *ngIf="transactionTime && isAcceleration">
+      <div class="title float-left">
+        <h2 id="acceleration-timeline" i18n="transaction.acceleration-timeline|Acceleration Timeline">Acceleration Timeline</h2>
+      </div>
+      <div class="clearfix"></div>
+      <app-acceleration-timeline [transactionTime]="transactionTime" [tx]="tx" [eta]="(ETA$ | async)" [standardETA]="(standardETA$ | async)?.time"></app-acceleration-timeline>
       <br>
     </ng-container>
 

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -112,6 +112,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   txChanged$ = new BehaviorSubject<boolean>(false); // triggered whenever this.tx changes (long term, we should refactor to make this.tx an observable itself)
   isAccelerated$ = new BehaviorSubject<boolean>(false); // refactor this to make isAccelerated an observable itself
   ETA$: Observable<ETA | null>;
+  standardETA$: Observable<ETA | null>;
   isCached: boolean = false;
   now = Date.now();
   da$: Observable<DifficultyAdjustment>;
@@ -809,6 +810,21 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         this.miningStats = stats;
         this.isAccelerated$.next(this.isAcceleration); // hack to trigger recalculation of ETA without adding another source observable
       });
+      if (!this.tx.status?.confirmed) {
+        this.standardETA$ = combineLatest([
+          this.stateService.mempoolBlocks$.pipe(startWith(null)),
+          this.stateService.difficultyAdjustment$.pipe(startWith(null)),
+        ]).pipe(
+          map(([mempoolBlocks, da]) => {
+            return this.etaService.calculateUnacceleratedETA(
+              this.tx,
+              mempoolBlocks,
+              da,
+              this.cpfpInfo,
+            );
+          })
+        )
+      }
     }
     this.isAccelerated$.next(this.isAcceleration);
   }


### PR DESCRIPTION
This PR brings some polishing to the acceleration timeline:
- it now includes the _unaccelerated ETA_, computed from transaction in-band fee and eventual CPFP data
- greys out badges of steps that have not occured yet (mined, accelerated)
- adds missing i18n

Timeline of an accelerated transaction in the mempool: 

<img width="1020" alt="Screenshot 2024-07-07 at 16 50 57" src="https://github.com/mempool/mempool/assets/46578910/cba0a9c6-946f-40b8-bc69-bf6e8544d53e">

-----------------------------------
[Not included in this PR]
It is possible to show the timeline on not yet accelerated transactions, like this for example: 

<img width="1018" alt="Screenshot 2024-07-07 at 16 55 33" src="https://github.com/mempool/mempool/assets/46578910/16336a6a-d4d9-4159-92cd-315f0099116d">

But I'm not sure if/where we want to put the timeline here. So **for now it's only displayed on already accelerated transactions**.