### PR TITLE
Add /api/address/:address/utxo endpoint

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -19,9 +19,11 @@ export interface AbstractBitcoinApi {
   $getRawBlock(hash: string): Promise<Buffer>;
   $getAddress(address: string): Promise<IEsploraApi.Address>;
   $getAddressTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
+  $getAddressUtxos(address: string): Promise<IEsploraApi.UTXO[]>;
   $getAddressPrefix(prefix: string): string[];
   $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash>;
   $getScriptHashTransactions(address: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]>;
+  $getScriptHashUtxos(scripthash: string): Promise<IEsploraApi.UTXO[]>;
   $sendRawTransaction(rawTransaction: string): Promise<string>;
   $testMempoolAccept(rawTransactions: string[], maxfeerate?: number): Promise<TestMempoolAcceptResult[]>;
   $submitPackage(rawTransactions: string[], maxfeerate?: number, maxburnamount?: number): Promise<SubmitPackageResult>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -153,12 +153,20 @@ class BitcoinApi implements AbstractBitcoinApi {
     throw new Error('Method getAddressTransactions not supported by the Bitcoin RPC API.');
   }
 
+  $getAddressUtxos(address: string): Promise<IEsploraApi.UTXO[]> {
+    throw new Error('Method getAddressUtxos not supported by the Bitcoin RPC API.');
+  }
+
   $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
     throw new Error('Method getScriptHash not supported by the Bitcoin RPC API.');
   }
 
   $getScriptHashTransactions(scripthash: string, lastSeenTxId: string): Promise<IEsploraApi.Transaction[]> {
     throw new Error('Method getScriptHashTransactions not supported by the Bitcoin RPC API.');
+  }
+
+  $getScriptHashUtxos(scripthash: string): Promise<IEsploraApi.UTXO[]> {
+    throw new Error('Method getScriptHashUtxos not supported by the Bitcoin RPC API.');
   }
 
   $getRawMempool(): Promise<IEsploraApi.Transaction['txid'][]> {

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -90,9 +90,11 @@ class BitcoinRoutes {
           .get(config.MEMPOOL.API_URL_PREFIX + 'address/:address', this.getAddress)
           .get(config.MEMPOOL.API_URL_PREFIX + 'address/:address/txs', this.getAddressTransactions)
           .get(config.MEMPOOL.API_URL_PREFIX + 'address/:address/txs/summary', this.getAddressTransactionSummary)
+          .get(config.MEMPOOL.API_URL_PREFIX + 'address/:address/utxo', this.getAddressUtxo)
           .get(config.MEMPOOL.API_URL_PREFIX + 'scripthash/:scripthash', this.getScriptHash)
           .get(config.MEMPOOL.API_URL_PREFIX + 'scripthash/:scripthash/txs', this.getScriptHashTransactions)
           .get(config.MEMPOOL.API_URL_PREFIX + 'scripthash/:scripthash/txs/summary', this.getScriptHashTransactionSummary)
+          .get(config.MEMPOOL.API_URL_PREFIX + 'scripthash/:scripthash/utxo', this.getScriptHashUtxo)
           .get(config.MEMPOOL.API_URL_PREFIX + 'address-prefix/:prefix', this.getAddressPrefix)
           ;
       }
@@ -667,6 +669,28 @@ class BitcoinRoutes {
     }
   }
 
+  private async getAddressUtxo(req: Request, res: Response): Promise<void> {
+    if (config.MEMPOOL.BACKEND === 'none') {
+      handleError(req, res, 405, 'Address lookups cannot be used with bitcoind as backend.');
+      return;
+    }
+    if (!ADDRESS_REGEX.test(req.params.address)) {
+      handleError(req, res, 501, `Invalid address`);
+      return;
+    }
+
+    try {
+      const addressData = await bitcoinApi.$getAddressUtxos(req.params.address);
+      res.json(addressData);
+    } catch (e) {
+      if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
+        handleError(req, res, 413, e.message);
+        return;
+      }
+      handleError(req, res, 500, 'Failed to get address');
+    }
+  }
+
   private async getAddressTransactionSummary(req: Request, res: Response): Promise<void> {
     if (config.MEMPOOL.BACKEND !== 'esplora') {
       handleError(req, res, 405, 'Address summary lookups require mempool/electrs backend.');
@@ -723,6 +747,30 @@ class BitcoinRoutes {
         return;
       }
       handleError(req, res, 500, 'Failed to get script hash transactions');
+    }
+  }
+
+  private async getScriptHashUtxo(req: Request, res: Response): Promise<void> {
+    if (config.MEMPOOL.BACKEND === 'none') {
+      handleError(req, res, 405, 'Address lookups cannot be used with bitcoind as backend.');
+      return;
+    }
+    if (!SCRIPT_HASH_REGEX.test(req.params.scripthash)) {
+      handleError(req, res, 501, `Invalid scripthash`);
+      return;
+    }
+
+    try {
+      // electrum expects scripthashes in little-endian
+      const electrumScripthash = req.params.scripthash.match(/../g)?.reverse().join('') ?? '';
+      const addressData = await bitcoinApi.$getScriptHashUtxos(electrumScripthash);
+      res.json(addressData);
+    } catch (e) {
+      if (e instanceof Error && e.message && (e.message.indexOf('too long') > 0 || e.message.indexOf('confirmed status') > 0)) {
+        handleError(req, res, 413, e.message);
+        return;
+      }
+      handleError(req, res, 500, 'Failed to get script hash');
     }
   }
 

