### PR TITLE
[accelerator] make bid boost graph bar min height taller

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
@@ -264,7 +264,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
           type: 'bar',
           barWidth: '90%',
           large: true,
-          barMinHeight: 1,
+          barMinHeight: 3,
         },
       ],
       dataZoom: (this.widget || data.length === 0 )? undefined : [{


### PR DESCRIPTION
It's very hard to see small bid boost acceleration on the graph, so I wanna make the min bar height a bit taller to be more informative visually

The diff obviously does not render very well on screenshots, so you gotta try it on your screen or open the screenshots full screen in another tab.

# Currently

![Screenshot 2024-08-29 at 20 51 44](https://github.com/user-attachments/assets/daff267f-53ba-4268-904b-8afdd5226a11)
![Screenshot 2024-08-29 at 20 55 21](https://github.com/user-attachments/assets/a9217b06-de0b-4998-8513-4932bf4b1abb)

# Updated

![Screenshot 2024-08-29 at 20 51 56](https://github.com/user-attachments/assets/0f5ccfd9-3ce2-4573-9d15-b6a4d2a8f910)
![Screenshot 2024-08-29 at 20 52 05](https://github.com/user-attachments/assets/179d9434-cc1c-4ad5-9267-76ca99903b17)
