### PR TITLE
Fix Dockerhub login variable on the retag workflow

### DIFF
--- a/.github/workflows/docker_update_latest_tag.yml
+++ b/.github/workflows/docker_update_latest_tag.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get source image manifest and SHAs


### PR DESCRIPTION
The login step on the retag workflow failed probably because it was reading the wrong secret

https://github.com/mempool/mempool/actions/runs/14321807078/job/40140013277