### PR TITLE
standardize ephemeral dust

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -328,7 +328,7 @@ export class Common {
         }
         if (vout.value < (dustSize * DUST_RELAY_TX_FEE)) {
           // under minimum output size
-          return true;
+          return !Common.isStandardEphemeralDust(tx, height);
         }
       }
     }
@@ -402,6 +402,26 @@ export class Common {
       && height <= this.ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[config.MEMPOOL.NETWORK]
     ) {
       // anchor outputs were non-standard to spend before v28.x (scheduled for 2024/09/30 https://github.com/bitcoin/bitcoin/issues/29891)
+      return true;
+    }
+    return false;
+  }
+
+  // Ephemeral dust is a new concept that allows a single dust output in a transaction, provided the transaction is zero fee
+  static EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT = {
+    'testnet4': 90_500,
+    'testnet': 4_550_000,
+    'signet': 260_000,
+    '': 905_000,
+  };
+  static isStandardEphemeralDust(tx: TransactionExtended, height?: number): boolean {
+    if (
+      tx.fee === 0
+      && (height == null || (
+        this.EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT[config.MEMPOOL.NETWORK]
+        && height >= this.EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT[config.MEMPOOL.NETWORK]
+      ))
+    ) {
       return true;
     }
     return false;

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -750,7 +750,7 @@ export class TrackerComponent implements OnInit, OnDestroy {
 
   checkAccelerationEligibility() {
     if (this.tx) {
-      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_time, this.stateService.network);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
       const replaceableInputs = (this.tx.flags & (TransactionFlags.sighash_none | TransactionFlags.sighash_acp)) > 0n;
       const highSigop = (this.tx.sigops * 20) > this.tx.weight;
       this.eligibleForAcceleration = !replaceableInputs && !highSigop;

--- a/frontend/src/app/components/transaction/transaction-raw.component.ts
+++ b/frontend/src/app/components/transaction/transaction-raw.component.ts
@@ -211,7 +211,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
       replaceUrl: true
     });
 
-    this.transaction.flags = getTransactionFlags(this.transaction, this.cpfpInfo, null, null, this.stateService.network);
+    this.transaction.flags = getTransactionFlags(this.transaction, this.cpfpInfo, null, this.transaction.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
     this.filters = this.transaction.flags ? toFilters(this.transaction.flags).filter(f => f.txPage) : [];
     if (this.transaction.sigops >= 0) {
       this.adjustedVsize = Math.max(this.transaction.weight / 4, this.transaction.sigops * 5);

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -930,7 +930,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       this.segwitEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'segwit');
       this.taprootEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'taproot');
       this.rbfEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'rbf');
-      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_time, this.stateService.network);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
       this.filters = this.tx.flags ? toFilters(this.tx.flags).filter(f => f.txPage) : [];
       this.checkAccelerationEligibility();
     } else {

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -437,7 +437,7 @@ export function isNonStandard(tx: Transaction, height?: number, network?: string
       }
       if (vout.value < (dustSize * DUST_RELAY_TX_FEE)) {
         // under minimum output size
-        return true;
+        return !isStandardEphemeralDust(tx, height, network);
       }
     }
   }
@@ -492,6 +492,26 @@ function isNonStandardAnchor(tx: Transaction, height?: number, network?: string)
     && height <= ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[network]
   ) {
     // anchor outputs were non-standard to spend before v28.x (scheduled for 2024/09/30 https://github.com/bitcoin/bitcoin/issues/29891)
+    return true;
+  }
+  return false;
+}
+
+// Ephemeral dust is a new concept that allows a single dust output in a transaction, provided the transaction is zero fee
+const EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT = {
+  'testnet4': 90_500,
+  'testnet': 4_550_000,
+  'signet': 260_000,
+  '': 905_000,
+};
+function isStandardEphemeralDust(tx: Transaction, height?: number, network?: string): boolean {
+  if (
+    tx.fee === 0
+    && (height == null || (
+      EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT[network]
+      && height >= EPHEMERAL_DUST_STANDARDNESS_ACTIVATION_HEIGHT[network]
+    ))
+  ) {
     return true;
   }
   return false;


### PR DESCRIPTION
This PR makes [ephemeral dust](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-29.0.md#mempool-policy-and-mining-changes) standard above the following block heights for Mempool Goggles classification:

|||
|-|-|
| mainnet | 905,000 |
| signet | 260,000 |
| testnet | 4,550,000 |
| testnet4 | 90,500 |