### PR TITLE
Hide fee delta on accelerated tx if bid boost is 0

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -609,10 +609,13 @@
       <td class="text-wrap">{{ tx.fee | number }} <span class="symbol" i18n="shared.sat|sat">sat</span> 
         @if (accelerationInfo?.bidBoost) {
           <span class="oobFees" i18n-ngbTooltip="Acceleration Fees" ngbTooltip="Acceleration fees paid out-of-band"> +{{ accelerationInfo.bidBoost | number }} </span><span class="symbol" i18n="shared.sat|sat">sat</span>
-        } @else if (tx.feeDelta) {
+          <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee + accelerationInfo.bidBoost"></app-fiat></span>
+        } @else if (tx.feeDelta && !accelerationInfo) {
           <span class="oobFees" i18n-ngbTooltip="Acceleration Fees" ngbTooltip="Acceleration fees paid out-of-band"> +{{ tx.feeDelta | number }} </span><span class="symbol" i18n="shared.sat|sat">sat</span>
-        }
-        <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee + (accelerationInfo?.bidBoost || tx.feeDelta || 0)"></app-fiat></span>
+          <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee + tx.feeDelta"></app-fiat></span>
+        } @else {
+          <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee"></app-fiat></span>
+        }        
       </td>
     </tr>
   } @else {


### PR DESCRIPTION
This PR fixes the following issue: 
- track an accelerated transaction that has a sufficient in-band fee to be mined anyway
- when the transaction gets mined, it will have a bid boost of 0
- the fee delta is still shown on the mined transaction

With this PR, the out-of-band fee fee delta is hidden if the bid boost is 0 after the acceleration gets mined.

for example:

https://github.com/user-attachments/assets/127ec359-ebe9-48fb-a1cc-0ff98dcd16e5

