### PR TITLE
detect and warn about address poisoning attacks

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -16,6 +16,11 @@
   <div class="header-bg box" [attr.data-cy]="'tx-' + i">
 
     <div *ngIf="errorUnblinded" class="error-unblinded">{{ errorUnblinded }}</div>
+    @if (similarityMatches.get(tx.txid)?.size) {
+      <div class="alert alert-mempool" role="alert">
+        <span i18n="transaction.poison.warning">Warning! This transaction involves deceptively similar addresses. It may be an address poisoning attack.</span>
+      </div>
+    }
     <div class="row">
       <div class="col">
         <table class="table table-fixed table-borderless smaller-text table-sm table-tx-vin">
@@ -68,9 +73,11 @@
                         </ng-template>
                       </ng-template>
                       <ng-template #defaultAddress>
-                        <a class="address" *ngIf="vin.prevout.scriptpubkey_address; else vinScriptPubkeyType" [routerLink]="['/address/' | relativeUrl, vin.prevout.scriptpubkey_address]" title="{{ vin.prevout.scriptpubkey_address }}">
-                          <app-truncate [text]="vin.prevout.scriptpubkey_address" [lastChars]="8"></app-truncate>
-                        </a>
+                        <app-address-text
+                          *ngIf="vin.prevout.scriptpubkey_address; else vinScriptPubkeyType"
+                          [address]="vin.prevout.scriptpubkey_address"
+                          [similarity]="similarityMatches.get(tx.txid)?.get(vin.prevout.scriptpubkey_address)"
+                        ></app-address-text>
                         <ng-template #vinScriptPubkeyType>
                           {{ vin.prevout.scriptpubkey_type?.toUpperCase() }}
                         </ng-template>
@@ -217,9 +224,11 @@
                 'highlight': this.addresses.length && ((vout.scriptpubkey_type !== 'p2pk' && addresses.includes(vout.scriptpubkey_address)) || this.addresses.includes(vout.scriptpubkey.slice(2, -2)))
               }">
                 <td class="address-cell">
-                  <a class="address" *ngIf="vout.scriptpubkey_address; else pubkey_type" [routerLink]="['/address/' | relativeUrl, vout.scriptpubkey_address]" title="{{ vout.scriptpubkey_address }}">
-                    <app-truncate [text]="vout.scriptpubkey_address" [lastChars]="8"></app-truncate>
-                  </a>
+                  <app-address-text
+                    *ngIf="vout.scriptpubkey_address; else pubkey_type"
+                    [address]="vout.scriptpubkey_address"
+                    [similarity]="similarityMatches.get(tx.txid)?.get(vout.scriptpubkey_address)"
+                  ></app-address-text>
                   <ng-template #pubkey_type>
                     <ng-container *ngIf="vout.scriptpubkey_type === 'p2pk'; else scriptpubkey_type">
                       P2PK <a class="address p2pk-address" [routerLink]="['/address/' | relativeUrl, vout.scriptpubkey.slice(2, -2)]" title="{{ vout.scriptpubkey.slice(2, -2) }}">

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -14,6 +14,7 @@ import { StorageService } from '@app/services/storage.service';
 import { OrdApiService } from '@app/services/ord-api.service';
 import { Inscription } from '@app/shared/ord/inscription.utils';
 import { Etching, Runestone } from '@app/shared/ord/rune.utils';
