### PR TITLE
Remove query param redirect on tx page

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -523,6 +523,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
               queryParamsHandling: 'merge',
               preserveFragment: true,
               queryParams: { mode: 'details' },
+              replaceUrl: true,
             });
           }
           this.seoService.setTitle(


### PR DESCRIPTION
I often experience the following issue on mobile: 
- While browsing on mempool.space, I click on a transaction
- To return to the previous page, I need to click the browser's back button twice


https://github.com/user-attachments/assets/d0e52638-649d-4bf0-84a8-310248adaf9c

Not redirecting to `mode=details` fixes the issue. I also checked that this does not break the pizza tracker redirection logic.