### PR TITLE
Add support for anchor output type

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -323,6 +323,7 @@ class BitcoinApi implements AbstractBitcoinApi {
       'witness_v1_taproot': 'v1_p2tr',
       'nonstandard': 'nonstandard',
       'multisig': 'multisig',
+      'anchor': 'anchor',
       'nulldata': 'op_return'
     };
 

--- a/frontend/src/app/components/address-labels/address-labels.component.ts
+++ b/frontend/src/app/components/address-labels/address-labels.component.ts
@@ -55,7 +55,7 @@ export class AddressLabelsComponent implements OnChanges {
   }
 
   handleVin() {
-    const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin])
+    const address = new AddressTypeInfo(this.network || 'mainnet', this.vin.prevout?.scriptpubkey_address, this.vin.prevout?.scriptpubkey_type as AddressType, [this.vin]);
     if (address?.scripts.size) {
       const script = address?.scripts.values().next().value;
       if (script.template?.label) {

--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -17,6 +17,7 @@ export type AddressType = 'fee'
   | 'v0_p2wsh'
   | 'v1_p2tr'
   | 'confidential'
+  | 'anchor'
   | 'unknown'
 
 const ADDRESS_PREFIXES = {
@@ -188,6 +189,12 @@ export class AddressTypeInfo {
         const v = vin[0];
         this.processScript(new ScriptInfo('scriptpubkey', v.prevout.scriptpubkey, v.prevout.scriptpubkey_asm));
       }
+    } else if (this.type === 'unknown') {
+      for (const v of vin) {
+        if (v.prevout?.scriptpubkey === '51024e73') {
+          this.type = 'anchor';
+        }
+      }
     }
     // and there's nothing more to learn from processing inputs for other types
   }
@@ -196,6 +203,10 @@ export class AddressTypeInfo {
     if (this.type === 'multisig') {
       if (!this.scripts.size) {
         this.processScript(new ScriptInfo('scriptpubkey', output.scriptpubkey, output.scriptpubkey_asm));
+      }
+    } else if (this.type === 'unknown') {
+      if (output.scriptpubkey === '51024e73') {
+        this.type = 'anchor';
       }
     }
   }

--- a/frontend/src/app/shared/components/address-type/address-type.component.html
+++ b/frontend/src/app/shared/components/address-type/address-type.component.html
@@ -20,6 +20,9 @@
   @case ('multisig') {
     <span i18n="address.bare-multisig">bare multisig</span>
   }
+  @case ('anchor') {
+    <span>anchor</span>
+  }
   @case (null) {
     <span>unknown</span>
   }

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -166,6 +166,7 @@ export const ScriptTemplates: { [type: string]: (...args: any) => ScriptTemplate
   ln_anchor: () => ({ type: 'ln_anchor', label: 'Lightning Anchor' }),
   ln_anchor_swept: () => ({ type: 'ln_anchor_swept', label: 'Swept Lightning Anchor' }),
   multisig: (m: number, n: number) => ({ type: 'multisig', m, n, label: $localize`:@@address-label.multisig:Multisig ${m}:multisigM: of ${n}:multisigN:` }),
+  anchor: () => ({ type: 'anchor', label: 'anchor' }),
 };
 
 export class ScriptInfo {


### PR DESCRIPTION
_(partially addresses #5492)_
_(counterpart to https://github.com/mempool/electrs/pull/99)_

This PR adds front and backend support for the new P2A anchor output type.

Note that the `anchor` type label in transaction details requires either `mempool/electrs` with https://github.com/mempool/electrs/pull/99, or Bitcoin Core v28.x as the backend.

![Screenshot 2024-08-30 at 9 42 40 PM](https://github.com/user-attachments/assets/0a79f0af-076c-4b18-b166-7112e5f1371c)
![Screenshot 2024-08-30 at 9 42 18 PM](https://github.com/user-attachments/assets/d512651f-5420-4329-8566-86debc7733e8)
![Screenshot 2024-08-30 at 9 42 09 PM](https://github.com/user-attachments/assets/426b45c6-bfb6-447a-a1ed-7dff64671a42)