### PR TITLE
PSBT support in transaction preview

### DIFF
--- a/frontend/src/app/components/transaction/transaction-raw.component.html
+++ b/frontend/src/app/components/transaction/transaction-raw.component.html
@@ -6,7 +6,7 @@
 
     <form [formGroup]="pushTxForm" (submit)="decodeTransaction()" novalidate>
       <div class="mb-3">
-        <textarea formControlName="txRaw" class="form-control" rows="5" i18n-placeholder="transaction.hex" placeholder="Transaction hex"></textarea>
+        <textarea formControlName="txRaw" class="form-control" rows="5" i18n-placeholder="transaction.hex-and-psbt" placeholder="Transaction hex or base64 encoded PSBT"></textarea>
       </div>
       <button [disabled]="isLoading" type="submit" class="btn btn-primary mr-2" i18n="shared.preview|Preview">Preview</button>
       <input type="checkbox" [checked]="!offlineMode" id="offline-mode" (change)="onOfflineModeChange($event)">
@@ -192,7 +192,7 @@
               </tr>
               <tr>
                 <td i18n="transaction.hex">Transaction hex</td>
-                <td><app-clipboard [text]="pushTxForm.get('txRaw').value" [leftPadding]="false"></app-clipboard></td>
+                <td><app-clipboard [text]="rawHexTransaction" [leftPadding]="false"></app-clipboard></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
builds on #5664

This PR adds support for visualizing PSBTs ([version 0](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) for now) in the transaction preview page. From a base64 or hex serialized PSBT data, we use its global map and inputs map to:
- extract the raw unsigned transaction
- populate inputs’ prevouts when available
- if offline mode is disabled and some prevouts are still missing, fetch the missing ones as usual.
- for each input, fill up signatures on a best-effort basis:
  - check if the input has a finalized signature
  - if not, look for redeem/witness scripts and partial signatures

Support for verifying the presence of a signature in each input, and adapting the transaction's metrics (vsize/feerate) will be added in a subsequent pull request.