### PR TITLE
Fix recursion loop in search bar

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -303,7 +303,6 @@ export class SearchFormComponent implements OnInit {
           (error) => { console.log(error); this.isSearching = false; }
         );
       } else {
-        this.searchResults.searchButtonClick();
         this.isSearching = false;
       }
     }


### PR DESCRIPTION
Fixes #5247

The recursion was caused by the following: 

Clicking on any item in the search results that does not match any regex, for example the future SegWit version address `bc1pfeessrawgf` (prior commit 7d7f9b16654215a97a69226c3ebbf0d86bab1ec6) would start a loop that never ends. 

https://github.com/mempool/mempool/blob/0a116804e86bcf8de20f69e52bb0ede262fdf7d5/frontend/src/app/components/search-form/search-results/search-results.component.ts#L70-L71

triggers
https://github.com/mempool/mempool/blob/0a116804e86bcf8de20f69e52bb0ede262fdf7d5/frontend/src/app/components/search-form/search-form.component.ts#L240-L242

triggers (because no regex match)
https://github.com/mempool/mempool/blob/0a116804e86bcf8de20f69e52bb0ede262fdf7d5/frontend/src/app/components/search-form/search-form.component.ts#L305-L307

triggers 
https://github.com/mempool/mempool/blob/0a116804e86bcf8de20f69e52bb0ede262fdf7d5/frontend/src/app/components/search-form/search-results/search-results.component.ts#L38-L40

...etc 
 **************************
This PR removes the line that triggers the search back when no regex matches.
