### PR TITLE
Fix liquid database index

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -797,8 +797,7 @@ class DatabaseMigration {
           ADD INDEX \`lastblockupdate\` (\`lastblockupdate\`),
           ADD INDEX \`blocktime\` (\`blocktime\`),
           ADD INDEX \`emergencyKey\` (\`emergencyKey\`),
-          ADD INDEX \`expiredAt\` (\`expiredAt\`),
-          ADD INDEX \`balance\` (\`balance\`)
+          ADD INDEX \`expiredAt\` (\`expiredAt\`)
       `);
       await this.updateToSchemaVersion(93);
     }


### PR DESCRIPTION
Fixes Liquid database migration that adds an index to the `balance` column in `federation_txos` table (there is no such column in this table)