### PR TITLE
Clear mining service cache on network change

### DIFF
--- a/frontend/src/app/services/mining.service.ts
+++ b/frontend/src/app/services/mining.service.ts
@@ -37,7 +37,11 @@ export class MiningService {
     private stateService: StateService,
     private apiService: ApiService,
     private storageService: StorageService,
-  ) { }
+  ) {
+    this.stateService.networkChanged$.subscribe((network) => {
+      this.clearCache();
+    });
+   }
 
   /**
    * Generate pool ranking stats
@@ -140,5 +144,10 @@ export class MiningService {
       miningUnits: miningUnits,
       totalBlockCount: parseInt(response.headers.get('x-total-count'), 10),
     };
+  }
+
+  private clearCache(): void {
+    this.cache = {};
+    this.poolsData = [];
   }
 }


### PR DESCRIPTION
This PR fixes the mining pool pie chart not updating on network change by clearing the mining service cache.

There is still some weird subscription behaviour, particularly visible on network change, causing duplicated API calls. This will need more investigation. 