### PR TITLE
Fix false positive address poisoning warnings on wallet page

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -194,7 +194,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
       }
 
       this.transactionsLength = this.transactions.length;
-      
+
       if (!this.txPreview) {
         this.cacheService.setTxCache(this.transactions);
       }
@@ -316,10 +316,7 @@ export class TransactionsListComponent implements OnInit, OnChanges {
 
       // Check for address poisoning similarity matches
       this.similarityMatches.set(tx.txid, new Map());
-      const comparableVouts = [
-        ...tx.vout.slice(0, 20),
-        ...this.addresses.map(addr => ({ scriptpubkey_address: addr, scriptpubkey_type: detectAddressType(addr, this.stateService.network) }))
-      ].filter(v => ['p2pkh', 'p2sh', 'v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(v.scriptpubkey_type));
+      const comparableVouts = tx.vout.slice(0, 20).filter(v => ['p2pkh', 'p2sh', 'v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(v.scriptpubkey_type));
       const comparableVins = tx.vin.slice(0, 20).map(v => v.prevout).filter(v => ['p2pkh', 'p2sh', 'v0_p2wpkh', 'v0_p2wsh', 'v1_p2tr'].includes(v?.scriptpubkey_type));
       for (const vout of comparableVouts) {
         const address = vout.scriptpubkey_address;


### PR DESCRIPTION
The address poisoning warning implementation on the wallet page currently checks for similarity matches against all of a wallets addresses (even if they aren't involved in a particular transaction).

If a wallet has many addresses, this is almost guaranteed to produce a huge number of false positives due to the birthday paradox:

<img width="1127" alt="Screenshot 2025-04-03 at 7 50 40 AM" src="https://github.com/user-attachments/assets/db50b8b2-5334-4fb7-b419-458e842aac02" />

This PR mitigates the issue by limiting comparisons to addresses within the same transaction.