### PR TITLE
handle /utxos error on address page

### DIFF
--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -219,9 +219,13 @@ export class AddressComponent implements OnInit, OnDestroy {
             address.is_pubkey
               ? this.electrsApiService.getScriptHashTransactions$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
               : this.electrsApiService.getAddressTransactions$(address.address),
-            utxoCount >= 2 && utxoCount <= 500 ? (address.is_pubkey
+            (utxoCount >= 2 && utxoCount <= 500 ? (address.is_pubkey
               ? this.electrsApiService.getScriptHashUtxos$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
-              : this.electrsApiService.getAddressUtxos$(address.address)) : of([])
+              : this.electrsApiService.getAddressUtxos$(address.address)) : of([])).pipe(
+                catchError(() => {
+                  return of([]);
+                })
+              )
           ]);
         }),
         switchMap(([transactions, utxos]) => {


### PR DESCRIPTION
Fixes a bug introduced with the new UTXO chart where a non-200 response from the `/utxos` API would error out the whole address page.

<img width="768" alt="Screenshot 2024-09-29 at 9 39 36 AM" src="https://github.com/user-attachments/assets/d21d81c5-86ff-4d47-8c5b-f1d8662fabd1">

This could happen when an address doesn't currently have too many utxos (so that we do attempt to load them), but did have too many at some point in the past (so the API throws a `Too many unspent transaction outputs` error).

(see https://github.com/mempool/electrs/blob/055aba1e8d0d8f4cf7080014c89e3b3055e3d0b7/src/new_index/schema.rs#L790-L793)

Example (assuming default `utxos_limit`):
https://mempool.space/address/bc1qjr2zgtqq6z0q05xt48f8scf78udlnpp45a6gf5
