### PR TITLE
[accelerator] improve rendering of acceleration fee rate graph

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.html
@@ -1,4 +1,4 @@
-<div class="fee-graph" *ngIf="tx && estimate">
+<div class="fee-graph" *ngIf="tx && estimate" #feeGraph>
   <div class="column">
     <ng-container *ngFor="let bar of bars">
       <div class="bar {{ bar.class }}" [class.active]="bar.active" [style]="bar.style" (click)="onClick($event, bar);">


### PR DESCRIPTION
Enforces a minimum height for the bars on the acceleration fee rate graph, so that the text is always legible.

| Before | After |
|-|-|
| <img width="224" alt="Screenshot 2024-07-08 at 2 45 03 PM" src="https://github.com/mempool/mempool/assets/83316221/3109463d-884f-4033-885d-1ad070797f94"> | <img width="224" alt="Screenshot 2024-07-08 at 2 45 14 PM" src="https://github.com/mempool/mempool/assets/83316221/639aec34-1c88-46c8-84e9-a93894c57172"> |
| <img width="224" alt="Screenshot 2024-07-08 at 2 48 33 PM" src="https://github.com/mempool/mempool/assets/83316221/cefc7edb-8d7c-4eb4-a878-08517d0883d5"> | <img width="224" alt="Screenshot 2024-07-08 at 2 48 43 PM" src="https://github.com/mempool/mempool/assets/83316221/605ed4c6-037a-4a98-9f14-7c8d944c7260"> |
