### PR TITLE
Fix truncated link to not refresh full window

### DIFF
--- a/frontend/src/app/shared/components/truncate/truncate.component.html
+++ b/frontend/src/app/shared/components/truncate/truncate.component.html
@@ -1,6 +1,6 @@
 <span class="truncate" [style.max-width]="maxWidth ? maxWidth + 'px' : null" [style.justify-content]="textAlign" [class.inline]="inline">
     <ng-container *ngIf="link">
-      <a [routerLink]="link" class="truncate-link" [target]="external ? '_blank' : ''">
+      <a [routerLink]="link" class="truncate-link" [target]="external ? '_blank' : '_self'">
         <ng-container *ngIf="rtl; then rtlTruncated; else ltrTruncated;"></ng-container>
       </a>
     </ng-container>


### PR DESCRIPTION
Clicking on a link using the component `app-truncate` reloads the full page, which can trigger a redirection to the pizza tracker in some cases, for example on cpfp: 

https://github.com/user-attachments/assets/8d9a386d-2082-4fcc-8b41-d5f21aed5af5

With this fix: 

https://github.com/user-attachments/assets/230e5a81-9c39-4022-9ce3-4ab1e6e9232b

