### PR TITLE
handle missing price data

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 100;
+  private static currentVersion = 101;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1297,6 +1297,10 @@ class DatabaseMigration {
     if (version < 58) {
       queries.push(`DELETE FROM state WHERE name = 'last_hashrates_indexing'`);
       queries.push(`DELETE FROM state WHERE name = 'last_weekly_hashrates_indexing'`);
+    }
+
+    if (version < 101) {
+      queries.push(`DELETE FROM prices WHERE USD = -1`);
     }
 
     return queries;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -887,7 +887,9 @@ class BlocksRepository {
         SELECT UNIX_TIMESTAMP(blocks.blockTimestamp) as timestamp, blocks.height
         FROM blocks
         LEFT JOIN blocks_prices ON blocks.height = blocks_prices.height
+        LEFT JOIN prices ON blocks_prices.price_id = prices.id
         WHERE blocks_prices.height IS NULL
+          OR prices.id IS NULL
         ORDER BY blocks.height
       `);
       return rows;
@@ -907,6 +909,7 @@ class BlocksRepository {
         query += ` (${price.height}, ${price.priceId}),`;
       }
       query = query.slice(0, -1);
+      query += ` ON DUPLICATE KEY UPDATE price_id = VALUES(price_id)`;
       await DB.query(query);
     } catch (e: any) {
       if (e.errno === 1062) { // ER_DUP_ENTRY - This scenario is possible upon node backend restart

--- a/backend/src/repositories/PricesRepository.ts
+++ b/backend/src/repositories/PricesRepository.ts
@@ -296,6 +296,7 @@ class PricesRepository {
         id,
         USD
       FROM prices
+      WHERE USD >= 0
       ORDER BY time
     `);
     return times as {time: number, id: number, USD: number}[];
@@ -305,6 +306,7 @@ class PricesRepository {
     const [rates] = await DB.query(`
       SELECT ${ApiPriceFields}
       FROM prices
+      WHERE USD >= 0
       ORDER BY time DESC
       LIMIT 1`
     );
@@ -321,6 +323,7 @@ class PricesRepository {
         SELECT ${ApiPriceFields}
         FROM prices
         WHERE UNIX_TIMESTAMP(time) < ?
+          AND USD >= 0
         ORDER BY time DESC
         LIMIT 1`,
         [timestamp]
@@ -332,6 +335,7 @@ class PricesRepository {
       const [latestPrices] = await DB.query(`
         SELECT ${ApiPriceFields}
         FROM prices
+        WHERE USD >= 0
         ORDER BY time DESC
         LIMIT 1
       `);
@@ -429,6 +433,7 @@ class PricesRepository {
       const [rates] = await DB.query(`
         SELECT ${ApiPriceFields}
         FROM prices
+        WHERE USD >= 0
         ORDER BY time DESC
       `);
       if (!Array.isArray(rates)) {


### PR DESCRIPTION
Much of the backend price & exchange rate functionality assumes that `prices` table includes only valid & complete USD price data.

However, some older instances may still have `USD = -1` rows in their DB from earlier versions of the backend.

This PR:
 - Fixes some DB queries to avoid returning bad data from e.g. the `historical-price` API.
 - Adds a DB migration to explicitly delete bad price rows from the database.
 - Fixes some issues with the price indexing code to allow updating/correcting bad data in the `prices` and `block_prices` tables.
 
Where bad price rows are referenced in the `blocks_prices` table, deleting these rows will cause those blocks to be omitted from some of the historical block fees/rewards APIs.

This probably doesn't actually affect any `blocks_prices` entries in prod, but in any case the broken foreign keys will be fixed during the next blocks prices indexing task.