--- a/backend/src/api/bitcoin/electrum-api.interface.ts
+++ b/backend/src/api/bitcoin/electrum-api.interface.ts
@@ -9,4 +9,11 @@ export namespace IElectrumApi {
     tx_hash: string;
     fee?: number;
   }
+
+  export interface ScriptHashUtxos {
+    tx_pos: number;
+    value: number;
+    tx_hash: string;
+    height: number;
+  }
 }

--- a/backend/src/api/bitcoin/electrum-api.ts
+++ b/backend/src/api/bitcoin/electrum-api.ts
@@ -160,6 +160,14 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
     }
   }
 
+  async $getAddressUtxos(address: string): Promise<IEsploraApi.UTXO[]> {
+    const addressInfo = await this.bitcoindClient.validateAddress(address);
+    if (!addressInfo || !addressInfo.isvalid) {
+      return [];
+    }
+    return await this.$getScriptHashUtxos(addressInfo.scriptPubKey);
+  }
+
   async $getScriptHashTransactions(scripthash: string, lastSeenTxId?: string): Promise<IEsploraApi.Transaction[]> {
     try {
       loadingIndicators.setProgress('address-' + scripthash, 0);
@@ -195,6 +203,44 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
       loadingIndicators.setProgress('address-' + scripthash, 100);
       throw new Error(typeof e === 'string' ? e : e && e.message || e);
     }
+  }
+
+  async $getScriptHashUtxos(scripthash: string): Promise<IEsploraApi.UTXO[]> {
+    const utxos = await this.$getScriptHashUnspent(scripthash);
+    const result: IEsploraApi.UTXO[] = [];
+    for(let utxo of utxos) {
+      if(utxo.height===0) {
+        //Unconfirmed
+        result.push({
+          txid: utxo.tx_hash,
+          vout: utxo.tx_pos,
+          status: {
+            confirmed: false
+          },
+          value: utxo.value
+        });
+      } else {
+        //Confirmed
+        const blockHash = await this.$getBlockHash(utxo.height);
+        const block = await this.$getBlock(blockHash);
+        result.push({
+          txid: utxo.tx_hash,
+          vout: utxo.tx_pos,
+          status: {
+            confirmed: true,
+            block_height: utxo.height,
+            block_hash: blockHash,
+            block_time: block.timestamp
+          },
+          value: utxo.value
+        });
+      }
+    }
+    return result;
+  }
+
+  private $getScriptHashUnspent(scriptHash: string): Promise<IElectrumApi.ScriptHashUtxos[]> {
+    return this.electrumClient.blockchainScripthash_listunspent(this.encodeScriptHash(scriptHash));
   }
 
   async $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof> {

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -192,4 +192,16 @@ export namespace IEsploraApi {
     block_height: number;
     pos: number;
   }
+
+  export interface UTXO {
+    txid: string;
+    vout: number;
+    status: {
+      confirmed: boolean;
+      block_height?: number;
+      block_hash?: string;
+      block_time?: number;
+    },
+    value: number;
+  }
 }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -441,12 +441,20 @@ class ElectrsApi implements AbstractBitcoinApi {
     throw new Error('Method getAddressTransactions not implemented.');
   }
 
+  $getAddressUtxos(address: string): Promise<IEsploraApi.UTXO[]> {
+    return this.failoverRouter.$get<IEsploraApi.UTXO[]>('/address/' + address + '/utxo');
+  }
+
   $getScriptHash(scripthash: string): Promise<IEsploraApi.ScriptHash> {
     throw new Error('Method getScriptHash not implemented.');
   }
 
   $getScriptHashTransactions(scripthash: string, txId?: string): Promise<IEsploraApi.Transaction[]> {
     throw new Error('Method getScriptHashTransactions not implemented.');
+  }
+
+  $getScriptHashUtxos(scripthash: string): Promise<IEsploraApi.UTXO[]> {
+    throw new Error('Method getScriptHashUtxos not implemented.');
   }
 
   $getAddressPrefix(prefix: string): string[] {


### PR DESCRIPTION
This PR adds the `/api/address/:address/utxo` endpoint as specified in the official mempool docs [here](https://mempool.space/docs/api/rest#get-address-utxo) when running with electrum as a backend.

This fixes the known issues some people have been having:
- https://community.umbrel.com/t/mempool-unable-to-get-utxo-of-an-address-endpoint-returning-cannot-get-error/22401
- https://github.com/romanz/electrs/issues/1057
