### PR TITLE
fix nonstandard anchor bug

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -253,7 +253,7 @@ export class Common {
         }
       } else if (['unknown', 'provably_unspendable', 'empty'].includes(vin.prevout?.scriptpubkey_type || '')) {
         return true;
-      } else if (this.isNonStandardAnchor(tx, height)) {
+      } else if (vin.prevout?.scriptpubkey_type === 'anchor' && this.isNonStandardAnchor(vin, height)) {
         return true;
       }
       // bad-witness-nonstandard
@@ -396,11 +396,12 @@ export class Common {
     'signet': 211_000,
     '': 863_500,
   };
-  static isNonStandardAnchor(tx: TransactionExtended, height?: number): boolean {
+  static isNonStandardAnchor(vin: IEsploraApi.Vin, height?: number): boolean {
     if (
       height != null
       && this.ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[config.MEMPOOL.NETWORK]
       && height <= this.ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[config.MEMPOOL.NETWORK]
+      && vin.prevout?.scriptpubkey === '51024e73'
     ) {
       // anchor outputs were non-standard to spend before v28.x (scheduled for 2024/09/30 https://github.com/bitcoin/bitcoin/issues/29891)
       return true;

--- a/frontend/src/app/components/tracker/tracker.component.ts
+++ b/frontend/src/app/components/tracker/tracker.component.ts
@@ -750,7 +750,8 @@ export class TrackerComponent implements OnInit, OnDestroy {
 
   checkAccelerationEligibility() {
     if (this.tx) {
-      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
+      const txHeight = this.tx.status?.block_height || (this.stateService.latestBlockHeight >= 0 ? this.stateService.latestBlockHeight + 1 : null);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, txHeight, this.stateService.network);
       const replaceableInputs = (this.tx.flags & (TransactionFlags.sighash_none | TransactionFlags.sighash_acp)) > 0n;
       const highSigop = (this.tx.sigops * 20) > this.tx.weight;
       this.eligibleForAcceleration = !replaceableInputs && !highSigop;

--- a/frontend/src/app/components/transaction/transaction-raw.component.ts
+++ b/frontend/src/app/components/transaction/transaction-raw.component.ts
@@ -270,7 +270,8 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
       replaceUrl: true
     });
 
-    this.transaction.flags = getTransactionFlags(this.transaction, this.cpfpInfo, null, this.transaction.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
+    const txHeight = this.transaction.status?.block_height || (this.stateService.latestBlockHeight >= 0 ? this.stateService.latestBlockHeight + 1 : null);
+    this.transaction.flags = getTransactionFlags(this.transaction, this.cpfpInfo, null, txHeight, this.stateService.network);
     this.filters = this.transaction.flags ? toFilters(this.transaction.flags).filter(f => f.txPage) : [];
 
     this.setupGraph();

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -930,7 +930,8 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
       this.segwitEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'segwit');
       this.taprootEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'taproot');
       this.rbfEnabled = !this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'rbf');
-      this.tx.flags = getTransactionFlags(this.tx, null, null, this.tx.status?.block_height || (this.stateService.latestBlockHeight + 1), this.stateService.network);
+      const txHeight = this.tx.status?.block_height || (this.stateService.latestBlockHeight >= 0 ? this.stateService.latestBlockHeight + 1 : null);
+      this.tx.flags = getTransactionFlags(this.tx, null, null, txHeight, this.stateService.network);
       this.filters = this.tx.flags ? toFilters(this.tx.flags).filter(f => f.txPage) : [];
       this.checkAccelerationEligibility();
     } else {

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -511,7 +511,7 @@ export function isNonStandard(tx: Transaction, height?: number, network?: string
       }
     } else if (['unknown', 'provably_unspendable', 'empty'].includes(vin.prevout?.scriptpubkey_type || '')) {
       return true;
-    } else if (isNonStandardAnchor(tx, height, network)) {
+    } else if (vin.prevout?.scriptpubkey_type === 'anchor' && isNonStandardAnchor(vin, height, network)) {
       return true;
     }
     // bad-witness-nonstandard
@@ -634,12 +634,13 @@ const ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT = {
   'signet': 211_000,
   '': 863_500,
 };
-function isNonStandardAnchor(tx: Transaction, height?: number, network?: string): boolean {
+function isNonStandardAnchor(vin: Vin, height?: number, network?: string): boolean {
   if (
     height != null
     && network != null
     && ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[network]
     && height <= ANCHOR_STANDARDNESS_ACTIVATION_HEIGHT[network]
+    && vin.prevout?.scriptpubkey === '51024e73'
   ) {
     // anchor outputs were non-standard to spend before v28.x (scheduled for 2024/09/30 https://github.com/bitcoin/bitcoin/issues/29891)
     return true;


### PR DESCRIPTION
This PR fixes a couple of intersecting bugs in the Goggles classification process which could cause the `Non-Standard` tag to be incorrectly shown on the `/tx` page for some unconfirmed transactions:
 - The non-standard anchor spend check didn't actually test if the input *was* p2a.
 - The frontend Goggles classification is sometimes run before the current blockheight is available, and defaulted to assuming the current height is zero (and therefore before the p2a standardization height)
 
Which together make unconfirmed transactions being classified on the /tx pages appear to carry a p2a spend before the network's p2a standardization blockheight, which would be non-standard.

After this PR, height based standardness rules are only applied if the current blockheight is available, and the anchor spend check is fixed to correctly identify p2a inputs.

---

#### Testing:

This bug currently reproduces when entering the site directly on the `/tx` page for an unconfirmed transaction containing inputs other than `p2sh`.

Following this fix, no unconfirmed transactions in the public mempool should display the non-standard goggles tag on the `/tx` page.

But this confirmed testnet4 p2a spend before activation height should continue to be labelled `Non-Standard`: https://mempool.space/testnet4/tx/4a89d5d1568b5cbcb4118559cb65d2357657d361a41cd96b14e74ed3d065975c#vin=0