### PR TITLE
Fix time traveling balance charts

### DIFF
--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -478,25 +478,30 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
   }
 
   extendSummary(summary) {
-    let extendedSummary = summary.slice();
+    const extendedSummary = summary.slice();
 
     // Add a point at today's date to make the graph end at the current time
     extendedSummary.unshift({ time: Date.now() / 1000, value: 0 });
-    extendedSummary.reverse();
 
-    let oneHour = 60 * 60;
+    let maxTime = Date.now() / 1000;
+
+    const oneHour = 60 * 60;
     // Fill gaps longer than interval
     for (let i = 0; i < extendedSummary.length - 1; i++) {
-      let hours = Math.floor((extendedSummary[i + 1].time - extendedSummary[i].time) / oneHour);      
+      if (extendedSummary[i].time > maxTime) {
+        extendedSummary[i].time = maxTime - 30;
+      }
+      maxTime = extendedSummary[i].time;
+      const hours = Math.floor((extendedSummary[i].time - extendedSummary[i + 1].time) / oneHour);
       if (hours > 1) {
         for (let j = 1; j < hours; j++) {
-          let newTime = extendedSummary[i].time + oneHour * j;
+          const newTime = extendedSummary[i].time - oneHour * j;
           extendedSummary.splice(i + j, 0, { time: newTime, value: 0 });
         }
         i += hours - 1;
       }
     }
 
-    return extendedSummary.reverse();
+    return extendedSummary;
   }
 }


### PR DESCRIPTION
Balance charts rely on block timestamps for the time axis. However, since block timestamps are not reliable, consecutive blocks are not necessarily timestamped in chronological order.

Before:
<img width="1063" alt="Screenshot 2025-01-14 at 9 05 30 AM" src="https://github.com/user-attachments/assets/bf6371fd-d545-4786-9905-c64c6147118b" />

Transactions must still be ordered in correct logical order (by block height & intra-block transaction index) to avoid negative or incorrect balances on the chart, so this PR simply adjusts any out-of-order timestamps to ensure they are always monotonically increasing.

After:
<img width="1063" alt="Screenshot 2025-01-14 at 9 05 59 AM" src="https://github.com/user-attachments/assets/309faf39-bae7-4122-81c3-ef241a02104b" />
