### PR TITLE
Don't zoom when double click on amount button (mobile)

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1408,3 +1408,7 @@ a {
 .btn-small-height {
 	line-height: 1;
 }
+
+button {
+  touch-action: manipulation;
+}


### PR DESCRIPTION
Some buttons in the app triggers a zoom on mobile devices when double clicked. See:

https://github.com/user-attachments/assets/a267d539-4f14-4443-9319-9728b6d434de

This PR disables this behavior by adding the css property `touch-action: manipulation` to button components.