### PR TITLE
Fix mobile routing to tx push and test pages

### DIFF
--- a/frontend/src/app/route-guards.ts
+++ b/frontend/src/app/route-guards.ts
@@ -13,7 +13,8 @@ class GuardService {
 
   trackerGuard(route: Route, segments: UrlSegment[]): boolean {
     const preferredRoute = this.router.getCurrentNavigation()?.extractedUrl.queryParams?.mode;
-    return (preferredRoute === 'status' || (preferredRoute !== 'details' && this.navigationService.isInitialLoad())) && window.innerWidth <= 767.98;
+    const path = this.router.getCurrentNavigation()?.extractedUrl.root.children.primary.segments;
+    return (preferredRoute === 'status' || (preferredRoute !== 'details' && this.navigationService.isInitialLoad())) && window.innerWidth <= 767.98 && !(path.length === 2 && ['push', 'test'].includes(path[1].path));
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where browsing to https://mempool.space/tx/push or https://mempool.space/tx/test on mobile would show a pizza tracker page instead of the broacast / test transaction page.