### PR TITLE
Add /api/block/:hash/status endpoint

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -14,6 +14,7 @@ export interface AbstractBitcoinApi {
   $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]>;
   $getBlockHash(height: number): Promise<string>;
   $getBlockHeader(hash: string): Promise<string>;
+  $getBlockStatus(hash: string): Promise<IEsploraApi.BlockStatus>;
   $getBlock(hash: string): Promise<IEsploraApi.Block>;
   $getRawBlock(hash: string): Promise<Buffer>;
   $getAddress(address: string): Promise<IEsploraApi.Address>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -130,6 +130,23 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.getBlockHeader(hash, false);
   }
 
+  async $getBlockStatus(hash: string): Promise<IEsploraApi.BlockStatus> {
+    const block = await this.$getBlock(hash);
+    if(block.stale) {
+      return {
+        in_best_chain: false
+      };
+    } else {
+      //Check for next blockhash if it exists
+      const nextBlockhash= await this.$getBlockHash(block.height + 1).catch(() => undefined);
+      return {
+        in_best_chain: true,
+        next_best: nextBlockhash,
+        height: block.height
+      };
+    }
+  }
+
   async $getBlock(hash: string): Promise<IEsploraApi.Block> {
     const foundBlock = blocks.getBlocks().find((block) => block.id === hash);
     if (foundBlock) {

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -48,6 +48,7 @@ class BitcoinRoutes {
       .get(config.MEMPOOL.API_URL_PREFIX + 'blocks/:height', this.getBlocks.bind(this))
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash', this.getBlock)
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/summary', this.getStrippedBlockTransactions)
+      .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/status', this.getBlockStatus)
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/tx/:txid/summary', this.getStrippedBlockTransaction)
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/audit-summary', this.getBlockAuditSummary)
       .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/tx/:txid/audit', this.$getBlockTxAuditSummary)
@@ -408,6 +409,19 @@ class BitcoinRoutes {
       res.json(block);
     } catch (e: any) {
       handleError(req, res, e?.response?.status === 404 ? 404 : 500, 'Failed to get block');
+    }
+  }
+
+  private async getBlockStatus(req: Request, res: Response): Promise<void> {
+    if (!BLOCK_HASH_REGEX.test(req.params.hash)) {
+      handleError(req, res, 501, `Invalid block hash`);
+      return;
+    }
+    try {
+      const status = await bitcoinApi.$getBlockStatus(req.params.hash);
+      res.json(status);
+    } catch (e) {
+      handleError(req, res, 500, 'Failed to get block status');
     }
   }
 

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -186,4 +186,10 @@ export namespace IEsploraApi {
     time: number;
     tx_position?: number;
   }
+
+  export interface BlockStatus {
+    in_best_chain: boolean;
+    next_best?: string;
+    height?: number;
+  }
 }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -376,6 +376,10 @@ class ElectrsApi implements AbstractBitcoinApi {
     return this.failoverRouter.$get<string>('/block/' + hash + '/header');
   }
 
+  $getBlockStatus(hash: string): Promise<IEsploraApi.BlockStatus> {
+    return this.failoverRouter.$get<IEsploraApi.BlockStatus>('/block/' + hash + '/status');
+  }
+
   $getBlock(hash: string): Promise<IEsploraApi.Block> {
     return this.failoverRouter.$get<IEsploraApi.Block>('/block/' + hash);
   }


### PR DESCRIPTION
This PR adds the /api/block/:hash/status endpoint as specified in the official mempool docs [here](https://mempool.space/docs/api/rest#get-block-status) when running with bitcoin core as a backend.