### PR TITLE
[indexing] make `blocks.definition_hash` nullable and exit early if appropriate

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 96;
+  private static currentVersion = 97;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1121,7 +1121,7 @@ class DatabaseMigration {
 
     // blocks pools-v2.json hash
     if (databaseSchemaVersion < 95) {
-      let poolJsonSha = 'f737d86571d190cf1a1a3cf5fd86b33ba9624254';
+      let poolJsonSha = 'f737d86571d190cf1a1a3cf5fd86b33ba9624254'; // https://github.com/mempool/mining-pools/commit/f737d86571d190cf1a1a3cf5fd86b33ba9624254
       const [poolJsonShaDb]: any[] = await DB.query(`SELECT string FROM state WHERE name = 'pools_json_sha'`);
       if (poolJsonShaDb?.length > 0) {
         poolJsonSha = poolJsonShaDb[0].string;
@@ -1134,6 +1134,17 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 96) {
       await this.$executeQuery(`ALTER TABLE blocks_audits MODIFY time timestamp NOT NULL DEFAULT 0`);
       await this.updateToSchemaVersion(96);
+    }
+
+    // Make definition_hash nullable
+    if (databaseSchemaVersion < 97) {
+      let poolJsonSha = '895cf0903e771beb647d0c1356bb4b8f4f123af7'; // https://github.com/mempool/mining-pools/commit/895cf0903e771beb647d0c1356bb4b8f4f123af7
+      const [poolJsonShaDb]: any[] = await DB.query(`SELECT string FROM state WHERE name = 'pools_json_sha'`);
+      if (poolJsonShaDb?.length > 0) {
+        poolJsonSha = poolJsonShaDb[0].string;
+      }
+      await this.$executeQuery(`ALTER TABLE blocks MODIFY COLUMN definition_hash varchar(255) NULL DEFAULT "${poolJsonSha}"`);
+      await this.updateToSchemaVersion(97);
     }
   }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -155,6 +155,11 @@ class Server {
     this.setUpWebsocketHandling();
 
     await poolsUpdater.updatePoolsJson(); // Needs to be done before loading the disk cache because we sometimes wipe it
+    if (config.DATABASE.ENABLED === true && config.MEMPOOL.ENABLED && ['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) && !poolsUpdater.currentSha) {
+      logger.err(`Failed to retreive pools-v2.json sha, cannot run block indexing. Please make sure you've set valid urls in your mempool-config.json::MEMPOOL::POOLS_JSON_URL and mempool-config.json::MEMPOOL::POOLS_JSON_TREE_UR, aborting now`);
+      return process.exit(1);
+    }
+
     await syncAssets.syncAssets$();
     if (config.DATABASE.ENABLED) {
       await mempoolBlocks.updatePools$();

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -45,13 +45,13 @@ class PoolsUpdater {
     this.lastRun = now;
 
     try {
+      if (config.DATABASE.ENABLED === true) {
+        this.currentSha = await this.getShaFromDb();
+      }
+
       const githubSha = await this.fetchPoolsSha(); // Fetch pools-v2.json sha from github
       if (githubSha === null) {
         return;
-      }
-
-      if (config.DATABASE.ENABLED === true) {
-        this.currentSha = await this.getShaFromDb();
       }
 
       logger.debug(`pools-v2.json sha | Current: ${this.currentSha} | Github: ${githubSha}`, this.tag);


### PR DESCRIPTION
Fix a bug introduced by https://github.com/mempool/mempool/pull/5665 where blocks indexing would get stuck forever if we're unable to set a valid `pools-v2.json` sha

The new column is now null-able, but we exit early in case the user actually want to index that data and the `pools-v2.json` sha cannot be retrieved.