### PR TITLE
respect INDEXING_BLOCKS_AMOUNT during summary indexing

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -406,8 +406,16 @@ class Blocks {
     }
 
     try {
+      const blockchainInfo = await bitcoinClient.getBlockchainInfo();
+      const currentBlockHeight = blockchainInfo.blocks;
+      let indexingBlockAmount = Math.min(config.MEMPOOL.INDEXING_BLOCKS_AMOUNT, currentBlockHeight);
+      if (indexingBlockAmount <= -1) {
+        indexingBlockAmount = currentBlockHeight + 1;
+      }
+      const lastBlockToIndex = Math.max(0, currentBlockHeight - indexingBlockAmount + 1);
+
       // Get all indexed block hash
-      const indexedBlocks = await blocksRepository.$getIndexedBlocks();
+      const indexedBlocks = (await blocksRepository.$getIndexedBlocks()).filter(block => block.height >= lastBlockToIndex);
       const indexedBlockSummariesHashesArray = await BlocksSummariesRepository.$getIndexedSummariesId();
 
       const indexedBlockSummariesHashes = {}; // Use a map for faster seek during the indexing loop


### PR DESCRIPTION
This PR changes `$generateBlocksSummariesDatabase` to explicitly enforce the `INDEXING_BLOCKS_AMOUNT` config setting, as it is for the main block indexing and CPFP and difficulty adjustment indexing tasks.

Previously this depended implicitly on however many blocks had already been indexed by `$generateBlockDatabase`, which made it difficult to pause or limit summary indexing without deleting blocks from the database.