### PR TITLE
Don't tag as latest by default

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -105,7 +105,6 @@ jobs:
           --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" \
           --platform linux/amd64,linux/arm64 \
           --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:$TAG \
-          --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \
           --build-context rustgbt=./rust \
           --build-context backend=./backend \
           --output "type=registry,push=true" \


### PR DESCRIPTION
It was intentional on the previous PR not to tag `latest` on this workflow.

The goal is to only push the current tag automatically and use the separate workflow to update `latest` with any given tag.

This allows us to control when `latest` is updated when rolling out or rolling back releases (for whatever reason), and also prevents updating only one of the images (`backend` or `frontend`) if the other one fails during the build process.

If this sounds too complicated we can just revert after tagging the first rc.