### PR TITLE
Fix accelerated arrow not appearing

### DIFF
--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -213,7 +213,7 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
         }
         if (state.mempoolPosition) {
           this.txPosition = state.mempoolPosition;
-          if (this.txPosition.accelerated && !oldTxPosition.accelerated) {
+          if (this.txPosition.accelerated && !oldTxPosition?.accelerated) {
             this.acceleratingArrow = true;
             setTimeout(() => {
               this.acceleratingArrow = false;


### PR DESCRIPTION
<img width="635" alt="Screenshot 2024-08-18 at 14 14 06" src="https://github.com/user-attachments/assets/260c6ffc-c96c-445c-bee3-bc08e397997d">

This console error happens when viewing unconfirmed accelerated transactions, resulting in the accelerating arrow not displaying:

<img width="932" alt="Screenshot 2024-08-18 at 14 13 58" src="https://github.com/user-attachments/assets/2c3281e3-399e-4cce-9296-59f7a6b5cb2d">
