### PR TITLE
Don't show negative timespans on timeline

### DIFF
--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.html
@@ -38,7 +38,7 @@
         <div class="node-spacer"></div>
         <div class="interval">
           <div class="interval-time">
-            <app-time [time]="acceleratedAt - transactionTime"></app-time>
+            <app-time [time]="firstSeenToAccelerated"></app-time>
           </div>
         </div>
         <div class="node-spacer"></div>
@@ -46,7 +46,7 @@
           <div class="interval-time">
             @if (tx.status.confirmed) {
               <div class="interval-time">
-                <app-time [time]="tx.status.block_time - acceleratedAt"></app-time>
+                <app-time [time]="acceleratedToMined"></app-time>
               </div>
             } @else if (standardETA && !tx.status.confirmed) {
               <!-- ~<app-time [time]="standardETA / 1000 - now"></app-time> -->

--- a/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
+++ b/frontend/src/app/components/acceleration-timeline/acceleration-timeline.component.ts
@@ -24,6 +24,8 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
   accelerateRatio: number;
   useAbsoluteTime: boolean = false;
   interval: number;
+  firstSeenToAccelerated: number;
+  acceleratedToMined: number;
 
   tooltipPosition = null;
   hoverInfo: any = null;
@@ -35,8 +37,6 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.acceleratedAt = this.tx.acceleratedAt ?? new Date().getTime() / 1000;
-    this.now = Math.floor(new Date().getTime() / 1000);
-    this.useAbsoluteTime = this.tx.status.block_time < this.now - 7 * 24 * 3600;
 
     this.miningService.getPools().subscribe(pools => {
       for (const pool of pools) {
@@ -44,10 +44,8 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
       }
     });
 
-    this.interval = window.setInterval(() => {
-      this.now = Math.floor(new Date().getTime() / 1000);
-      this.useAbsoluteTime = this.tx.status.block_time < this.now - 7 * 24 * 3600;
-    }, 60000);
+    this.updateTimes();
+    this.interval = window.setInterval(this.updateTimes.bind(this), 60000);
   }
 
   ngOnChanges(changes): void {
@@ -62,6 +60,13 @@ export class AccelerationTimelineComponent implements OnInit, OnChanges {
     //     }
     //   }
     // }
+  }
+
+  updateTimes(): void {
+    this.now = Math.floor(new Date().getTime() / 1000);
+    this.useAbsoluteTime = this.tx.status.block_time < this.now - 7 * 24 * 3600;
+    this.firstSeenToAccelerated = Math.max(0, this.acceleratedAt - this.transactionTime);
+    this.acceleratedToMined = Math.max(0, this.tx.status.block_time - this.acceleratedAt);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Partially addresses #5544

This PR avoids showing negative timespans on the acceleration timeline (example https://mempool.space/tx/6f1ed999edf679edf20cc8b11feff696a478647435f2e3c9ee6d7a989d32ddfd)

The issue should be definitely fixed once #5543 is implemented, by using first seen time instead of block time.