### PR TITLE
[accelerator] avoid duplicated accel request with double click

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -75,6 +75,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   @Output() changeMode = new EventEmitter<boolean>();
 
   calculating = true;
+  processing = false;
   selectedOption: 'wait' | 'accel';
   cantPayReason = '';
   quoteError = ''; // error fetching estimate or initial data
@@ -378,9 +379,10 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
    * Account-based acceleration request
    */
   accelerateWithMempoolAccount(): void {
-    if (!this.canPay || this.calculating) {
+    if (!this.canPay || this.calculating || this.processing) {
       return;
     }
+    this.processing = true;
     if (this.accelerationSubscription) {
       this.accelerationSubscription.unsubscribe();
     }
@@ -390,6 +392,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
       this.accelerationUUID
     ).subscribe({
       next: () => {
+        this.processing = false;
         this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
         this.audioService.playSound('ascend-chime-cartoon');
         this.showSuccess = true;
@@ -397,6 +400,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
         this.moveToStep('paid');
       },
       error: (response) => {
+        this.processing = false;
         this.accelerateError = response.error;
       }
     });
@@ -466,10 +470,14 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
    * APPLE PAY
    */
   async requestApplePayPayment(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
     if (this.conversionsSubscription) {
       this.conversionsSubscription.unsubscribe();
     }
 
+    this.processing = true;
     this.conversionsSubscription = this.stateService.conversions$.subscribe(
       async (conversions) => {
         this.conversions = conversions;
@@ -494,6 +502,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
             console.error(`Unable to find apple pay button id='apple-pay-button'`);
             // Try again
             setTimeout(this.requestApplePayPayment.bind(this), 500);
+            this.processing = false;
             return;
           }
           this.loadingApplePay = false;
@@ -505,6 +514,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
               if (!card || !card.brand || !card.expMonth || !card.expYear || !card.last4) {
                 console.error(`Cannot retreive payment card details`);
                 this.accelerateError = 'apple_pay_no_card_details';
+                this.processing = false;
                 return;
               }
               const cardTag = md5(`${card.brand}${card.expMonth}${card.expYear}${card.last4}`.toLowerCase());
@@ -516,6 +526,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                 this.accelerationUUID
               ).subscribe({
                 next: () => {
+                  this.processing = false;
                   this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                   this.audioService.playSound('ascend-chime-cartoon');
                   if (this.applePay) {
@@ -526,6 +537,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                   }, 1000);
                 },
                 error: (response) => {
+                  this.processing = false;
                   this.accelerateError = response.error;
                   if (!(response.status === 403 && response.error === 'not_available')) {
                     setTimeout(() => {
@@ -537,6 +549,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                 }
               });
             } else {
+              this.processing = false;
               let errorMessage = `Tokenization failed with status: ${tokenResult.status}`;
               if (tokenResult.errors) {
                 errorMessage += ` and errors: ${JSON.stringify(
@@ -547,6 +560,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
             }
           });
         } catch (e) {
+          this.processing = false;
           console.error(e);
         }
       }
@@ -557,10 +571,14 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
    * GOOGLE PAY
    */
   async requestGooglePayPayment(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
     if (this.conversionsSubscription) {
       this.conversionsSubscription.unsubscribe();
     }
-
+    
+    this.processing = true;
     this.conversionsSubscription = this.stateService.conversions$.subscribe(
       async (conversions) => {
         this.conversions = conversions;
@@ -595,6 +613,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
             if (!card || !card.brand || !card.expMonth || !card.expYear || !card.last4) {
               console.error(`Cannot retreive payment card details`);
               this.accelerateError = 'apple_pay_no_card_details';
+              this.processing = false;
               return;
             }
             const cardTag = md5(`${card.brand}${card.expMonth}${card.expYear}${card.last4}`.toLowerCase());
@@ -606,6 +625,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
               this.accelerationUUID
             ).subscribe({
               next: () => {
+                this.processing = false;
                 this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                 this.audioService.playSound('ascend-chime-cartoon');
                 if (this.googlePay) {
@@ -616,6 +636,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                 }, 1000);
               },
               error: (response) => {
+                this.processing = false;
                 this.accelerateError = response.error;
                 if (!(response.status === 403 && response.error === 'not_available')) {
                   setTimeout(() => {
@@ -627,6 +648,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
               }
             });
           } else {
+            this.processing = false;
             let errorMessage = `Tokenization failed with status: ${tokenResult.status}`;
             if (tokenResult.errors) {
               errorMessage += ` and errors: ${JSON.stringify(
@@ -644,10 +666,14 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
    * CASHAPP
    */
   async requestCashAppPayment(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
     if (this.conversionsSubscription) {
       this.conversionsSubscription.unsubscribe();
     }
 
+    this.processing = true;
     this.conversionsSubscription = this.stateService.conversions$.subscribe(
       async (conversions) => {
         this.conversions = conversions;
@@ -678,6 +704,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
         this.cashAppPay.addEventListener('ontokenization', event => {
           const { tokenResult, error } = event.detail;
           if (error) {
+            this.processing = false;
             this.accelerateError = error;
           } else if (tokenResult.status === 'OK') {
             this.servicesApiService.accelerateWithCashApp$(
@@ -688,6 +715,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
               this.accelerationUUID
             ).subscribe({
               next: () => {
+                this.processing = false;
                 this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                 this.audioService.playSound('ascend-chime-cartoon');
                 if (this.cashAppPay) {
@@ -702,6 +730,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                 }, 1000);
               },
               error: (response) => {
+                this.processing = false;
                 this.accelerateError = response.error;
                 if (!(response.status === 403 && response.error === 'not_available')) {
                   setTimeout(() => {


### PR DESCRIPTION
Add a basic boolean flag to avoid sending multiple acceleration request by clicking multiple times on the payment button.

Backend already protects against this right now using the `accelerationUUID`, but I'll remove it in another PR in favor on that frontend only fix.

It is very easy to reproduce the issue by enabling the debugger throttling. By setting yourself in GPRS mode before requesting a pro acceleration, without this fix, you can effectively click on the `Pay` button as many times as you want.

