### PR TITLE
Make v3 transactions standard

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -323,6 +323,7 @@ class BitcoinApi implements AbstractBitcoinApi {
       'witness_v1_taproot': 'v1_p2tr',
       'nonstandard': 'nonstandard',
       'multisig': 'multisig',
+      'anchor': 'anchor',
       'nulldata': 'op_return'
     };
 

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1106,7 +1106,7 @@ class BlocksRepository {
         let summaryVersion = 0;
         if (config.MEMPOOL.BACKEND === 'esplora') {
           const txs = (await bitcoinApi.$getTxsForBlock(dbBlk.id)).map(tx => transactionUtils.extendTransaction(tx));
-          summary = blocks.summarizeBlockTransactions(dbBlk.id, txs);
+          summary = blocks.summarizeBlockTransactions(dbBlk.id, dbBlk.height, txs);
           summaryVersion = 1;
         } else {
           // Call Core RPC

--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -55,7 +55,7 @@ export class AddressLabelsComponent implements OnChanges {
   }
 
   handleVin() {
-    const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin])
+    const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin]);
     if (address?.scripts.size) {
       const script = address?.scripts.values().next().value;
       if (script.template?.label) {

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -747,7 +747,7 @@ export class TrackerComponent implements OnInit, OnDestroy {
 
   checkAccelerationEligibility() {
     if (this.tx) {
-      this.tx.flags = getTransactionFlags(this.tx);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_time, this.stateService.network);
       const replaceableInputs = (this.tx.flags & (TransactionFlags.sighash_none | TransactionFlags.sighash_acp)) > 0n;
       const highSigop = (this.tx.sigops * 20) > this.tx.weight;
       this.eligibleForAcceleration = !replaceableInputs && !highSigop;

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -901,7 +901,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       this.segwitEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'segwit');
       this.taprootEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'taproot');
       this.rbfEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'rbf');
-      this.tx.flags = getTransactionFlags(this.tx);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_time, this.stateService.network);
       this.filters = this.tx.flags ? toFilters(this.tx.flags).filter(f => f.txPage) : [];
       this.checkAccelerationEligibility();
     } else {

--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -17,6 +17,7 @@ export type AddressType = 'fee'
   | 'v0_p2wsh'
   | 'v1_p2tr'
   | 'confidential'
+  | 'anchor'
   | 'unknown'
 
 const ADDRESS_PREFIXES = {
@@ -188,6 +189,12 @@ export class AddressTypeInfo {
         const v = vin[0];
         this.processScript(new ScriptInfo('scriptpubkey', v.prevout.scriptpubkey, v.prevout.scriptpubkey_asm));
       }
+    } else if (this.type === 'unknown') {
+      for (const v of vin) {
+        if (v.prevout?.scriptpubkey === '51024e73') {
+          this.type = 'anchor';
+        }
+      }
     }
     // and there's nothing more to learn from processing inputs for other types
   }
@@ -196,6 +203,10 @@ export class AddressTypeInfo {
     if (this.type === 'multisig') {
       if (!this.scripts.size) {
         this.processScript(new ScriptInfo('scriptpubkey', output.scriptpubkey, output.scriptpubkey_asm));
+      }
+    } else if (this.type === 'unknown') {
+      if (output.scriptpubkey === '51024e73') {
+        this.type = 'anchor';
       }
     }
   }

--- a/frontend/src/app/shared/components/address-type/address-type.component.html
+++ b/frontend/src/app/shared/components/address-type/address-type.component.html
@@ -20,6 +20,9 @@
   @case ('multisig') {
     <span i18n="address.bare-multisig">bare multisig</span>
   }
+  @case ('anchor') {
+    <span>anchor</span>
+  }
   @case (null) {
     <span>unknown</span>
   }

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -166,6 +166,7 @@ export const ScriptTemplates: { [type: string]: (...args: any) => ScriptTemplate
   ln_anchor: () => ({ type: 'ln_anchor', label: 'Lightning Anchor' }),
   ln_anchor_swept: () => ({ type: 'ln_anchor_swept', label: 'Swept Lightning Anchor' }),
   multisig: (m: number, n: number) => ({ type: 'multisig', m, n, label: $localize`:@@address-label.multisig:Multisig ${m}:multisigM: of ${n}:multisigN:` }),
+  anchor: () => ({ type: 'anchor', label: 'anchor' }),
 };
 
 export class ScriptInfo {


### PR DESCRIPTION
_(resolves #5488)_
_(builds on #5493)_

This PR updates the Mempool Goggles standardness detection rules to allow v3 transactions, which will become standard from Bitcoin Core v28 (see https://github.com/bitcoin/bitcoin/pull/29496).

Before:
[test transaction](https://mempool.space/testnet4/tx/8e3f38bf6854dd3c358be8d4f9a40a6dccc50de49616125d27af9fdbe65287eb)
<img width="1131" alt="Screenshot 2024-08-29 at 2 09 03 PM" src="https://github.com/user-attachments/assets/23bc24b5-389d-440f-a8e4-acd045c0f00d">

After:
<img width="1131" alt="Screenshot 2024-08-29 at 2 09 17 PM" src="https://github.com/user-attachments/assets/55501ded-b413-4e74-b962-6d28134f6227">

TODO:
 - [x] Retain previous rules for blocks below some sensible activation height