### PR TITLE
Fix scriptsig_asm in coinbase on non-esplora backends

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -294,7 +294,7 @@ class BitcoinApi implements AbstractBitcoinApi {
         is_coinbase: !!vin.coinbase,
         prevout: null,
         scriptsig: vin.scriptSig && vin.scriptSig.hex || vin.coinbase || '',
-        scriptsig_asm: vin.scriptSig && transactionUtils.convertScriptSigAsm(vin.scriptSig.hex) || '',
+        scriptsig_asm: vin.scriptSig ? transactionUtils.convertScriptSigAsm(vin.scriptSig.hex) : (vin.coinbase ? transactionUtils.convertScriptSigAsm(vin.coinbase) : ''),
         sequence: vin.sequence,
         txid: vin.txid || '',
         vout: vin.vout || 0,


### PR DESCRIPTION
`scriptsig_asm` field was not filled on non-esplora backend:

| Before  | After |
| ------------- | ------------- |
| <img width="358" height="346" alt="Screenshot 2025-08-04 at 11 27 21" src="https://github.com/user-attachments/assets/5bec74e8-7f4a-437c-8f59-bdd51228bb89" /> | <img width="358" height="346" alt="Screenshot 2025-08-04 at 11 27 04" src="https://github.com/user-attachments/assets/93695d76-83bf-4f8a-bc97-a3797fec5178" /> |