### PR TITLE
Get all pools in accelerations list

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
@@ -83,9 +83,9 @@ export class AccelerationsListComponent implements OnInit, OnDestroy {
         this.pageChange(this.page);
       });
 
-      this.miningService.getMiningStats('1m').subscribe(stats => {
-        for (const pool of stats.pools) {
-          this.pools[pool.poolUniqueId] = pool;
+      this.miningService.getPools().subscribe(pools => {
+        for (const pool of pools) {
+          this.pools[pool.unique_id] = pool;
         }
       });
     }

--- a/frontend/src/app/services/mining.service.ts
+++ b/frontend/src/app/services/mining.service.ts
@@ -31,6 +31,7 @@ export class MiningService {
       data: MiningStats;
     }
   } = {};
+  poolsData: SinglePoolStats[] = [];
 
   constructor(
     private stateService: StateService,
@@ -57,7 +58,19 @@ export class MiningService {
       );
     }
   }
-
+  
+  /** 
+   * Get names and slugs of all pools
+   */
+  public getPools(): Observable<any[]> {
+    return this.poolsData.length ? of(this.poolsData) : this.apiService.listPools$(undefined).pipe(
+      map(response => {
+        this.poolsData = response.body;
+        return this.poolsData;
+      })
+    );
+    
+  }
   /**
    * Set the hashrate power of ten we want to display
    */


### PR DESCRIPTION
Currently, we only fetch the pools that mined a block in the last month in the accelerations list. In the future, this might prevent the pools from appearing in the table. 
This PR fixes this issue by fetching all the pools instead of the last month data. 