### PR TITLE
hotfix option 1 for axios breaking change to unix sockets

### DIFF
--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -89,7 +89,7 @@ class FailoverRouter {
     for (const host of this.hosts) {
       try {
         const result = await (host.socket
-          ? this.pollConnection.get<number>('/blocks/tip/height', { socketPath: host.host, timeout: config.ESPLORA.FALLBACK_TIMEOUT })
+          ? this.pollConnection.get<number>('http://localhost/blocks/tip/height', { socketPath: host.host, timeout: config.ESPLORA.FALLBACK_TIMEOUT })
           : this.pollConnection.get<number>(host.host + '/blocks/tip/height', { timeout: config.ESPLORA.FALLBACK_TIMEOUT })
         );
         if (result) {


### PR DESCRIPTION
_(alternative to 5503)_

Upgrading from axios 1.7.2 to 1.7.4 broke our use of unix sockets in the esplora API module because it no longer recognizes relative paths as valid URLs

This PR adds a `http://localhost` prefix to the esplora socket requests, which seems to satisfy the new spec and still works.