### PR TITLE
Enable storage of blocks first seen

### DIFF
--- a/production/bitcoin.conf
+++ b/production/bitcoin.conf
@@ -15,6 +15,7 @@ whitelist=127.0.0.1
 whitelist=103.99.168.0/22
 whitelist=2401:b140::/32
 blocksxor=0
+logtimemicros=1
 #uacomment=@wiz
 
 [main]

--- a/production/mempool-config.mainnet.json
+++ b/production/mempool-config.mainnet.json
@@ -30,7 +30,8 @@
   "CORE_RPC": {
     "PORT": 8332,
     "USERNAME": "__BITCOIN_RPC_USER__",
-    "PASSWORD": "__BITCOIN_RPC_PASS__"
+    "PASSWORD": "__BITCOIN_RPC_PASS__",
+    "DEBUG_LOG_PATH": "/bitcoin/debug.log"
   },
   "SECOND_CORE_RPC": {
     "PORT": 8302,


### PR DESCRIPTION
Enables https://github.com/mempool/mempool/pull/5567 on prod mainnet by adding following flags to prod configs:
- `DEBUG_LOG_PATH` flag to the mainnet backend config
- `logtimemicros=1` flag to `bitcoin.conf` (microsecond logging)