### PR TITLE
fix frontend goggles annex detection

### DIFF
--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -634,8 +634,8 @@ export function getTransactionFlags(tx: Transaction, cpfpInfo?: CpfpInfo, replac
         // created before taproot activation don't need to have any witness data
         // (see https://mempool.space/tx/b10c007c60e14f9d087e0291d4d0c7869697c6681d979c6639dbd960792b4d41)
         if (vin.witness?.length) {
-          // in taproot, if the last witness item begins with 0x50, it's an annex
-          const hasAnnex = vin.witness?.[vin.witness.length - 1].startsWith('50');
+          // in taproot, if there are at least two witness elements, and the first byte of the last element is 0x50, that last element is an annex
+          const hasAnnex = vin.witness?.length > 1 &&  vin.witness?.[vin.witness.length - 1].startsWith('50');
           // script spends have more than one witness item, not counting the annex (if present)
           if (vin.witness.length > (hasAnnex ? 2 : 1)) {
             // the script itself is the second-to-last witness item, not counting the annex


### PR DESCRIPTION
Fixes a bug in the frontend annex detection code for Mempool Goggles which can wrongly identify taproot keypath spend signatures as annexes if they start with `0x50`.

Note that this only affects _frontend_ goggles classification for the tags on the `/tx` page. Backend classification handles the annex correctly so Goggles in the block visualizations and indexed data is already correct.

e.g. https://mempool.space/tx/5da872428ece0556b0f31c6e8855231f4585ccdc8abd5206e0bb513c8830a3c8
<img width="537" height="151" alt="Screenshot 2025-07-12 at 4 24 09 AM" src="https://github.com/user-attachments/assets/9c27f6b8-ea4d-4c67-bae7-735821caa574" />

---

Before:

<img width="353" height="109" alt="Screenshot 2025-07-12 at 4 24 19 AM" src="https://github.com/user-attachments/assets/215937a4-fe98-461f-9514-f36acf3660f1" />

After:
<img width="353" height="109" alt="Screenshot 2025-07-12 at 4 24 36 AM" src="https://github.com/user-attachments/assets/64da9e10-9dbb-48a5-8e55-d688b5c53aa5" />