### PR TITLE
Reset block audit on block navigation

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -163,6 +163,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         this.block = undefined;
         this.error = undefined;
         this.fees = undefined;
+        this.blockAudit = undefined;
         this.oobFees = 0;
 
         if (history.state.data && history.state.data.blockHeight) {


### PR DESCRIPTION
This PR fixes an issue that sometimes happen when browsing through blocks, where previous block's health is still displayed while current audit is loading.