### PR TITLE
Fix missing accelerated fee rate in timeline tooltip

### DIFF
--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline-tooltip.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline-tooltip.component.html
@@ -31,7 +31,7 @@
           <td style="color: #905cf4;" class="value">{{ accelerationInfo.bidBoost | number }} <span class="symbol" i18n="shared.sat|sat">sat</span></td>
         }
       </tr>
-      <tr *ngIf="accelerationInfo.fee && accelerationInfo.weight && (accelerationInfo.feeDelta || accelerationInfo.bidBoost)">
+      <tr *ngIf="accelerationInfo.fee && accelerationInfo.weight">
         @if (accelerationInfo.status === 'seen') {
           <td class="label" i18n="transaction.fee-rate">Fee rate</td>
           <td class="value"><app-fee-rate [fee]="accelerationInfo.fee" [weight]="accelerationInfo.weight"></app-fee-rate></td>


### PR DESCRIPTION
On accelerations with a bid boost of 0, the fee rate line was missing.

Before:
<img width="303" alt="Screenshot 2024-07-30 at 17 24 31" src="https://github.com/user-attachments/assets/95d74bcb-7a97-4a44-8664-46769ef28061">

After: 
<img width="295" alt="Screenshot 2024-07-30 at 17 25 06" src="https://github.com/user-attachments/assets/c1e6e6eb-2770-4313-870a-4ad16af5b0b3">
