### PR TITLE
Reset acceleration flow state when leaving transaction

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -966,6 +966,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.filters = [];
     this.showCpfpDetails = false;
     this.showAccelerationDetails = false;
+    this.accelerationFlowCompleted = false;
     this.accelerationInfo = null;
     this.cashappEligible = false;
     this.txInBlockIndex = null;


### PR DESCRIPTION
Using the search bar after accelerating a transaction to display another transaction will cause the accelerator checkout to be hidden while it should be visible by default. See: 

https://github.com/user-attachments/assets/edd29ef5-381a-4647-ad98-36bdd078e2f2

This is fixed by reinitialising `accelerationFlowCompleted` when leaving the transaction.
