### PR TITLE
Fix unconfirmed badge on broken RBF txs

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -24,6 +24,7 @@
           [height]="tx?.status?.block_height"
           [replaced]="replaced"
           [removed]="this.rbfInfo?.mined && !this.tx?.status?.confirmed"
+          [cached]="isCached"
         ></app-confirmations>
       </div>
     </ng-container>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.html
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.html
@@ -11,9 +11,9 @@
 <ng-template [ngIf]="!hideUnconfirmed && !confirmations && replaced">
   <button type="button" class="btn btn-sm btn-warning no-cursor {{buttonClass}}" i18n="transaction.replaced|Transaction replaced state">Replaced</button>
 </ng-template>
-<ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && removed">
+<ng-template [ngIf]="!hideUnconfirmed && !confirmations && !replaced && (removed || cached)">
   <button type="button" class="btn btn-sm btn-warning no-cursor {{buttonClass}}" i18n="transaction.audit.removed|Transaction removed state">Removed</button>
 </ng-template>
-<ng-template [ngIf]="!hideUnconfirmed && chainTip != null && !confirmations && !replaced && !removed">
+<ng-template [ngIf]="!hideUnconfirmed && chainTip != null && !confirmations && !replaced && !(removed || cached)">
   <button type="button" class="btn btn-sm btn-danger no-cursor {{buttonClass}}" i18n="transaction.unconfirmed|Transaction unconfirmed state">Unconfirmed</button>
 </ng-template>

--- a/frontend/src/app/shared/components/confirmations/confirmations.component.ts
+++ b/frontend/src/app/shared/components/confirmations/confirmations.component.ts
@@ -12,6 +12,7 @@ export class ConfirmationsComponent implements OnChanges {
   @Input() height: number;
   @Input() replaced: boolean = false;
   @Input() removed: boolean = false;
+  @Input() cached: boolean = false;
   @Input() hideUnconfirmed: boolean = false;
   @Input() buttonClass: string = '';
 


### PR DESCRIPTION
This PR fixes an edge case where replaced/evicted transactions can be labeled "unconfirmed" instead of "replaced" or "removed" if they get evicted from the mempool indirectly, making it unclear whether the transaction is still in the mempool or not.

### Testing

To reproduce (best on regtest):

- submit a parent transaction
- submit a child transaction
- RBF the child
- RBF the parent
- visit either of the child txids
- observe that the transaction is labeled "unconfirmed", despite being evicted from the mempool (due to the replaced parent)

<img width="922" alt="Screenshot 2025-01-14 at 6 30 43 AM" src="https://github.com/user-attachments/assets/a09d3af3-37fa-421d-bea7-39d00aafd7bc" />

With this PR, the transaction will be correctly labeled "removed" instead.

<img width="922" alt="Screenshot 2025-01-14 at 6 31 47 AM" src="https://github.com/user-attachments/assets/93ab18f9-1641-46e5-a3dd-595a9c49d083" />

