### PR TITLE
Fix median fee calculation in underfilled blocks

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -244,7 +244,7 @@ class Blocks {
    */
   private async $getBlockExtended(block: IEsploraApi.Block, transactions: TransactionExtended[]): Promise<BlockExtended> {
     const coinbaseTx = transactionUtils.stripCoinbaseTransaction(transactions[0]);
-    
+
     const blk: Partial<BlockExtended> = Object.assign({}, block);
     const extras: Partial<BlockExtension> = {};
 
@@ -296,7 +296,7 @@ class Blocks {
         extras.medianFeeAmt = extras.feePercentiles[3];
       }
     }
-  
+
     extras.virtualSize = block.weight / 4.0;
     if (coinbaseTx?.vout.length > 0) {
       extras.coinbaseAddress = coinbaseTx.vout[0].scriptpubkey_address ?? null;

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 99;
+  private static currentVersion = 100;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1159,6 +1159,13 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 99) {
       await this.$executeQuery('ALTER TABLE statistics ADD COLUMN vsize_0 int(11) NOT NULL DEFAULT 0');
       await this.updateToSchemaVersion(99);
+    }
+
+    // Add "block indexed at version" index_version column to the blocks table
+    // to be used for lazy migrations & reindexing tasks
+    if (databaseSchemaVersion < 100) {
+      await this.$executeQuery('ALTER TABLE `blocks` ADD index_version INT NOT NULL DEFAULT 0');
+      await this.$executeQuery('ALTER TABLE `blocks` ADD INDEX `index_version` (`index_version`)');
     }
   }
 

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -11,6 +11,7 @@ import auditReplicator from './replication/AuditReplication';
 import statisticsReplicator from './replication/StatisticsReplication';
 import AccelerationRepository from './repositories/AccelerationRepository';
 import BlocksAuditsRepository from './repositories/BlocksAuditsRepository';
