### PR TITLE
Fix navigation to use relative paths

### DIFF
--- a/frontend/src/app/components/blocks-list/blocks-list.component.ts
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.ts
@@ -9,6 +9,7 @@ import { WebsocketService } from '@app/services/websocket.service';
 import { SeoService } from '@app/services/seo.service';
 import { OpenGraphService } from '@app/services/opengraph.service';
 import { seoDescriptionNetwork } from '@app/shared/common.utils';
+import { RelativeUrlPipe } from '@app/shared/pipes/relative-url/relative-url.pipe';
 
 @Component({
   selector: 'app-blocks-list',
@@ -49,6 +50,7 @@ export class BlocksList implements OnInit {
     private ogService: OpenGraphService,
     private route: ActivatedRoute,
     private router: Router,
+    private relativeUrlPipe: RelativeUrlPipe,
     @Inject(LOCALE_ID) private locale: string,
   ) {
     this.isMempoolModule = this.stateService.env.BASE_MODULE === 'mempool';
@@ -182,7 +184,7 @@ export class BlocksList implements OnInit {
   }
 
   pageChange(page: number): void {
-    this.router.navigate(['blocks', page]);
+    this.router.navigate([this.relativeUrlPipe.transform('/blocks/'), page]);
   }
 
   trackByBlock(index: number, block: BlockExtended): number {

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -267,7 +267,7 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
 
       if (event.key === prevKey) {
         if (this.mempoolBlocks[this.markIndex - 1]) {
-          this.router.navigate([this.relativeUrlPipe.transform('mempool-block/'), this.markIndex - 1]);
+          this.router.navigate([this.relativeUrlPipe.transform('/mempool-block/'), this.markIndex - 1]);
         } else {
           const blocks = this.stateService.blocksSubject$.getValue();
           for (const block of (blocks || [])) {


### PR DESCRIPTION
Mempool blocks at `/mempool-blocks/1` and blocks list at `/blocks/1` were broken on non-root network. This is fixed by using relative URL paths.