### PR TITLE
preview stratum coinbase transactions

### DIFF
--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -219,7 +219,12 @@
                   <table class="job-table table table-xs table-borderless table-fixed table-data">
                     <thead>
                       <tr>
-                        <th class="data-title clip text-center coinbase" i18n="latest-blocks.coinbasetag">Coinbase tag</th>
+                        <th class="data-title clip text-center coinbase" i18n="latest-blocks.coinbasetag">
+                          <a class="title-link" [routerLink]="['/tx/preview' | relativeUrl]" [fragment]="'hex=' + job.coinbase">
+                            Coinbase tag <span>&nbsp;</span>
+                            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)"></fa-icon>
+                          </a>
+                        </th>
                         <th class="data-title clip text-center clean" i18n="next-block.clean">Clean</th>
                         <th class="data-title clip text-center prevhash" i18n="next-block.prevhash">Prevhash</th>
                         <th class="data-title clip text-center job-received" i18n="next-block.job-received">Job Received</th>

--- a/frontend/src/app/components/stratum/stratum-list/stratum-list.component.html
+++ b/frontend/src/app/components/stratum/stratum-list/stratum-list.component.html
@@ -45,7 +45,9 @@
               <app-amount [satoshis]="row.job.reward"></app-amount>
             </td>
             <td class="height">
-              {{ row.job.height }}
+              <a [routerLink]="['/tx/preview' | relativeUrl]" [fragment]="'hex=' + row.job.coinbase">
+                {{ row.job.height }}
+              </a>
             </td>
           </tr>
         }

--- a/frontend/src/app/components/transaction/transaction-raw.component.html
+++ b/frontend/src/app/components/transaction/transaction-raw.component.html
@@ -19,7 +19,11 @@
 
   @if (transaction && !error && !isLoading) {
     <div class="title-block">
-      <h1 i18n="shared.preview-transaction|Preview Transaction">Preview Transaction</h1>
+      @if (isCoinbase) {
+        <h1 i18n="shared.preview-coinbase|Preview Coinbase">Preview Coinbase</h1>
+      } @else {
+        <h1 i18n="shared.preview-transaction|Preview Transaction">Preview Transaction</h1>
+      }
 
       <span class="tx-link">
         <span class="txid">
@@ -39,19 +43,21 @@
 
     <div class="clearfix"></div>
 
-    <div class="alert alert-mempool" style="align-items: center;">
-      <span>
-        <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon>
-        <ng-container *ngIf="!successBroadcast" i18n="transaction.local-tx|This transaction is stored locally in your browser.">
-          This transaction is stored locally in your browser. Broadcast it to add it to the mempool.
-        </ng-container>
-        <ng-container *ngIf="successBroadcast" i18n="transaction.redirecting|Redirecting to transaction page...">
-          Redirecting to transaction page...
-        </ng-container>
-      </span>
-      <button *ngIf="!successBroadcast" [disabled]="isLoadingBroadcast" type="button" class="btn btn-sm btn-primary btn-broadcast" i18n="transaction.broadcast|Broadcast" (click)="postTx()">Broadcast</button>
-      <button *ngIf="successBroadcast" type="button" class="btn btn-sm btn-success no-cursor btn-broadcast" i18n="transaction.broadcasted|Broadcasted">Broadcasted</button>
-    </div>
+    @if (!isCoinbase) {
+      <div class="alert alert-mempool" style="align-items: center;">
+        <span>
+          <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon>
+          <ng-container *ngIf="!successBroadcast" i18n="transaction.local-tx|This transaction is stored locally in your browser.">
+            This transaction is stored locally in your browser. Broadcast it to add it to the mempool.
+          </ng-container>
+          <ng-container *ngIf="successBroadcast" i18n="transaction.redirecting|Redirecting to transaction page...">
+            Redirecting to transaction page...
+          </ng-container>
+        </span>
+        <button *ngIf="!successBroadcast" [disabled]="isLoadingBroadcast" type="button" class="btn btn-sm btn-primary btn-broadcast" i18n="transaction.broadcast|Broadcast" (click)="postTx()">Broadcast</button>
+        <button *ngIf="successBroadcast" type="button" class="btn btn-sm btn-success no-cursor btn-broadcast" i18n="transaction.broadcasted|Broadcasted">Broadcasted</button>
+      </div>
+    }
 
     @if (!hasPrevouts) {
       <div class="alert alert-mempool">


### PR DESCRIPTION
This PR adds support for quickly previewing the coinbase transactions from stratum jobs in the new /tx/preview page.


https://github.com/user-attachments/assets/5d44066d-0ba1-4a22-84cd-12c9fb0da913



To support this, the PR also updates the transaction preview page:
 - allow transaction raw hex & offline mode preference to be provided in URL fragment params
 - some UI changes when the transaction is a coinbase
     - (disable broadcast button & "stored in your browser" alert message)
     - (different title)
 - proactively updating URL fragment params when new raw transactions are submitted and/or offline mode preference changes.

These changes have the nice side effect of allowing the user's current previewed transaction to persist across page reloads, and to allow sharing a transaction preview by URL.