### PR TITLE
Fix offline button wrongly opening tx preview

### DIFF
--- a/frontend/src/app/components/transaction/transaction-raw.component.ts
+++ b/frontend/src/app/components/transaction/transaction-raw.component.ts
@@ -91,7 +91,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
         if (offline) {
           this.offlineMode = offline === 'true';
         }
-        if (this.pushTxForm.get('txRaw').value) {
+        if (hex && this.pushTxForm.get('txRaw').value) {
           this.decodeTransaction();
         }
       }


### PR DESCRIPTION
This PR fixes a bug where toggling offline mode on the preview tx page triggers the preview of the transaction:

https://github.com/user-attachments/assets/3db2bcdb-c7cf-490c-9274-3a482e1ffe57

This fix does not break the coinbase visualization from the stratum page: 

https://github.com/user-attachments/assets/c613581f-d1dc-402f-85f2-d1a0ed46a841

