### PR TITLE
Fix effective fee rate detection on tx page

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -622,8 +622,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
                 ancestors: tx.ancestors,
                 bestDescendant: tx.bestDescendant,
               });
-              const hasRelatives = !!(tx.ancestors?.length || tx.bestDescendant);
-              this.hasEffectiveFeeRate = hasRelatives || (tx.effectiveFeePerVsize && (Math.abs(tx.effectiveFeePerVsize - tx.feePerVsize) >= 0.1));
+              const hasRelatives = !!(tx.ancestors?.length || tx.bestDescendant || tx.descendants);
+              this.hasEffectiveFeeRate = hasRelatives || (tx.effectiveFeePerVsize && tx.effectiveFeePerVsize !== (this.tx.fee / (this.tx.weight / 4)) && tx.effectiveFeePerVsize !== (tx.fee / Math.ceil(tx.weight / 4)));
             } else {
               this.fetchCpfp$.next(this.tx.txid);
             }
@@ -831,8 +831,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       this.sigops = this.cpfpInfo.sigops;
       this.adjustedVsize = this.cpfpInfo.adjustedVsize;
     }
-    this.hasCpfp =!!(this.cpfpInfo && (this.cpfpInfo.bestDescendant || this.cpfpInfo.descendants?.length || this.cpfpInfo.ancestors?.length));
-    this.hasEffectiveFeeRate = hasRelatives || (this.tx.effectiveFeePerVsize && (Math.abs(this.tx.effectiveFeePerVsize - this.tx.feePerVsize) > 0.01));
+    this.hasCpfp =!!(this.cpfpInfo && relatives.length);
+    this.hasEffectiveFeeRate = hasRelatives || (this.tx.effectiveFeePerVsize && this.tx.effectiveFeePerVsize !== (this.tx.fee / (this.tx.weight / 4)) && this.tx.effectiveFeePerVsize !== (this.tx.fee / Math.ceil(this.tx.weight / 4)));
   }
 
   setIsAccelerated(initialState: boolean = false) {

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -17,6 +17,7 @@ export interface Transaction {
   feePerVsize?: number;
   effectiveFeePerVsize?: number;
   ancestors?: Ancestor[];
+  descendants?: Ancestor[];
   bestDescendant?: BestDescendant | null;
   cpfpChecked?: boolean;
   acceleration?: boolean;


### PR DESCRIPTION
Fixes the frontend logic used to detect when to display an effective fee rate row on the transaction page.

Previously we allowed the `effectiveFeePerVsize` to differ from the regular fee rate by up to 0.1 or 0.01 sats/vb before displaying the effective fee rate row, to allow for differences due to vsize rounding. However, for very small transactions this is insufficient.

This PR checks instead whether the `effectiveFeePerVsize` exactly matches the simple rate calculated with and without vsize rounding, which more accurately identifies the relevant transactions.

Before: (effective fee rate row incorrectly shown due to large vsize rounding error)
<img width="847" alt="Screenshot 2024-07-30 at 11 51 30 AM" src="https://github.com/user-attachments/assets/6fe1c89d-a992-45ff-b4dc-f1dd80f7ed18">

After:
<img width="847" alt="Screenshot 2024-07-30 at 11 51 21 AM" src="https://github.com/user-attachments/assets/fc0cce5b-7321-48c8-b99e-c425da80a460">

