### PR TITLE
Update Docker images and Github workflow

### DIFF
--- a/.github/workflows/docker_update_latest_tag.yml
+++ b/.github/workflows/docker_update_latest_tag.yml
@@ -1,0 +1,181 @@
+name: Docker - Update latest tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The Docker image tag to pull'
+        required: true
+        type: string
+
+jobs:
+  retag-and-push:
+    strategy:
+      matrix:
+        service:
+          - frontend
+          - backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: buildx
+        with:
+          install: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Get source image manifest and SHAs
+        id: source-manifest
+        run: |
+          set -e
+          echo "Fetching source manifest..."
+          MANIFEST=$(docker manifest inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:${{ github.event.inputs.tag }})
+          if [ -z "$MANIFEST" ]; then
+            echo "No manifest found. Assuming single-arch image."
+            exit 1
+          fi
+          
+          echo "Original source manifest:"
+          echo "$MANIFEST" | jq .
+          
+          AMD64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+          ARM64_SHA=$(echo "$MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+          
+          if [ -z "$AMD64_SHA" ] || [ -z "$ARM64_SHA" ]; then
+            echo "Source image is not multi-arch (missing amd64 or arm64)"
+            exit 1
+          fi
+          
+          echo "Source amd64 manifest digest: $AMD64_SHA"
+          echo "Source arm64 manifest digest: $ARM64_SHA"
+          
+          echo "amd64_sha=$AMD64_SHA" >> $GITHUB_OUTPUT
+          echo "arm64_sha=$ARM64_SHA" >> $GITHUB_OUTPUT
+
+      - name: Pull and retag architecture-specific images
+        run: |
+          set -e
+          
+          docker buildx inspect --bootstrap
+          
+          # Remove any existing local images to avoid cache interference
+          echo "Removing existing local images if they exist..."
+          docker image rm ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:${{ github.event.inputs.tag }} || true
+          
+          # Pull amd64 image by digest
+          echo "Pulling amd64 image by digest..."
+          docker pull --platform linux/amd64 ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.amd64_sha }}
+          PULLED_AMD64_MANIFEST_DIGEST=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.amd64_sha }} --format '{{index .RepoDigests 0}}' | cut -d@ -f2)
+          PULLED_AMD64_IMAGE_ID=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.amd64_sha }} --format '{{.Id}}')
+          echo "Pulled amd64 manifest digest: $PULLED_AMD64_MANIFEST_DIGEST"
+          echo "Pulled amd64 image ID (sha256): $PULLED_AMD64_IMAGE_ID"
+          
+          # Pull arm64 image by digest
+          echo "Pulling arm64 image by digest..."
+          docker pull --platform linux/arm64 ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.arm64_sha }}
+          PULLED_ARM64_MANIFEST_DIGEST=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.arm64_sha }} --format '{{index .RepoDigests 0}}' | cut -d@ -f2)
+          PULLED_ARM64_IMAGE_ID=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.arm64_sha }} --format '{{.Id}}')
+          echo "Pulled arm64 manifest digest: $PULLED_ARM64_MANIFEST_DIGEST"
+          echo "Pulled arm64 image ID (sha256): $PULLED_ARM64_IMAGE_ID"
+          
+          # Tag the images
+          docker tag ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.amd64_sha }} ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64
+          docker tag ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.arm64_sha }} ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64
+          
+          # Verify tagged images
+          TAGGED_AMD64_IMAGE_ID=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64 --format '{{.Id}}')
+          TAGGED_ARM64_IMAGE_ID=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64 --format '{{.Id}}')
+          echo "Tagged amd64 image ID (sha256): $TAGGED_AMD64_IMAGE_ID"
+          echo "Tagged arm64 image ID (sha256): $TAGGED_ARM64_IMAGE_ID"
+
+      - name: Push architecture-specific images
+        run: |
+          set -e
+          
+          echo "Pushing amd64 image..."
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64
+          PUSHED_AMD64_DIGEST=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64 --format '{{index .RepoDigests 0}}' | cut -d@ -f2)
+          echo "Pushed amd64 manifest digest (local): $PUSHED_AMD64_DIGEST"
+          
+          # Fetch manifest from registry after push
+          echo "Fetching pushed amd64 manifest from registry..."
+          PUSHED_AMD64_REGISTRY_MANIFEST=$(docker manifest inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64)
+          PUSHED_AMD64_REGISTRY_DIGEST=$(echo "$PUSHED_AMD64_REGISTRY_MANIFEST" | jq -r '.config.digest')
+          echo "Pushed amd64 manifest digest (registry): $PUSHED_AMD64_REGISTRY_DIGEST"
+          
+          echo "Pushing arm64 image..."
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64
+          PUSHED_ARM64_DIGEST=$(docker inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64 --format '{{index .RepoDigests 0}}' | cut -d@ -f2)
+          echo "Pushed arm64 manifest digest (local): $PUSHED_ARM64_DIGEST"
+          
+          # Fetch manifest from registry after push
+          echo "Fetching pushed arm64 manifest from registry..."
+          PUSHED_ARM64_REGISTRY_MANIFEST=$(docker manifest inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64)
+          PUSHED_ARM64_REGISTRY_DIGEST=$(echo "$PUSHED_ARM64_REGISTRY_MANIFEST" | jq -r '.config.digest')
+          echo "Pushed arm64 manifest digest (registry): $PUSHED_ARM64_REGISTRY_DIGEST"
+
+      - name: Create and push multi-arch manifest with original digests
+        run: |
+          set -e
+          
+          echo "Creating multi-arch manifest with original digests..."
+          docker manifest create ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest \
+            ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.amd64_sha }} \
+            ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}@${{ steps.source-manifest.outputs.arm64_sha }}
+            
+          echo "Pushing multi-arch manifest..."
+          docker manifest push ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest
+
+      - name: Clean up intermediate tags
+        if: success()
+        run: |
+          docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-amd64 || true
+          docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest-arm64 || true
+          docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:${{ github.event.inputs.tag }} || true
+
+      - name: Verify final manifest
+        run: |
+          set -e
+          echo "Fetching final generated manifest..."
+          FINAL_MANIFEST=$(docker manifest inspect ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest)
+          echo "Generated final manifest:"
+          echo "$FINAL_MANIFEST" | jq .
+          
+          FINAL_AMD64_SHA=$(echo "$FINAL_MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest')
+          FINAL_ARM64_SHA=$(echo "$FINAL_MANIFEST" | jq -r '.manifests[] | select(.platform.architecture=="arm64" and .platform.os=="linux") | .digest')
+          
+          echo "Final amd64 manifest digest: $FINAL_AMD64_SHA"
+          echo "Final arm64 manifest digest: $FINAL_ARM64_SHA"
+          
+          # Compare all digests
+          echo "Comparing digests..."
+          echo "Source amd64 digest: ${{ steps.source-manifest.outputs.amd64_sha }}"
+          echo "Pulled amd64 manifest digest: $PULLED_AMD64_MANIFEST_DIGEST"
+          echo "Pushed amd64 manifest digest (local): $PUSHED_AMD64_DIGEST"
+          echo "Pushed amd64 manifest digest (registry): $PUSHED_AMD64_REGISTRY_DIGEST"
+          echo "Final amd64 digest: $FINAL_AMD64_SHA"
+          echo "Source arm64 digest: ${{ steps.source-manifest.outputs.arm64_sha }}"
+          echo "Pulled arm64 manifest digest: $PULLED_ARM64_MANIFEST_DIGEST"
+          echo "Pushed arm64 manifest digest (local): $PUSHED_ARM64_DIGEST"
+          echo "Pushed arm64 manifest digest (registry): $PUSHED_ARM64_REGISTRY_DIGEST"
+          echo "Final arm64 digest: $FINAL_ARM64_SHA"
+          
+          if [ "$FINAL_AMD64_SHA" != "${{ steps.source-manifest.outputs.amd64_sha }}" ] || [ "$FINAL_ARM64_SHA" != "${{ steps.source-manifest.outputs.arm64_sha }}" ]; then
+            echo "Error: Final manifest SHAs do not match source SHAs"
+            exit 1
+          fi
+          
+          echo "Successfully created multi-arch ${{ secrets.DOCKER_USERNAME }}/${{ matrix.service }}:latest from ${{ github.event.inputs.tag }}"

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -105,7 +105,7 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" \
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
-          # --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
+          --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
           --build-context rustgbt=./rust \
           --build-context backend=./backend \
           --output "type=registry,push=true" \

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -105,7 +105,7 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" \
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
-          --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
+          # --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
           --build-context rustgbt=./rust \
           --build-context backend=./backend \
           --output "type=registry,push=true" \

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -2,7 +2,7 @@ name: Docker build on tag
 env:
   DOCKER_CLI_EXPERIMENTAL: enabled
   TAG_FMT: "^refs/tags/(((.?[0-9]+){3,4}))$"
-  DOCKER_BUILDKIT: 0
+  DOCKER_BUILDKIT: 1  # Enable BuildKit for better performance
   COMPOSE_DOCKER_CLI_BUILD: 0
 
 on:
@@ -25,13 +25,12 @@ jobs:
     timeout-minutes: 120
     name: Build and push to DockerHub
     steps:
-      # Workaround based on JonasAlfredsson/docker-on-tmpfs@v1.0.1
       - name: Replace the current swap file
         shell: bash
         run: |
-          sudo swapoff /mnt/swapfile
-          sudo rm -v /mnt/swapfile
-          sudo fallocate -l 13G /mnt/swapfile
+          sudo swapoff /mnt/swapfile || true
+          sudo rm -f /mnt/swapfile
+          sudo fallocate -l 16G /mnt/swapfile
           sudo chmod 600 /mnt/swapfile
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
@@ -50,7 +49,7 @@ jobs:
             echo "Directory '/var/lib/docker' not found"
             exit 1
           fi
-          sudo mount -t tmpfs -o size=10G tmpfs /var/lib/docker
+          sudo mount -t tmpfs -o size=12G tmpfs /var/lib/docker
           sudo systemctl restart docker
           sudo df -h | grep docker
 
@@ -75,10 +74,16 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
         id: qemu
 
       - name: Setup Docker buildx action
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          driver-opts: |
+            network=host
         id: buildx
 
       - name: Available platforms
@@ -89,19 +94,20 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.service }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.service }}-
 
       - name: Run Docker buildx for ${{ matrix.service }} against tag
         run: |
           docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" \
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
           --build-context rustgbt=./rust \
           --build-context backend=./backend \
