### PR TITLE
Mempool Goggles™ Anchor + TRUC Support

### DIFF
--- a/backend/src/__tests__/api/common.ts
+++ b/backend/src/__tests__/api/common.ts
@@ -36,6 +36,120 @@ describe('Common', () => {
         expect(Common.isNonStandard(tx)).toEqual(false);
       });
     });
+
+    describe('TRUC (BIP-431)', () => {
+      const { TransactionFlags } = require('../../mempool.interfaces');
+      const makeTx = (version: number, vsize: number, ancestors: any[] = [], descendants: any[] = []) => ({
+        version,
+        vsize,
+        weight: vsize * 4,
+        sigops: 0,
+        ancestors,
+        descendants,
+        vin: [{
+          sequence: 0xfffffffd,
+          is_coinbase: false,
+          scriptsig: '',
+          scriptsig_asm: '',
+          prevout: { scriptpubkey_type: 'v0_p2wpkh', scriptpubkey: '00140000000000000000000000000000000000000000', scriptpubkey_asm: '', value: 10000 },
+          witness: [],
+        }],
+        vout: [{ scriptpubkey_type: 'v0_p2wpkh', scriptpubkey: '00140000000000000000000000000000000000000000', scriptpubkey_asm: '', value: 1000 }],
+      } as unknown as TransactionExtended);
+
+      test('flags a v3 parent and child in a CPFP package', () => {
+        const parent = makeTx(3, 400, [], [{ txid: 'child' }]);
+        const child = makeTx(3, 200, [{ txid: 'parent' }], []);
+        const parentFlags = Common.getTransactionFlags(parent);
+        const childFlags = Common.getTransactionFlags(child);
+        expect(BigInt(parentFlags) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+        expect(BigInt(childFlags) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+      });
+
+      test('does not flag a standalone v3 transaction', () => {
+        const flags = Common.getTransactionFlags(makeTx(3, 200));
+        expect(BigInt(flags) & TransactionFlags.truc).toEqual(0n);
+        expect(BigInt(flags) & TransactionFlags.v3).toEqual(TransactionFlags.v3);
+      });
+
+      test('does not flag non-v3 package members', () => {
+        const parent = makeTx(2, 400, [], [{ txid: 'child' }]);
+        const child = makeTx(2, 200, [{ txid: 'parent' }], []);
+        expect(BigInt(Common.getTransactionFlags(parent)) & TransactionFlags.truc).toEqual(0n);
+        expect(BigInt(Common.getTransactionFlags(child)) & TransactionFlags.truc).toEqual(0n);
+      });
+
+      test('enforces the BIP-431 vsize limits inclusively', () => {
+        // parent must be no larger than 10,000vB, child no larger than 1,000vB
+        const parent = makeTx(3, 10000, [], [{ txid: 'child' }]);
+        const tooBigParent = makeTx(3, 10001, [], [{ txid: 'child' }]);
+        const child = makeTx(3, 1000, [{ txid: 'parent' }], []);
+        const tooBigChild = makeTx(3, 1001, [{ txid: 'parent' }], []);
+        expect(BigInt(Common.getTransactionFlags(parent)) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+        expect(BigInt(Common.getTransactionFlags(tooBigParent)) & TransactionFlags.truc).toEqual(0n);
+        expect(BigInt(Common.getTransactionFlags(child)) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+        expect(BigInt(Common.getTransactionFlags(tooBigChild)) & TransactionFlags.truc).toEqual(0n);
+      });
+
+      test('does not flag mid-chain v3 transactions', () => {
+        const midChain = makeTx(3, 200, [{ txid: 'parent' }], [{ txid: 'grandchild' }]);
+        expect(BigInt(Common.getTransactionFlags(midChain)) & TransactionFlags.truc).toEqual(0n);
+      });
+
+      test('recalculates TRUC status as packages form and dissolve', () => {
+        // tx already classified (has stored flags), as happens on mempool updates
+        const tx = makeTx(3, 200, [{ txid: 'parent' }], []);
+        tx.flags = Common.getTransactionFlags(tx);
+        expect(BigInt(tx.flags as number) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+        // the package dissolves: the flag must be cleared on reclassification
+        tx.ancestors = [];
+        tx.flags = Common.getTransactionFlags(tx);
+        expect(BigInt(tx.flags as number) & TransactionFlags.truc).toEqual(0n);
+        // ...and set again if a new package forms
+        tx.ancestors = [{ txid: 'new-parent' }] as any;
+        tx.flags = Common.getTransactionFlags(tx);
+        expect(BigInt(tx.flags as number) & TransactionFlags.truc).toEqual(TransactionFlags.truc);
+      });
+    });
+
+    describe('P2A anchors', () => {
+      const { TransactionFlags } = require('../../mempool.interfaces');
+      const makeAnchorTx = (direction: 'input' | 'output') => ({
+        version: 3,
+        vsize: 200,
+        weight: 800,
+        sigops: 0,
+        vin: [{
+          sequence: 0xfffffffd,
+          is_coinbase: false,
+          scriptsig: '',
+          scriptsig_asm: '',
+          prevout: {
+            scriptpubkey_type: direction === 'input' ? 'anchor' : 'v0_p2wpkh',
+            scriptpubkey: direction === 'input' ? '51024e73' : '00140000000000000000000000000000000000000000',
+            scriptpubkey_asm: direction === 'input' ? 'OP_1 OP_PUSHBYTES_2 4e73' : '',
+            value: 330,
+          },
+          witness: [],
+        }],
+        vout: [{
+          scriptpubkey_type: direction === 'output' ? 'anchor' : 'v0_p2wpkh',
+          scriptpubkey: direction === 'output' ? '51024e73' : '00140000000000000000000000000000000000000000',
+          scriptpubkey_asm: direction === 'output' ? 'OP_1 OP_PUSHBYTES_2 4e73' : '',
+          value: 330,
+        }],
+      } as unknown as TransactionExtended);
+
+      test('flags transactions spending from or paying to anchor outputs', () => {
+        expect(BigInt(Common.getTransactionFlags(makeAnchorTx('input'))) & TransactionFlags.p2a).toEqual(TransactionFlags.p2a);
+        expect(BigInt(Common.getTransactionFlags(makeAnchorTx('output'))) & TransactionFlags.p2a).toEqual(TransactionFlags.p2a);
+      });
+
+      test('does not flag transactions without anchor outputs', () => {
+        const tx = randomTransactions[0];
+        expect(BigInt(Common.getTransactionFlags(tx)) & TransactionFlags.p2a).toEqual(0n);
+      });
+    });
   });
 
   describe('Effective Fee Statistics', () => {

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -648,6 +648,7 @@ export class Common {
       }
       if (vin.prevout?.scriptpubkey_type) {
         switch (vin.prevout?.scriptpubkey_type) {
+          case 'anchor': flags |= TransactionFlags.p2a; break;
           case 'p2pk': flags |= TransactionFlags.p2pk; break;
           case 'multisig': flags |= TransactionFlags.p2ms; break;
           case 'p2pkh': flags |= TransactionFlags.p2pkh; break;
@@ -701,6 +702,7 @@ export class Common {
     let olgaSize = 0;
     for (const vout of tx.vout) {
       switch (vout.scriptpubkey_type) {
+        case 'anchor': flags |= TransactionFlags.p2a; break;
         case 'p2pk': {
           flags |= TransactionFlags.p2pk;
           // detect fake pubkey (i.e. not a valid DER point on the secp256k1 curve)

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -23,6 +23,8 @@ const MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
 const MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
 const DUST_RELAY_TX_FEE = 3;
 const MAX_OP_RETURN_RELAY = 83;
+const TRUC_MAX_VSIZE = 10_000; // BIP-431: v3 transactions must be 10,000 vB or smaller
+const TRUC_CHILD_MAX_VSIZE = 1_000; // BIP-431: v3 transactions with an unconfirmed v3 ancestor must be 1,000 vB or smaller
 const DEFAULT_PERMIT_BAREMULTISIG = true;
 const MAX_TX_LEGACY_SIGOPS = 2_500 * 4; // witness-adjusted sigops
 
@@ -607,10 +609,44 @@ export class Common {
     return isTaproot || !isNotTaproot;
   }
 
+  /**
+   * TRUC (BIP-431) heuristic: a version 3 transaction playing exactly one role
+   * (parent or child) in an in-mempool CPFP package, within the vsize limit
+   * for that role.
+   *
+   * Note: the cpfp_parent/cpfp_child flags reflect actual CPFP relationships,
+   * so a v3 transaction with in-mempool relatives but no fee-bumping
+   * dependency is not flagged, and the versions of its relatives cannot be
+   * checked here.
+   *
+   * Must be called after the CPFP flags are (re)set, and before the
+   * static-flags early return in getTransactionFlags, so that TRUC status is
+   * re-evaluated on every mempool update as packages form and dissolve.
+   */
+  static isTruc(flags: bigint, tx: TransactionExtended): boolean {
+    if (tx.version !== 3) {
+      return false;
+    }
+    const isChild = (flags & TransactionFlags.cpfp_child) === TransactionFlags.cpfp_child;
+    const isParent = (flags & TransactionFlags.cpfp_parent) === TransactionFlags.cpfp_parent;
+    if (isChild && isParent) {
+      // mid-chain v3 transactions violate BIP-431's two-transaction package topology
+      return false;
+    }
+    if (isChild) {
+      return tx.vsize <= TRUC_CHILD_MAX_VSIZE;
+    }
+    if (isParent) {
+      return tx.vsize <= TRUC_MAX_VSIZE;
+    }
+    // version 3 transaction without an in-mempool package
+    return false;
+  }
+
   static getTransactionFlags(tx: TransactionExtended, height?: number): number {
     let flags = tx.flags ? BigInt(tx.flags) : 0n;
 
-    // Update variable flags (CPFP, RBF)
+    // Update variable flags (CPFP, RBF, TRUC)
     flags &= ~TransactionFlags.cpfp_child;
     if (tx.ancestors?.length) {
       flags |= TransactionFlags.cpfp_child;
@@ -622,6 +658,10 @@ export class Common {
     flags &= ~TransactionFlags.replacement;
     if (tx.replacement) {
       flags |= TransactionFlags.replacement;
+    }
+    flags &= ~TransactionFlags.truc;
+    if (this.isTruc(flags, tx)) {
+      flags |= TransactionFlags.truc;
     }
 
     // Already processed static flags, no need to do it again

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -274,6 +274,7 @@ export const TransactionFlags = {
   p2wpkh:                                             0b00010000_00000000n,
   p2wsh:                                              0b00100000_00000000n,
   p2tr:                                               0b01000000_00000000n,
+  p2a:                                                0b10000000_00000000n,
   // behavior
   cpfp_parent:                               0b00000001_00000000_00000000n,
   cpfp_child:                                0b00000010_00000000_00000000n,

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -279,6 +279,9 @@ export const TransactionFlags = {
   cpfp_parent:                               0b00000001_00000000_00000000n,
   cpfp_child:                                0b00000010_00000000_00000000n,
   replacement:                               0b00000100_00000000_00000000n,
+  // (acceleration is only set client-side from the separate acceleration marker, the bit is reserved here)
+  acceleration:                              0b00001000_00000000_00000000n,
+  truc:                                      0b00010000_00000000_00000000n,
   // data
   op_return:                        0b00000001_00000000_00000000_00000000n,
   fake_pubkey:                      0b00000010_00000000_00000000_00000000n,

--- a/contributors/portlandhodl.txt
+++ b/contributors/portlandhodl.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of August 29, 2026.
+
+Signed: portlandhodl

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -36,6 +36,7 @@ export const TransactionFlags = {
   p2wpkh:                                             0b00010000_00000000n,
   p2wsh:                                              0b00100000_00000000n,
   p2tr:                                               0b01000000_00000000n,
+  p2a:                                                0b10000000_00000000n,
   // behavior
   cpfp_parent:                               0b00000001_00000000_00000000n,
   cpfp_child:                                0b00000010_00000000_00000000n,
@@ -93,6 +94,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     p2wpkh: { key: 'p2wpkh', label: 'P2WPKH', flag: TransactionFlags.p2wpkh, important: true, tooltip: false, },
     p2wsh: { key: 'p2wsh', label: 'P2WSH', flag: TransactionFlags.p2wsh, important: true, tooltip: false, },
     p2tr: { key: 'p2tr', label: 'Taproot', flag: TransactionFlags.p2tr, important: true, tooltip: false, },
+    p2a: { key: 'p2a', label: 'P2A (Anchor)', flag: TransactionFlags.p2a, important: true, tooltip: true, txPage: true, },
     /* behavior */
     cpfp_parent: { key: 'cpfp_parent', label: 'Paid for by child', flag: TransactionFlags.cpfp_parent, important: true, tooltip: true, txPage: false, },
     cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child, important: true, tooltip: true, txPage: false, },
@@ -118,7 +120,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
 
 export const FilterGroups: { label: string, filters: Filter[]}[] = [
   { label: $localize`:@@885666551418fd59011ceb09d5c481095940193b:Features`, filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3', 'nonstandard'] },
-  { label: $localize`Address Types`, filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
+  { label: $localize`Address Types`, filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr', 'p2a'] },
   { label: $localize`Behavior`, filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration'] },
   { label: $localize`Data`, filters: ['op_return', 'fake_pubkey', 'fake_scripthash', 'inscription', 'annex'] },
   { label: $localize`Heuristics`, filters: ['coinjoin', 'consolidation', 'batch_payout'] },

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -42,6 +42,7 @@ export const TransactionFlags = {
   cpfp_child:                                0b00000010_00000000_00000000n,
   replacement:                               0b00000100_00000000_00000000n,
   acceleration:                              0b00001000_00000000_00000000n,
+  truc:                                      0b00010000_00000000_00000000n,
   // data
   op_return:                        0b00000001_00000000_00000000_00000000n,
   fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
@@ -100,6 +101,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child, important: true, tooltip: true, txPage: false, },
     replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement, important: true, tooltip: true, txPage: false, },
     acceleration: window?.['__env']?.ACCELERATOR ? { key: 'acceleration', label: $localize`:@@b484583f0ce10f3341ab36750d05271d9d22c9a1:Accelerated`, flag: TransactionFlags.acceleration, important: false } : undefined,
+    truc: { key: 'truc', label: 'TRUC package', flag: TransactionFlags.truc, important: true, tooltip: true, txPage: true, },
     /* data */
     op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return, important: true, tooltip: true, txPage: true, },
     fake_pubkey: { key: 'fake_pubkey', label: 'Fake pubkey', flag: TransactionFlags.fake_pubkey, tooltip: true, txPage: true, },
@@ -121,7 +123,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
 export const FilterGroups: { label: string, filters: Filter[]}[] = [
   { label: $localize`:@@885666551418fd59011ceb09d5c481095940193b:Features`, filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3', 'nonstandard'] },
   { label: $localize`Address Types`, filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr', 'p2a'] },
-  { label: $localize`Behavior`, filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration'] },
+  { label: $localize`Behavior`, filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration', 'truc'] },
   { label: $localize`Data`, filters: ['op_return', 'fake_pubkey', 'fake_scripthash', 'inscription', 'annex'] },
   { label: $localize`Heuristics`, filters: ['coinjoin', 'consolidation', 'batch_payout'] },
   { label: $localize`Sighash Flags`, filters: ['sighash_all', 'sighash_none', 'sighash_single', 'sighash_default', 'sighash_acp'] },

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -20,6 +20,8 @@ const MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
 const MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
 const DUST_RELAY_TX_FEE = 3;
 export const MAX_OP_RETURN_RELAY = 83;
+const TRUC_MAX_VSIZE = 10_000; // BIP-431: v3 transactions must be 10,000 vB or smaller
+const TRUC_CHILD_MAX_VSIZE = 1_000; // BIP-431: v3 transactions with an unconfirmed v3 ancestor must be 1,000 vB or smaller
 const DEFAULT_PERMIT_BAREMULTISIG = true;
 const MAX_TX_LEGACY_SIGOPS = 2_500 * 4; // witness-adjusted sigops
 
@@ -796,16 +798,55 @@ export function isBurnKey(pubkey: string): boolean {
   ].includes(pubkey);
 }
 
+/**
+ * TRUC (BIP-431) heuristic: a version 3 transaction playing exactly one role
+ * (parent or child) in an in-mempool CPFP package, within the vsize limit
+ * for that role. Mirrors Common.isTruc in the backend.
+ *
+ * Note: the cpfp_parent/cpfp_child flags reflect actual CPFP relationships,
+ * so a v3 transaction with in-mempool relatives but no fee-bumping
+ * dependency is not flagged, and the versions of its relatives cannot be
+ * checked here.
+ */
+export function isTruc(flags: bigint, tx: Transaction): boolean {
+  if (tx.version !== 3) {
+    return false;
+  }
+  const isChild = (flags & TransactionFlags.cpfp_child) === TransactionFlags.cpfp_child;
+  const isParent = (flags & TransactionFlags.cpfp_parent) === TransactionFlags.cpfp_parent;
+  if (isChild && isParent) {
+    // mid-chain v3 transactions violate BIP-431's two-transaction package topology
+    return false;
+  }
+  // the frontend Transaction model has no vsize, so derive it from the weight
+  const vsize = Math.ceil(tx.weight / 4);
+  if (isChild) {
+    return vsize <= TRUC_CHILD_MAX_VSIZE;
+  }
+  if (isParent) {
+    return vsize <= TRUC_MAX_VSIZE;
+  }
+  // version 3 transaction without an in-mempool package
+  return false;
+}
+
 export function getTransactionFlags(tx: Transaction, cpfpInfo?: CpfpInfo, replacement?: boolean, height?: number, network?: string): bigint {
   let flags = tx.flags ? BigInt(tx.flags) : 0n;
 
-  // Update variable flags (CPFP, RBF)
+  // Update variable flags (CPFP, RBF, TRUC)
   if (cpfpInfo) {
     if (cpfpInfo.ancestors.length) {
       flags |= TransactionFlags.cpfp_child;
     }
     if (cpfpInfo.descendants?.length) {
       flags |= TransactionFlags.cpfp_parent;
+    }
+    // TRUC status depends on CPFP package membership, so re-evaluate it
+    // whenever CPFP info is refreshed (otherwise preserve the flag
+    // computed by the backend)
+    flags &= ~TransactionFlags.truc;
+    if (isTruc(flags, tx)) {
+      flags |= TransactionFlags.truc;
     }
   }
   if (replacement) {

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -835,6 +835,7 @@ export function getTransactionFlags(tx: Transaction, cpfpInfo?: CpfpInfo, replac
       rbf = true;
     }
     switch (vin.prevout?.scriptpubkey_type) {
+      case 'anchor': flags |= TransactionFlags.p2a; break;
       case 'p2pk': flags |= TransactionFlags.p2pk; break;
       case 'multisig': flags |= TransactionFlags.p2ms; break;
       case 'p2pkh': flags |= TransactionFlags.p2pkh; break;
@@ -887,6 +888,7 @@ export function getTransactionFlags(tx: Transaction, cpfpInfo?: CpfpInfo, replac
   let olgaSize = 0;
   for (const vout of tx.vout) {
     switch (vout.scriptpubkey_type) {
+      case 'anchor': flags |= TransactionFlags.p2a; break;
       case 'p2pk': {
         flags |= TransactionFlags.p2pk;
         // detect fake pubkey (i.e. not a valid DER point on the secp256k1 curve)


### PR DESCRIPTION
- Add Support to Mempool Goggles™ enabling a filter by the P2A (Anchor) output type that was made standard in Bitcoin Core 28.0. [Source](https://github.com/bitcoin/bitcoin/blob/e7c479495509c068215b73f6df070af2d406ae15/src/script/script.cpp#L207-L222)

- Add Support to Mempool Goggles™ enabling a filter by the TRUC Package type that was made available in Bitcoin Core 28.0. [Source](https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki)

## Implementation notes

- A `p2a` flag is set when a transaction spends from or pays to an `'anchor'` script type, and a `truc` flag is set for version 3 transactions playing exactly one role (parent or child) in an in-mempool CPFP package, within the BIP-431 vsize limit for that role (≤ 10,000 vB parent, ≤ 1,000 vB child). Mid-chain v3 transactions (both roles) are excluded as they violate the two-transaction package topology.
- The TRUC test runs in the variable-flags section of `getTransactionFlags` (above the static-flags early return, with clear-then-set), so TRUC status is recalculated on every mempool update as packages form and dissolve (per mononaut's review).
- The frontend mirrors the backend logic; vsize is derived from `ceil(weight / 4)` since the frontend `Transaction` model has no `vsize` field.
- The backend `TransactionFlags` copy now reserves the `acceleration` bit position to match the frontend.
- Rebased on current master (merge commits dropped); frontend and backend `TransactionFlags` maps verified identical.

_Example: A signet TRUC mempool transaction package_
![image](https://github.com/user-attachments/assets/cc882493-1b86-4f10-9b2e-d3e980230830)

_Example: highlighting a P2A Anchor TXN_
![image](https://github.com/user-attachments/assets/9ad638df-3b69-4ca3-a953-21602b5ad929)

_Goggles™ Selection Menu [Addresses]_
![image](https://github.com/user-attachments/assets/c7eb78b6-c7fb-49fd-955d-d0e381ececd3)
