### PR TITLE
handle sub-1-sat-vb in audits

### DIFF
--- a/backend/src/api/audit.ts
+++ b/backend/src/api/audit.ts
@@ -55,7 +55,7 @@ class Audit {
         } else if (mempool[txid]?.lastBoosted != null && (now - (mempool[txid]?.lastBoosted || 0)) <= PROPAGATION_MARGIN) {
           // tx was recently cpfp'd, miner may not have the latest effective rate
           fresh.push(txid);
-        } else {
+        } else if (mempool[txid].effectiveFeePerVsize >= 1) { // transactions paying < 1 sat/vbyte are never considered censored
           isCensored[txid] = true;
         }
         displacedWeight += mempool[txid]?.weight || 0;

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -600,7 +600,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         // set transaction statuses
         for (const tx of blockAudit.template) {
           tx.context = 'projected';
-          if (isCensored[tx.txid]) {
+          if (isCensored[tx.txid] && tx.rate >= 1) {
             tx.status = 'censored';
           } else if (inBlock[tx.txid]) {
             tx.status = 'found';


### PR DESCRIPTION
This PR adds special handling for <1 sat/vb transactions to avoid marking transactions as "removed" which are more likely simply below the default `minTxRelayFee`.

Before:
sub-1 sat/vb transactions in the local mempool marked as "removed" and reduce block health score
<img width="1127" height="697" alt="Screenshot 2025-07-12 at 4 03 24 AM" src="https://github.com/user-attachments/assets/3753ff65-59f9-42e7-b601-1b8ebfa0fd15" />

After:
sub-1 sat/vb transactions marked as "marginal feerate" and excluded from the health score calculation
<img width="1127" height="701" alt="Screenshot 2025-07-12 at 4 02 56 AM" src="https://github.com/user-attachments/assets/e1bc43f4-db57-41dc-b952-cbb59e98d27a" />
