### PR TITLE
Fix broken pizza rbf link to /tracker

### DIFF
--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -46,7 +46,7 @@
       @if (replaced) {
         <div class="alert-replaced" role="alert">
           <span i18n="transaction.rbf.replacement|RBF replacement">This transaction has been replaced by:</span>
-          <app-truncate [text]="latestReplacement" [lastChars]="12" [link]="['/tracker/' | relativeUrl, latestReplacement]"></app-truncate>
+          <app-truncate [text]="latestReplacement" [lastChars]="12" [link]="['/tx/' | relativeUrl, latestReplacement]" [queryParams]="{mode: 'status'}"></app-truncate>
         </div>
       } @else {
         <div class="tracker-bar">

--- a/frontend/src/app/route-guards.ts
+++ b/frontend/src/app/route-guards.ts
@@ -13,7 +13,7 @@ class GuardService {
 
   trackerGuard(route: Route, segments: UrlSegment[]): boolean {
     const preferredRoute = this.router.getCurrentNavigation()?.extractedUrl.queryParams?.mode;
-    return preferredRoute !== 'details' && this.navigationService.isInitialLoad() && window.innerWidth <= 767.98;
+    return (preferredRoute === 'status' || (preferredRoute !== 'details' && this.navigationService.isInitialLoad())) && window.innerWidth <= 767.98;
   }
 }
 

--- a/frontend/src/app/shared/components/truncate/truncate.component.html
+++ b/frontend/src/app/shared/components/truncate/truncate.component.html
@@ -1,6 +1,6 @@
 <span class="truncate" [style.max-width]="maxWidth ? maxWidth + 'px' : null" [style.justify-content]="textAlign" [class.inline]="inline">
     <ng-container *ngIf="link">
-      <a [routerLink]="link" class="truncate-link" [target]="external ? '_blank' : '_self'">
+      <a [routerLink]="link" [queryParams]="queryParams" class="truncate-link" [target]="external ? '_blank' : '_self'">
         <ng-container *ngIf="rtl; then rtlTruncated; else ltrTruncated;"></ng-container>
       </a>
     </ng-container>

--- a/frontend/src/app/shared/components/truncate/truncate.component.ts
+++ b/frontend/src/app/shared/components/truncate/truncate.component.ts
@@ -10,6 +10,7 @@ export class TruncateComponent {
   @Input() text: string;
   @Input() link: any = null;
   @Input() external: boolean = false;
+  @Input() queryParams: any = undefined;
   @Input() lastChars: number = 4;
   @Input() maxWidth: number = null;
   @Input() inline: boolean = false;


### PR DESCRIPTION
Fixes a stray link to `/tracker` in the pizza tracker RBF alert, and adds a `?mode=status` query param control to allow navigating between pizza tracker transactions.