### PR TITLE
Fix accelerator error message positioning

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -564,7 +564,7 @@
         <span i18n="transaction.accelerate|Accelerate button label">Accelerate</span>
       </button>
       @if (quoteError || cantPayReason) {
-        <span class="btn-error"><app-mempool-error [error]="quoteError || cantPayReason" [textOnly]="true" alertClass=""></app-mempool-error></span>
+        <div class="btn-error-wrapper"><span class="btn-error"><app-mempool-error [error]="quoteError || cantPayReason" [textOnly]="true" alertClass=""></app-mempool-error></span></div>
       }
     </div>
   }

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
@@ -195,5 +195,11 @@
   right: 0;
   font-size: 12px;
   color: var(--red);
-  white-space: nowrap;
+  text-align: center;
+  width: 200px;
+  white-space: normal;
+}
+
+.btn-error-wrapper {
+  height: 26px;
 }

--- a/frontend/src/app/shared/components/mempool-error/mempool-error.component.html
+++ b/frontend/src/app/shared/components/mempool-error/mempool-error.component.html
@@ -6,4 +6,4 @@
   </span>
 }
 
-<ng-template #lowBalance i18n="accelerator.low-balance">Your balance is too low. Please <a style="color:#105fb0" href="/services/accelerator/overview">top up your account</a>.</ng-template>
+<ng-template #lowBalance i18n="accelerator.low-balance">Your balance is too low.<br/>Please <a style="color:#105fb0" href="/services/accelerator/overview">top up your account</a>.</ng-template>


### PR DESCRIPTION
Made sure the error text can handle 2 rows of overflowing text with centered fixed width, and not overflow the UI. 

| Before | After |
|-|-|
| <img width="304" alt="Screenshot 2024-07-08 at 16 34 22" src="https://github.com/mempool/mempool/assets/8561090/c1095b83-47c0-4619-a15c-232011105ba4"> | <img width="297" alt="Screenshot 2024-07-08 at 16 38 24" src="https://github.com/mempool/mempool/assets/8561090/0b40b9bf-e688-4443-b367-b05185569d5d"> |
| <img width="349" alt="Screenshot 2024-07-08 at 16 34 26" src="https://github.com/mempool/mempool/assets/8561090/fe652558-3744-43f5-a122-00f60f11ec05"> | <img width="249" alt="Screenshot 2024-07-08 at 16 42 03" src="https://github.com/mempool/mempool/assets/8561090/1d6e185f-8f1d-400c-b6d6-37cc71880b1c"> |
