### PR TITLE
Fix accelerations list page navigation on first load

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input, ChangeDetectorRef, OnDestroy, Inject, LOCALE_ID } from '@angular/core';
-import { BehaviorSubject, Observable, Subscription, catchError, filter, of, switchMap, tap, throttleTime } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription, catchError, combineLatest, filter, of, switchMap, tap, throttleTime, timer } from 'rxjs';
 import { Acceleration, BlockExtended, SinglePoolStats } from '../../../interfaces/node-api.interface';
 import { StateService } from '../../../services/state.service';
 import { WebsocketService } from '../../../services/websocket.service';
@@ -61,8 +61,11 @@ export class AccelerationsListComponent implements OnInit, OnDestroy {
       this.websocketService.want(['blocks']);
       this.seoService.setTitle($localize`:@@02573b6980a2d611b4361a2595a4447e390058cd:Accelerations`);
 
-      this.paramSubscription = this.route.params.pipe(
-        tap(params => {
+      this.paramSubscription = combineLatest([
+        this.route.params,
+        timer(0),
+      ]).pipe(
+        tap(([params]) => {
           this.page = +params['page'] || 1;
           this.pageSubject.next(this.page);
         })


### PR DESCRIPTION
This PR fixes an issue where directly loading https://mempool.space/acceleration/list/10 from the URL would correctly display page 10, but the page selector stays stuck at page 1:

<img width="695" alt="Screenshot 2024-09-18 at 16 59 55" src="https://github.com/user-attachments/assets/571b9dcb-8eac-498a-b3eb-cf28c957ae93">
