### PR TITLE
[accelerator] revalidate user choice after choosing fee option

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -374,6 +374,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
       this.selectFeeRateIndex = index;
       this.userBid = Math.max(0, fee);
       this.cost = this.userBid + this.estimate.mempoolBaseFee + this.estimate.vsizeFee;
+      this.validateChoice();
     }
   }
 


### PR DESCRIPTION
Without this, user might be stuck in a "not enough balance" state if user's balance is not enough for the default option