### PR TITLE
always show out-of-band block fees to 8 decimal places

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -411,7 +411,7 @@
         <td class="text-wrap">
           <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
           <span *ngIf="oobFees" class="oobFees" i18n-ngbTooltip="Acceleration Fees" ngbTooltip="Acceleration fees paid out-of-band">
-             <app-amount [satoshis]="oobFees" digitsInfo="1.2-8" [noFiat]="true" [addPlus]="true"></app-amount>
+             <app-amount [satoshis]="oobFees" digitsInfo="1.8-8" [noFiat]="true" [addPlus]="true"></app-amount>
           </span>
           <span *ngIf="blockAudit.feeDelta" class="difference" [class.positive]="blockAudit.feeDelta <= 0" [class.negative]="blockAudit.feeDelta > 0">
             {{ blockAudit.feeDelta < 0 ? '+' : '' }}{{ (-blockAudit.feeDelta * 100) | amountShortener: 2 }}%


### PR DESCRIPTION
Before:
<img width="440" alt="Screenshot 2024-07-10 at 3 54 37 AM" src="https://github.com/mempool/mempool/assets/83316221/098979c7-9fca-4ec6-89cb-00f75bada152">


After:

<img width="440" alt="Screenshot 2024-07-10 at 3 53 54 AM" src="https://github.com/mempool/mempool/assets/83316221/d696357f-f6ff-492a-891b-578d87b59ed9">
