### PR TITLE
Add amount mode selector to footer

### DIFF
--- a/frontend/src/app/components/amount-selector/amount-selector.component.html
+++ b/frontend/src/app/components/amount-selector/amount-selector.component.html
@@ -1,0 +1,7 @@
+<div [formGroup]="amountForm" class="text-small text-center">
+    <select formControlName="mode" class="custom-select custom-select-sm form-control-secondary form-control mx-auto" style="width: 70px;" (change)="changeMode()">
+        <option value="btc" i18n="shared.btc|BTC">BTC</option>
+        <option value="sats" i18n="shared.sat|sat">sat</option>
+        <option value="fiat" i18n="shared.fiat|Fiat">Fiat</option>
+    </select>
+</div>

--- a/frontend/src/app/components/amount-selector/amount-selector.component.ts
+++ b/frontend/src/app/components/amount-selector/amount-selector.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { StorageService } from '../../services/storage.service';
+import { StateService } from '../../services/state.service';
+
+@Component({
+  selector: 'app-amount-selector',
+  templateUrl: './amount-selector.component.html',
+  styleUrls: ['./amount-selector.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AmountSelectorComponent implements OnInit {
+  amountForm: UntypedFormGroup;
+  modes = ['btc', 'sats', 'fiat'];
+
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private stateService: StateService,
+    private storageService: StorageService,
+  ) { }
+
+  ngOnInit() {
+    this.amountForm = this.formBuilder.group({
+      mode: ['btc']
+    });
+    this.stateService.viewAmountMode$.subscribe((mode) => {
+      this.amountForm.get('mode')?.setValue(mode);
+    });
+  }
+
+  changeMode() {
+    const newMode = this.amountForm.get('mode')?.value;
+    this.storageService.setValue('view-amount-mode', newMode);
+    this.stateService.viewAmountMode$.next(newMode);
+  }
+}

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.html
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.html
@@ -27,27 +27,27 @@
           <div class="selector">
             <app-rate-unit-selector></app-rate-unit-selector>
           </div>
-          <div class="selector d-none d-sm-flex">
+          <div class="selector d-none" [ngClass]="isServicesPage ? 'd-lg-flex' : 'd-md-flex'">
             <app-amount-selector></app-amount-selector>
           </div>
           @if (!env.customize?.theme) {
-            <div class="selector d-none d-sm-flex">
+            <div class="selector d-none" [ngClass]="isServicesPage ? 'd-lg-flex' : 'd-md-flex'">
               <app-theme-selector></app-theme-selector>
             </div>
           }
-          <a *ngIf="stateService.isMempoolSpaceBuild" class="btn btn-purple sponsor d-none d-sm-flex justify-content-center" [routerLink]="['/login']">
+          <a *ngIf="stateService.isMempoolSpaceBuild" class="btn btn-purple sponsor d-none justify-content-center" [ngClass]="isServicesPage ? 'd-lg-flex' : 'd-md-flex'" [routerLink]="['/login']">
             <span *ngIf="user" i18n="shared.my-account" class="nowrap">My Account</span>
             <span *ngIf="!user" i18n="shared.sign-in" class="nowrap">Sign In</span>
           </a>
         </div>
         @if (!env.customize?.theme) {
-          <div class="selector d-flex d-sm-none justify-content-center ml-auto mr-auto mt-0">
+          <div class="selector d-flex justify-content-center ml-auto mr-auto mt-0" [ngClass]="isServicesPage ? 'd-lg-none' : 'd-md-none'">
             <app-amount-selector class="add-margin"></app-amount-selector>
             <app-theme-selector class="add-margin"></app-theme-selector>
           </div>
         }
         @if (!enterpriseInfo?.footer_img) {
-          <a *ngIf="stateService.isMempoolSpaceBuild" class="btn btn-purple sponsor d-flex d-sm-none justify-content-center ml-auto mr-auto mt-0 mb-2" [routerLink]="['/login']">
+          <a *ngIf="stateService.isMempoolSpaceBuild" class="btn btn-purple sponsor d-flex justify-content-center ml-auto mr-auto mt-0 mb-2" [ngClass]="isServicesPage ? 'd-lg-none' : 'd-md-none'" [routerLink]="['/login']">
             <span *ngIf="user" i18n="shared.my-account" class="nowrap">My Account</span>
             <span *ngIf="!user" i18n="shared.sign-in" class="nowrap">Sign In</span>
           </a>

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.html
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.html
@@ -27,6 +27,9 @@
           <div class="selector">
             <app-rate-unit-selector></app-rate-unit-selector>
           </div>
+          <div class="selector d-none d-sm-flex">
+            <app-amount-selector></app-amount-selector>
+          </div>
           @if (!env.customize?.theme) {
             <div class="selector d-none d-sm-flex">
               <app-theme-selector></app-theme-selector>
@@ -39,7 +42,8 @@
         </div>
         @if (!env.customize?.theme) {
           <div class="selector d-flex d-sm-none justify-content-center ml-auto mr-auto mt-0">
-            <app-theme-selector></app-theme-selector>
+            <app-amount-selector class="add-margin"></app-amount-selector>
+            <app-theme-selector class="add-margin"></app-theme-selector>
           </div>
         }
         @if (!enterpriseInfo?.footer_img) {

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.scss
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.scss
@@ -159,7 +159,7 @@ footer .nowrap {
   display: block;
 }
 
-@media (min-width: 951px) {
+@media (min-width: 1020px) {
   :host-context(.ltr-layout) .language-selector {
     float: right !important;
   }
@@ -177,7 +177,24 @@ footer .nowrap {
 }
 
 .services {
-  @media (min-width: 951px) and (max-width: 1147px) {
+  @media (min-width: 1300px) {
+    :host-context(.ltr-layout) .language-selector {
+      float: right !important;
+    }
+    :host-context(.rtl-layout) .language-selector {
+      float: left !important;
+    }
+  
+    .explore-tagline-desktop {
+      display: block;
+    }
+  
+    .explore-tagline-mobile {
+      display: none;
+    }
+  }
+
+  @media (max-width: 1300px) {
     :host-context(.ltr-layout) .services .language-selector {
       float: none !important;
     }
@@ -253,7 +270,7 @@ footer .nowrap {
 
 }
 
-@media (max-width: 950px) {
+@media (max-width: 1019px) {
 
   .main-logo {
     width: 220px;
@@ -292,7 +309,7 @@ footer .nowrap {
   }
 }
 
-@media (max-width: 1147px) {
+@media (max-width: 1300px) {
 
   .services.main-logo {
     width: 220px;

--- a/frontend/src/app/shared/components/global-footer/global-footer.component.scss
+++ b/frontend/src/app/shared/components/global-footer/global-footer.component.scss
@@ -76,6 +76,11 @@ footer .selector {
   display: inline-block;
 }
 
+footer .add-margin {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
 footer .row.link-tree {
   max-width: 1140px;
   margin: 0 auto;

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -35,6 +35,7 @@ import { LanguageSelectorComponent } from '../components/language-selector/langu
 import { FiatSelectorComponent } from '../components/fiat-selector/fiat-selector.component';
 import { RateUnitSelectorComponent } from '../components/rate-unit-selector/rate-unit-selector.component';
 import { ThemeSelectorComponent } from '../components/theme-selector/theme-selector.component';
+import { AmountSelectorComponent } from '../components/amount-selector/amount-selector.component';
 import { BrowserOnlyDirective } from './directives/browser-only.directive';
 import { ServerOnlyDirective } from './directives/server-only.directive';
 import { ColoredPriceDirective } from './directives/colored-price.directive';
@@ -131,6 +132,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     FiatSelectorComponent,
     ThemeSelectorComponent,
     RateUnitSelectorComponent,
+    AmountSelectorComponent,
     ScriptpubkeyTypePipe,
     RelativeUrlPipe,
     NoSanitizePipe,
@@ -278,6 +280,7 @@ import { OnlyVsizeDirective, OnlyWeightDirective } from './components/weight-dir
     FiatSelectorComponent,
     RateUnitSelectorComponent,
     ThemeSelectorComponent,
+    AmountSelectorComponent,
     ScriptpubkeyTypePipe,
     RelativeUrlPipe,
     Hex2asciiPipe,


### PR DESCRIPTION
This PR: 

1) adds a selector in the footer to directly change the amount mode (bitcoin, sats or fiat) instead of having to browse to a random transaction to change it:

<img width="996" alt="Screenshot 2024-08-19 at 17 22 50" src="https://github.com/user-attachments/assets/87d27855-4d74-4590-8bfd-025f911bb319">

<img width="876" alt="Screenshot 2024-08-19 at 17 23 01" src="https://github.com/user-attachments/assets/9addec8c-83ba-463f-a979-04c97a63b785">

<img width="557" alt="Screenshot 2024-08-19 at 17 23 29" src="https://github.com/user-attachments/assets/c7b85262-e9d0-4806-bae8-b253d6373f09">

2) fixes an issue where the footer was being cropped on the services page on some screen widths:

| Before  | After |
| ------------- | ------------- |
| <img width="769" alt="Screenshot 2024-08-19 at 18 29 33" src="https://github.com/user-attachments/assets/9f1b62c9-bf7c-4258-920f-74c789618809">  | <img width="766" alt="Screenshot 2024-08-19 at 18 30 24" src="https://github.com/user-attachments/assets/8d02b8ba-34c8-4126-a35f-1818383dbfeb">  |

Note: we will need to adapt `sat` to `sats` in the selector dropdown if #5437 gets merged later