### PR TITLE
Allow OP_0 in multisig scripts

### DIFF
--- a/backend/src/utils/bitcoin-script.ts
+++ b/backend/src/utils/bitcoin-script.ts
@@ -158,7 +158,7 @@ export function parseMultisigScript(script: string): void | { m: number, n: numb
   if (!opN) {
     return;
   }
-  if (!opN.startsWith('OP_PUSHNUM_')) {
+  if (opN !== 'OP_0' && !opN.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const n = parseInt(opN.match(/[0-9]+/)?.[0] || '', 10);
@@ -178,7 +178,7 @@ export function parseMultisigScript(script: string): void | { m: number, n: numb
   if (!opM) {
     return;
   }
-  if (!opM.startsWith('OP_PUSHNUM_')) {
+  if (opM !== 'OP_0' && !opM.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const m = parseInt(opM.match(/[0-9]+/)?.[0] || '', 10);

--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -135,7 +135,7 @@ export function parseMultisigScript(script: string): void | { m: number, n: numb
     return;
   }
   const opN = ops.pop();
-  if (!opN.startsWith('OP_PUSHNUM_')) {
+  if (opN !== 'OP_0' && !opN.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const n = parseInt(opN.match(/[0-9]+/)[0], 10);
@@ -152,7 +152,7 @@ export function parseMultisigScript(script: string): void | { m: number, n: numb
     }
   }
   const opM = ops.pop();
-  if (!opM.startsWith('OP_PUSHNUM_')) {
+  if (opM !== 'OP_0' && !opM.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const m = parseInt(opM.match(/[0-9]+/)[0], 10);

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -266,7 +266,7 @@ export function parseMultisigScript(script: string): undefined | { m: number, n:
   if (!opN) {
     return;
   }
-  if (!opN.startsWith('OP_PUSHNUM_')) {
+  if (opN !== 'OP_0' && !opN.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const n = parseInt(opN.match(/[0-9]+/)?.[0] || '', 10);
@@ -286,7 +286,7 @@ export function parseMultisigScript(script: string): undefined | { m: number, n:
   if (!opM) {
     return;
   }
-  if (!opM.startsWith('OP_PUSHNUM_')) {
+  if (opM !== 'OP_0' && !opM.startsWith('OP_PUSHNUM_')) {
     return;
   }
   const m = parseInt(opM.match(/[0-9]+/)?.[0] || '', 10);


### PR DESCRIPTION
Because the opcode `0x00` is decoded as `OP_0` and not `OP_PUSHNUM_0`, multisig scripts with zero keys and/or signatures are currently not labeled as such, even though they are perfectly valid. They are of course an extremely uncommon edge case and not very useful, but I think it's still better to label them than not.

Example transaction: [c3e384db67470346df163a2fa50024d674ef1b3e75aa97ec6534d806c82fee7e](https://mempool.space/tx/c3e384db67470346df163a2fa50024d674ef1b3e75aa97ec6534d806c82fee7e)

![0of0](https://github.com/user-attachments/assets/d631b4c9-d93c-4568-83b7-64be30d266a3)
