### PR TITLE
tweak chart colors

### DIFF
--- a/frontend/src/app/app.constants.ts
+++ b/frontend/src/app/app.constants.ts
@@ -1,5 +1,5 @@
 export const defaultMempoolFeeColors = [
-  '557d00',
+  '497d2b',
   '557d00',
   '5d7d01',
   '637d02',
@@ -41,7 +41,7 @@ export const defaultMempoolFeeColors = [
 ];
 
 export const contrastMempoolFeeColors = [
-  '0082e6',
+  '007be9',
   '0082e6',
   '0984df',
   '1285d9',
@@ -123,6 +123,7 @@ export const chartColors = [
   "#263238",
   "#801313",
 ];
+export const originalChartColors = chartColors.slice(1);
 
 export const poolsColor = {
   'unknown': '#FDD835',

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -5,7 +5,7 @@ import { delay, map, retryWhen, share, startWith, switchMap, tap } from 'rxjs/op
 import { ApiService } from '@app/services/api.service';
 import { SeoService } from '@app/services/seo.service';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
-import { chartColors, poolsColor } from '@app/app.constants';
+import { originalChartColors as chartColors, poolsColor } from '@app/app.constants';
 import { StorageService } from '@app/services/storage.service';
 import { MiningService } from '@app/services/mining.service';
 import { download } from '@app/shared/graphs.utils';

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.ts
@@ -8,7 +8,7 @@ import { SeoService } from '@app/services/seo.service';
 import { StorageService } from '@app//services/storage.service';
 import { MiningService, MiningStats } from '@app/services/mining.service';
 import { StateService } from '@app/services/state.service';
-import { chartColors, poolsColor } from '@app/app.constants';
+import { originalChartColors as chartColors, poolsColor } from '@app/app.constants';
 import { RelativeUrlPipe } from '@app/shared/pipes/relative-url/relative-url.pipe';
 import { download } from '@app/shared/graphs.utils';
 import { isMobile } from '@app/shared/common.utils';

--- a/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.ts
+++ b/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.ts
@@ -7,7 +7,7 @@ import { AmountShortenerPipe } from '@app/shared/pipes/amount-shortener.pipe';
 import { StateService } from '@app/services/state.service';
 import { SeriesOption } from 'echarts';
 import { WalletStats } from '@app/shared/wallet-stats';
-import { chartColors } from '@app/app.constants';
+import { originalChartColors as chartColors } from '@app/app.constants';
 import { Treasury } from '../../../interfaces/node-api.interface';
 
 

--- a/frontend/src/app/components/treasuries/treasuries-pie/treasuries-pie.component.ts
+++ b/frontend/src/app/components/treasuries/treasuries-pie/treasuries-pie.component.ts
@@ -6,7 +6,7 @@ import { download } from '@app/shared/graphs.utils';
 import { isMobile } from '@app/shared/common.utils';
 import { WalletStats } from '@app/shared/wallet-stats';
 import { AddressTxSummary } from '@interfaces/electrs.interface';
-import { chartColors } from '@app/app.constants';
+import { originalChartColors as chartColors } from '@app/app.constants';
 import { formatNumber } from '@angular/common';
 import { Treasury } from '@interfaces/node-api.interface';
 

--- a/frontend/src/app/components/treasuries/treasuries.component.ts
+++ b/frontend/src/app/components/treasuries/treasuries.component.ts
@@ -6,7 +6,7 @@ import { StateService } from '@app/services/state.service';
 import { catchError, map, scan, shareReplay, startWith, switchMap, tap } from 'rxjs/operators';
 import { WalletStats } from '@app/shared/wallet-stats';
 import { Router } from '@angular/router';
-import { chartColors } from '@app/app.constants';
+import { originalChartColors as chartColors } from '@app/app.constants';
 import { Treasury } from '@interfaces/node-api.interface';
 @Component({
   selector: 'app-treasuries',

--- a/frontend/src/app/lightning/nodes-per-country-chart/nodes-per-country-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-country-chart/nodes-per-country-chart.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit, HostBinding, NgZone } from 
 import { Router } from '@angular/router';
 import { EChartsOption, PieSeriesOption } from '@app/graphs/echarts';
 import { map, Observable, share, tap } from 'rxjs';
-import { chartColors } from '@app/app.constants';
+import { originalChartColors as chartColors } from '@app/app.constants';
 import { ApiService } from '@app/services/api.service';
 import { SeoService } from '@app/services/seo.service';
 import { StateService } from '@app/services/state.service';

--- a/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
+++ b/frontend/src/app/lightning/nodes-per-isp-chart/nodes-per-isp-chart.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit, HostBinding, NgZone, Input 
 import { Router } from '@angular/router';
 import { EChartsOption, PieSeriesOption } from '@app/graphs/echarts';
 import { combineLatest, map, Observable, share, startWith, Subject, switchMap, tap } from 'rxjs';
-import { chartColors } from '@app/app.constants';
+import { originalChartColors as chartColors } from '@app/app.constants';
 import { ApiService } from '@app/services/api.service';
 import { SeoService } from '@app/services/seo.service';
 import { StateService } from '@app/services/state.service';


### PR DESCRIPTION
This PR subtly differentiates the color of the 0-1 and 1-2 sat/vb feerate bands:

<img width="800" alt="Screenshot 2025-06-26 at 8 54 31 AM" src="https://github.com/user-attachments/assets/a42e5c8f-a72a-4e4b-a6b3-71581c86f190" />



and also restores the previous color palette for all charts other than the main mempool chart:

|before | after |
|-|-|
| <img width="540" alt="Screenshot 2025-06-26 at 9 10 25 AM" src="https://github.com/user-attachments/assets/854e0519-ca78-44a5-a4c4-2d8a582ac7f0" /> | <img width="540" alt="Screenshot 2025-06-26 at 9 10 12 AM" src="https://github.com/user-attachments/assets/a048900f-9c93-41e8-9990-192885ad4d2c" /> |

<img width="1199" alt="Screenshot 2025-06-26 at 9 12 27 AM" src="https://github.com/user-attachments/assets/a40a6f60-6675-4cef-ad06-da3f656c6daa" />

