### PR TITLE
avoid requesting infinite acceleration history pages

### DIFF
--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -169,9 +169,10 @@ export class ServicesApiServices {
           page,
           total: parseInt(response.headers.get('X-Total-Count'), 10) || 0,
           accelerations: accelerations.concat(response.body || []),
+          pageAccelerations: response.body || [],
         })),
-        switchMap(({page, total, accelerations}) => {
-          if (accelerations.length >= Math.min(total, limit ?? Infinity) || (findTxid && accelerations.find((acc) => acc.txid === findTxid))) {
+        switchMap(({page, total, accelerations, pageAccelerations }) => {
+          if (pageAccelerations.length === 0 || accelerations.length >= Math.min(total, limit ?? Infinity) || (findTxid && accelerations.find((acc) => acc.txid === findTxid))) {
             return of({ page, total, accelerations });
           } else {
             return getPage$(page + 1, accelerations);


### PR DESCRIPTION
Fixes a possible bug where a mismatch between the X-Total-Count header & the actual API content of the acceleration history endpoint could cause the client to attempt to fetch infinite pages.