### PR TITLE
polish pool updates

### DIFF
--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -99,7 +99,7 @@ class PoolsUpdater {
 
     } catch (e) {
       // fast-forward lastRun to 10 minutes before the next scheduled update
-      this.lastRun = now - (config.MEMPOOL.POOLS_UPDATE_DELAY - 600);
+      this.lastRun = now - Math.max(config.MEMPOOL.POOLS_UPDATE_DELAY - 600, 600);
       logger.err(`PoolsUpdater failed. Will try again in 10 minutes. Exception: ${JSON.stringify(e)}`, this.tag);
     }
   }

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -98,7 +98,8 @@ class PoolsUpdater {
       logger.info(`Mining pools-v2.json (${githubSha}) import completed`, this.tag);
 
     } catch (e) {
-      this.lastRun = now - 600; // Try again in 10 minutes
+      // fast-forward lastRun to 10 minutes before the next scheduled update
+      this.lastRun = now - (config.MEMPOOL.POOLS_UPDATE_DELAY - 600);
       logger.err(`PoolsUpdater failed. Will try again in 10 minutes. Exception: ${JSON.stringify(e)}`, this.tag);
     }
   }


### PR DESCRIPTION
Fixes some minor issues related to the automatic pool updates:
 - on failure, retry in 10 minutes (as the logs claim) instead of 10 minutes before the next scheduled check
 - refresh the in-memory and persistent recent block caches with the new data if anything changed
