### PR TITLE
sats -> sat

### DIFF
--- a/frontend/src/app/components/amount/amount.component.html
+++ b/frontend/src/app/components/amount/amount.component.html
@@ -33,7 +33,7 @@
         &lrm;{{ addPlus && satoshis >= 0 ? '+' : '' }}{{ satoshis | amountShortener : satoshis < 1000 && satoshis > -1000 ? 0 : 1 }}
       }
       <span class="symbol">
-        <ng-container *ngTemplateOutlet="prefix"></ng-container>sats
+        <ng-container *ngTemplateOutlet="prefix"></ng-container>sat
       </span>
     }
   </ng-template>


### PR DESCRIPTION
When amounts are toggled to sats, use `sat` instead of `sats` for consistency.