### PR TITLE
Avoid briefly showing incorrect health value

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -66,10 +66,10 @@
                     [class.badge-success]="blockAudit?.matchRate >= 99"
                     [class.badge-warning]="blockAudit?.matchRate >= 75 && blockAudit?.matchRate < 99"
                     [class.badge-danger]="blockAudit?.matchRate < 75"
-                    *ngIf="blockAudit?.matchRate != null; else nullHealth"
+                    *ngIf="blockAudit?.matchRate != null && blockAudit?.id === block.id; else nullHealth"
                   >{{ blockAudit?.matchRate }}%</span>
                   <ng-template #nullHealth>
-                    <ng-container *ngIf="!isLoadingOverview; else loadingHealth">
+                    <ng-container *ngIf="!isLoadingOverview && blockAudit?.id === block.id; else loadingHealth">
                       <span class="health-badge badge badge-secondary" i18n="unknown">Unknown</span>
                     </ng-container>
                   </ng-template>

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -163,7 +163,6 @@ export class BlockComponent implements OnInit, OnDestroy {
         this.block = undefined;
         this.error = undefined;
         this.fees = undefined;
-        this.blockAudit = undefined;
         this.oobFees = 0;
 
         if (history.state.data && history.state.data.blockHeight) {


### PR DESCRIPTION
Reverts the change made by #5563, and actually solves the issue: when quickly browsing through blocks, previous block's health is still displayed for a short time:

https://github.com/user-attachments/assets/5b87d6e7-3957-4104-b940-20187d2c92f1

