### PR TITLE
Use actual block weight in median fee calculation

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -900,9 +900,11 @@ export class Common {
     let medianWeight = 0;
 
     // calculate the "medianFee" as the average fee rate of the middle 0.25% weight units of transactions
-    const halfWidth = config.MEMPOOL.BLOCK_WEIGHT_UNITS / 800;
-    const leftBound = Math.floor((config.MEMPOOL.BLOCK_WEIGHT_UNITS / 2) - halfWidth);
-    const rightBound = Math.ceil((config.MEMPOOL.BLOCK_WEIGHT_UNITS / 2) + halfWidth);
+    // Also ensure we use actual block weight rather than assuming full block
+    const effectiveBlockWeight = transactions.reduce((sum, tx) => sum + tx.weight, 0);
+    const halfWidth = effectiveBlockWeight / 800;
+    const leftBound = Math.floor((effectiveBlockWeight / 2) - halfWidth);
+    const rightBound = Math.ceil((effectiveBlockWeight / 2) + halfWidth);
     for (let i = 0; i < sortedTxs.length && weightCount < rightBound; i++) {
       const left = weightCount;
       const right = weightCount + sortedTxs[i].weight;


### PR DESCRIPTION
Fixes #5908 by using actual transaction weight instead of full block weight in median fee rate calculation (this meant that medianFee was returning 0 for blocks less than half full).
