### PR TITLE
Add 'None' filter mode to mempool goggles

### DIFF
--- a/frontend/src/app/components/block-filters/block-filters.component.html
+++ b/frontend/src/app/components/block-filters/block-filters.component.html
@@ -1,4 +1,4 @@
-<div class="block-filters" [class.filters-active]="activeFilters.length > 0" [class.any-mode]="filterMode === 'or'" [class.menu-open]="menuOpen" [class.small]="cssWidth < 500" [class.vsmall]="cssWidth < 400" [class.tiny]="cssWidth < 200">
+<div class="block-filters" [class.filters-active]="activeFilters.length > 0" [class.any-mode]="filterMode === 'or'" [class.none-mode]="filterMode === 'nor'" [class.menu-open]="menuOpen" [class.small]="cssWidth < 500" [class.vsmall]="cssWidth < 400" [class.tiny]="cssWidth < 200">
   <a *ngIf="menuOpen" [routerLink]="['/docs/faq' | relativeUrl]" fragment="how-do-mempool-goggles-work" class="info-badges float-right" i18n-ngbTooltip="Mempool Goggles&trade; tooltip" ngbTooltip="select filter categories to highlight matching transactions">
     <fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true" size="lg"></fa-icon>
   </a>
@@ -22,6 +22,9 @@
           </label>
           <label class="btn btn-xs green mode-toggle" [class.active]="filterMode === 'or'">
             <input type="radio" [value]="'any'" fragment="any" (click)="setFilterMode('or')"><ng-container i18n="mempool-goggles.any">Any</ng-container>
+          </label>
+          <label class="btn btn-xs red mode-toggle" [class.active]="filterMode === 'nor'">
+            <input type="radio" [value]="'nor'" fragment="nor" (click)="setFilterMode('nor')"><ng-container i18n="mempool-goggles.none">None</ng-container>
           </label>
         </div>
       </div>

--- a/frontend/src/app/components/block-filters/block-filters.component.scss
+++ b/frontend/src/app/components/block-filters/block-filters.component.scss
@@ -94,6 +94,15 @@
     }
   }
 
+  &.none-mode {
+    .filter-tag {
+      border: solid 1px var(--danger);
+      &.selected {
+        background-color: var(--danger);
+      }
+    }
+  }
+
   .btn-group {
     font-size: 0.9em;
     margin-right: 0.25em;
@@ -124,6 +133,12 @@
       border: solid 1px var(--success);
       &.active {
         background: var(--success);
+      }
+    }
+    &.red {
+      border: solid 1px var(--danger);
+      &.active {
+        background: var(--danger);
       }
     }
     &.yellow {

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -665,7 +665,7 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
           matches = flags === 0n || (tx.bigintFlags & flags) > 0n;
           break;
         case 'nor':
-          matches = flags === 0n || (tx.bigintFlags & flags) === 0n;
+          matches = (tx.bigintFlags & flags) === 0n;
           break;
       }
       if (matches) {

--- a/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
+++ b/frontend/src/app/components/block-overview-graph/block-overview-graph.component.ts
@@ -656,7 +656,19 @@ export class BlockOverviewGraphComponent implements AfterViewInit, OnDestroy, On
 
   getFilterColorFunction(flags: bigint, gradient: 'fee' | 'age'): ((tx: TxView) => Color) {
     return (tx: TxView) => {
-      if ((this.filterMode === 'and' && (tx.bigintFlags & flags) === flags) || (this.filterMode === 'or' && (flags === 0n || (tx.bigintFlags & flags) > 0n))) {
+      let matches = false;
+      switch (this.filterMode) {
+        case 'and':
+          matches = (tx.bigintFlags & flags) === flags;
+          break;
+        case 'or':
+          matches = flags === 0n || (tx.bigintFlags & flags) > 0n;
+          break;
+        case 'nor':
+          matches = flags === 0n || (tx.bigintFlags & flags) === 0n;
+          break;
+      }
+      if (matches) {
         if (this.themeService.theme !== 'contrast' && this.themeService.theme !== 'bukele') {
           return (gradient === 'age') ? ageColorFunction(tx, defaultColors.fee, defaultAuditColors, this.relativeTime || (Date.now() / 1000)) : defaultColorFunction(tx, defaultColors.fee, defaultAuditColors, this.relativeTime || (Date.now() / 1000));
         } else {

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -9,7 +9,7 @@ export interface Filter {
   txPage?: boolean,
 }
 
-export type FilterMode = 'and' | 'or';
+export type FilterMode = 'and' | 'or' | 'nor';
 
 export type GradientMode = 'fee' | 'age';
 


### PR DESCRIPTION
This PR introduces a `None` filtering mode to Mempool Goggles, which can be nice to have in some scenarios. 

For example with current filters we can't highlight non data-carrying transactions: we have to manually toggle the data-carrying flags on `Any` mode and look for the non-highlighted transactions, which can be tricky if there is only a few such transactions in the block.

find transaction with neither ancestors nor descendants:
| `Any`: need to look for darkened txs  | `None`: target txs are highlighted |
| ------------- | ------------- |
| <img width="482" height="482" alt="Screenshot 2025-08-01 at 15 08 25" src="https://github.com/user-attachments/assets/08674ac7-735c-4a28-b18b-66ea1acc389e" /> | <img width="482" height="482" alt="Screenshot 2025-08-01 at 15 08 23" src="https://github.com/user-attachments/assets/cc5ddf1e-e102-49ac-8c94-81b956cfaa10" /> |

Or if we want to find transactions only using P2WSH: 
| `Any`  | `None` |
| ------------- | ------------- |
| <img width="482" height="482" alt="Screenshot 2025-08-01 at 14 46 23" src="https://github.com/user-attachments/assets/4e32deb0-4a08-462c-b6a2-24275c47fc2f" /> |<img width="482" height="482" alt="Screenshot 2025-08-01 at 14 46 13" src="https://github.com/user-attachments/assets/49c58f1c-81be-4452-9e31-4ea4b9e06cc5" /> |


