### PR TITLE
support sub-1 sat txs in projected block fee charts

### DIFF
--- a/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
+++ b/frontend/src/app/components/fee-distribution-graph/fee-distribution-graph.component.ts
@@ -25,6 +25,8 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
 
   simple: boolean = false;
   data: number[][];
+  maxValue: number = 0;
+  minValue: number = 0;
   labelInterval: number = 50;
   smallScreen: boolean = window.innerWidth < 450;
 
@@ -66,7 +68,9 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
       return;
     }
     const samples = [];
-    const txs = this.transactions.map(tx => { return { vsize: tx.vsize, rate: tx.rate || (tx.fee / tx.vsize) }; }).sort((a, b) => { return b.rate - a.rate; });
+    const txs = this.transactions.map(tx => { return { vsize: tx.vsize, rate: tx.rate ?? (tx.fee / tx.vsize) }; }).sort((a, b) => { return b.rate - a.rate; });
+    this.maxValue = txs.reduce((max, tx) => Math.max(max, tx.rate), 0);
+    this.minValue = txs.reduce((min, tx) => Math.min(min, tx.rate), Infinity);
     const maxBlockVSize = this.stateService.env.BLOCK_WEIGHT_UNITS / 4;
     const sampleInterval = maxBlockVSize / this.numSamples;
     let cumVSize = 0;
@@ -83,7 +87,7 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
       }
 
       while (txs[txIndex] && nextSample < cumVSize + txs[txIndex].vsize) {
-        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, txs[txIndex].rate || 0.000001]);
+        samples.push([(1 - (sampleIndex / this.numSamples)) * 100, txs[txIndex].rate ?? 0.000001]);
         nextSample += sampleInterval;
         sampleIndex++;
       }
@@ -121,8 +125,8 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
       },
       yAxis: {
         type: 'log',
-        min: 1,
-        max: this.data.reduce((min, val) => Math.max(min, val[1]), 1),
+        min: this.minValue >= 1 ? 1 : 0.1,
+        max: this.maxValue,
         // name: 'Effective Fee Rate s/vb',
         // nameLocation: 'middle',
         splitLine: {
@@ -138,7 +142,15 @@ export class FeeDistributionGraphComponent implements OnInit, OnChanges, OnDestr
             const unitValue = this.weightMode ? value / 4 : value;
             const selectedPowerOfTen = selectPowerOfTen(unitValue);
             const scaledValue = unitValue / selectedPowerOfTen.divider;
-            const newVal = scaledValue >= 100 ? Math.round(scaledValue) : scaledValue.toPrecision(3);
+            let newVal = '';
+            switch (true) {
+              case scaledValue >= 100:
+                return Math.round(scaledValue).toString();
+              case scaledValue >= 10:
+                return scaledValue.toFixed(1);
+              default:
+                return scaledValue.toFixed(2);
+            }
             return `${newVal}${selectedPowerOfTen.unit}`;
           },
         },


### PR DESCRIPTION
Reduces the minimum y-axis value on the projected block fee distribution chart from 1 to 0.1 (where relevant).

Before:

<img width="531" height="291" alt="Screenshot 2025-07-16 at 5 29 06 AM" src="https://github.com/user-attachments/assets/bbe9e404-5214-4e38-8126-ffd9f288e3a4" />

After:

<img width="531" height="291" alt="Screenshot 2025-07-16 at 5 28 54 AM" src="https://github.com/user-attachments/assets/5f78a3ef-19a6-4c41-8636-540d78ccd7c7" />
