### PR TITLE
Fix coinbase tx details toggle

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -174,7 +174,7 @@
                         <td style="text-align: left;">
                           <ng-container *ngFor="let witness of vin.witness; index as windex">
                             <p class="witness-item">
-                              <ng-container *ngIf="tx['_sigmap'][witness] as sigInfo">
+                              <ng-container *ngIf="tx['_sigmap']?.[witness] as sigInfo">
                                 <span class="sig sig-key sig-inline sighash-{{sigInfo.sig.sighash}}"
                                       [class.hovered]="selectedSig && selectedSig.txIndex === i && selectedSig.vindex === vindex && selectedSig.sig === sigInfo.sig"
                                       (mouseenter)="showSigInfo(i, vindex, sigInfo.sig)" 
@@ -195,7 +195,7 @@
                                   {{ witness }}
                                 }
                               } @else if (witness) {
-                                <ng-container *ngIf="tx['_sigmap'][witness]?.sig.sighash !== 0 && tx['_sigmap'][witness] as sigInfo; else plainSig">
+                                <ng-container *ngIf="tx['_sigmap']?.[witness]?.sig.sighash !== 0 && tx['_sigmap']?.[witness] as sigInfo; else plainSig">
                                   <span class="witness">
                                     {{witness.slice(0, -2)}}<span class="sig sighash-{{sigInfo.sig.sighash}}" 
                                           [class.hovered]="selectedSig && selectedSig.txIndex === i && selectedSig.vindex === vindex && selectedSig.sig === sigInfo.sig"

--- a/frontend/src/app/shared/components/asm/asm.component.html
+++ b/frontend/src/app/shared/components/asm/asm.component.html
@@ -2,7 +2,7 @@
   @for (instruction of instructions; track instruction.instruction) {
     <span [class]='opcodeStyles.get(instruction.instruction)'>OP_{{instruction.instruction}}</span>
     @for (arg of instruction.args; track arg) {
-      <ng-container *ngIf="annotations.signatures[arg] as sigInfo; else plainArg">
+      <ng-container *ngIf="annotations.signatures?.[arg] as sigInfo; else plainArg">
         <span class="sig sig-key sig-inline sighash-{{sigInfo.sig.sighash}}"
               [class.hovered]="annotations.selectedSig && annotations.selectedSig === sigInfo.sig"
               (mouseenter)="doShowSigInfo(sigInfo.sig)"


### PR DESCRIPTION
Toggling the details of a coinbase transaction was broken because we don't process signature data on coinbase transactions.

<img width="1024" alt="Screenshot 2025-05-21 at 13 36 18" src="https://github.com/user-attachments/assets/7dd96eb9-13db-4d92-87cc-bbb9cd4eb520" />