-          --output "type=registry" ./${{ matrix.service }}/ \
-          --build-arg commitHash=$SHORT_SHA
+          --output "type=registry,push=true" \
+          --build-arg commitHash=$SHORT_SHA \
+          ./${{ matrix.service }}/

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:20.15.0-buster-slim AS builder
+FROM rust:1.84-bookworm AS builder
 
 ARG commitHash
 ENV MEMPOOL_COMMIT_HASH=${commitHash}
 
 WORKDIR /build
+
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs build-essential python3 pkg-config && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . .
 
-RUN apt-get update
-RUN apt-get install -y build-essential python3 pkg-config curl ca-certificates
-
-# Install Rust via rustup
-RUN CPU_ARCH=$(uname -m); if [ "$CPU_ARCH" = "armv7l" ]; then c_rehash; fi
-#RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-#Workaround to run on github actions from https://github.com/rust-lang/rustup/issues/2700#issuecomment-1367488985
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sed 's#/proc/self/exe#\/bin\/sh#g' | sh -s -- -y --default-toolchain stable
-ENV PATH="/root/.cargo/bin:$PATH"
+ENV PATH="/usr/local/cargo/bin:$PATH"
 
 COPY --from=backend . .
 COPY --from=rustgbt . ../rust/
@@ -24,7 +24,14 @@ RUN npm install --omit=dev --omit=optional
 WORKDIR /build
 RUN npm run package
 
