### PR TITLE
Hide accelerator panel if tx gets accelerated on another session

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -196,9 +196,11 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
     if (changes.scrollEvent && this.scrollEvent) {
       this.scrollToElement('acceleratePreviewAnchor', 'start');
     }
-    if (changes.accelerating) {
-      if ((this.step === 'processing' || this.step === 'paid') && this.accelerating) {
+    if (changes.accelerating && this.accelerating) {
+      if (this.step === 'processing' || this.step === 'paid') {
         this.moveToStep('success');
+      } else { // Edge case where the transaction gets accelerated by someone else or on another session
+        this.closeModal();
       }
     }
   }


### PR DESCRIPTION
Currently the accelerator checkout is not hidden on a transaction that gets externally accelerated: 

https://github.com/user-attachments/assets/c3ad9fc3-4dd7-4ea6-9cfe-d033390fdbfa

With this PR: 

https://github.com/user-attachments/assets/e241de29-bc86-4cf3-8db8-3201f3b7d79d

