### PR TITLE
Revert "hotfix option 1 for axios breaking change to unix sockets"

### DIFF
--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -89,7 +89,7 @@ class FailoverRouter {
     for (const host of this.hosts) {
       try {
         const result = await (host.socket
-          ? this.pollConnection.get<number>('http://localhost/blocks/tip/height', { socketPath: host.host, timeout: config.ESPLORA.FALLBACK_TIMEOUT })
+          ? this.pollConnection.get<number>('/blocks/tip/height', { socketPath: host.host, timeout: config.ESPLORA.FALLBACK_TIMEOUT })
           : this.pollConnection.get<number>(host.host + '/blocks/tip/height', { timeout: config.ESPLORA.FALLBACK_TIMEOUT })
         );
         if (result) {


### PR DESCRIPTION
Reverts mempool/mempool#5502

```
Sep  9 07:52:57 [35906] WARN: esplora request failed undefined /bitcoin/socket/esplora-bitcoin-mainnet/block/00000000000000000003a6921e3dd9674dc0927ca5135e0b0f778cc186871c4e
Sep  9 07:52:57 [35906] WARN: Invalid URL
Sep  9 07:52:57 [35906] WARN: esplora request failed undefined /bitcoin/socket/esplora-bitcoin-mainnet/mempool/txids
Sep  9 07:52:57 [35906] WARN: Invalid URL
Sep  9 07:52:57 [35906] DEBUG: Exception in runMainUpdateLoop() (count: 2). Retrying in 1 sec. Reason: Invalid URL. Stack trace: TypeError: Invalid URL
    at new URL (node:internal/url:796:36)
    at dispatchHttpRequest (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:2766:20)
    at /mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:2686:5
    at new Promise (<anonymous>)
    at wrapAsync (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:2666:10)
    at http (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:2704:10)
    at Axios.dispatchRequest (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:4110:10)
    at Axios._request (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:4390:33)
    at Axios.request (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:4257:25)
    at Axios.<computed> [as get] (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:4416:17)
    at Axios.request (/mempool/mainnet/backend/node_modules/axios/dist/node/axios.cjs:4262:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Server.runMainUpdateLoop (/mempool/mainnet/backend/dist/index.js:236:32)

```