### PR TITLE
refactor miner name truncation

### DIFF
--- a/backend/src/utils/bitcoin-script.ts
+++ b/backend/src/utils/bitcoin-script.ts
@@ -223,5 +223,5 @@ export function parseDATUMTemplateCreator(coinbaseRaw: string): string[] | null 
   let tagString = String.fromCharCode(...tags);
   tagString = tagString.replace('\x00', '');
 
-  return tagString.split('\x0f');
+  return tagString.split('\x0f').map((name) => name.replace(/[^a-zA-Z0-9 ]/g, ''));
 }

--- a/frontend/src/app/components/block/block-preview.component.html
+++ b/frontend/src/app/components/block/block-preview.component.html
@@ -53,32 +53,28 @@
             <td i18n="block.miner">Miner</td>
             <td *ngIf="stateService.env.MINING_DASHBOARD">
               <a placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, block.extras.pool.slug]" class="badge" style="color: #FFF;padding:0;">
-                <ng-container *ngIf="block.extras.pool.minerNames != undefined && block.extras.pool.minerNames.length > 1 && block.extras.pool.minerNames[1] != ''; else centralisedPool">
-                  {{ block.extras.pool.minerNames[1] }}
-                  <div class="on-pool">
-                    on
-                    <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
-                    {{ block.extras.pool.name}}
-                  </div>
-                </ng-container>
-                <ng-template #centralisedPool>
-                  <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
-                  {{ block.extras.pool.name }}
-                </ng-template>
+                <span class="miner-name" *ngIf="block.extras.pool.minerNames?.length > 1 && block.extras.pool.minerNames[1] != ''">
+                  @if (block.extras.pool.minerNames[1].length > 16) {
+                    {{ block.extras.pool.minerNames[1].slice(0, 15) }}…
+                  } @else {
+                    {{ block.extras.pool.minerNames[1] }}
+                  }
+                </span>
+                <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
+                {{ block.extras.pool.name }}
               </a>
             </td>
             <td *ngIf="!stateService.env.MINING_DASHBOARD && stateService.env.BASE_MODULE === 'mempool'">
               <span [attr.data-cy]="'block-details-miner-badge'" placement="bottom" class="badge"
                 [class]="!block?.extras.pool.name || block?.extras.pool.slug === 'unknown' ? 'badge-secondary' : 'badge-primary'">
-                <ng-container *ngIf="block?.extras.pool.minerNames != undefined && block?.extras.pool.minerNames.length > 1 && block?.extras.pool.minerNames[1] != ''; else centralisedPool">
-                  {{ block?.extras.pool.minerNames[1] }}
-                  <div class="on-pool">
-                    on {{ block?.extras.pool.name }}
-                  </div>
-                </ng-container>
-                <ng-template #centralisedPool>
-                  {{ block?.extras.pool.name }}
-                </ng-template>
+                <span class="miner-name" *ngIf="block.extras.pool.minerNames?.length > 1 && block.extras.pool.minerNames[1] != ''">
+                  @if (block.extras.pool.minerNames[1].length > 16) {
+                    {{ block.extras.pool.minerNames[1].slice(0, 15) }}…
+                  } @else {
+                    {{ block.extras.pool.minerNames[1] }}
+                  }
+                </span>
+                {{ block.extras.pool.name }}
               </span>
             </td>
           </tr>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -182,16 +182,15 @@
         <td i18n="block.miner">Miner</td>
         <td *ngIf="stateService.env.MINING_DASHBOARD">
           <a placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, block.extras.pool.slug]" class="badge" style="color: #FFF;padding:0;">
-            <div class="on-pool-container" *ngIf="block.extras.pool.minerNames != undefined && block.extras.pool.minerNames.length > 1 && block.extras.pool.minerNames[1] != ''; else centralisedPool">
-              {{ block.extras.pool.minerNames[1] }}
-              <div class="on-pool">
-                <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
-                {{ block.extras.pool.name }}
-              </div>
-            </div>
-            <ng-template #centralisedPool>
-              <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'"> {{ block.extras.pool.name }}
-            </ng-template>
+            <span class="miner-name" *ngIf="block.extras.pool.minerNames?.length > 1 && block.extras.pool.minerNames[1] != ''">
+              @if (block.extras.pool.minerNames[1].length > 16) {
+                {{ block.extras.pool.minerNames[1].slice(0, 15) }}…
+              } @else {
+                {{ block.extras.pool.minerNames[1] }}
+              }
+            </span>
+            <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
+            {{ block.extras.pool.name }}
           </a>
         </td>
         <td *ngIf="!stateService.env.MINING_DASHBOARD && stateService.env.BASE_MODULE === 'mempool'">

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -81,17 +81,9 @@ h1 {
   }
 }
 
