### PR TITLE
avoid creating incomplete RBF trees

### DIFF
--- a/backend/src/api/rbf-cache.ts
+++ b/backend/src/api/rbf-cache.ts
@@ -119,7 +119,11 @@ class RbfCache {
 
 
   public add(replaced: MempoolTransactionExtended[], newTxExtended: MempoolTransactionExtended): void {
-    if (!newTxExtended || !replaced?.length || this.txs.has(newTxExtended.txid)) {
+    if ( !newTxExtended
+      || !replaced?.length
+      || this.txs.has(newTxExtended.txid)
+      || !(replaced.some(tx => !this.replacedBy.has(tx.txid)))
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes a bug where partial RBF trees could be created in the case where all of the replaced transactions already belonged to different trees.

<img width="486" alt="Screenshot 2025-01-14 at 6 36 48 AM" src="https://github.com/user-attachments/assets/394b1f9c-3987-4091-b694-95fc9edb3416" />

This can occur where two separate new transactions txB and txC each spend a different input of the same evicted transaction txA, in the same mempool update (or within a short period).

This PR fixes the bug by checking if all of the "replaced" transactions in an identified RBF event already belong to other trees before proceeding to create a new RBF tree.