### PR TITLE
Add fee to Cpfp API

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -160,6 +160,7 @@ class BitcoinRoutes {
           descendants: tx.descendants || null,
           effectiveFeePerVsize: tx.effectiveFeePerVsize || null,
           sigops: tx.sigops,
+          fee: tx.fee,
           adjustedVsize: tx.adjustedVsize,
           acceleration: tx.acceleration,
           acceleratedBy: tx.acceleratedBy || undefined,

--- a/backend/src/api/cpfp.ts
+++ b/backend/src/api/cpfp.ts
@@ -32,6 +32,7 @@ export function calculateCpfp(tx: MempoolTransactionExtended, mempool: { [txid: 
       descendants: tx.descendants || [],
       effectiveFeePerVsize: tx.effectiveFeePerVsize || tx.adjustedFeePerVsize || tx.feePerVsize,
       sigops: tx.sigops,
+      fee: tx.fee,
       adjustedVsize: tx.adjustedVsize,
       acceleration: tx.acceleration
     };
@@ -70,6 +71,7 @@ export function calculateCpfp(tx: MempoolTransactionExtended, mempool: { [txid: 
     descendants: tx.descendants || [],
     effectiveFeePerVsize: tx.effectiveFeePerVsize || tx.adjustedFeePerVsize || tx.feePerVsize,
     sigops: tx.sigops,
+    fee: tx.fee,
     adjustedVsize: tx.adjustedVsize,
     acceleration: tx.acceleration
   };

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -223,6 +223,7 @@ export interface CpfpInfo {
   sigops?: number;
   adjustedVsize?: number,
   acceleration?: boolean,
+  fee?: number;
 }
 
 export interface TransactionStripped {


### PR DESCRIPTION
Example new output:

```
{
    "ancestors": [
        {
            "txid": "247bff526463e547a3c6ac2134c190caf3c4fbdda4e2c62b2472158937c66070",
            "fee": 918,
            "weight": 609
        },
        {
            "txid": "7c488559534a7ceb3f145ab1f0adfaef8a660d517fa8362328b0e0d2d104c53b",
            "fee": 1614,
            "weight": 1074
        }
    ],
    "bestDescendant": null,
    "descendants": [],
    "effectiveFeePerVsize": 6.019116977696859,
    "sigops": 0,
    "fee": 774,
    "adjustedVsize": 128.5
}
```