+import { ADDRESS_SIMILARITY_THRESHOLD, AddressMatch, AddressSimilarity, AddressType, AddressTypeInfo, checkedCompareAddressStrings, detectAddressType } from '@app/shared/address-utils';
 
 @Component({
   selector: 'app-transactions-list',
@@ -55,6 +56,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
   showFullScript: { [vinIndex: number]: boolean } = {};
   showFullWitness: { [vinIndex: number]: { [witnessIndex: number]: boolean } } = {};
   showOrdData: { [key: string]: { show: boolean; inscriptions?: Inscription[]; runestone?: Runestone, runeInfo?: { [id: string]: { etching: Etching; txid: string; } }; } } = {};
+  similarityMatches: Map<string, Map<string, { score: number, match: AddressMatch, group: number }>> = new Map();
 
   constructor(
     public stateService: StateService,
@@ -144,6 +146,8 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       this.currency = currency;
       this.refreshPrice();
     });
+
+    this.updateAddressSimilarities();
   }
 
   refreshPrice(): void {
@@ -183,6 +187,8 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       }
     }
     if (changes.transactions || changes.addresses) {
+      this.similarityMatches.clear();
+      this.updateAddressSimilarities();
       if (!this.transactions || !this.transactions.length) {
         return;
       }
@@ -291,6 +297,56 @@ export class TransactionsListComponent implements OnInit, OnChanges {
         const txIds = this.transactions.filter((tx) => !tx._channels).map((tx) => tx.txid);
         if (txIds.length) {
           this.refreshChannels$.next(txIds);
+        }
+      }
+    }
+  }
+
+  updateAddressSimilarities(): void {
+    if (!this.transactions || !this.transactions.length) {
+      return;
+    }
+    for (const tx of this.transactions) {
+      if (this.similarityMatches.get(tx.txid)) {
+        continue;
+      }
+
+      const similarityGroups: Map<string, number> = new Map();
+      let lastGroup = 0;
+
+      // Check for address poisoning similarity matches
+      this.similarityMatches.set(tx.txid, new Map());
+      const comparableVouts = [
+        ...tx.vout.slice(0, 20),
+        ...this.addresses.map(addr => ({ scriptpubkey_address: addr, scriptpubkey_type: detectAddressType(addr, this.stateService.network) }))
+      ].filter(v => ['p2pkh', 'p2sh', 'v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(v.scriptpubkey_type));
+      const comparableVins = tx.vin.slice(0, 20).map(v => v.prevout).filter(v => ['p2pkh', 'p2sh', 'v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(v?.scriptpubkey_type));
+      for (const vout of comparableVouts) {
+        const address = vout.scriptpubkey_address;
+        const addressType = vout.scriptpubkey_type;
+        if (this.similarityMatches.get(tx.txid)?.has(address)) {
+          continue;
+        }
+        for (const compareAddr of [
+          ...comparableVouts.filter(v => v.scriptpubkey_type === addressType && v.scriptpubkey_address !== address),
+          ...comparableVins.filter(v => v.scriptpubkey_type === addressType && v.scriptpubkey_address !== address)
+        ]) {
+          const similarity = checkedCompareAddressStrings(address, compareAddr.scriptpubkey_address, addressType as AddressType, this.stateService.network);
+          if (similarity?.status === 'comparable' && similarity.score > ADDRESS_SIMILARITY_THRESHOLD) {
+            let group = similarityGroups.get(address) || lastGroup++;
+            similarityGroups.set(address, group);
+            const bestVout = this.similarityMatches.get(tx.txid)?.get(address);
+            if (!bestVout || bestVout.score < similarity.score) {
+              this.similarityMatches.get(tx.txid)?.set(address, { score: similarity.score, match: similarity.left, group });
+            }
+            // opportunistically update the entry for the compared address
+            const bestCompare = this.similarityMatches.get(tx.txid)?.get(compareAddr.scriptpubkey_address);
+            if (!bestCompare || bestCompare.score < similarity.score) {
+              group = similarityGroups.get(compareAddr.scriptpubkey_address) || lastGroup++;
+              similarityGroups.set(compareAddr.scriptpubkey_address, group);
+              this.similarityMatches.get(tx.txid)?.set(compareAddr.scriptpubkey_address, { score: similarity.score, match: similarity.right, group });
+            }
+          }
         }
       }
     }

--- a/frontend/src/app/shared/components/address-text/address-text.component.html
+++ b/frontend/src/app/shared/components/address-text/address-text.component.html
@@ -1,0 +1,17 @@
+
+@if (similarity) {
+  <div class="address-text">
+    <a class="address" style="display: contents;" [routerLink]="['/address/' | relativeUrl, address]" title="{{ address }}">
+      <span class="prefix">{{ similarity.match.prefix }}</span>
+      <span class="infix" [ngStyle]="{'text-decoration-color': groupColors[similarity.group % (groupColors.length)]}">{{ address.slice(similarity.match.prefix.length || 0, -similarity.match.postfix.length || undefined) }}</span>
+      <span class="postfix"> {{ similarity.match.postfix }}</span>
+    </a>
+    <span class="poison-alert" *ngIf="similarity" i18n-ngbTooltip="address-poisoning.warning-tooltip" ngbTooltip="This address is deceptively similar to another output. It may be part of an address poisoning attack.">
+      <fa-icon [icon]="['fas', 'exclamation-triangle']" [fixedWidth]="true"></fa-icon>
+    </span>
+  </div>
+} @else {
+  <a class="address" [routerLink]="['/address/' | relativeUrl, address]" title="{{ address }}">
+    <app-truncate [text]="address" [lastChars]="8"></app-truncate>
+  </a>
+}

--- a/frontend/src/app/shared/components/address-text/address-text.component.scss
+++ b/frontend/src/app/shared/components/address-text/address-text.component.scss
@@ -1,0 +1,32 @@
+.address-text {
+  text-overflow: unset;
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+  position: relative;
+
+	font-family: monospace;
+
+  .infix {
+    flex-grow: 0;
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    user-select: none;
+
+    text-decoration: underline 2px;
+  }
+
+  .prefix, .postfix {
+    flex-shrink: 0;
+    flex-grow: 0;
+    user-select: none;
+
+    text-decoration: underline var(--red) 2px;
+  }
+}
+
+.poison-alert {
+  margin-left: .5em;
+  color: var(--yellow);
+}

--- a/frontend/src/app/shared/components/address-text/address-text.component.ts
+++ b/frontend/src/app/shared/components/address-text/address-text.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+import { AddressMatch, AddressTypeInfo } from '@app/shared/address-utils';
+
+@Component({
+  selector: 'app-address-text',
+  templateUrl: './address-text.component.html',
+  styleUrls: ['./address-text.component.scss']
+})
+export class AddressTextComponent {
+  @Input() address: string;
+  @Input() info: AddressTypeInfo | null;
+  @Input() similarity: { score: number, match: AddressMatch, group: number } | null;
+
+  groupColors: string[] = [
+    'var(--primary)',
+    'var(--success)',
+    'var(--info)',
+    'white',
+  ];
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -7,7 +7,7 @@ import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, fa
   faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl, faDownload, faQrcode, faArrowRightArrowLeft, faArrowsRotate, faCircleLeft,
   faFastForward, faWallet, faUserClock, faWrench, faUserFriends, faQuestionCircle, faHistory, faSignOutAlt, faKey, faSuitcase, faIdCardAlt, faNetworkWired, faUserCheck,
   faCircleCheck, faUserCircle, faCheck, faRocket, faScaleBalanced, faHourglassStart, faHourglassHalf, faHourglassEnd, faWandMagicSparkles, faFaucetDrip, faTimeline,
-  faCircleXmark, faCalendarCheck, faMoneyBillTrendUp, faRobot, faShareNodes, faCreditCard, faMicroscope } from '@fortawesome/free-solid-svg-icons';
+  faCircleXmark, faCalendarCheck, faMoneyBillTrendUp, faRobot, faShareNodes, faCreditCard, faMicroscope, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { MenuComponent } from '@components/menu/menu.component';
 import { PreviewTitleComponent } from '@components/master-page-preview/preview-title.component';
@@ -94,6 +94,7 @@ import { SatsComponent } from '@app/shared/components/sats/sats.component';
 import { BtcComponent } from '@app/shared/components/btc/btc.component';
 import { FeeRateComponent } from '@app/shared/components/fee-rate/fee-rate.component';
 import { AddressTypeComponent } from '@app/shared/components/address-type/address-type.component';
+import { AddressTextComponent } from '@app/shared/components/address-text/address-text.component';
 import { TruncateComponent } from '@app/shared/components/truncate/truncate.component';
 import { SearchResultsComponent } from '@components/search-form/search-results/search-results.component';
 import { TimestampComponent } from '@app/shared/components/timestamp/timestamp.component';
@@ -214,6 +215,7 @@ import { GithubLogin } from '../components/github-login.component/github-login.c
     BtcComponent,
     FeeRateComponent,
     AddressTypeComponent,
+    AddressTextComponent,
     TruncateComponent,
     SearchResultsComponent,
     TimestampComponent,
@@ -360,6 +362,7 @@ import { GithubLogin } from '../components/github-login.component/github-login.c
     BtcComponent,
     FeeRateComponent,
     AddressTypeComponent,
+    AddressTextComponent,
     TruncateComponent,
     SearchResultsComponent,
     TimestampComponent,
@@ -465,5 +468,6 @@ export class SharedModule {
     library.addIcons(faShareNodes);
     library.addIcons(faCreditCard);
     library.addIcons(faMicroscope);
+    library.addIcons(faExclamationTriangle);
   }
 }


### PR DESCRIPTION
_(resolves #5756)_

This PR adds some basic protections against address poisoning attacks.

First, it implements a simple detection algorithm which looks for pairs of addresses within the same transaction with suspiciously matching prefixes and/or postfixes.

Then, for matches above a certain improbability threshold:
 - highlights the similarities and differences
 - adds inline warning icons with explanatory tooltips
 - adds a warning banner to the top of the transaction box
 
Once we add an FAQ entry for address poisoning, we can link to it from both the banner and warning icons.
 
![Screenshot 2025-02-04 at 11 57 47 AM](https://github.com/user-attachments/assets/3426ae94-832b-4eef-b125-144f699b49e4)

![Screenshot 2025-02-04 at 12 00 38 PM](https://github.com/user-attachments/assets/34b07a83-5298-4f62-ae46-67c110f13ffd)

This is performed at the level of the `TransactionList` component, so applies to both the transaction page and anywhere else we show lists of transactions (address, wallet, block pages etc).

![Screenshot 2025-02-04 at 11 57 33 AM](https://github.com/user-attachments/assets/512dd941-7388-4f90-80c5-97023f792467)

---

### Details

#### Address poisoning detection algorithm
This is a simple, fast algorithm that counts matching sequences of characters at the start and end of addresses.

Within each sequence (prefix and postfix) we tolerate up to one edit (a substitution, insertion or deletion in either address), which makes the detection slightly more robust.

Common prefixes for each address type are ignored, since those are always expected to match (i.e. the human-readable part + witness version of a bech32(m) address, or the first character of a legacy base58check address).

Once we have a count of suspiciously matching characters, we assign a score based on the probability of that number of matches considering the size of the alphabet of the address encoding scheme used.

I have somewhat arbitrarily set the threshold for warnings such that less than 1 in every 10 million comparisons will generate a false positive, which corresponds to 4+ matching base58 characters or 5+ matching bech32(m) (excluding common prefixes).

This sounds like quite a high bar, but any lower threshold generates a surprising number of false positives in larger transactions due to the birthday paradox effect, and any higher misses some genuinely confusing matches.

We could potentially be a bit smarter here by e.g. considering visually similar characters or more general similarity metrics, but the tradeoff between sensitivity and false positive rate gets worse as we generalize away from the most obvious attacks.

#### Application

This implementation primarily focuses on visible outputs, since I assume attackers can't generate transactions spending inputs controlled by a victim's real address, and that for an address poisoning attack to be effective at least one of the addresses needs to be "above the fold" and immediately visible on the page. (although perhaps these assumptions don't hold true for all threat models?)

So for the first ~20 output addresses of each transaction, we check for confusingly similar addresses in each of the first ~20 inputs and other outputs.

On address and wallet pages, we additionally check those first 20 inputs and outputs against the page's relevant address(es).