### PR TITLE
[accelerator] show square receipt if available

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -567,14 +567,29 @@
   } @else if (step === 'success') {
     <div class="row mb-1 text-center">
       <div class="col-sm">
-        <h1 style="font-size: larger;"><ng-content select="[slot='accelerated-title']"></ng-content><span class="default-slot" i18n="accelerator.success-message">Your transaction is being accelerated!</span></h1>
+        <h1 style="font-size: larger;"><ng-content select="[slot='accelerated-title']"></ng-content>
+          @if (accelerationResponse) {
+            <span class="default-slot" i18n="accelerator.success-message">Your transaction is being accelerated!</span>
+          } @else {
+            <span class="default-slot" i18n="accelerator.success-message-third-party">Transaction is already being accelerated!</span>
+          }
+        </h1>
       </div>
     </div>
     <div class="row text-center mt-1">
       <div class="col-sm">
         <div class="d-flex flex-row justify-content-center align-items-center">
-          <span i18n="accelerator.confirmed-acceleration-with-miners">Your transaction has been accepted for acceleration by our mining pool partners.</span>
+          @if (accelerationResponse) {        
+            <span i18n="accelerator.confirmed-acceleration-with-miners">Your transaction has been accepted for acceleration by our mining pool partners.</span>
+          } @else {
+            <span i18n="accelerator.confirmed-acceleration-with-miners-third-party">Transaction has already been accepted for acceleration by our mining pool partners.</span>
+          }
         </div>
+        @if (accelerationResponse?.receiptUrl) {
+          <div class="d-flex flex-row justify-content-center align-items-center">
+            <span i18n="accelerator.receipt-label"><a [href]="accelerationResponse.receiptUrl" target="_blank">Click here to get a receipt.</a></span>
+          </div>
+        }
       </div>
     </div>
     <hr>

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -87,6 +87,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   math = Math;
   isMobile: boolean = window.innerWidth <= 767.98;
   isProdDomain = false;
+  accelerationResponse: { receiptUrl: string | null } | undefined;
 
   private _step: CheckoutStep = 'summary';
   simpleMode: boolean = true;
@@ -194,11 +195,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
       this.scrollToElement('acceleratePreviewAnchor', 'start');
     }
     if (changes.accelerating && this.accelerating) {
-      if (this.step === 'processing' || this.step === 'paid') {
-        this.moveToStep('success', true);
-      } else { // Edge case where the transaction gets accelerated by someone else or on another session
-        this.closeModal();
-      }
+      this.moveToStep('success', true);
     }
   }
 
@@ -541,7 +538,8 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                   `accelerator-${this.tx.txid.substring(0, 15)}-${Math.round(new Date().getTime() / 1000)}`,
                   costUSD
                 ).subscribe({
-                  next: () => {
+                  next: (response) => {
+                    this.accelerationResponse = response;
                     this.processing = false;
                     this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                     this.audioService.playSound('ascend-chime-cartoon');
@@ -668,7 +666,8 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
                 costUSD,
                 verificationToken.userChallenged
               ).subscribe({
-                next: () => {
+                next: (response) => {
+                  this.accelerationResponse = response;
                   this.processing = false;
                   this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                   this.audioService.playSound('ascend-chime-cartoon');
@@ -777,7 +776,8 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
             costUSD,
             verificationToken.userChallenged
           ).subscribe({
-            next: () => {
+            next: (response) => {
+              this.accelerationResponse = response;
               this.processing = false;
               this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
               this.audioService.playSound('ascend-chime-cartoon');

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -200,7 +200,7 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
   }
 
   moveToStep(step: CheckoutStep, force: boolean = false): void {
-    if (this.isCheckoutLocked > 0 && !force) {
+    if (this.isCheckoutLocked > 0 && !force || this.step === 'success') {
       return;
     }
     this.processing = false;

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -870,7 +870,8 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
               tokenResult.details.cashAppPay.referenceId,
               costUSD
             ).subscribe({
-              next: () => {
+              next: (response) => {
+                this.accelerationResponse = response;
                 this.processing = false;
                 this.apiService.logAccelerationRequest$(this.tx.txid).subscribe();
                 this.audioService.playSound('ascend-chime-cartoon');


### PR DESCRIPTION
Requires https://github.com/mempool/mempool.space/pull/1582

In order to always show the `success` state, I've tweaked the copy.

### Tab that made the payment

<img width="1147" alt="Screenshot 2025-03-12 at 15 16 25" src="https://github.com/user-attachments/assets/b93e375b-fae2-4872-a797-a429f5b95350" />


### Tab that got front run

<img width="1134" alt="Screenshot 2025-03-12 at 15 16 21" src="https://github.com/user-attachments/assets/7dab8b95-7415-43fd-911d-aa709a39b4ef" />
