### PR TITLE
[`/api/v1/block/:hash`] respect 404 error code instead of misleading 500

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -406,8 +406,8 @@ class BitcoinRoutes {
 
       res.setHeader('Expires', new Date(Date.now() + 1000 * cacheDuration).toUTCString());
       res.json(block);
-    } catch (e) {
-      handleError(req, res, 500, 'Failed to get block');
+    } catch (e: any) {
+      handleError(req, res, e?.response?.status === 404 ? 404 : 500, 'Failed to get block');
     }
   }
 


### PR DESCRIPTION
Because we have an hardcoded 500 for `/api/v1/block/:hash` API, the services backend is mislead into thinking that something went wrong in the mempool backend. So we print an error in slack.

However, this 500 status code is hardcoded in the `catch` block, which is executed as soon as we query a non existing block. EG:

```
[23:13:10] nymkappa @ /Users/nymkappa $ curl -v https://mempool.space/api/v1/block/000000000000000000010d196eb6888ca340787b6d781d42eb02abda3323a779
...
* Request completely sent off
< HTTP/2 500
...
{"error":"Failed to get block"}%
```

The `bitcoin.routes.ts` API needs quite some love in terms of error handling 😄.

Recent ops change made this issue very obvious because we're hitting different servers within a very short timeframe (I assume) from the services backend and so our slack channel is being spammed.
