### PR TITLE
improve op_return display

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -342,16 +342,20 @@
                           <button (click)="toggleOrdData(tx.txid, 'vout', vindex)" type="button" class="btn btn-sm badge badge-ord">Runestone</button>
                         } @else {
                           <a placement="bottom" style="cursor: pointer;">
-                            <span *ngIf="vout.scriptpubkey_asm !== 'OP_RETURN'" class="badge badge-secondary scriptmessage" (click)="toggleShowFullOpReturnPreview(vindex)">{{ vout.scriptpubkey_asm | hex2ascii | slice:0:200 }}</span>
-                            <ng-container *ngIf="(showDetails$ | async) === false">
-                              @if ((vout.scriptpubkey_asm | hex2ascii).length > 200) {
-                                @if (!showFullOpReturnPreview[vindex]) {
-                                  <span class="badge badge-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show more</span>
-                                } @else {
-                                  <span class="badge badge-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show less</span>
+                            @if ((vout.scriptpubkey_asm | hex2ascii).length > 200) {
+                              <span *ngIf="vout.scriptpubkey_asm !== 'OP_RETURN'" class="badge badge-secondary scriptmessage opreturn-msg" (click)="toggleShowFullOpReturnPreview(vindex)">{{ vout.scriptpubkey_asm | hex2ascii | slice:0:200 }}</span>
+                              <ng-container *ngIf="(showDetails$ | async) === false">
+                                @if ((vout.scriptpubkey_asm | hex2ascii).length > 200) {
+                                  @if (!showFullOpReturnPreview[vindex]) {
+                                    <span class="badge badge-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show more</span>
+                                  } @else {
+                                    <span class="badge badge-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show less</span>
+                                  }
                                 }
-                              }
-                            </ng-container>
+                              </ng-container>
+                            } @else {
+                              <span *ngIf="vout.scriptpubkey_asm !== 'OP_RETURN'" [ngbTooltip]="vout.scriptpubkey_asm | hex2ascii" class="badge badge-secondary scriptmessage">{{ vout.scriptpubkey_asm | hex2ascii }}</span>
+                            }
                           </a>
                         }
                       </ng-template>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.scss
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.scss
@@ -324,3 +324,25 @@ h2 {
 		background-color: var(--primary);
 	}
 }
+
+.scriptmessage.opreturn-msg {
+	max-width: 20px;
+	@media (min-width: 476px) {
+		max-width: 110px;
+	}
+	@media (min-width: 576px) {
+		max-width: 190px;
+	}
+	@media (min-width: 768px) {
+    max-width: 330px;
+	}
+	@media (min-width: 850px) {
+    max-width: 452px;
+	}
+	@media (min-width: 992px) {
+		max-width: 120px;
+	}
+	@media (min-width: 1200px) {
+		max-width: 180px;
+	}
+}

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -553,9 +553,7 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   toggleShowFullOpReturnPreview(voutIndex: number): void {
-    console.log('toggleShowFullOpReturnPreview', voutIndex);
     this.showFullOpReturnPreview[voutIndex] = !this.showFullOpReturnPreview[voutIndex];
-    console.log(this.showFullOpReturnPreview[voutIndex]);
   }
 
   toggleOrdData(txid: string, type: 'vin' | 'vout', index: number) {


### PR DESCRIPTION
This PR improves the UX for viewing the decoded content of large op_returns by:
 - replacing the tooltip with a toggle-able inline element
 - formatting to preserve newlines (`whitespace: pre-line`)
 
 
<img width="542" height="158" alt="Screenshot 2025-07-26 at 1 36 17 AM" src="https://github.com/user-attachments/assets/677dc251-7331-49d8-acc5-c45416a9bc30" />
<img width="534" height="836" alt="Screenshot 2025-07-26 at 1 36 29 AM" src="https://github.com/user-attachments/assets/ce25a8de-287e-4c44-ba7d-a98a226e682e" />
<img width="529" height="592" alt="Screenshot 2025-07-26 at 1 35 59 AM" src="https://github.com/user-attachments/assets/81a30ddf-dc72-488f-be3b-70f52fcab933" />
