### PR TITLE
Fix pool pie position on safari

### DIFF
--- a/frontend/src/app/components/acceleration/active-acceleration-box/active-acceleration-box.component.html
+++ b/frontend/src/app/components/acceleration/active-acceleration-box/active-acceleration-box.component.html
@@ -1,7 +1,7 @@
 @if (chartOnly) {
   <ng-container *ngTemplateOutlet="pieChart"></ng-container>
 } @else {
-<table>
+<table style="width: 100%;">
   <tbody>
     <tr>
       <td class="td-width field-label" [class]="chartPositionLeft ? 'chart-left' : ''" i18n="transaction.accelerated-to-feerate|Accelerated to feerate">Accelerated to</td>


### PR DESCRIPTION
On Safari the pool pie was incorrectly positioned when the chart was on the left (on smaller screens).

Before: 

<img width="652" alt="Screenshot 2024-08-08 at 11 24 32" src="https://github.com/user-attachments/assets/88048484-bbe7-46a6-8c26-8ca14c024664">

After:

<img width="656" alt="Screenshot 2024-08-08 at 11 24 46" src="https://github.com/user-attachments/assets/15672bd9-a124-45d1-9667-9dc4b6d3605a">

