### PR TITLE
Smaller block arrow

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -59,7 +59,7 @@
               <app-time kind="since" [time]="block.timestamp" [fastRender]="true" [precision]="1" minUnit="minute"></app-time></div>
           </ng-container>
         </div>
-        <div class="animated" [class]="markHeight === block.height ? 'hide' : 'show'" *ngIf="block.extras?.pool != undefined && showPools">
+        <div class="animated" *ngIf="block.extras?.pool != undefined && showPools">
           <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
             <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'"> 
             {{ block.extras.pool.name}}
@@ -86,7 +86,7 @@
     </ng-template>
   </div>
   <div [hidden]="!arrowVisible" id="arrow-up" [style.transition]="arrowTransition"
-    [ngStyle]="{'left': arrowLeftPx + 'px' }"></div>
+    [ngStyle]="{'left': arrowLeftPx + 8 + 'px' }"></div>
 </div>
 
 <ng-template #loadingBlocksTemplate>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -125,12 +125,12 @@
 #arrow-up {
   position: relative;
   left: calc(var(--block-size) * 0.6);
-  top: calc(var(--block-size) * 1.12);
+  top: calc(var(--block-size) * 1.28);
   width: 0;
   height: 0;
-  border-left: calc(var(--block-size) * 0.3) solid transparent;
-  border-right: calc(var(--block-size) * 0.3) solid transparent;
-  border-bottom: calc(var(--block-size) * 0.3) solid var(--fg);
+  border-left: calc(var(--block-size) * 0.2) solid transparent;
+  border-right: calc(var(--block-size) * 0.2) solid transparent;
+  border-bottom: calc(var(--block-size) * 0.2) solid var(--fg);
 }
 
 .flashing {
@@ -170,14 +170,7 @@
 
 .animated {
   transition: all 0.15s ease-in-out;
-}
-.show {
-  opacity: 1;
   white-space: nowrap;
-}
-.hide {
-  opacity: 0.4;
-  pointer-events : none;
 }
 
 .time-ltr {

--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -14,8 +14,7 @@
 }
 
 .blockchain-wrapper {
-  height: 250px;
-
+  height: 260px;
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+/Edge */

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -114,7 +114,7 @@
 #arrow-up {
   position: relative;
   right: calc(var(--block-size) * 0.6);
-  top: calc(var(--block-size) * 1.12);
+  top: calc(var(--block-size) * 1.20);
   width: 0;
   height: 0;
   border-left: calc(var(--block-size) * 0.3) solid transparent;


### PR DESCRIPTION
* The dashboard is moved 10px down from the blockchain blocks
* The arrow is smaller on the blocks to not cover the miner tags, but still bigger on the mempool blocks

<img width="1185" alt="Screenshot 2024-07-10 at 01 42 45" src="https://github.com/mempool/mempool/assets/8561090/2719a713-b464-4712-ae65-a13b06ab52a3">
