### PR TITLE
experimental sighash highlighting

### DIFF
--- a/frontend/src/app/components/transaction/transaction-raw.component.html
+++ b/frontend/src/app/components/transaction/transaction-raw.component.html
@@ -147,7 +147,7 @@
     </div>
 
 
-    <app-transactions-list #txList [transactions]="[transaction]" [transactionPage]="true" [txPreview]="true"></app-transactions-list>
+    <app-transactions-list #txList [transactions]="[transaction]" [transactionPage]="true" [txPreview]="true" [signatures]="true"></app-transactions-list>
 
     <div class="title text-left">
       <h2 i18n="transaction.details|Transaction Details">Details</h2>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -59,19 +59,25 @@
                   <td class="sig-td">
                     <div class="sig-stack">
                       @if (tx['_sigs'][vindex].length === 0) {
-                        <span class="sig-key sig-no-lock" title="unsigned">
+                        <span class="sig sig-key sig-no-lock" title="unsigned">
                           <fa-icon [icon]="['fas', 'lock-open']" [fixedWidth]="true"></fa-icon>
                         </span>
                       } @else {
                         @for (sig of tx['_sigs'][vindex]; track sig.signature; let idx = $index) {
                           @if (idx < 10) {
-                            <span class="sig-key sighash-{{sig.sighash}}" (mouseenter)="showSigInfo(i, vindex, sig)" (mouseleave)="hideSigInfo()" [title]="sighashLabels[sig.sighash]">
+                            <span
+                              class="sig sig-key sighash-{{sig.sighash}}"
+                              (mouseenter)="showSigInfo(i, vindex, sig)"
+                              (mouseleave)="hideSigInfo()"
+                              [title]="sighashLabels[sig.sighash]"
+                              [class.hovered]="selectedSig && selectedSig.txIndex === i && selectedSig.vindex === vindex && selectedSig.sig === sig"
+                            >
                               <fa-icon [icon]="['fas', 'key']" [fixedWidth]="true"></fa-icon>
                             </span>
                           }
                         }
                         @if (tx['_sigs'][vindex].length > 10) {
-                          <span class="sig-key sig-overflow">
+                          <span class="sig sig-key sig-overflow">
                             +{{ tx['_sigs'][vindex].length - 10 }}
                           </span>
                         }
@@ -159,27 +165,47 @@
                       <tr *ngIf="vin.witness" class="vin-witness">
                         <td i18n="transactions-list.witness">Witness</td>
                         <td style="text-align: left;">
-                          <ng-container *ngFor="let witness of vin.witness; index as i">
+                          <ng-container *ngFor="let witness of vin.witness; index as windex">
                             <p class="witness-item">
+                              <ng-container *ngIf="signatures && tx['_sigmap'][witness] as sigInfo">
+                                <span class="sig sig-key sig-inline sighash-{{sigInfo.sig.sighash}}"
+                                      [class.hovered]="selectedSig && selectedSig.txIndex === i && selectedSig.vindex === vindex && selectedSig.sig === sigInfo.sig"
+                                      (mouseenter)="showSigInfo(i, vindex, sigInfo.sig)" 
+                                      (mouseleave)="hideSigInfo()" 
+                                      [title]="sighashLabels[sigInfo.sig.sighash]">
+                                  <fa-icon [icon]="['fas', 'key']" [fixedWidth]="true"></fa-icon>
+                                </span>
+                              </ng-container>
                               @if (witness.length > 1000) {
-                                @if (!showFullWitness[vindex][i]) {
+                                @if (!showFullWitness[vindex][windex]) {
                                   {{ witness | slice:0:1000 }}
                                 } @else {
                                   {{ witness }}
                                 }
                               } @else if (witness) {
-                                {{ witness }}
+                                <ng-container *ngIf="signatures && tx['_sigmap'][witness]?.sig.sighash !== 0 && tx['_sigmap'][witness] as sigInfo; else plainSig">
+                                  <span class="witness">
+                                    {{witness.slice(0, -2)}}<span class="sig sighash-{{sigInfo.sig.sighash}}" 
+                                          [class.hovered]="selectedSig && selectedSig.txIndex === i && selectedSig.vindex === vindex && selectedSig.sig === sigInfo.sig"
+                                          (mouseenter)="showSigInfo(i, vindex, sigInfo.sig)" 
+                                          (mouseleave)="hideSigInfo()" 
+                                          [title]="sighashLabels[sigInfo.sig.sighash]">{{witness.slice(-2)}}</span>
+                                  </span>
+                                </ng-container>
+                                <ng-template #plainSig>
+                                  {{ witness }}
+                                </ng-template>
                               } @else {
                                 &lt;empty&gt;
                               }
                             </p>
                             @if (witness.length > 1000) {
                               <div style="display: flex;">
-                                @if (!showFullWitness[vindex][i]) {
+                                @if (!showFullWitness[vindex][windex]) {
                                   <span>...</span>
                                 }
-                                <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullWitness(vindex, i)" style="margin-left: auto;">
-                                  @if (!showFullWitness[vindex][i]) {
+                                <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullWitness(vindex, windex)" style="margin-left: auto;">
+                                  @if (!showFullWitness[vindex][windex]) {
                                     <span i18n="show-all">Show all</span>
                                   } @else {
                                     <span i18n="show-less">Show less</span>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -28,7 +28,8 @@
             <ng-template ngFor let-vin let-vindex="index" [ngForOf]="tx.vin.slice(0, getVinLimit(tx))" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{
                 'assetBox': (assetsMinimal && vin.prevout && assetsMinimal[vin.prevout.asset] && !vin.is_coinbase && vin.prevout.scriptpubkey_address && tx._unblinded) || inputIndex === vindex,
-                'highlight': this.addresses.length && ((vin.prevout?.scriptpubkey_type !== 'p2pk' && addresses.includes(vin.prevout?.scriptpubkey_address)) || this.addresses.includes(vin.prevout?.scriptpubkey.slice(2, -2)))
+                'highlight': this.addresses.length && ((vin.prevout?.scriptpubkey_type !== 'p2pk' && addresses.includes(vin.prevout?.scriptpubkey_address)) || this.addresses.includes(vin.prevout?.scriptpubkey.slice(2, -2))),
+                'sigged': selectedSig && selectedSig.txIndex === i && sigHighlights.vin[vindex],
               }">
                 <td class="arrow-td">
                   <ng-template [ngIf]="vin.prevout === null && !vin.is_pegin" [ngIfElse]="hasPrevout">
@@ -54,6 +55,30 @@
                     </ng-template>
                   </ng-template>
                 </td>
+                @if (signatures) {
+                  <td class="sig-td">
+                    <div class="sig-stack">
+                      @if (tx['_sigs'][vindex].length === 0) {
+                        <span class="sig-key sig-no-lock" title="unsigned">
+                          <fa-icon [icon]="['fas', 'lock-open']" [fixedWidth]="true"></fa-icon>
+                        </span>
+                      } @else {
+                        @for (sig of tx['_sigs'][vindex]; track sig.signature; let idx = $index) {
+                          @if (idx < 10) {
+                            <span class="sig-key sighash-{{sig.sighash}}" (mouseenter)="showSigInfo(i, vindex, sig)" (mouseleave)="hideSigInfo()" [title]="sighashLabels[sig.sighash]">
+                              <fa-icon [icon]="['fas', 'key']" [fixedWidth]="true"></fa-icon>
+                            </span>
+                          }
+                        }
+                        @if (tx['_sigs'][vindex].length > 10) {
+                          <span class="sig-key sig-overflow">
+                            +{{ tx['_sigs'][vindex].length - 10 }}
+                          </span>
+                        }
+                      }
+                    </div>
+                  </td>
+                }
                 <td class="address-cell">
                   <div [ngSwitch]="true">
                     <ng-container *ngSwitchCase="vin.is_coinbase"><span i18n="transactions-list.coinbase">Coinbase</span><ng-template [ngIf]="network !== 'liquid' && network !== 'liquidtestnet'">&nbsp;<span i18n="transactions-list.newly-generated-coins">(Newly Generated Coins)</span></ng-template><br /><a placement="bottom" [ngbTooltip]="vin.scriptsig | hex2ascii"><span class="badge badge-secondary scriptmessage longer">{{ vin.scriptsig | hex2ascii }}</span></a></ng-container>
@@ -106,15 +131,19 @@
               </tr>
               <tr *ngIf="showOrdData[tx.txid + '-vin-' + vindex]?.show" [ngClass]="{
                 'assetBox': (assetsMinimal && vin.prevout && assetsMinimal[vin.prevout.asset] && !vin.is_coinbase && vin.prevout.scriptpubkey_address && tx._unblinded) || inputIndex === vindex,
-                'highlight': addresses?.length && (addresses.includes(vin.prevout?.scriptpubkey_address) || (vin.prevout?.scriptpubkey_type === 'p2pk' && addresses.includes(vin.prevout?.scriptpubkey.slice(2, -2))))
+                'highlight': addresses?.length && (addresses.includes(vin.prevout?.scriptpubkey_address) || (vin.prevout?.scriptpubkey_type === 'p2pk' && addresses.includes(vin.prevout?.scriptpubkey.slice(2, -2)))),
+                'sigged': selectedSig && selectedSig.txIndex === i && sigHighlights.vin[vindex],
               }">
                 <td></td>
+                @if (signatures) {
+                  <td></td>
+                }
                 <td colspan="2">
                   <app-ord-data [inscriptions]="showOrdData[tx.txid + '-vin-' + vindex]['inscriptions']" [type]="'vin'"></app-ord-data>
                 </td>
               </tr>
               <tr *ngIf="(showDetails$ | async) === true">
-                <td colspan="3" class="details-container" >
+                <td [attr.colspan]="signatures ? 4 : 3" class="details-container" >
                   <table class="table table-striped table-fixed table-borderless details-table mb-3">
                     <tbody>
                       <ng-template [ngIf]="vin.scriptsig">
@@ -201,7 +230,7 @@
               </tr>
             </ng-template>
             <tr *ngIf="tx.vin.length > getVinLimit(tx)">
-              <td colspan="3" class="text-center">
+              <td [attr.colspan]="signatures ? 4 : 3" class="text-center">
                 <button class="btn btn-sm btn-primary mt-2" (click)="showMoreInputs(tx)">
                   <span *ngIf="getVinLimit(tx, true) >= tx.vin.length; else showMoreInputsLabel" i18n="show-all">Show all</span>
                   <ng-template #showMoreInputsLabel>
@@ -221,7 +250,8 @@
             <ng-template ngFor let-vout let-vindex="index" [ngForOf]="tx.vout.slice(0, getVoutLimit(tx))" [ngForTrackBy]="trackByIndexFn">
               <tr [ngClass]="{
                 'assetBox': assetsMinimal && assetsMinimal[vout.asset] && vout.scriptpubkey_address && tx.vin && !tx.vin[0].is_coinbase && tx._unblinded || outputIndex === vindex,
-                'highlight': this.addresses.length && ((vout.scriptpubkey_type !== 'p2pk' && addresses.includes(vout.scriptpubkey_address)) || this.addresses.includes(vout.scriptpubkey.slice(2, -2)))
+                'highlight': this.addresses.length && ((vout.scriptpubkey_type !== 'p2pk' && addresses.includes(vout.scriptpubkey_address)) || this.addresses.includes(vout.scriptpubkey.slice(2, -2))),
+                'sigged': selectedSig && selectedSig.txIndex === i && sigHighlights.vout[vindex],
               }">
                 <td class="address-cell">
                   <app-address-text
@@ -303,14 +333,15 @@
 
               <tr *ngIf="showOrdData[tx.txid + '-vout-' + vindex]?.show" [ngClass]="{
                 'assetBox': assetsMinimal && assetsMinimal[vout.asset] && vout.scriptpubkey_address && tx.vin && !tx.vin[0].is_coinbase && tx._unblinded || outputIndex === vindex,
-                'highlight': addresses?.length && (addresses.includes(vout.scriptpubkey_address) || (vout.scriptpubkey_type === 'p2pk' && addresses.includes(vout.scriptpubkey.slice(2, -2))))
+                'highlight': addresses?.length && (addresses.includes(vout.scriptpubkey_address) || (vout.scriptpubkey_type === 'p2pk' && addresses.includes(vout.scriptpubkey.slice(2, -2)))),
+                'sigged': selectedSig && selectedSig.txIndex === i && sigHighlights.vout[vindex],
               }">
                 <td colspan="3">
                     <app-ord-data [runestone]="showOrdData[tx.txid + '-vout-' + vindex]['runestone']" [runeInfo]="showOrdData[tx.txid + '-vout-' + vindex]['runeInfo']" [type]="'vout'"></app-ord-data>
                 </td>
               </tr>
               <tr *ngIf="(showDetails$ | async) === true">
-                <td colspan="3" class=" details-container" >
+                <td [attr.colspan]="signatures ? 4 : 3" class=" details-container" >
                   <table class="table table-striped table-borderless details-table mb-3">
                     <tbody>
                       <tr>
@@ -335,7 +366,7 @@
               </tr>
             </ng-template>
             <tr *ngIf="tx.vout.length > getVoutLimit(tx)">
-              <td colspan="3" class="text-center">
+              <td [attr.colspan]="3" class="text-center">
                 <button class="btn btn-sm btn-primary mt-2" (click)="showMoreOutputs(tx)">
                   <span *ngIf="getVoutLimit(tx, true) >= tx.vout.length; else showMoreOutputsLabel" i18n="show-all">Show all</span>
                   <ng-template #showMoreOutputsLabel>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -61,63 +61,69 @@
 	}
 }
 
-.sig-key {
-	position: absolute;
-	top: 0;
-	left: 0;
+.sig {
 	cursor: pointer;
-	transition: transform 0.2s ease;
-	pointer-events: none;
-	// opacity: 0.8;
+	
 
 	&.sighash-0 {
-		--keycolor: var(--green);
+		--sigColor: var(--green);
 	}
 	&.sighash-1 {
-		--keycolor: var(--green);
+		--sigColor: var(--green);
 	}
 	&.sighash-2 {
-		--keycolor: gold;
+		--sigColor: gold;
 	}
 	&.sighash-3 {
-		--keycolor: cornflowerblue;
+		--sigColor: cornflowerblue;
 	}
 	&.sighash-129 {
-		--keycolor: darkviolet;
+		--sigColor: darkviolet;
 	}
 	&.sighash-130 {
-		--keycolor: darkorange;
+		--sigColor: darkorange;
 	}
 	&.sighash-131 {
-		--keycolor: var(--pink);
+		--sigColor: var(--pink);
 	}
 	&.sig-no-lock {
-		--keycolor: var(--red);
+		--sigColor: var(--red);
 	}
-	color: var(--keycolor);
+	color: var(--sigColor);
 
-	@for $i from 1 through 3 {
+	@for $i from 1 through 10 {
 		&:nth-child(#{$i}) {
 			transform: translate(#{($i - 1) * 3}px, #{($i - 1) * 3}px);
-			color: color-mix(in srgb, var(--keycolor) #{100 - ($i - 1) * 20} + '%', white);
+			color: color-mix(in srgb, var(--sigColor) #{100 - ($i - 1) * 10} + '%', black);
 			z-index: #{10 - $i};
 		}
 	}
 	@for $i from 4 through 10 {
 		&:nth-child(#{$i}) {
 			transform: translate(9px, 9px);
-			color: color-mix(in srgb, var(--keycolor) 60%, white);
-			z-index: #{10 - $i};
 		}
 	}
 
-	&:hover {
-		// opacity: 1;
-		color: color-mix(in srgb, var(--keycolor) 80%, black);
+	&:hover, &.hovered {
+		color: color-mix(in srgb, var(--sigColor) 80%, white);
 	}
 
 	::ng-deep svg path {
 		pointer-events: auto;
+	}
+}
+
+.sig-key {
+	position: absolute;
+	top: 0;
+	left: 0;
+	transition: transform 0.2s ease;
+	pointer-events: none;
+
+	&.sig-inline {
+		position: relative;
+		pointer-events: auto;
+		margin-right: -5px;
 	}
 }
 

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -1,3 +1,17 @@
+.col {
+	&:first-child {
+		padding-right: 0;
+		td:last-child {
+			padding-right: calc(0.3em + 15px);
+		}
+	}
+	&:last-child {
+		padding-left: 0;
+		td:first-child {
+			padding-left: calc(0.3em + 15px);
+		}
+	}
+}
 
 .arrow-td {
 	width: 30px;
@@ -22,6 +36,103 @@
 
 .grey {
   color: var(--grey);
+}
+
+.sig-td {
+	width: 30px;
+	position: relative;
+}
+
+.sig-stack {
+	position: relative;
+	width: 30px;
+	transition: transform 0.2s ease;
+}
+
+.sig-td:hover {
+	.sig-stack {	
+		.sig-key {
+			@for $i from 1 through 10 {
+				&:nth-child(#{$i}) {
+					transform: translate(#{($i - 1) * 6}px, #{($i - 1) * 6}px);
+				}
+			}
+		}
+	}
+}
+
+.sig-key {
+	position: absolute;
+	top: 0;
+	left: 0;
+	cursor: pointer;
+	transition: transform 0.2s ease;
+	pointer-events: none;
+	// opacity: 0.8;
+
+	&.sighash-0 {
+		--keycolor: var(--green);
+	}
+	&.sighash-1 {
+		--keycolor: var(--green);
+	}
+	&.sighash-2 {
+		--keycolor: gold;
+	}
+	&.sighash-3 {
+		--keycolor: cornflowerblue;
+	}
+	&.sighash-129 {
+		--keycolor: darkviolet;
+	}
+	&.sighash-130 {
+		--keycolor: darkorange;
+	}
+	&.sighash-131 {
+		--keycolor: var(--pink);
+	}
+	&.sig-no-lock {
+		--keycolor: var(--red);
+	}
+	color: var(--keycolor);
+
+	@for $i from 1 through 3 {
+		&:nth-child(#{$i}) {
+			transform: translate(#{($i - 1) * 3}px, #{($i - 1) * 3}px);
+			color: color-mix(in srgb, var(--keycolor) #{100 - ($i - 1) * 20} + '%', white);
+			z-index: #{10 - $i};
+		}
+	}
+	@for $i from 4 through 10 {
+		&:nth-child(#{$i}) {
+			transform: translate(9px, 9px);
+			color: color-mix(in srgb, var(--keycolor) 60%, white);
+			z-index: #{10 - $i};
+		}
+	}
+
+	&:hover {
+		// opacity: 1;
+		color: color-mix(in srgb, var(--keycolor) 80%, black);
+	}
+
+	::ng-deep svg path {
+		pointer-events: auto;
+	}
+}
+
+.sig-overflow {
+	// background-color: var(--tertiary);
+	color: white;
+	border-radius: 50%;
+	width: 20px;
+	height: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 10px;
+	font-weight: bold;
+	z-index: 1;
 }
 
 .mobile-bottomcol {
@@ -140,6 +251,10 @@ h2 {
 
 .highlight {
 	background-color: var(--stat-box-bg);
+}
+
+.sigged {
+	background-color: #ffffff22;
 }
 
 .summary {

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -295,6 +295,12 @@ export class TransactionsListComponent implements OnInit, OnChanges {
 
           // process signature data
           tx['_sigs'] = tx.vin.map(vin => processInputSignatures(vin));
+          tx['_sigmap'] = tx['_sigs'].reduce((map, sigs, vindex) => {
+            sigs.forEach(sig => {
+              map[sig.signature] = { sig, vindex };
+            });
+            return map;
+          }, {});
         }
 
         tx.largeInput = tx.largeInput || tx.vin.some(vin => (vin?.prevout?.value > 1000000000));

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -1,3 +1,6 @@
+import { Vin } from "../interfaces/electrs.interface";
+import { AddressType, detectAddressType } from "./address-utils";
+
 const opcodes = {
   OP_FALSE: 0,
   OP_0: 0,

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -7,7 +7,7 @@ import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, fa
   faFileAlt, faRedoAlt, faArrowAltCircleRight, faExternalLinkAlt, faBook, faListUl, faDownload, faQrcode, faArrowRightArrowLeft, faArrowsRotate, faCircleLeft,
   faFastForward, faWallet, faUserClock, faWrench, faUserFriends, faQuestionCircle, faHistory, faSignOutAlt, faKey, faSuitcase, faIdCardAlt, faNetworkWired, faUserCheck,
   faCircleCheck, faUserCircle, faCheck, faRocket, faScaleBalanced, faHourglassStart, faHourglassHalf, faHourglassEnd, faWandMagicSparkles, faFaucetDrip, faTimeline,
-  faCircleXmark, faCalendarCheck, faMoneyBillTrendUp, faRobot, faShareNodes, faCreditCard, faMicroscope, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+  faCircleXmark, faCalendarCheck, faMoneyBillTrendUp, faRobot, faShareNodes, faCreditCard, faMicroscope, faExclamationTriangle, faLockOpen } from '@fortawesome/free-solid-svg-icons';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { MenuComponent } from '@components/menu/menu.component';
 import { PreviewTitleComponent } from '@components/master-page-preview/preview-title.component';
@@ -467,5 +467,6 @@ export class SharedModule {
     library.addIcons(faCreditCard);
     library.addIcons(faMicroscope);
     library.addIcons(faExclamationTriangle);
+    library.addIcons(faLockOpen);
   }
 }

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -4,6 +4,7 @@ import { Transaction, Vin } from '@interfaces/electrs.interface';
 import { CpfpInfo, RbfInfo, TransactionStripped } from '@interfaces/node-api.interface';
 import { StateService } from '@app/services/state.service';
 import { hash, Hash } from './sha256';
+import { AddressType } from './address-utils';
 
 // Bitcoin Core default policy settings
 const MAX_STANDARD_TX_WEIGHT = 400_000;
@@ -83,6 +84,154 @@ export function isDERSig(w: string): boolean {
     && ['01', '02', '03', '81', '82', '83'].includes(w.slice(-2)) // signature must end with a valid sighash flag
     && (w.length === (2 * parseInt(w.slice(2, 4), 16)) + 6) // second byte encodes the combined length of the R and S components
   );
+}
+
+export enum SighashFlag {
+  DEFAULT = 0,
+  ALL = 1,
+  NONE = 2,
+  SINGLE = 3,
+  ANYONECANPAY = 0x80
+}
+
+export type SighashValue =
+  SighashFlag.DEFAULT |
+  SighashFlag.ALL |
+  SighashFlag.NONE |
+  SighashFlag.SINGLE |
+  (SighashFlag.ALL & SighashFlag.ANYONECANPAY) |
+  (SighashFlag.NONE & SighashFlag.ANYONECANPAY) |
+  (SighashFlag.SINGLE & SighashFlag.ANYONECANPAY) |
+  (SighashFlag.ALL & SighashFlag.NONE);
+
+export interface SigInfo {
+  signature: string;
+  sighash: SighashValue;
+}
+
+export class Sighash {
+  static isACP(val: SighashValue): boolean {
+    return val >= SighashFlag.ANYONECANPAY;
+  }
+
+  static isNone(val: SighashValue): boolean {
+    return (val & 0x7F) === SighashFlag.NONE;
+  }
+
+  static isSingle(val: SighashValue): boolean {
+    return (val & 0x7F) === SighashFlag.SINGLE;
+  }
+
+  static isAll(val: SighashValue): boolean {
+    return (val & 0x7F) === SighashFlag.ALL;
+  }
+
+  static isDefault(val: SighashValue): boolean {
+    return val === SighashFlag.DEFAULT;
+  }
+}
+
+export function decodeSighashFlag(sighash: number): SighashValue {
+  if (sighash >= 0 && sighash <= 0x03 || sighash > 0x80 && sighash <= 0x83) {
+    return sighash as SighashValue;
+  }
+  return SighashFlag.DEFAULT;
+}
+
+export function extractDERSignaturesWitness(witness: string[]): SigInfo[] {
+  if (!witness?.length) {
+    return [];
+  }
+
+  const signatures: SigInfo[] = [];
+
+  for (const w of witness) {
+    if (isDERSig(w)) {
+      signatures.push({
+        signature: w,
+        sighash: decodeSighashFlag(parseInt(w.slice(-2), 16)),
+      });
+    }
+  }
+
+  return signatures;
+}
+
+export function extractDERSignaturesASM(script_asm: string): SigInfo[] {
+  if (!script_asm) {
+    return [];
+  }
+
+  const signatures: SigInfo[] = [];
+  const ops = script_asm.split(' ');
+
+  for (let i = 0; i < ops.length - 1; i++) {
+    // Look for OP_PUSHBYTES_N followed by a hex string
+    if (ops[i].startsWith('OP_PUSHBYTES_')) {
+      const hexData = ops[i + 1];
+      if (isDERSig(hexData)) {
+        const sighash = decodeSighashFlag(parseInt(hexData.slice(-2), 16));
+        signatures.push({
+          signature: hexData.slice(0, -2), // Remove sighash byte
+          sighash
+        });
+      }
+    }
+  }
+
+  return signatures;
+}
+
+export function extractSchnorrSignatures(witnesses: string[]): SigInfo[] {
+  if (!witnesses?.length) {
+    return [];
+  }
+
+  const signatures: SigInfo[] = [];
+
+  for (const witness of witnesses) {
+    if (witness.length === 130) {
+      signatures.push({
+        signature: witness,
+        sighash: decodeSighashFlag(parseInt(witness.slice(-2), 16)),
+      });
+    } else if (witness.length === 128) {
+      signatures.push({
+        signature: witness,
+        sighash: SighashFlag.DEFAULT,
+      });
+    }
+  }
+
+  return signatures;
+}
+
+export function processInputSignatures(vin: Vin): SigInfo[] {
+  const addressType = vin.prevout?.scriptpubkey_type as AddressType;
+  let signatures: SigInfo[] = [];
+  switch(addressType) {
+    case 'p2pk':
+    case 'multisig':
+    case 'p2pkh':
+      signatures = extractDERSignaturesASM(vin.scriptsig_asm);
+      break;
+    case 'p2sh':
+      signatures = [...extractDERSignaturesASM(vin.scriptsig_asm), ...extractDERSignaturesASM(vin.inner_redeemscript_asm), ...extractDERSignaturesWitness(vin.witness || [])];
+      break;
+    case 'v0_p2wpkh':
+      signatures = extractDERSignaturesWitness(vin.witness || []);
+      break;
+    case 'v0_p2wsh':
+      signatures = extractDERSignaturesWitness(vin.witness || []);
+      break;
+    case 'v1_p2tr':
+      signatures = extractSchnorrSignatures(vin.witness.slice(0, vin.witness.length - ((vin.witness.length > 1 && vin.witness[vin.witness.length - 1].startsWith('50')) ? 1 : 0)));
+      break;
+    default:
+      // non-signed input types?
+      break;
+  }
+  return signatures;
 }
 
 /**


### PR DESCRIPTION
Draft PR for an experimental sighash highlighting/visualization feature.

Color-coded icons are displayed to show how many signatures were used to spend each input, and with which sighash modes.

Hovering over the icons highlights which inputs and outputs that signature committed

<img width="1128" alt="Screenshot 2025-04-16 at 2 56 50 AM" src="https://github.com/user-attachments/assets/fded461f-b71e-442b-aaeb-e0a4415c3511" />
<img width="1131" alt="Screenshot 2025-04-16 at 2 55 10 AM" src="https://github.com/user-attachments/assets/9f2092fe-0746-4705-a00e-ed07fe37b04a" />

In the expanded transaction details view, individual signatures (and their sighash flags) in the witness data are similarly identified.

<img width="519" alt="Screenshot 2025-04-16 at 2 55 39 AM" src="https://github.com/user-attachments/assets/41bdcc67-ab06-4fec-b5aa-2e3f4c5e9d98" />
