### PR TITLE
Fix colspan value

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -379,7 +379,7 @@
                 </td>
               </tr>
               <tr *ngIf="(showDetails$ | async) === true">
-                <td [attr.colspan]="tx['_showSignatures'] ? 4 : 3" class=" details-container" >
+                <td [attr.colspan]="3" class="details-container">
                   <table class="table table-striped table-borderless details-table mb-3">
                     <tbody>
                       <tr>


### PR DESCRIPTION
Toggling transaction details when signatures mode is on breaks table alignment: 

https://github.com/user-attachments/assets/9f107314-b43f-42ff-88f4-e71c8241aa24

