### PR TITLE
Pin node 22 to 22.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     strategy:
       matrix:
-        node: ["22"]
+        node: ["22.14.0"]
         flavor: ["dev", "prod"]
       fail-fast: false
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
     if: "(github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')) || github.event_name == 'push'"
     strategy:
       matrix:
-        node: ["22"]
+        node: ["22.14.0"]
         flavor: ["dev", "prod"]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e_parameterized.yml
+++ b/.github/workflows/e2e_parameterized.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22.14.0
           registry-url: "https://registry.npmjs.org"
 
       - name: Install (Prod dependencies only)
@@ -151,7 +151,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 22.14.0
           cache: "npm"
           cache-dependency-path: ${{ matrix.module }}/frontend/package-lock.json
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /build
 RUN apt-get update && \
     apt-get install -y curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs build-essential python3 pkg-config && \
+    apt-get install -y nodejs=22.14.0-1nodesource1 build-essential python3 pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,7 +29,7 @@ FROM rust:1.84-bookworm AS runtime
 RUN apt-get update && \
     apt-get install -y curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y nodejs=22.14.0-1nodesource1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS builder
+FROM node:22.14.0-bookworm-slim AS builder
 
 ARG commitHash
 ENV DOCKER_COMMIT_HASH=${commitHash}


### PR DESCRIPTION
Stop floating major node version on Docker images and CI