-FROM node:20.15.0-buster-slim
+FROM rust:1.84-bookworm AS runtime
+
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /backend
 

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.15.0-buster-slim AS builder
+FROM node:22-bookworm-slim AS builder
 
 ARG commitHash
 ENV DOCKER_COMMIT_HASH=${commitHash}


### PR DESCRIPTION
In preparation for the v3.1.0 release, this PR updates the Docker images to Debian Buster, node v22 and Rust 1.84.

The Github Action to build the images is also updated to address recent build failures when cross compiling to ARM.

Tested on local umbrelOS (NUC) and Pi4 instances, as well as the internal VM.

```
VM:

docker exec mempool_api_1 uname -a
Linux 7e7572296677 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux

docker exec mempool_api_1 node -v
v22.14.0

docker exec mempool_api_1 rustc --version
rustc 1.84.1 (e71f9a9a9 2025-01-27)

docker exec mempool_web_1 uname -a
Linux 705335597c19 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 Linux

Pi:

docker exec mempool_api_1 uname -a
Linux b879cff87178 6.6.51+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.6.51-1+rpt3 (2024-10-08) aarch64 GNU/Linux

docker exec mempool_api_1 rustc --version
rustc 1.84.1 (e71f9a9a9 2025-01-27)

docker exec mempool_web_1 uname -a
Linux bdecd33910cd 6.6.51+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.6.51-1+rpt3 (2024-10-08) aarch64 Linux

```