### PR TITLE
fix stuck mempool block on network change

### DIFF
--- a/frontend/src/app/services/websocket.service.ts
+++ b/frontend/src/app/services/websocket.service.ts
@@ -37,6 +37,7 @@ export class WebsocketService {
   private isTrackingWallet: boolean = false;
   private trackingWalletName: string;
   private trackingMempoolBlock: number;
+  private trackingMempoolBlockNetwork: string;
   private stoppingTrackMempoolBlock: any | null = null;
   private latestGitCommit = '';
   private onlineCheckTimeout: number;
@@ -226,10 +227,11 @@ export class WebsocketService {
       clearTimeout(this.stoppingTrackMempoolBlock);
     }
     // skip duplicate tracking requests
-    if (force || this.trackingMempoolBlock !== block) {
+    if (force || this.trackingMempoolBlock !== block || this.network !== this.trackingMempoolBlockNetwork) {
       this.websocketSubject.next({ 'track-mempool-block': block });
       this.isTrackingMempoolBlock = true;
       this.trackingMempoolBlock = block;
+      this.trackingMempoolBlockNetwork = this.network;
       return true;
     }
     return false;


### PR DESCRIPTION
Fixes #5603, a bug where the projected block visualization gets stuck when switching networks.

This was introduced by #5445, which allowed the visualization to be persisted between different pages. The logic to avoid unnecessarily unsubscribing and resubscribing to the same `mempool-block` didn't check for network changes, and so prevented opening a new subscription to the same mempool block number after switching to a different network.

Before:

https://github.com/user-attachments/assets/1a8fd710-ef91-407a-b7bd-c83124e14bd4

After:

https://github.com/user-attachments/assets/afdd7374-2e93-4dfb-8e12-e6176ba9a1c5

