### PR TITLE
Fix accelerated time centering

### DIFF
--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -96,7 +96,7 @@
             @if (useAbsoluteTime) {
             <span>{{ acceleratedAt * 1000 | date }}</span>
             } @else {
-            <app-time kind="since" [time]="acceleratedAt" [lowercaseStart]="true"></app-time>
+            <app-time kind="since" [time]="acceleratedAt" [lowercaseStart]="!tx.status.confirmed"></app-time>
             }
           </div>
         </div>

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -89,7 +89,7 @@
           @if (tx.status.confirmed) {
             <div class="status"><span class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span></div>
           }
-          <div class="time offset-left" [class.no-margin]="!tx.status.confirmed">
+          <div class="time" [class.no-margin]="!tx.status.confirmed" [class.offset-left]="!tx.status.confirmed">
             @if (!tx.status.confirmed) {
             <span i18n="transaction.audit.accelerated">Accelerated</span>{{ "" }} 
             }


### PR DESCRIPTION
The relative time of the acceleration request had an incorrect offset on mined transaction: 

<img width="104" alt="Screenshot 2024-07-30 at 17 31 50" src="https://github.com/user-attachments/assets/9f5f6bac-e6b9-49c1-9779-aa4398472e7e">


This PR also fixes a small capitalization issue (capitalize `Just now` if the transaction is mined)