### PR TITLE
Fix fiat tick precision on address balance chart

### DIFF
--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -116,7 +116,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
                     } else if (this.conversions && this.conversions['USD']) {
                       price = this.conversions['USD'];
                     }
-                    return { ...item, price: price }
+                    return { ...item, price: price };
                   });
                 }
               }),
@@ -338,7 +338,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
           axisLabel: {
             color: 'rgb(110, 112, 121)',
             formatter: function(val) {
-              return `$${this.amountShortenerPipe.transform(val, 0, undefined, true)}`;
+              return `$${this.amountShortenerPipe.transform(val, 3, undefined, true, true)}`;
             }.bind(this)
           },
           splitLine: {
@@ -406,7 +406,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
 
   onChartClick(e) {
     if (this.hoverData?.length && this.hoverData[0]?.[2]?.txid) {
-      this.zone.run(() => { 
+      this.zone.run(() => {
         const url = this.relativeUrlPipe.transform(`/tx/${this.hoverData[0][2].txid}`);
         if (e.event.event.shiftKey || e.event.event.ctrlKey || e.event.event.metaKey) {
           window.open(url);
@@ -471,7 +471,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
     // Add a point at today's date to make the graph end at the current time
     extendedSummary.unshift({ time: Date.now() / 1000, value: 0 });
     extendedSummary.reverse();
-    
+
     let oneHour = 60 * 60;
     // Fill gaps longer than interval
     for (let i = 0; i < extendedSummary.length - 1; i++) {
@@ -484,7 +484,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
         i += hours - 1;
       }
     }
-  
+
     return extendedSummary.reverse();
   }
 }

--- a/frontend/src/app/shared/pipes/amount-shortener.pipe.ts
+++ b/frontend/src/app/shared/pipes/amount-shortener.pipe.ts
@@ -8,8 +8,12 @@ export class AmountShortenerPipe implements PipeTransform {
     const digits = args[0] ?? 1;
     const unit = args[1] || undefined;
     const isMoney = args[2] || false;
+    const sigfigs = args[3] || false; // if true, "digits" is the number of significant digits, not the number of decimal places
 
     if (num < 1000) {
+      if (sigfigs) {
+        return Number(num.toPrecision(digits));
+      }
       return num.toFixed(digits);
     }
 
@@ -25,10 +29,15 @@ export class AmountShortenerPipe implements PipeTransform {
     const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
     const item = lookup.slice().reverse().find((item) => num >= item.value);
 
-    if (unit !== undefined) {
-      return item ? (num / item.value).toFixed(digits).replace(rx, '$1') + ' ' + item.symbol + unit : '0';
-    } else {
-      return item ? (num / item.value).toFixed(digits).replace(rx, '$1') + item.symbol : '0';
+    if (!item) {
+      return '0';
     }
+
+    const scaledNum = num / item.value;
+    const formattedNum = Number(sigfigs ? scaledNum.toPrecision(digits) : scaledNum.toFixed(digits)).toString();
+
+    return unit !== undefined
+      ? formattedNum + ' ' + item.symbol + unit
+      : formattedNum + item.symbol;
   }
 }


### PR DESCRIPTION
Adds a new `sigfigs` boolean param to the `AmountShortenerPipe`, which formats numbers with a certain number of significant figures instead of a fixed number of decimal places, and uses it to fix the USD y-axis ticks on the address balance chart.

| Before | After |
|-|-|
| <img width="256" alt="Screenshot 2024-12-07 at 8 32 45 PM" src="https://github.com/user-attachments/assets/21dce1e5-7c11-4c7d-a5e5-095c893b3adf"> | <img width="256" alt="Screenshot 2024-12-07 at 8 31 47 PM" src="https://github.com/user-attachments/assets/8b1b21b1-26fa-4381-9d3b-b3271018e9d7"> |