### PR TITLE
Don't show "effective fee rate" on accelerated tx

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -629,7 +629,7 @@
       <td i18n="transaction.fee-rate|Transaction fee rate">Fee rate</td>
       <td>
         <app-fee-rate [fee]="tx.feePerVsize"></app-fee-rate>
-        @if (tx?.status?.confirmed && tx.fee && !hasEffectiveFeeRate && !accelerationInfo) {
+        @if (tx?.status?.confirmed && tx.fee && !hasEffectiveFeeRate && !accelerationInfo?.acceleratedFeeRate) {
           &nbsp;
           <app-tx-fee-rating [tx]="tx"></app-tx-fee-rating>
         }
@@ -642,7 +642,7 @@
 
 <ng-template #effectiveRateRow>
   @if (!isLoadingTx) {
-    @if ((cpfpInfo && hasEffectiveFeeRate) || accelerationInfo) {
+    @if ((cpfpInfo && hasEffectiveFeeRate) || accelerationInfo?.acceleratedFeeRate) {
       <tr>
         @if (isAcceleration) {
           <td i18n="transaction.accelerated-fee-rate|Accelerated transaction fee rate">Accelerated fee rate</td>
@@ -657,7 +657,7 @@
               <app-fee-rate [class.oobFees]="isAcceleration" [fee]="tx.effectiveFeePerVsize"></app-fee-rate>
             }
 
-            @if (tx?.status?.confirmed && !tx.acceleration && !accelerationInfo && tx.fee && tx.effectiveFeePerVsize) {
+            @if (tx?.status?.confirmed && !tx.acceleration && !accelerationInfo?.acceleratedFeeRate && tx.fee && tx.effectiveFeePerVsize) {
               <app-tx-fee-rating class="ml-2 mr-2 effective-fee-rating" [tx]="tx"></app-tx-fee-rating>
             }
           </div>

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -360,7 +360,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       for (const acceleration of accelerationHistory) {
         if (acceleration.txid === this.txId && (acceleration.status === 'completed' || acceleration.status === 'completed_provisional')) {
           const boostCost = acceleration.boostCost || acceleration.bidBoost;
-          acceleration.acceleratedFeeRate = Math.max(acceleration.effectiveFee, acceleration.effectiveFee + boostCost) / acceleration.effectiveVsize;
+          if (acceleration.pools.includes(acceleration.minedByPoolUniqueId)) {
+            acceleration.acceleratedFeeRate = Math.max(acceleration.effectiveFee, acceleration.effectiveFee + boostCost) / acceleration.effectiveVsize;
+          }
           acceleration.boost = boostCost;
           this.tx.acceleratedAt = acceleration.added;
           this.accelerationInfo = acceleration;


### PR DESCRIPTION
Try to address the issue on acceleration detection discussed in #5449