### PR TITLE
Run CI workflow after merging too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,13 @@ name: CI Pipeline for the Backend and Frontend
 on:
   pull_request:
     types: [opened, review_requested, synchronize]
+  push:
+    branches:
+      - master
 
 jobs:
   backend:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
+    if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     strategy:
       matrix:
         node: ["20", "21"]
@@ -157,7 +160,7 @@ jobs:
 
   frontend:
     needs: cache
-    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
+    if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     strategy:
       matrix:
         node: ["20", "21"]
@@ -245,7 +248,7 @@ jobs:
           VERBOSE: 1
   
   e2e:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
+    if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     runs-on: ubuntu-latest
     needs: frontend
     strategy:
@@ -375,9 +378,8 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
-
   validate_docker_json:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
+    if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     runs-on: ubuntu-latest
     name: Validate generated backend Docker JSON
 


### PR DESCRIPTION
The CI workflow hasn't been running after merging. 

There should be no difference between the premerge and postmerge tests, but it's causing the Tests badge to be shown as always failing since the it was the last status before being disabled.