### PR TITLE
align block arrows & reposition selected block pool tag

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -60,11 +60,12 @@
           </ng-container>
         </div>
         <div class="animated" *ngIf="block.extras?.pool != undefined && showPools">
-          <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
+          <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge" [class.animate]="animatePoolTag" [class.selectedBlock]="markHeight === block.height" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
             <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'"> 
             {{ block.extras.pool.name}}
           </a>
         </div>
+        <div [class.arrow-visible]="markHeight === block.height" id="arrow-up"></div>
       </div>
     </ng-container>
     <ng-template #placeholderBlock>
@@ -85,8 +86,6 @@
       </ng-container>
     </ng-template>
   </div>
-  <div [hidden]="!arrowVisible" id="arrow-up" [style.transition]="arrowTransition"
-    [ngStyle]="{'left': arrowLeftPx + 8 + 'px' }"></div>
 </div>
 
 <ng-template #loadingBlocksTemplate>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -123,14 +123,20 @@
 }
 
 #arrow-up {
-  position: relative;
-  left: calc(var(--block-size) * 0.6);
-  top: calc(var(--block-size) * 1.28);
+  position: absolute;
+  left: calc(var(--block-size) * 0.3);
+  top: calc(var(--block-size) * 1);
   width: 0;
   height: 0;
   border-left: calc(var(--block-size) * 0.2) solid transparent;
   border-right: calc(var(--block-size) * 0.2) solid transparent;
   border-bottom: calc(var(--block-size) * 0.2) solid var(--fg);
+  opacity: 0;
+  transition: opacity 500ms;
+
+  &.arrow-visible {
+    opacity: 1;
+  }
 }
 
 .flashing {
@@ -158,6 +164,14 @@
   top: 15px;
   z-index: 101;
   color: #FFF;
+
+  &.animate {
+    transition: transform 500ms;
+  }
+
+  &.selectedBlock {
+    transform: translateY(20px);
+  }
 }
 
 .pool-logo {

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -5,6 +5,7 @@ import { specialBlocks } from '../../app.constants';
 import { BlockExtended } from '../../interfaces/node-api.interface';
 import { Location } from '@angular/common';
 import { CacheService } from '../../services/cache.service';
+import { nextTick } from 'process';
 
 interface BlockchainBlock extends BlockExtended {
   placeholder?: boolean;
@@ -58,6 +59,7 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
   arrowLeftPx = 30;
   blocksFilled = false;
   arrowTransition = '1s';
+  animatePoolTag = false;
   timeLtrSubscription: Subscription;
   timeLtr: boolean;
 
@@ -186,6 +188,9 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
       .subscribe((state) => {
         this.markHeight = undefined;
         if (state.blockHeight !== undefined) {
+          nextTick(() => {
+            this.animatePoolTag = true;
+          });
           this.markHeight = state.blockHeight;
         }
         this.moveArrowToPosition(false);

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.html
@@ -51,7 +51,7 @@
         </div>
       </ng-template>
     </div>
-    <div *ngIf="arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + (blockWidth * 0.3) + containerOffset + 'px', transition: transition }" [class.blink]="txPosition?.accelerated"></div>
+    <div *ngIf="arrowVisible" id="arrow-up" [ngStyle]="{'right': rightPosition + (blockWidth * 0.2) + containerOffset + 'px', transition: transition }" [class.blink]="txPosition?.accelerated"></div>
   </div>
 </ng-container>
 

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.scss
@@ -114,12 +114,12 @@
 #arrow-up {
   position: relative;
   right: calc(var(--block-size) * 0.6);
-  top: calc(var(--block-size) * 1.20);
+  top: calc(var(--block-size) * 1);
   width: 0;
   height: 0;
-  border-left: calc(var(--block-size) * 0.3) solid transparent;
-  border-right: calc(var(--block-size) * 0.3) solid transparent;
-  border-bottom: calc(var(--block-size) * 0.3) solid var(--fg);
+  border-left: calc(var(--block-size) * 0.2) solid transparent;
+  border-right: calc(var(--block-size) * 0.2) solid transparent;
+  border-bottom: calc(var(--block-size) * 0.2) solid var(--fg);
 }
 
 .blockLink {


### PR DESCRIPTION
possible alternative to #5302.

the smaller block arrow is used for both mempool & mined blocks, and positioned immediately under the blocks. To make room for the arrow, the pool tag shifts down for the active block.

the PR also adds a slight fade in/out effect to the mined block arrow to reduce flicker on page transitions.


https://github.com/mempool/mempool/assets/83316221/360af3eb-cc0d-4abe-a253-678c51dda3e0

