### PR TITLE
Fix cropped difficulty series in hashrate chart

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -370,9 +370,10 @@ export class HashrateChartComponent implements OnInit {
             const newMin = Math.floor(firstYAxisMin / selectedPowerOfTen.divider / 10)
             return 600 / 2 ** 32 * newMin * selectedPowerOfTen.divider * 10;
           },
-          max: (_) => {
+          max: (value) => {
             const firstYAxisMax = this.chartInstance.getModel().getComponent('yAxis', 0).axis.scale.getExtent()[1];
-            return 600 / 2 ** 32 * firstYAxisMax;
+            const scaledMax = 600 / 2 ** 32 * firstYAxisMax;
+            return Math.max(scaledMax, value.max);
           },
           axisLabel: {
             color: 'rgb(110, 112, 121)',


### PR DESCRIPTION
Fixes #5868


If the difficulty exceeds the scaled y-axis maximum, update its y-axis to match the difficulty max value. This fixes the overflow while keeping the scaled axis when there is no overflow issues.

testnet4: 
| Before  | After |
| ------------- | ------------- |
| <img width="504" alt="Screenshot 2025-04-14 at 17 45 49" src="https://github.com/user-attachments/assets/6a9e8dfc-c2bc-43b9-b56f-5c636b6d7b53" /> | <img width="504" alt="Screenshot 2025-04-14 at 17 44 57" src="https://github.com/user-attachments/assets/73a278de-6fab-4ceb-963d-f84887f8a6e1" /> |
