### PR TITLE
Support pool deletion

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 96;
+  private static currentVersion = 97;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1134,6 +1134,12 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 96) {
       await this.$executeQuery(`ALTER TABLE blocks_audits MODIFY time timestamp NOT NULL DEFAULT 0`);
       await this.updateToSchemaVersion(96);
+    }
+
+    if (databaseSchemaVersion < 97) {
+      await this.$executeQuery('ALTER TABLE blocks DROP FOREIGN KEY IF EXISTS `blocks_ibfk_1`');
+      await this.$executeQuery('ALTER TABLE blocks ADD FOREIGN KEY (`pool_id`) REFERENCES `pools` (`id`) ON DELETE CASCADE');
+      await this.updateToSchemaVersion(97);
     }
   }
 

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -163,6 +163,35 @@ class PoolsRepository {
   }
 
   /**
+   * Delete a mining pool from the database
+   * 
+   * @param poolId 
+   */
+  public async $deleteMiningPool(poolId: number): Promise<void> {
+    try {
+      const unknownPool = await this.$getUnknownPool();
+      if (!unknownPool) {
+        throw new Error('Cannot find Unknown pool');
+      }
+
+      await DB.query(`
+        UPDATE blocks
+        SET pool_id = ?
+        WHERE pool_id = ?`,
+        [unknownPool.id, poolId]
+      );
+
+      await DB.query(`
+        DELETE FROM pools
+        WHERE id = ?`,
+        [poolId]
+      );
+    } catch (e: any) {
+      logger.err(`Cannot delete mining pool id ${poolId}. Reason: ` + (e instanceof Error ? e.message : e));
+    }
+  }
+
+  /**
    * Rename an existing mining pool
    * 
    * @param dbId

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -98,7 +98,8 @@ class PoolsUpdater {
       logger.info(`Mining pools-v2.json (${githubSha}) import completed`, this.tag);
 
     } catch (e) {
-      this.lastRun = now - 600; // Try again in 10 minutes
+      // fast-forward lastRun to 10 minutes before the next scheduled update
+      this.lastRun = now - (config.MEMPOOL.POOLS_UPDATE_DELAY - 600);
       logger.err(`PoolsUpdater failed. Will try again in 10 minutes. Exception: ${JSON.stringify(e)}`, this.tag);
     }
   }


### PR DESCRIPTION
_(builds on #5838)_

Supports *deleting* pools from the pools-v2.json (not just renaming), and updating indexed blocks etc accordingly.

This doesn't really make sense in production, but can be useful for local testing & dev stuff when you want to undo and reapply changes to the pools list.