### PR TITLE
Fix acceleration list observable subscription logic

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.html
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.html
@@ -4,7 +4,7 @@
 
   <div class="clearfix"></div>
 
-  <div class="acceleration-list">
+  <div class="acceleration-list" *ngIf="{ accelerations: accelerationList$ | async } as state">
     <table *ngIf="nonEmptyAccelerations; else noData" class="table table-borderless table-fixed">
       <thead>
         <th class="txid text-left" i18n="dashboard.latest-transactions.txid">TXID</th>
@@ -21,8 +21,8 @@
           <th class="date text-right" i18n="accelerator.requested" *ngIf="!this.widget">Requested</th>
         </ng-container>
       </thead>
-      <tbody *ngIf="accelerationList$ | async as accelerations; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
-        <tr *ngFor="let acceleration of accelerations; let i= index;">
+      <tbody *ngIf="state.accelerations && nonEmptyAccelerations; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
+        <tr *ngFor="let acceleration of state.accelerations; let i= index;">
           <td class="txid text-left">
             <a [routerLink]="['/tx' | relativeUrl, acceleration.txid]">
               <app-truncate [text]="acceleration.txid" [lastChars]="5"></app-truncate>


### PR DESCRIPTION
Fixes a bug that could cause the recent accelerations list widget not to update properly when new accelerations arrive.

#5398 moved the implicit async pipe `accelerationList$` subscription inside another element, conditional on a simple `nonEmptyAccelerations` variable.

This means that when `nonEmptyAccelerations` turns false (i.e. whenever the accelerationsList$ observable emits an empty list), that inner part of the template is removed, Angular automatically unsubscribes from the observable, and we get stuck in the empty state forever.

This PR moves the `accelerationList$` async pipe back to the top level so that the subscription is maintained for the full lifetime of the component.