### PR TITLE
Fix miner loading forever

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -88,6 +88,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   blocksSubscription: Subscription;
   miningSubscription: Subscription;
   auditSubscription: Subscription;
+  txConfirmedSubscription: Subscription;
   currencyChangeSubscription: Subscription;
   fragmentParams: URLSearchParams;
   rbfTransaction: undefined | Transaction;
@@ -625,7 +626,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       );
 
-    this.stateService.txConfirmed$.subscribe(([txConfirmed, block]) => {
+    this.txConfirmedSubscription = this.stateService.txConfirmed$.subscribe(([txConfirmed, block]) => {
       if (txConfirmed && this.tx && !this.tx.status.confirmed && txConfirmed === this.tx.txid) {
         if (this.tx.acceleration) {
           this.waitingForAccelerationInfo = true;
@@ -1070,6 +1071,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.blocksSubscription.unsubscribe();
     this.miningSubscription?.unsubscribe();
     this.auditSubscription?.unsubscribe();
+    this.txConfirmedSubscription?.unsubscribe();
     this.currencyChangeSubscription?.unsubscribe();
     this.leaveTransaction();
   }


### PR DESCRIPTION
Fixes #5102

You can reproduce this intermittent issue by doing the following:
- Go on the next block page at https://mempool.space/mempool-block/0
- Click on a random transaction to start tracking it
- Go back to the next block page
- Go back to the same tracked transaction
- The miner tag (as well as the audit data) won't appear when the transaction gets mined

Closing the txConfirmed subscription when leaving the tx page fixes the issue. 