-.on-pool-container {
-  display: inline;
-  flex-direction: row;
-}
-
-.on-pool {
-  background-color: var(--bg);
-  display: inline-block;
-  margin-top: 4px;
-  padding: .25em .4em;
-  border-radius: .25rem;
+.miner-name {
+  margin-right: 4px;
+  vertical-align: top;
 }
 
 .pool-logo {

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -60,11 +60,11 @@
           </ng-container>
         </div>
         <div class="animated" *ngIf="block.extras?.pool != undefined && showPools">
-          <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
-            <div *ngIf="block.extras.pool.minerNames != undefined && block.extras.pool.minerNames.length > 1 && block.extras.pool.minerNames[1] != ''; else centralisedPool">
+          <a [attr.data-cy]="'bitcoin-block-' + offset + '-index-' + i + '-pool'" class="badge" [class.miner-name]="block.extras.pool.minerNames?.length > 1 && block.extras.pool.minerNames[1] != ''" [routerLink]="[('/mining/pool/' + block.extras.pool.slug) | relativeUrl]">
+            <ng-container *ngIf="block.extras.pool.minerNames?.length > 1 && block.extras.pool.minerNames[1] != ''; else centralisedPool">
               <img [ngbTooltip]="block.extras.pool.name" class="pool-logo faded" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'">
               {{ block.extras.pool.minerNames[1] }}
-            </div>
+            </ng-container>
             <ng-template #centralisedPool>
               <img class="pool-logo" [src]="'/resources/mining-pools/' + block.extras.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block.extras.pool.name + ' mining pool'"> {{ block.extras.pool.name }}
             </ng-template>

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -187,9 +187,16 @@
 
 .badge {
   position: relative;
-  top: 15px;
+  top: 19px;
   z-index: 101;
   color: #FFF;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 145px;
+
+  &.miner-name {
+    max-width: 125px;
+  }
 }
 
 .pool-logo {

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -281,15 +281,6 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
         if (block?.extras) {
           block.extras.minFee = this.getMinBlockFee(block);
           block.extras.maxFee = this.getMaxBlockFee(block);
-          if (block.extras.pool?.minerNames) {
-            block.extras.pool.minerNames = block.extras.pool.minerNames.map((name) => {
-              name = name.replace(/[^a-zA-Z0-9 ]/g, '');
-              if (name.length > 16) {
-                return name.slice(0, 16) + '…';
-              }
-              return name;
-            });
-          }
         }
       }
       this.blocks.push(block || {
@@ -332,14 +323,6 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
       if (block?.extras) {
         block.extras.minFee = this.getMinBlockFee(block);
         block.extras.maxFee = this.getMaxBlockFee(block);
-        if (block.extras.pool?.minerNames) {
-          block.extras.pool.minerNames = block.extras.pool.minerNames.map((name) => {
-            if (name.length > 16) {
-              return name.slice(0, 16) + '…';
-            }
-            return name;
-          });
-        }
       }
       this.blocks[blockIndex] = block;
       this.blockStyles[blockIndex] = this.getStyleForBlock(block, blockIndex);

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -684,17 +684,15 @@
         @if (pool) {
           <td class="wrap-cell">
             <a placement="bottom" [routerLink]="['/mining/pool' | relativeUrl, pool.slug]" class="badge" style="color: #FFF;padding:0;">
-              <div class="on-pool-container" *ngIf="pool.minerNames != undefined && pool.minerNames.length > 1 && pool.minerNames[1] != ''; else centralisedPool">
-                {{ pool.minerNames[1] }}
-                <div class="on-pool">
-                  <img class="pool-logo" [src]="'/resources/mining-pools/' + pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + pool.name + ' mining pool'">
-                  {{ pool.name }}
-                </div>
-              </div>
-              <ng-template #centralisedPool>
-                <img class="pool-logo" [src]="'/resources/mining-pools/' + pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + pool.name + ' mining pool'">
-                {{ pool.name }}
-              </ng-template>
+              <span class="miner-name" *ngIf="pool.minerNames?.length > 1 && pool.minerNames[1] != ''">
+                @if (pool.minerNames[1].length > 16) {
+                  {{ pool.minerNames[1].slice(0, 15) }}…
+                } @else {
+                  {{ pool.minerNames[1] }}
+                }
+              </span>
+              <img class="pool-logo" [src]="'/resources/mining-pools/' + pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + pool.name + ' mining pool'">
+              {{ pool.name }}
             </a>
           </td>
         } @else {

--- a/frontend/src/app/components/transaction/transaction.component.scss
+++ b/frontend/src/app/components/transaction/transaction.component.scss
@@ -60,17 +60,9 @@
 	top: -1px;
 }
 
-.on-pool-container {
-  display: inline;
-  flex-direction: row;
-}
-
-.on-pool {
-  background-color: var(--bg);
-  display: inline-block;
-  margin-top: 4px;
-  padding: .25em .4em;
-  border-radius: .25rem;
+.miner-name {
+  margin-right: 4px;
+  vertical-align: top;
 }
 
 .pool-logo {


### PR DESCRIPTION
a light refactor of a few parts of the miner name tag feature:
 - moves the ASCII filtering into the backend to reduce code repetition.
 - simplifies the HTML templates.
 - changes the miner name truncation on the blockchain blocks to use CSS `text-overflow: ellipsis`, to take better advantage of the limited space available.
 - adds JS truncation to the names on the block and transaction pages.
     - limit of 16 characters, *including* any ellipsis.
     
The `text-overflow` CSS property isn't compatible with the baseline vertical alignment we were previously using on those badges, so for consistency this PR applies the overflow ellipsis to *all* badges, not just the new miner name ones.

This means some particularly long historical pool names are now truncated where they weren't before, although I think this is an improvement. To avoid changing the appearance of active pools with borderline length names like "Carbon Negative", the width limit is slightly more generous for existing pool names than it is for the new miner names. (145px vs 125px)

| Before | After |
|-|-|
| ![Screenshot 2024-09-26 at 5 23 03 PM](https://github.com/user-attachments/assets/c3601ae5-1667-40bd-9370-2b87baf290b9) | ![Screenshot 2024-09-26 at 5 23 10 PM](https://github.com/user-attachments/assets/c6e87a78-40b7-4fa7-a6da-cc7e740cc8dd) |
