### PR TITLE
Backend config generator script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -106,6 +106,25 @@ In particular, make sure:
   - "esplora" if you're using [mempool/electrs](https://github.com/mempool/electrs)
   - "none" if you're not using any Electrum Server
 
+You can use the `generate-config.js` script to define your configuration in a non-interactive way.
+Basic usage:
+
+```
+node generate-config.js ELECTRUM.PORT=50001 CORE_RPC.COOKIE=true CORE_RPC.COOKIE_PATH=/var/lib/bitcoind/.cookie REPLICATION.SERVERS='["example1.com","example2.com"]'
+```
+
+This will create the `mempool-config.json` file using all default values from the sample file
+except for the custom values specified.
+
+The special parameters `SOURCE_CONFIG_FILE` and `DEST_CONFIG_FILE` allows specifying a custom source
+template and/or a custom destination file.
+
+If present, they must be accessible valid paths on the local filesystem.
+
+```
+node generate-config.js ELECTRUM.PORT=50001 SOURCE_CONFIG_FILE=another-sample.json DEST_CONFIG_FILE=/etc/mempool/backend.json
+```
+
 ### 6. Run Mempool Backend
 
 Run the Mempool backend:

--- a/backend/generate-config.js
+++ b/backend/generate-config.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+
+const SAMPLE_CONFIG_FILE_NAME = 'mempool-config.sample.json';
+const CONFIG_FILE_NAME = 'mempool-config.json';
+
+const settings = {};
+const args = process.argv.slice(2);
+
+let sourcePath = SAMPLE_CONFIG_FILE_NAME;
+let destinationPath = CONFIG_FILE_NAME;
+
+function castedValue(value) {
+  if (String(value).toLowerCase() === 'true') {
+    value = true;
+  } else if (String(value).toLowerCase() === 'false') {
+    value = false;
+  } else if (!isNaN(value) && String(value).trim() !== '') {
+    value = Number(value);
+  }
+  try {
+    const decoded = JSON.parse(value);
+    if (decoded instanceof Array) {
+      value = decoded;
+    }
+  } catch (e) {
+  }
+  return value;
+}
+
+function updateConfig(names, value, node) {
+  const name = names.shift();
+  if (Object.hasOwn(node, name)) {
+    if (typeof node[name] === 'object' && !(node[name] instanceof Array)) {
+      updateConfig(names, value, node[name]);
+    } else {
+      node[name] = value;
+    }
+  }
+}
+
+args.forEach(setting => {
+  setting = setting.split('=');
+  if (setting[0] === 'SOURCE_CONFIG_FILE') {
+    sourcePath = setting[1];
+  } else if (setting[0] === 'DEST_CONFIG_FILE') {
+    destinationPath = setting[1];
+  } else {
+    const key = setting[0];
+    const value = setting[1];
+    settings[key] = castedValue(value);
+  }
+});
+
+const config = JSON.parse(fs.readFileSync(sourcePath, 'utf-8'));
+
+for (const key in settings) {
+  if (Object.hasOwn(settings, key)) {
+    updateConfig(key.split('.'), settings[key], config);
+  }
+}
+
+fs.writeFileSync(destinationPath, JSON.stringify(config, null, 2) + '\n', 'utf8');

--- a/contributors/1ma.txt
+++ b/contributors/1ma.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of August 18, 2024.
+
+Signed: 1ma


### PR DESCRIPTION
Counterpart to the frontend's [update-config.js](https://github.com/mempool/mempool/blob/master/frontend/update-config.js)/[generate-config.js](https://github.com/mempool/mempool/blob/master/frontend/generate-config.js) scripts, but for building the backend configuration file.

I've rewritten the script to not depend on any new dependency, and added a couple special `SOURCE_CONFIG_FILE` and `DEST_CONFIG_FILE` arguments to be able to specify custom source and destination files.