### PR TITLE
use relative paths for critical /app imports

### DIFF
--- a/frontend/src/app/app.module.server.ts
+++ b/frontend/src/app/app.module.server.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 
 import { ZONE_SERVICE } from '@app/injection-tokens';
-import { AppModule } from '@app/app.module';
+import { AppModule } from './app.module';
 import { AppComponent } from '@components/app/app.component';
 import { HttpCacheInterceptor } from '@app/services/http-cache.interceptor';
 import { ZoneService } from '@app/services/zone.service';

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ZONE_SERVICE } from '@app/injection-tokens';
-import { AppRoutingModule } from '@app/app-routing.module';
+import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from '@components/app/app.component';
 import { ElectrsApiService } from '@app/services/electrs-api.service';
 import { OrdApiService } from '@app/services/ord-api.service';

--- a/frontend/src/app/components/asset/asset.component.ts
+++ b/frontend/src/app/components/asset/asset.component.ts
@@ -9,7 +9,7 @@ import { AudioService } from '@app/services/audio.service';
 import { ApiService } from '@app/services/api.service';
 import { of, merge, Subscription, combineLatest } from 'rxjs';
 import { SeoService } from '@app/services/seo.service';
-import { environment } from '@app/../environments/environment';
+import { environment } from '@environments/environment';
 import { AssetsService } from '@app/services/assets.service';
 import { moveDec } from '@app/bitcoin.utils';
 

--- a/frontend/src/app/previews.module.ts
+++ b/frontend/src/app/previews.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '@app/shared/shared.module';
 import { RouterModule } from '@angular/router';
 import { GraphsModule } from '@app/graphs/graphs.module';
-import { PreviewsRoutingModule } from '@app/previews.routing.module';
+import { PreviewsRoutingModule } from './previews.routing.module';
 import { TransactionPreviewComponent } from '@components/transaction/transaction-preview.component';
 import { BlockPreviewComponent } from '@components/block/block-preview.component';
 import { AddressPreviewComponent } from '@components/address/address-preview.component';


### PR DESCRIPTION
reverts to relative paths for a few critical /app imports so that we can safely override other `@app/` paths in `tsconfig.json` 