### PR TITLE
Immediately show oob fee on accelerated transaction

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -462,9 +462,23 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
             if (txPosition.position.acceleratedBy) {
               txPosition.cpfp.acceleratedBy = txPosition.position.acceleratedBy;
             }
+            if (txPosition.position.acceleratedAt) {
+              txPosition.cpfp.acceleratedAt = txPosition.position.acceleratedAt;
+            }
+            if (txPosition.position.feeDelta) {
+              txPosition.cpfp.feeDelta = txPosition.position.feeDelta;
+            }
             this.setCpfpInfo(txPosition.cpfp);
-          } else if ((this.tx?.acceleration && txPosition.position.acceleratedBy)) {
-            this.tx.acceleratedBy = txPosition.position.acceleratedBy;
+          } else if ((this.tx?.acceleration)) {
+            if (txPosition.position.acceleratedBy) {
+              this.tx.acceleratedBy = txPosition.position.acceleratedBy;
+            }
+            if (txPosition.position.acceleratedAt) {
+              this.tx.acceleratedAt = txPosition.position.acceleratedAt;
+            }
+            if (txPosition.position.feeDelta) {
+              this.tx.feeDelta = txPosition.position.feeDelta;
+            }
           }
 
           if (this.stateService.network === '') {

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -253,6 +253,8 @@ export interface MempoolPosition {
   vsize: number,
   accelerated?: boolean,
   acceleratedBy?: number[],
+  acceleratedAt?: number,
+  feeDelta?: number,
 }
 
 export interface AccelerationPosition extends MempoolPosition {


### PR DESCRIPTION
Currently we need to refresh the page to see the the out-of-band fee paid in transaction details.

With this PR: 

https://github.com/user-attachments/assets/6f5e1e24-728c-4b88-ac0b-d5bc8ed659be

