### PR TITLE
fix undefined mempool tx errors

### DIFF
--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -688,7 +688,7 @@ class MempoolBlocks {
       [pool: string]: { name: string, block: number, vsize: number, accelerations: string[], complete: boolean };
     } = {};
     // prepare a list of accelerations in ascending order (we'll pop items off the end of the list)
-    const accQueue: { acceleration: Acceleration, rate: number, vsize: number }[] = Object.values(accelerations).map(acc => {
+    const accQueue: { acceleration: Acceleration, rate: number, vsize: number }[] = Object.values(accelerations).filter(acc => acc.txid in mempoolCache).map(acc => {
       let vsize = mempoolCache[acc.txid].vsize;
       for (const ancestor of mempoolCache[acc.txid].ancestors || []) {
         vsize += (ancestor.weight / 4);

--- a/backend/src/api/mempool-blocks.ts
+++ b/backend/src/api/mempool-blocks.ts
@@ -382,7 +382,7 @@ class MempoolBlocks {
 
     const ancestors: Ancestor[] = [];
     const descendants: Ancestor[] = [];
-    let ancestor: MempoolTransactionExtended
+    let ancestor: MempoolTransactionExtended;
     for (const cluster of clusters) {
       for (const memberTxid of cluster) {
         const mempoolTx = mempool[memberTxid];
@@ -462,7 +462,7 @@ class MempoolBlocks {
 
       for (let i = 0; i < block.length; i++) {
         const txid = block[i];
-        if (txid) {
+        if (txid in mempool) {
           mempoolTx = mempool[txid];
           // save position in projected blocks
           mempoolTx.position = {
@@ -481,6 +481,9 @@ class MempoolBlocks {
               mempoolTx.acceleratedAt = acceleration?.added;
               mempoolTx.feeDelta = acceleration?.feeDelta;
               for (const ancestor of mempoolTx.ancestors || []) {
+                if (!(ancestor.txid in mempool)) {
+                  continue;
+                }
                 if (!mempool[ancestor.txid].acceleration) {
                   mempool[ancestor.txid].cpfpDirty = true;
                 }


### PR DESCRIPTION
adds some missing checks and guards to prevent undefined property accesses while processing mempool blocks in rare edge cases.