### PR TITLE
Fix race condition between accelerations and block audit api calls

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -327,7 +327,7 @@ export class BlockComponent implements OnInit, OnDestroy {
       })
     ).subscribe((accelerations) => {
       this.accelerations = accelerations;
-      if (accelerations.length) {
+      if (accelerations.length && this.strippedTransactions) { // Don't call setupBlockAudit if we don't have transactions yet; it will be called later in overviewSubscription
         this.setupBlockAudit();
       }
     });


### PR DESCRIPTION
This PR fixes an issue happening during the load a block containing accelerations, when acceleration data is loaded before the block's transactions which caused the frontend to show the non-audit view until transactions are finally loaded. 

Before: 

https://github.com/user-attachments/assets/a1e32983-4239-4a53-b52c-d0eef9fbce0e

After: 

https://github.com/user-attachments/assets/9d6ad7dc-9f30-4009-b8c1-dbe21dcfa0a7

