### PR TITLE
Fix stray loading spinner in block unfurl

### DIFF
--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.html
@@ -2,10 +2,12 @@
 <div class="graph-alignment" [class.grid-align]="!autofit" [style.gridTemplateColumns]="'repeat(auto-fit, ' + resolution + 'px)'">
   <div class="block-overview-graph">
     <canvas *browserOnly class="block-overview-canvas" [class.clickable]="!!hoverTx" #blockCanvas></canvas>
-    <div class="loader-wrapper" [class.hidden]="(!isLoading || disableSpinner) && !unavailable">
-      <div *ngIf="!unavailable" class="spinner-border ml-3 loading" role="status"></div>
-      <div *ngIf="!isLoading && unavailable" class="ml-3" i18n="block.not-available">not available</div>
-    </div>
+    @if (!disableSpinner) {
+      <div class="loader-wrapper" [class.hidden]="!isLoading && !unavailable">
+        <div *ngIf="!unavailable" class="spinner-border ml-3 loading" role="status"></div>
+        <div *ngIf="!isLoading && unavailable" class="ml-3" i18n="block.not-available">not available</div>
+      </div>
+    }
     <app-block-overview-tooltip
       [tx]="selectedTx || hoverTx"
       [cursorPosition]="tooltipPosition"


### PR DESCRIPTION
fixes broken logic to hide the loading spinner on the block preview block visualization component, which sometimes caused the spinner to be visible in unfurler images, e.g:

![loadingunfurl](https://github.com/user-attachments/assets/585285c4-0142-4775-9b2d-06388d5a6101)
