### PR TITLE
Don't clobber effective fee rates

### DIFF
--- a/backend/src/api/transaction-utils.ts
+++ b/backend/src/api/transaction-utils.ts
@@ -121,6 +121,7 @@ class TransactionUtils {
     const adjustedVsize = Math.max(fractionalVsize, sigops *  5); // adjusted vsize = Max(weight, sigops * bytes_per_sigop) / witness_scale_factor
     const feePerVbytes = (transaction.fee || 0) / fractionalVsize;
     const adjustedFeePerVsize = (transaction.fee || 0) / adjustedVsize;
+    const effectiveFeePerVsize = transaction['effectiveFeePerVsize'] || adjustedFeePerVsize || feePerVbytes;
     const transactionExtended: MempoolTransactionExtended = Object.assign(transaction, {
       order: this.txidToOrdering(transaction.txid),
       vsize,
@@ -128,7 +129,7 @@ class TransactionUtils {
       sigops,
       feePerVsize: feePerVbytes,
       adjustedFeePerVsize: adjustedFeePerVsize,
-      effectiveFeePerVsize: adjustedFeePerVsize,
+      effectiveFeePerVsize: effectiveFeePerVsize,
     });
     if (!transactionExtended?.status?.confirmed && !transactionExtended.firstSeen) {
       transactionExtended.firstSeen = Math.round((Date.now() / 1000));


### PR DESCRIPTION
Fixes a bug where CPFP effective fee rates would get unintentionally overwritten in certain circumstances. Then, since the change occurred outside of the normal GBT effective fee rate lifecycle, it would not be corrected in subsequent mempool updates.

Specifically, `transactionUtils.extendMempoolTransaction(transaction, ...)` resets the effectiveFeePerVsize back to the non-CPFP adjusted fee rate:

https://github.com/mempool/mempool/blob/8876bb8f43b6bc8a810fb0c41f15864c8cd2ba62/backend/src/api/transaction-utils.ts#L124-L132

This function is normally only called when transactions are first added to the mempool to initialize certain fields *before* GBT updates the effectiveFeePerVsize with the correct value.

However, (since https://github.com/mempool/mempool/pull/5479), we also use it to ensure all fields are present in `mempool.handleRbfTransactions`, and as a side-effect of the `getTransaction` API with non-esplora backends.

Rather than try to avoid ever calling `extendMempoolTransaction` after a transaction has been assigned an effective fee rate, this PR fixes the issue by preserving any existing `effectiveFeePerVsize` on the transaction object.