### PR TITLE
Tapscript multisig parsing feedback

### DIFF
--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -316,7 +316,7 @@ export function parseTapscriptMultisig(script: string): undefined | { m: number,
   }
 
   const finalOp = ops.pop();
-  if (finalOp !== 'OP_NUMEQUAL' && finalOp !== 'OP_GREATERTHANOREQUAL') {
+  if (!['OP_NUMEQUAL', 'OP_NUMEQUALVERIFY', 'OP_GREATERTHANOREQUAL', 'OP_GREATERTHAN', 'OP_EQUAL', 'OP_EQUALVERIFY'].includes(finalOp)) {
     return;
   }
 
@@ -329,6 +329,10 @@ export function parseTapscriptMultisig(script: string): undefined | { m: number,
     m = parseInt(ops.pop().match(/[0-9]+/)?.[0], 10);
   } else {
     return;
+  }
+
+  if (finalOp === 'OP_GREATERTHAN') {
+    m += 1;
   }
 
   if (ops.length % 3 !== 0) {

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -310,8 +310,10 @@ export function parseTapscriptMultisig(script: string): undefined | { m: number,
   }
 
   const ops = script.split(' ');
-  // At minimum, one pubkey group (3 tokens) + m push + final opcode = 5 tokens
-  if (ops.length < 5) return;
+  // At minimum, 2 pubkey group (3 tokens) + m push + final opcode = 8 tokens
+  if (ops.length < 8) {
+    return;
+  }
 
   const finalOp = ops.pop();
   if (finalOp !== 'OP_NUMEQUAL' && finalOp !== 'OP_GREATERTHANOREQUAL') {


### PR DESCRIPTION
This PR addresses some of the comments from #5800:

- add `OP_NUMEQUALVERIFY`, `OP_GREATERTHAN`, and `OP_EQUAL(VERIFY)` to the allowed opcodes for multisig parsing
- changes the minimum required pubkeys from 1 to 2