+import BlocksRepository from './repositories/BlocksRepository';
 
 export interface CoreIndex {
   name: string;
@@ -194,6 +195,7 @@ class Indexer {
       await statisticsReplicator.$sync();
       await AccelerationRepository.$indexPastAccelerations();
       await BlocksAuditsRepository.$migrateAuditsV0toV1();
+      await BlocksRepository.$migrateBlocks();
       // do not wait for classify blocks to finish
       blocks.$classifyBlocks();
     } catch (e) {

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -337,6 +337,7 @@ export interface BlockExtension {
 export interface BlockExtended extends IEsploraApi.Block {
   extras: BlockExtension;
   canonical?: string;
+  indexVersion?: number;
 }
 
 export interface BlockSummary {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -18,6 +18,7 @@ import { parseDATUMTemplateCreator } from '../utils/bitcoin-script';
 import poolsUpdater from '../tasks/pools-updater';
 
 interface DatabaseBlock {
+  index_version: number;
   id: string;
   height: number;
   version: number;
@@ -62,6 +63,7 @@ interface DatabaseBlock {
 }
 
 const BLOCK_DB_FIELDS = `
+  blocks.index_version AS indexVersion,
   blocks.hash AS id,
   blocks.height,
   blocks.version,
@@ -106,6 +108,8 @@ const BLOCK_DB_FIELDS = `
 `;
 
 class BlocksRepository {
+  static version = 1;
+
   /**
    * Save indexed block data in the database
    */
@@ -124,7 +128,7 @@ class BlocksRepository {
         coinbase_signature, utxoset_size,             utxoset_change,    avg_tx_size,
         total_inputs,       total_outputs,            total_input_amt,   total_output_amt,
         fee_percentiles,    segwit_total_txs,         segwit_total_size, segwit_total_weight,
-        median_fee_amt,     coinbase_signature_ascii, definition_hash
+        median_fee_amt,     coinbase_signature_ascii, definition_hash,   index_version
       ) VALUE (
         ?, ?, FROM_UNIXTIME(?), ?,
         ?, ?, ?, ?,
@@ -135,7 +139,7 @@ class BlocksRepository {
         ?, ?, ?, ?,
         ?, ?, ?, ?,
         ?, ?, ?, ?,
-        ?, ?, ?
+        ?, ?, ?, ?
       )`;
 
       const poolDbId = await PoolsRepository.$getPoolByUniqueId(block.extras.pool.id);
@@ -182,7 +186,8 @@ class BlocksRepository {
         block.extras.segwitTotalWeight,
         block.extras.medianFeeAmt,
         truncatedCoinbaseSignatureAscii,
-        poolsUpdater.currentSha
+        poolsUpdater.currentSha,
+        BlocksRepository.version
       ];
 
       await DB.query(query, params);
@@ -1067,7 +1072,7 @@ class BlocksRepository {
     blk.weight = dbBlk.weight;
     blk.previousblockhash = dbBlk.previousblockhash;
     blk.mediantime = dbBlk.mediantime;
-    
+    blk.indexVersion = dbBlk.index_version;
     // BlockExtension
     extras.totalFees = dbBlk.totalFees;
     extras.medianFee = dbBlk.medianFee;
@@ -1154,6 +1159,74 @@ class BlocksRepository {
 
     blk.extras = <BlockExtension>extras;
     return <BlockExtended>blk;
+  }
+
+  // Execute reindexing tasks & lazy schema migrations
+  public async $migrateBlocks(): Promise<number> {
+    let blocksMigrated = 0;
+    blocksMigrated = await this.$migrateBlocksToV1();
+    if (blocksMigrated > 0) {
+      // return early, run the next migration on the next indexing loop
+      return blocksMigrated;
+    }
+    return 0;
+  }
+
+  // migration to fix median fee bug
+  private async $migrateBlocksToV1(): Promise<number> {
+    let blocksMigrated = 0;
+    try {
+      // median fee bug only affects mmre-than-half but less-than-completely full blocks
+      const minWeight = config.MEMPOOL.BLOCK_WEIGHT_UNITS / 2 - (config.MEMPOOL.BLOCK_WEIGHT_UNITS / 800);
+      const maxWeight = config.MEMPOOL.BLOCK_WEIGHT_UNITS - (config.MEMPOOL.BLOCK_WEIGHT_UNITS / 400);
+      const [rows]: any[] = await DB.query(`
+        SELECT height, hash, index_version
+        FROM blocks
+        WHERE index_version < 1
+          AND weight >= ?
+          AND weight <= ?
+        ORDER BY height DESC
+      `, [minWeight, maxWeight]);
+      const blocksToMigrate = rows.length;
+
+      let timer = Date.now() / 1000;
+      const startedAt = Date.now() / 1000;
+
+      for (const row of rows) {
+        // fetch block summary
+        const transactions = await blocks.$getStrippedBlockTransactions(row.hash);
+        // recalculate effective fee statistics using latest methodology
+        const feeStats = Common.calcEffectiveFeeStatistics(transactions.map(tx => ({
+          weight: tx.vsize * 4,
+          effectiveFeePerVsize: tx.rate,
+          txid: tx.txid,
+          acceleration: tx.acc,
+        })));
+
+        // update block db
+        await DB.query(`
+          UPDATE blocks SET index_version = 1, median_fee = ?, fee_span = ?
+          WHERE hash = ?`,
+          [feeStats.medianFee, JSON.stringify(feeStats.feeRange), row.hash]
+        );
+
+        const elapsedSeconds = (Date.now() / 1000) - timer;
+        if (elapsedSeconds > 5) {
+          const runningFor = (Date.now() / 1000) - startedAt;
+          const blockPerSeconds = blocksMigrated / elapsedSeconds;
+          const progress = Math.round(blocksMigrated / blocksToMigrate * 10000) / 100;
+          logger.debug(`Migrating blocks to version 1 | ~${blockPerSeconds.toFixed(2)} blocks/sec | height: ${row.height} | total: ${blocksMigrated}/${blocksToMigrate} (${progress}%) | elapsed: ${runningFor.toFixed(2)} seconds`);
+          timer = Date.now() / 1000;
+        }
+
+        blocksMigrated++;
+      }
+      logger.notice(`Migrating blocks to version 1 completed: migrated ${blocksMigrated} blocks`);
+    } catch (e) {
+      logger.err(`Migrating blocks to version 1 failed. Trying again later. Reason: ${(e instanceof Error ? e.message : e)}`);
+      throw e;
+    }
+    return blocksMigrated;
   }
 }
 


### PR DESCRIPTION
Fixes a bug where the effective median block fee calculation used the wrong weight offset when blocks were more than half full but less than completely full.

Before:

"median" taken from near the highest rate transactions:

<img width="247" alt="Screenshot 2025-07-06 at 4 40 04 AM" src="https://github.com/user-attachments/assets/36b16a8f-67a6-4ca8-9446-767008b1fe7f" />

After:

"median correctly taken from the middle of the block:

<img width="247" alt="Screenshot 2025-07-06 at 4 39 41 AM" src="https://github.com/user-attachments/assets/1476372b-4493-46b0-a23c-17574d95f53a" />

The PR also adds an indexer task to lazily fix the median for affected historic blocks, and adds an `index_version` column to the blocks table to support this (to allow fine-grained versioning of blocks, rather than having to fix the data in a single slow database migration).