### PR TITLE
Implement v1 audit in tx audit API

### DIFF
--- a/backend/src/repositories/BlocksAuditsRepository.ts
+++ b/backend/src/repositories/BlocksAuditsRepository.ts
@@ -132,11 +132,12 @@ class BlocksAuditRepositories {
             firstSeen = tx.time;
           }
         });
+        const wasSeen = blockAudit.version === 1 ? !blockAudit.unseenTxs.includes(txid) : (isExpected || isPrioritized || isAccelerated);
 
         return {
-          seen: isExpected || isPrioritized || isAccelerated,
+          seen: wasSeen,
           expected: isExpected,
-          added: isAdded,
+          added: isAdded && (blockAudit.version === 0 || !wasSeen),
           prioritized: isPrioritized,
           conflict: isConflict,
           accelerated: isAccelerated,


### PR DESCRIPTION
Updates the new `/api/v1/block/:hash/tx/:txid/audit` endpoint to correctly handle v1 audits.

Before, "added & prioritized" transactions show correctly as `Not seen in Mempool` and `Prioritized` when interpreting a cached v1 block audit (e.g. after clicking through to the transaction from a block page), but incorrectly show `Seen in Mempool` when loading the audit status from the tx audit endpoint (e.g, after refreshing the transaction page).

https://mempool.space/tx/b0b03d5496f65244f2461ccfd7a9616dae430665fafdab60a107df013ba63618
<img width="461" alt="Screenshot 2024-08-10 at 10 01 35 PM" src="https://github.com/user-attachments/assets/03da5d53-df10-4488-977f-3bbf9571f877">
<img width="461" alt="Screenshot 2024-08-10 at 10 01 46 PM" src="https://github.com/user-attachments/assets/e415ffe3-6b13-4d8a-9df5-a816b17eeba9">

After, the correct audit tags are displayed in both cases.
