### PR TITLE
Update tx acceleration state on confirmation

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -639,7 +639,7 @@
         }
         <td>
           <div class="effective-fee-container">
-            @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize)) {
+            @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize || tx.acceleration)) {
               <app-fee-rate [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
             } @else {
               <app-fee-rate [fee]="tx.effectiveFeePerVsize"></app-fee-rate>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -132,6 +132,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   tooltipPosition: { x: number, y: number };
   isMobile: boolean;
   firstLoad = true;
+  waitingForAccelerationInfo: boolean = false;
 
   featuresEnabled: boolean;
   segwitEnabled: boolean;
@@ -338,6 +339,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
           acceleration.boost = boostCost;
           this.tx.acceleratedAt = acceleration.added;
           this.accelerationInfo = acceleration;
+          this.waitingForAccelerationInfo = false;
           this.setIsAccelerated();
         }
       }
@@ -616,6 +618,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.stateService.txConfirmed$.subscribe(([txConfirmed, block]) => {
       if (txConfirmed && this.tx && !this.tx.status.confirmed && txConfirmed === this.tx.txid) {
+        if (this.tx.acceleration) {
+          this.waitingForAccelerationInfo = true;
+        }
         this.tx.status = {
           confirmed: true,
           block_height: block.height,
@@ -812,7 +817,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   setIsAccelerated(initialState: boolean = false) {
-    this.isAcceleration = (this.tx.acceleration || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id))));
+    this.isAcceleration = ((this.tx.acceleration && (!this.tx.status.confirmed || this.waitingForAccelerationInfo)) || (this.accelerationInfo && this.pool && this.accelerationInfo.pools.some(pool => (pool === this.pool.id))));
     if (this.isAcceleration) {
       if (initialState) {
         this.accelerationFlowCompleted = true;


### PR DESCRIPTION
[not tested on actual prod accelerations, only locally]

This PR fixes an issue where a pending accelerated tx would not properly update its state when getting included in a block: 

- The `Accelerated fee rate` field is not updated to the fair acceleration rate 
- If for some reason the tx is mined by a non-participating pool, the `Accelerated` tag stills appears until reload