### PR TITLE
disambiguate fee stats

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 94;
+  private static currentVersion = 95;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1117,6 +1117,16 @@ class DatabaseMigration {
         await this.$executeQuery('ALTER TABLE `accelerations` ADD requested datetime DEFAULT NULL');
       }
       await this.updateToSchemaVersion(94);
+    }
+
+    if (databaseSchemaVersion < 95) {
+      // Version 95
+      await this.$executeQuery(`
+        ALTER TABLE \`blocks\`
+          ADD \`effective_median_fee\` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+          ADD \`effective_fee_span\` JSON DEFAULT NULL;
+      `);
+      await this.updateToSchemaVersion(95);
     }
   }
 

--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -63,7 +63,8 @@ class FeeApi {
   }
 
   private optimizeMedianFee(pBlock: MempoolBlock, nextBlock: MempoolBlock | undefined, previousFee?: number): number {
-    const useFee = previousFee ? (pBlock.medianFee + previousFee) / 2 : pBlock.medianFee;
+    const medianFee = pBlock.effectiveMedianFee ?? pBlock.medianFee;
+    const useFee = previousFee ? (medianFee + previousFee) / 2 : medianFee;
     if (pBlock.blockVSize <= 500000) {
       return this.defaultFee;
     }

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -73,6 +73,8 @@ export interface MempoolBlock {
   medianFee: number;
   totalFees: number;
   feeRange: number[];
+  effectiveMedianFee?: number;
+  effectiveFeeRange?: number[];
 }
 
 export interface MempoolBlockWithTransactions extends MempoolBlock {
@@ -288,8 +290,10 @@ export const TransactionFlags = {
 
 export interface BlockExtension {
   totalFees: number;
-  medianFee: number; // median fee rate
-  feeRange: number[]; // fee rate percentiles
+  medianFee: number; // core median fee rate
+  feeRange: number[]; // core fee rate percentiles
+  effectiveMedianFee?: number; // effective median fee rate
+  effectiveFeeRange?: number[]; // effective fee rate percentiles
   reward: number;
   matchRate: number | null;
   expectedFees: number | null;
@@ -369,9 +373,18 @@ export interface MempoolStats {
   tx_count: number;
 }
 
+// Core fee stats
+// measured in individual sats/vbyte
+export interface FeeStats {
+  median: number; // median core fee rate
+  range: number[]; // 0th, 10th, 25th, 50th, 75th, 90th, 100th percentiles
+}
+
+// Mempool effective fee stats
+// measured in effective sats/vbyte
 export interface EffectiveFeeStats {
-  medianFee: number; // median effective fee rate
-  feeRange: number[]; // 2nd, 10th, 25th, 50th, 75th, 90th, 98th percentiles
+  effective_median: number; // median effective fee rate by weight
+  effective_range: number[]; // 2nd, 10th, 25th, 50th, 75th, 90th, 98th percentiles
 }
 
 export interface WorkingEffectiveFeeStats extends EffectiveFeeStats {

--- a/backend/src/repositories/AccelerationRepository.ts
+++ b/backend/src/repositories/AccelerationRepository.ts
@@ -315,12 +315,12 @@ class AccelerationRepository {
             Infinity
           );
           const feeStats = Common.calcEffectiveFeeStatistics(template);
-          boostRate = feeStats.medianFee;
+          boostRate = feeStats.effective_median;
         }
         const accelerationSummaries = accelerations.map(acc => ({
           ...acc,
           pools: acc.pools,
-        }))
+        }));
         for (const acc of accelerations) {
           if (blockTxs[acc.txid] && acc.pools.includes(block.extras.pool.id)) {
             const tx = blockTxs[acc.txid];

--- a/frontend/src/app/components/block/block-preview.component.html
+++ b/frontend/src/app/components/block/block-preview.component.html
@@ -32,9 +32,9 @@
             <td i18n="block.weight">Weight</td>
             <td [innerHTML]="'&lrm;' + (block?.weight | wuBytes: 2)"></td>
           </tr>
-          <tr *ngIf="block?.extras?.medianFee != undefined">
+          <tr *ngIf="block?.extras?.medianFee != undefined && block?.extras?.effectiveMedianFee != undefined">
             <td class="td-width" i18n="block.median-fee">Median fee</td>
-            <td>~<app-fee-rate [fee]="block?.extras?.medianFee" rounding="1.0-0"></app-fee-rate></td>
+            <td>~<app-fee-rate [fee]="block?.extras?.effectiveMedianFee ?? block?.extras?.medianFee" rounding="1.0-0"></app-fee-rate></td>
           </tr>
           <ng-template [ngIf]="fees !== undefined">
             <tr>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -132,11 +132,11 @@
         <td i18n="mempool-block.fee-span">Fee span</td>
         <td><app-fee-rate [fee]="block.extras?.minFee" [showUnit]="false" rounding="1.0-0"></app-fee-rate> - <app-fee-rate [fee]="block.extras?.maxFee" rounding="1.0-0"></app-fee-rate></td>
       </tr>
-      <tr *ngIf="block.extras?.medianFee != undefined">
+      <tr *ngIf="block.extras?.effectiveMedianFee != undefined || block.extras?.medianFee != undefined">
         <td class="td-width" i18n="block.median-fee">Median fee</td>
-        <td>~<app-fee-rate [fee]="block.extras?.medianFee" rounding="1.0-0"></app-fee-rate>
+        <td>~<app-fee-rate [fee]="block.extras?.effectiveMedianFee ?? block.extras?.medianFee" rounding="1.0-0"></app-fee-rate>
           <span class="fiat">
-            <app-fiat [blockConversion]="blockConversion" [value]="block.extras?.medianFee * 140" digitsInfo="1.2-2"
+            <app-fiat [blockConversion]="blockConversion" [value]="(block.extras?.effectiveMedianFee ?? block.extras?.medianFee) * 140" digitsInfo="1.2-2"
               i18n-ngbTooltip="Transaction fee tooltip" ngbTooltip="Based on average native segwit transaction of 140 vBytes"
               placement="bottom"></app-fiat>
           </span>

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -792,6 +792,9 @@ export class BlockComponent implements OnInit, OnDestroy {
   }
 
   getMinBlockFee(block: BlockExtended): number {
+    if (block?.extras?.effectiveFeeRange) {
+      return block.extras.effectiveFeeRange[0];
+    }
     if (block?.extras?.feeRange) {
       // heuristic to check if feeRange is adjusted for effective rates
       if (block.extras.medianFee === block.extras.feeRange[3]) {
@@ -804,6 +807,9 @@ export class BlockComponent implements OnInit, OnDestroy {
   }
 
   getMaxBlockFee(block: BlockExtended): number {
+    if (block?.extras?.effectiveFeeRange) {
+      return block.extras.effectiveFeeRange[block.extras.effectiveFeeRange.length - 1];
+    }
     if (block?.extras?.feeRange) {
       return block.extras.feeRange[block.extras.feeRange.length - 1];
     }

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -23,7 +23,7 @@
         <div class="block-body">
           <ng-container *ngIf="!minimal">
             <div *ngIf="block?.extras; else emptyfees" [attr.data-cy]="'bitcoin-block-offset=' + offset + '-index-' + i + '-fees'" class="fees">
-              ~<app-fee-rate [fee]="block?.extras?.medianFee" unitClass="" rounding="1.0-0"></app-fee-rate>
+              ~<app-fee-rate [fee]="block?.extras?.effectiveMedianFee ?? block?.extras?.medianFee" unitClass="" rounding="1.0-0"></app-fee-rate>
             </div>
             <ng-template #emptyfees>
               <div [attr.data-cy]="'bitcoin-block-offset=' + offset + '-index-' + i + '-fees'" class="fees">

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.ts
@@ -414,6 +414,9 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   getMinBlockFee(block: BlockExtended): number {
+    if (block?.extras?.effectiveFeeRange) {
+      return block.extras.effectiveFeeRange[0];
+    }
     if (block?.extras?.feeRange) {
       // heuristic to check if feeRange is adjusted for effective rates
       if (block.extras.medianFee === block.extras.feeRange[3]) {
@@ -426,6 +429,9 @@ export class BlockchainBlocksComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   getMaxBlockFee(block: BlockExtended): number {
+    if (block?.extras?.effectiveFeeRange) {
+      return block.extras.effectiveFeeRange[block.extras.effectiveFeeRange.length - 1];
+    }
     if (block?.extras?.feeRange) {
       return block.extras.feeRange[block.extras.feeRange.length - 1];
     }

--- a/frontend/src/app/components/mempool-block/mempool-block.component.ts
+++ b/frontend/src/app/components/mempool-block/mempool-block.component.ts
@@ -57,6 +57,9 @@ export class MempoolBlockComponent implements OnInit, OnDestroy {
                   this.mempoolBlockIndex--;
                 }
                 const ordinal = this.getOrdinal(mempoolBlocks[this.mempoolBlockIndex]);
+                // prefer effective fee stats if available
+                mempoolBlocks[this.mempoolBlockIndex].feeRange = mempoolBlocks[this.mempoolBlockIndex].effectiveFeeRange ?? mempoolBlocks[this.mempoolBlockIndex].feeRange;
+                mempoolBlocks[this.mempoolBlockIndex].medianFee = mempoolBlocks[this.mempoolBlockIndex].effectiveMedianFee ?? mempoolBlocks[this.mempoolBlockIndex].medianFee;
                 this.ordinal$.next(ordinal);
                 this.seoService.setTitle(ordinal);
                 this.seoService.setDescription($localize`:@@meta.description.mempool-block:See stats for ${this.stateService.network==='liquid'||this.stateService.network==='liquidtestnet'?'Liquid':'Bitcoin'}${seoDescriptionNetwork(this.stateService.network)} transactions in the mempool: fee range, aggregate size, and more. Mempool blocks are updated in real-time as the network receives new transactions.`);

--- a/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
+++ b/frontend/src/app/components/mempool-blocks/mempool-blocks.component.ts
@@ -171,6 +171,8 @@ export class MempoolBlocksComponent implements OnInit, OnChanges, OnDestroy {
           block.index = this.blockIndex + i;
           block.height = lastBlock.height + i + 1;
           block.blink = specialBlocks[block.height]?.networks.includes(this.stateService.network || 'mainnet') ? true : false;
+          block.medianFee = block.effectiveMedianFee ?? block.medianFee;
+          block.feeRange = block.effectiveFeeRange ?? block.feeRange;
         });
 
         const stringifiedBlocks = JSON.stringify(mempoolBlocks);

--- a/frontend/src/app/components/tx-fee-rating/tx-fee-rating.component.ts
+++ b/frontend/src/app/components/tx-fee-rating/tx-fee-rating.component.ts
@@ -30,7 +30,7 @@ export class TxFeeRatingComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnInit() {
     this.blocksSubscription = this.cacheService.loadedBlocks$.subscribe((block) => {
-      if (this.tx.status.confirmed && this.tx.status.block_height === block.height && block?.extras?.medianFee > 0) {
+      if (this.tx.status.confirmed && this.tx.status.block_height === block.height && (block?.extras?.effectiveMedianFee ?? block?.extras?.medianFee) > 0) {
         this.calculateRatings(block);
         this.cd.markForCheck();
       }
@@ -45,7 +45,7 @@ export class TxFeeRatingComponent implements OnInit, OnChanges, OnDestroy {
     this.cacheService.loadBlock(this.tx.status.block_height);
 
     const foundBlock = this.cacheService.getCachedBlock(this.tx.status.block_height) || null;
-    if (foundBlock && foundBlock?.extras?.medianFee > 0) {
+    if (foundBlock && (foundBlock?.extras?.effectiveMedianFee ?? foundBlock?.extras?.medianFee) > 0) {
       this.calculateRatings(foundBlock);
     }
   }
@@ -56,7 +56,7 @@ export class TxFeeRatingComponent implements OnInit, OnChanges, OnDestroy {
 
   calculateRatings(block: BlockExtended) {
     const feePervByte = this.tx.effectiveFeePerVsize || this.tx.fee / (this.tx.weight / 4);
-    this.medianFeeNeeded = block?.extras?.medianFee;
+    this.medianFeeNeeded = block?.extras?.effectiveMedianFee ?? block?.extras?.medianFee;
 
     // Block not filled
     if (block.weight < this.stateService.env.BLOCK_WEIGHT_UNITS * 0.95) {

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -196,6 +196,8 @@ export interface BlockExtension {
   minFee?: number;
   maxFee?: number;
   feeRange?: number[];
+  effectiveMedianFee?: number;
+  effectiveFeeRange?: number[];
   reward?: number;
   coinbaseRaw?: string;
   matchRate?: number;

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -61,8 +61,10 @@ export interface MempoolBlock {
   blockVSize: number;
   nTx: number;
   medianFee: number;
+  effectiveMedianFee?: number;
   totalFees: number;
   feeRange: number[];
+  effectiveFeeRange?: number[];
   index: number;
   isStack?: boolean;
 }


### PR DESCRIPTION
Currently, the mempool backend indexes & serves the "best available" fee statistics (i.e. the median fee rate & fee rate percentiles) for each block, which may either be simple rounded statistics using individual transaction fee rates as provided by Bitcoin Core, or more precise statistics calculated in the mempool backend using _effective_ fee rates and some other heuristics to exclude misleading outliers.

This is convenient for the front end, but means the data may not be entirely consistent between different instances for other API users.

This draft PR adds new block fields for the mempool-calculated median fee and fee range/percentiles (`effectiveMedianFee` and `effectiveFeeRange`), and now reserves the original `medianFee` and `feeRange` fields for the unadjusted figures provided by Bitcoin Core.

In some cases, where transaction data is already available, the simple `medianFee` and `feeRange` will be calculated in the mempool backend to avoid making unnecessary RPC requests. This should generate the same results, but more testing may be needed to be absolutely sure. 

The PR also adapts the front end to choose the "best available" statistics from both sets of fields wherever appropriate, so that these backend changes should not affect the values displayed on the website.

A re-index is required to update historic block data to the new scheme.