### PR TITLE
Fix ETA calculation error

### DIFF
--- a/frontend/src/app/services/eta.service.ts
+++ b/frontend/src/app/services/eta.service.ts
@@ -166,7 +166,7 @@ export class EtaService {
         pools[pool.poolUniqueId] = pool;
       }
       const unacceleratedPosition = this.mempoolPositionFromFees(getUnacceleratedFeeRate(tx, true), mempoolBlocks);
-      const totalAcceleratedHashrate = accelerationPositions.reduce((total, pos) => total + (pools[pos.poolId].lastEstimatedHashrate), 0);
+      const totalAcceleratedHashrate = accelerationPositions.reduce((total, pos) => total + (pools[pos.poolId]?.lastEstimatedHashrate || 0), 0);
       const shares = [
         {
           block: unacceleratedPosition.block,
@@ -174,7 +174,7 @@ export class EtaService {
         },
         ...accelerationPositions.map(pos => ({
           block: pos.block,
-          hashrateShare: ((pools[pos.poolId].lastEstimatedHashrate) / miningStats.lastEstimatedHashrate)
+          hashrateShare: ((pools[pos.poolId]?.lastEstimatedHashrate || 0) / miningStats.lastEstimatedHashrate)
         }))
       ];
       return this.calculateETAFromShares(shares, da);


### PR DESCRIPTION
This PR fixes the error occuring in ETA calculation that occured when a participating mining pool does not appear in the fetch mining statistics. 