### PR TITLE
never show a utxo chart with missing data

### DIFF
--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -219,11 +219,11 @@ export class AddressComponent implements OnInit, OnDestroy {
             address.is_pubkey
               ? this.electrsApiService.getScriptHashTransactions$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
               : this.electrsApiService.getAddressTransactions$(address.address),
-            (utxoCount >= 2 && utxoCount <= 500 ? (address.is_pubkey
+            (utxoCount > 2 && utxoCount <= 500 ? (address.is_pubkey
               ? this.electrsApiService.getScriptHashUtxos$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
-              : this.electrsApiService.getAddressUtxos$(address.address)) : of([])).pipe(
+              : this.electrsApiService.getAddressUtxos$(address.address)) : of(null)).pipe(
                 catchError(() => {
-                  return of([]);
+                  return of(null);
                 })
               )
           ]);
@@ -350,27 +350,29 @@ export class AddressComponent implements OnInit, OnDestroy {
     }
 
     // update utxos in-place
-    let utxosChanged = false;
-    for (const vin of transaction.vin) {
-      const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === vin.txid && utxo.vout === vin.vout);
-      if (utxoIndex !== -1) {
-        this.utxos.splice(utxoIndex, 1);
-        utxosChanged = true;
+    if (this.utxos != null) {
+      let utxosChanged = false;
+      for (const vin of transaction.vin) {
+        const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === vin.txid && utxo.vout === vin.vout);
+        if (utxoIndex !== -1) {
+          this.utxos.splice(utxoIndex, 1);
+          utxosChanged = true;
+        }
       }
-    }
-    for (const [index, vout] of transaction.vout.entries()) {
-      if (vout.scriptpubkey_address === this.address.address) {
-        this.utxos.push({
-          txid: transaction.txid,
-          vout: index,
-          value: vout.value,
-          status: JSON.parse(JSON.stringify(transaction.status)),
-        });
-        utxosChanged = true;
+      for (const [index, vout] of transaction.vout.entries()) {
+        if (vout.scriptpubkey_address === this.address.address) {
+          this.utxos.push({
+            txid: transaction.txid,
+            vout: index,
+            value: vout.value,
+            status: JSON.parse(JSON.stringify(transaction.status)),
+          });
+          utxosChanged = true;
+        }
       }
-    }
-    if (utxosChanged) {
-      this.utxos = this.utxos.slice();
+      if (utxosChanged) {
+        this.utxos = this.utxos.slice();
+      }
     }
     return true;
   }
@@ -385,29 +387,31 @@ export class AddressComponent implements OnInit, OnDestroy {
     this.transactions = this.transactions.slice();
 
     // update utxos in-place
-    let utxosChanged = false;
-    for (const vin of transaction.vin) {
-      if (vin.prevout?.scriptpubkey_address === this.address.address) {
-        this.utxos.push({
-          txid: vin.txid,
-          vout: vin.vout,
-          value: vin.prevout.value,
-          status: { confirmed: true }, // Assuming the input was confirmed
-        });
-        utxosChanged = true;
-      }
-    }
-    for (const [index, vout] of transaction.vout.entries()) {
-      if (vout.scriptpubkey_address === this.address.address) {
-        const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === transaction.txid && utxo.vout === index);
-        if (utxoIndex !== -1) {
-          this.utxos.splice(utxoIndex, 1);
+    if (this.utxos != null) {
+      let utxosChanged = false;
+      for (const vin of transaction.vin) {
+        if (vin.prevout?.scriptpubkey_address === this.address.address) {
+          this.utxos.push({
+            txid: vin.txid,
+            vout: vin.vout,
+            value: vin.prevout.value,
+            status: { confirmed: true }, // Assuming the input was confirmed
+          });
           utxosChanged = true;
         }
       }
-    }
-    if (utxosChanged) {
-      this.utxos = this.utxos.slice();
+      for (const [index, vout] of transaction.vout.entries()) {
+        if (vout.scriptpubkey_address === this.address.address) {
+          const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === transaction.txid && utxo.vout === index);
+          if (utxoIndex !== -1) {
+            this.utxos.splice(utxoIndex, 1);
+            utxosChanged = true;
+          }
+        }
+      }
+      if (utxosChanged) {
+        this.utxos = this.utxos.slice();
+      }
     }
 
     return true;
@@ -415,27 +419,29 @@ export class AddressComponent implements OnInit, OnDestroy {
 
   confirmTransaction(transaction: Transaction): void {
     // update utxos in-place
-    let utxosChanged = false;
-    for (const vin of transaction.vin) {
-      if (vin.prevout?.scriptpubkey_address === this.address.address) {
-        const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === vin.txid && utxo.vout === vin.vout);
-        if (utxoIndex !== -1) {
-          this.utxos[utxoIndex].status = JSON.parse(JSON.stringify(transaction.status));
-          utxosChanged = true;
+    if (this.utxos != null) {
+      let utxosChanged = false;
+      for (const vin of transaction.vin) {
+        if (vin.prevout?.scriptpubkey_address === this.address.address) {
+          const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === vin.txid && utxo.vout === vin.vout);
+          if (utxoIndex !== -1) {
+            this.utxos[utxoIndex].status = JSON.parse(JSON.stringify(transaction.status));
+            utxosChanged = true;
+          }
         }
       }
-    }
-    for (const [index, vout] of transaction.vout.entries()) {
-      if (vout.scriptpubkey_address === this.address.address) {
-        const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === transaction.txid && utxo.vout === index);
-        if (utxoIndex !== -1) {
-          this.utxos[utxoIndex].status = JSON.parse(JSON.stringify(transaction.status));
-          utxosChanged = true;
+      for (const [index, vout] of transaction.vout.entries()) {
+        if (vout.scriptpubkey_address === this.address.address) {
+          const utxoIndex = this.utxos.findIndex((utxo) => utxo.txid === transaction.txid && utxo.vout === index);
+          if (utxoIndex !== -1) {
+            this.utxos[utxoIndex].status = JSON.parse(JSON.stringify(transaction.status));
+            utxosChanged = true;
+          }
         }
       }
-    }
-    if (utxosChanged) {
-      this.utxos = this.utxos.slice();
+      if (utxosChanged) {
+        this.utxos = this.utxos.slice();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes a bug with the address page where a utxo chart could be displayed with partial data (recieved via websocket some time after page load) even if the initial `/utxos` request failed or was skipped due to too many or too few utxos.

e.g:
![mempool space_address_bc1qmcdp5999hswqmdpkzk93kf788xj8sn5g7qj3gp](https://github.com/user-attachments/assets/3ae3d3f8-5b06-4435-a416-d91f3b895f59)

This PR disables the utxo chart for the rest of the page visit if we didn't obtain the initial `/utxos` state.