### PR TITLE
[accelerator] minor tweak to dashboard `recent` widget to align status

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.html
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.html
@@ -1,4 +1,4 @@
-<div class="container-lg widget-container" [class.widget]="widget" [class.full-height]="!widget">
+<div class="container-lg widget-container p-0" [class.widget]="widget" [class.full-height]="!widget">
   <h1 *ngIf="!widget" class="float-left" i18n="accelerator.accelerations">Accelerations</h1>
   <div *ngIf="!widget && isLoading" class="spinner-border ml-3" role="status"></div>
 

--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
@@ -141,7 +141,7 @@ tr, td, th {
   }
 
   .fee {
-    width: 30%;
+    width: 25%;
     text-align: end !important;
   }
 
@@ -153,7 +153,7 @@ tr, td, th {
   }
 
   .status {
-    width: 20%
+    width: 25%
   }
 }
 


### PR DESCRIPTION
### Prod

<img width="556" height="420" alt="Screenshot 2025-08-12 at 5 02 05 PM" src="https://github.com/user-attachments/assets/5e55e94d-607c-4a9f-a9b6-33e15eabe6b2" />

### Fix

<img width="562" height="430" alt="Screenshot 2025-08-12 at 5 02 00 PM" src="https://github.com/user-attachments/assets/d9f7ca3f-4c03-4f0d-a0c1-2c85735e4d6e" />
