### PR TITLE
Fix inscription badge disappearing when loading more inputs

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -351,8 +351,12 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       this.electrsApiService.getTransaction$(tx.txid)
         .subscribe((newTx) => {
           tx['@vinLoaded'] = true;
+          let temp = tx.vin;
           tx.vin = newTx.vin;
           tx.fee = newTx.fee;
+          for (const [index, vin] of temp.entries()) {
+            newTx.vin[index].isInscription = vin.isInscription;
+          }
           this.ref.markForCheck();
         });
     }


### PR DESCRIPTION
When more inputs are loaded, the `Inscription` badge in the transaction inputs disappears.

Transaction  `008ea8e38f0b28cacf17664a69d6cd85457ec4aa05bf85529301278e2f4ae144`:

https://github.com/user-attachments/assets/80087468-0fb3-47c7-8487-fc9ceb65506f

