### PR TITLE
Fix websocket price data

### DIFF
--- a/backend/src/tasks/price-updater.ts
+++ b/backend/src/tasks/price-updater.ts
@@ -279,6 +279,7 @@ class PriceUpdater {
 
     if (this.latestPrices.USD === -1) {
       this.latestPrices = await PricesRepository.$getLatestConversionRates();
+      logger.warn(`No BTC price available, falling back to latest known price: ${JSON.stringify(this.latestPrices)}`);
     }
 
     if (this.ratesChangedCallback) {

--- a/backend/src/tasks/price-updater.ts
+++ b/backend/src/tasks/price-updater.ts
@@ -273,16 +273,16 @@ class PriceUpdater {
     this.latestPrices.time = Math.round(new Date().getTime() / 1000);
     logger.info(`Latest BTC fiat averaged price: ${JSON.stringify(this.latestPrices)}`);
 
-    if (this.ratesChangedCallback) {
-      this.ratesChangedCallback(this.latestPrices);
-    }
-
     if (!forceUpdate) {
       this.cyclePosition++;
     }
 
     if (this.latestPrices.USD === -1) {
       this.latestPrices = await PricesRepository.$getLatestConversionRates();
+    }
+
+    if (this.ratesChangedCallback) {
+      this.ratesChangedCallback(this.latestPrices);
     }
   }
 


### PR DESCRIPTION
Fixes #5998

When the backend can't retrieve updated rates, it correctly falls back to the last known prices from the database but it was sending the rates to the WebSocket before performing the fallback 😅 

This PR ensures that the fallback to latest known prices occurs before sending it to websocket.
Also adds a log when falling back to latest known rates:
```
Aug  6 16:55:00 [38157] INFO: Latest BTC fiat averaged price: {"time":1754492101,"USD":-1,"EUR":-1,"GBP":-1,"CAD":-1,"CHF":-1,"AUD":-1,"JPY":-1}
Aug  6 16:55:00 [38157] WARN: No BTC price available, falling back to latest known price: {"time":1754488800,"USD":114168,"EUR":98260,"GBP":85716,"CAD":157089,"CHF":92381,"AUD":176111,"JPY":16600000}
```