### PR TITLE
fix missing prevout goggles

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -8,6 +8,7 @@ import transactionUtils from './transaction-utils';
 import { isPoint } from '../utils/secp256k1';
 import logger from '../logger';
 import { getVarIntLength, opcodes, parseMultisigScript } from '../utils/bitcoin-script';
+import { IEsploraApi } from './bitcoin/esplora-api.interface';
 
 // Bitcoin Core default policy settings
 const MAX_STANDARD_TX_WEIGHT = 400_000;
@@ -507,6 +508,51 @@ export class Common {
     return flags;
   }
 
+  static inputIsMaybeInscription(vin: IEsploraApi.Vin): boolean {
+    // check if this is actually a taproot input
+    let isTaproot = false;
+    let isNotTaproot = false;
+
+    // taproot inputs have no scriptsig (otherwise probably wrapped segwit)
+    if (vin.scriptsig?.length) {
+      isNotTaproot = true;
+    }
+
+    // p2wpkh consist of a DER-encoded signature followed by a compressed pubkey
+    if (!isNotTaproot
+      && this.isDERSig(vin.witness[0])
+      && (vin.witness[1].startsWith('02') || vin.witness[1].startsWith('03'))
+      && vin.witness[1].length === 66) {
+      isNotTaproot = true;
+    }
+
+    // p2wsh could be almost anything, but ends with a script which
+    // probably doesn't match a valid taproot control block length (32 + 33m)
+    if (!isNotTaproot
+      && vin.witness.length >= 2
+    ) {
+      const hasAnnex = vin.witness[vin.witness.length - 1].startsWith('50');
+      const controlBlock = vin.witness[vin.witness.length - (hasAnnex ? 2 : 1)];
+      if ((controlBlock.length - 66) % 64 === 0) {
+        isNotTaproot = true;
+      }
+    }
+
+    // signed taproot inscriptions should have 3 non-annex witness items:
+    //  1) schnorr signature
+    //  2) inscription script
+    //  3) control block (length 33 + 32m)
+    if (!isTaproot
+      && vin.witness.length >= 3
+      && vin.witness[0].length === 128 || vin.witness[0].length === 130
+      && (vin.witness[2].length - 66) % 64 === 0
+    ) {
+      isTaproot = true;
+    }
+
+    return isTaproot || !isNotTaproot;
+  }
+
   static getTransactionFlags(tx: TransactionExtended, height?: number): number {
     let flags = tx.flags ? BigInt(tx.flags) : 0n;
 
@@ -567,7 +613,8 @@ export class Common {
         }
       } else {
         // no prevouts, optimistically check witness-bearing inputs
-        if (vin.witness?.length >= 2) {
+        if (vin.witness?.length >= 2 && Common.inputIsMaybeInscription(vin)) {
+          // try to parse the witness as a taproot inscription
           try {
             flags = Common.isInscription(vin, flags);
           } catch {


### PR DESCRIPTION
Resolves #5972 by:
1) Tightening the heuristic used for identifying inscriptions when prevout data is unavailable.
2) Recalculating Mempool Goggles flags when prevouts are added later, so that classification errors due to incomplete data do not persist longer than necessary.

---

#### Background

When using non-esplora backends, prevout data for mempool transactions with many inputs is loaded lazily to avoid overloading Bitcoin Core and degrading performance.

However, prevout data is required to identify input address types and e.g. to distinguish taproot from legacy segwit inputs.

In response to #4677, we added logic to optimistically identify inscriptions from the witness data alone using a duck-test approach (looking for multiple witness items where the second-to-last item parses as a valid script containing `OP_0 OP_IF`).

This heuristic breaks down for some legacy segwit inputs where the p2wpkh signature happens to parse as a valid inscription-bearing script, which is particularly likely to occur in large consolidations of p2wpkh inputs.

---

#### Solution

This PR tightens the heuristic to explicitly exclude inputs that are more likely to be legacy segwit inputs than taproot, because e.g:
 - the witness looks like a P2WPKH input (first item looks like a DER signature, second looks like a compressed pubkey).
 - witness data doesn't appear to include a valid control block.
 - witness data doesn't appear to start with a schnorr signature.
 
It also clears and recalculates the Mempool Goggles flags as soon as full prevouts are added to the transaction.

---

Before:
| <img width="414" height="310" alt="Screenshot 2025-07-16 at 1 20 04 PM" src="https://github.com/user-attachments/assets/341c2062-d994-47d4-b83a-26a78587349c" /> | <img width="422" height="300" alt="Screenshot 2025-07-16 at 1 19 50 PM" src="https://github.com/user-attachments/assets/990e7e03-455f-4cd6-9ba5-da402647d8fa" /> |
|-|-|

After:
| <img width="395" height="274" alt="Screenshot 2025-07-16 at 1 20 54 PM" src="https://github.com/user-attachments/assets/7d6e7dca-6e3b-4a52-937b-2019a191847a" /> | <img width="422" height="300" alt="Screenshot 2025-07-16 at 1 20 43 PM" src="https://github.com/user-attachments/assets/5baef411-8713-4afc-a164-0159e92dd06d" /> |
|-|-|

