### PR TITLE
Fix missing y axis on difficulty chart

### DIFF
--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -364,8 +364,11 @@ export class HashrateChartComponent implements OnInit {
         {
           type: 'value',
           position: 'right',
-          min: (_) => {
+          min: (value) => {
             const firstYAxisMin = this.chartInstance.getModel().getComponent('yAxis', 0).axis.scale.getExtent()[0];
+            if (firstYAxisMin === Infinity) {
+              return value.min;
+            }
             const selectedPowerOfTen: any = selectPowerOfTen(firstYAxisMin);
             const newMin = Math.floor(firstYAxisMin / selectedPowerOfTen.divider / 10)
             return 600 / 2 ** 32 * newMin * selectedPowerOfTen.divider * 10;


### PR DESCRIPTION
The right-side y-axis was missing from the hashrate chart when only the difficulty was displayed:

<img width="1208" alt="Screenshot 2025-05-30 at 13 04 21" src="https://github.com/user-attachments/assets/a1d61412-1e9b-4386-8338-be837da3c801" />
