### PR TITLE
Fix tx frontend issues after acceleration cancellation

### DIFF
--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -217,10 +217,10 @@
     <tr>
       <td class="td-width" i18n="transaction.fee|Transaction fee">Fee</td>
       <td class="text-wrap">{{ tx.fee | number }} <span class="symbol" i18n="shared.sats">sats</span>
-        @if (accelerationInfo?.bidBoost ?? tx.feeDelta > 0) {
+        @if (isAcceleration && accelerationInfo?.bidBoost ?? tx.feeDelta > 0) {
           <span class="oobFees" i18n-ngbTooltip="Acceleration Fees" ngbTooltip="Acceleration fees paid out-of-band"> +{{ accelerationInfo?.bidBoost ?? tx.feeDelta | number }} </span><span class="symbol" i18n="shared.sats">sats</span>
         }
-        <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee + ((accelerationInfo?.bidBoost ?? tx.feeDelta) || 0)"></app-fiat></span>
+        <span class="fiat"><app-fiat [blockConversion]="tx.price" [value]="tx.fee + (isAcceleration ? ((accelerationInfo?.bidBoost ?? tx.feeDelta) || 0) : 0)"></app-fiat></span>
       </td>
     </tr>
   } @else {

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -879,6 +879,9 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       this.tx.acceleratedAt = cpfpInfo.acceleratedAt;
       this.tx.feeDelta = cpfpInfo.feeDelta;
       this.setIsAccelerated(firstCpfp);
+    } else if (this.tx.acceleration) { // Acceleration was cancelled while on the tx page, reset acceleration state
+      this.tx.acceleration = false;
+      this.setIsAccelerated(firstCpfp);
     }
     
     if (this.notAcceleratedOnLoad === null) {


### PR DESCRIPTION
Fixes a few issues that occur when cancelling an acceleration: 

- ETA was loading forever 
- Fee delta was still being displayed in transaction details
- acceleration timeline was not removed upon cancellation


https://github.com/user-attachments/assets/79a30c13-7d39-47f3-83c9-4cdf13dca309



I will include some visualization of the cancellation in the timeline in a separate PR.

