### PR TITLE
Add /api/tx/:txId/merkle-proof endpoint

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -8,6 +8,7 @@ export interface AbstractBitcoinApi {
   $getMempoolTransactions(txids: string[]): Promise<IEsploraApi.Transaction[]>;
   $getAllMempoolTransactions(lastTxid?: string, max_txs?: number);
   $getTransactionHex(txId: string): Promise<string>;
+  $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof>;
   $getBlockHeightTip(): Promise<number>;
   $getBlockHashTip(): Promise<string>;
   $getTxIdsForBlock(hash: string): Promise<string[]>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -95,6 +95,10 @@ class BitcoinApi implements AbstractBitcoinApi {
       });
   }
 
+  $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof> {
+    throw new Error('Method getTransactionMerkleProof not supported by the Bitcoin RPC API.');
+  }
+
   $getBlockHeightTip(): Promise<number> {
     return this.bitcoindClient.getBlockCount();
   }

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -76,6 +76,7 @@ class BitcoinRoutes {
           .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/hex', this.getRawTransaction)
           .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/status', this.getTransactionStatus)
           .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/outspends', this.getTransactionOutspends)
+          .get(config.MEMPOOL.API_URL_PREFIX + 'tx/:txId/merkle-proof', this.getTransactionMerkleProof)
           .get(config.MEMPOOL.API_URL_PREFIX + 'txs/outspends', this.$getBatchedOutspends)
           .get(config.MEMPOOL.API_URL_PREFIX + 'block/:hash/header', this.getBlockHeader)
           .get(config.MEMPOOL.API_URL_PREFIX + 'blocks/tip/hash', this.getBlockTipHash)
@@ -918,6 +919,19 @@ class BitcoinRoutes {
       res.json(result);
     } catch (e) {
       handleError(req, res, 500, 'Failed to get transaction outspends');
+    }
+  }
+
+  private async getTransactionMerkleProof(req: Request, res: Response): Promise<void> {
+    if (!TXID_REGEX.test(req.params.txId)) {
+      handleError(req, res, 501, `Invalid transaction ID`);
+      return;
+    }
+    try {
+      const result = await bitcoinApi.$getTransactionMerkleProof(req.params.txId);
+      res.json(result);
+    } catch (e) {
+      handleError(req, res, 500, e instanceof Error ? e.message : 'Failed to get transaction merkle proof');
     }
   }
 

--- a/backend/src/api/bitcoin/electrum-api.ts
+++ b/backend/src/api/bitcoin/electrum-api.ts
@@ -197,6 +197,11 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
     }
   }
 
+  async $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof> {
+    const tx = await this.$getRawTransaction(txId);
+    return this.electrumClient.blockchainTransaction_getMerkle(txId, tx.status.block_height);
+  }
+
   private $getScriptHashBalance(scriptHash: string): Promise<IElectrumApi.ScriptHashBalance> {
     return this.electrumClient.blockchainScripthash_getBalance(this.encodeScriptHash(scriptHash));
   }

--- a/backend/src/api/bitcoin/esplora-api.interface.ts
+++ b/backend/src/api/bitcoin/esplora-api.interface.ts
@@ -186,4 +186,10 @@ export namespace IEsploraApi {
     time: number;
     tx_position?: number;
   }
+
+  export interface MerkleProof {
+    merkle: string[];
+    block_height: number;
+    pos: number;
+  }
 }

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -396,6 +396,10 @@ class ElectrsApi implements AbstractBitcoinApi {
     return this.failoverRouter.$get<string>('/tx/' + txId + '/hex');
   }
 
+  $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof> {
+    return this.failoverRouter.$get<IEsploraApi.MerkleProof>('/tx/' + txId + '/merkle-proof');
+  }
+
   $getBlockHeightTip(): Promise<number> {
     return this.failoverRouter.$get<number>('/blocks/tip/height');
   }


### PR DESCRIPTION
This PR adds the `/api/tx/:txId/merkle-proof` endpoint as specified in the official mempool docs [here](https://mempool.space/docs/api/rest#get-transaction-merkle-proof) when running with electrum as a backend.
