### PR TITLE
adjust pie colors to handle more pools

### DIFF
--- a/frontend/src/app/components/acceleration/active-acceleration-box/active-acceleration-box.component.ts
+++ b/frontend/src/app/components/acceleration/active-acceleration-box/active-acceleration-box.component.ts
@@ -67,12 +67,13 @@ export class ActiveAccelerationBox implements OnChanges {
 
     const acceleratingPools = (poolList || []).filter(id => pools[id]).sort((a,b) => pools[a].lastEstimatedHashrate - pools[b].lastEstimatedHashrate);
     const totalAcceleratedHashrate = acceleratingPools.reduce((total, pool) => total + pools[pool].lastEstimatedHashrate, 0);
+    const lightenStep = acceleratingPools.length ? (0.48 / acceleratingPools.length) : 0;
     acceleratingPools.forEach((poolId, index) => {
       const pool = pools[poolId];
       const poolShare = ((pool.lastEstimatedHashrate / this.miningStats.lastEstimatedHashrate) * 100).toFixed(1);
       data.push(getDataItem(
         pool.lastEstimatedHashrate,
-        toRGB(lighten({ r: 147, g: 57, b: 244 }, index * .08)),
+        toRGB(lighten({ r: 147, g: 57, b: 244 }, index * lightenStep)),
         `<b style="color: white">${pool.name} (${poolShare}%)</b>`,
         true,
       ) as PieSeriesOption);


### PR DESCRIPTION
pick accelerator hashrate pie chart colors from a fixed range instead of lightening by a constant increment (avoids washing out the colors when there are more pools)

| Before | After |
|-|-|
| ![Screenshot 2024-08-02 at 4 53 32 PM](https://github.com/user-attachments/assets/85b0c989-30f8-4de7-bca5-554b39a10312) | ![Screenshot 2024-08-02 at 4 53 48 PM](https://github.com/user-attachments/assets/bec9a53b-391f-4875-bc7a-649308b8e899) |

(extreme example, but you get the idea)
