### PR TITLE
fix acceleration history paging w/ undefined total

### DIFF
--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -165,7 +165,7 @@ export class ServicesApiServices {
       return this.getAccelerationHistoryObserveResponse$({...params, page}).pipe(
         map((response) => ({
           page,
-          total: parseInt(response.headers.get('X-Total-Count'), 10),
+          total: parseInt(response.headers.get('X-Total-Count'), 10) || 0,
           accelerations: accelerations.concat(response.body || []),
         })),
         switchMap(({page, total, accelerations}) => {


### PR DESCRIPTION
Fixes a bug where `getAllAccelerationHistory` would try to load infinite pages if the `X-Total-Count` header was missing or not parseable.