### PR TITLE
Quick fix for statistics replication

### DIFF
--- a/production/mempool-config.mainnet.json
+++ b/production/mempool-config.mainnet.json
@@ -131,7 +131,6 @@
       "node208.fra.mempool.space",
       "node209.fra.mempool.space",
       "node210.fra.mempool.space",
-      "node211.fra.mempool.space",
       "node212.fra.mempool.space",
       "node213.fra.mempool.space",
       "node214.fra.mempool.space",


### PR DESCRIPTION
The statistics replication service currently has two bugs that need fixing:

1. The service may add statistics that are already present in the table.
2. The service does not sanitize the data before adding it to the table, which can lead to problems if some of the trusted servers send wrong data.

This PR should mitigate the first bug by filtering more aggressively on what data we actually need to fill. 

Since the second bug is not fixed, this PR also disables the service on prod until I come up with a decent way to sanitizing the data.