### PR TITLE
always serve latest good prices

### DIFF
--- a/backend/src/tasks/price-updater.ts
+++ b/backend/src/tasks/price-updater.ts
@@ -56,6 +56,7 @@ class PriceUpdater {
   private feeds: PriceFeed[] = [];
   private currencies: string[] = ['USD', 'EUR', 'GBP', 'CAD', 'CHF', 'AUD', 'JPY'];
   private latestPrices: ApiPrice;
+  private latestGoodPrices: ApiPrice;
   private currencyConversionFeed: ConversionFeed | undefined;
   private newCurrencies: string[] = ['BGN', 'BRL', 'CNY', 'CZK', 'DKK', 'HKD', 'HRK', 'HUF', 'IDR', 'ILS', 'INR', 'ISK', 'KRW', 'MXN', 'MYR', 'NOK', 'NZD', 'PHP', 'PLN', 'RON', 'RUB', 'SEK', 'SGD', 'THB', 'TRY', 'ZAR'];
   private lastTimeConversionsRatesFetched: number = 0;
@@ -64,6 +65,7 @@ class PriceUpdater {
 
   constructor() {
     this.latestPrices = this.getEmptyPricesObj();
+    this.latestGoodPrices = this.getEmptyPricesObj();
 
     this.feeds.push(new BitflyerApi()); // Does not have historical endpoint
     this.feeds.push(new KrakenApi());
@@ -76,7 +78,7 @@ class PriceUpdater {
   }
 
   public getLatestPrices(): ApiPrice {
-    return this.latestPrices;
+    return this.latestGoodPrices;
   }
 
   public getEmptyPricesObj(): ApiPrice {
@@ -128,6 +130,7 @@ class PriceUpdater {
    */
   public async $initializeLatestPriceWithDb(): Promise<void> {
     this.latestPrices = await PricesRepository.$getLatestConversionRates();
+    this.latestGoodPrices = JSON.parse(JSON.stringify(this.latestPrices));
   }
 
   public async $run(): Promise<void> {
@@ -177,6 +180,14 @@ class PriceUpdater {
     }
 
     this.running = false;
+  }
+
+  private setLatestPrice(currency, price): void {
+    this.latestPrices[currency] = price;
+    if (price ?? price > -1) {
+      this.latestGoodPrices[currency] = price;
+      this.latestGoodPrices.time = Math.round(new Date().getTime() / 1000);
+    }
   }
 
   private getMillisecondsSinceBeginningOfHour(): number {
@@ -245,16 +256,16 @@ class PriceUpdater {
       // Compute average price, non weighted
       prices = prices.filter(price => price > 0);
       if (prices.length === 0) {
-        this.latestPrices[currency] = -1;
+        this.setLatestPrice(currency, -1);
       } else {
-        this.latestPrices[currency] = Math.round(getMedian(prices));
+        this.setLatestPrice(currency, Math.round(getMedian(prices)));
       }
     }
 
     if (config.FIAT_PRICE.API_KEY && this.latestPrices.USD > 0 && Object.keys(this.latestConversionsRatesFromFeed).length > 0) {
       for (const conversionCurrency of this.newCurrencies) {
         if (this.latestConversionsRatesFromFeed[conversionCurrency] > 0 && this.latestPrices.USD * this.latestConversionsRatesFromFeed[conversionCurrency] < MAX_PRICES[conversionCurrency]) {
-          this.latestPrices[conversionCurrency] = Math.round(this.latestPrices.USD * this.latestConversionsRatesFromFeed[conversionCurrency]);
+          this.setLatestPrice(conversionCurrency, Math.round(this.latestPrices.USD * this.latestConversionsRatesFromFeed[conversionCurrency]));
         }
       }
     }
@@ -277,14 +288,13 @@ class PriceUpdater {
     }
 
     if (this.latestPrices.USD === -1) {
-      this.latestPrices = await PricesRepository.$getLatestConversionRates();
-      logger.warn(`No BTC price available, falling back to latest known price: ${JSON.stringify(this.latestPrices)}`);
+      logger.warn(`No BTC price available, falling back to latest known price: ${JSON.stringify(this.latestGoodPrices)}`);
     } else {
-      logger.info(`Latest BTC fiat averaged price: ${JSON.stringify(this.latestPrices)}`);
+      logger.info(`Latest BTC fiat averaged price: ${JSON.stringify(this.latestGoodPrices)}`);
     }
 
-    if (this.ratesChangedCallback && this.latestPrices.USD > 0) {
-      this.ratesChangedCallback(this.latestPrices);
+    if (this.ratesChangedCallback && this.latestGoodPrices.USD > 0) {
+      this.ratesChangedCallback(this.latestGoodPrices);
     }
   }
 

--- a/backend/src/tasks/price-updater.ts
+++ b/backend/src/tasks/price-updater.ts
@@ -184,7 +184,7 @@ class PriceUpdater {
 
   private setLatestPrice(currency, price): void {
     this.latestPrices[currency] = price;
-    if (price ?? price > -1) {
+    if (price > 0) {
       this.latestGoodPrices[currency] = price;
       this.latestGoodPrices.time = Math.round(new Date().getTime() / 1000);
     }


### PR DESCRIPTION
This PR extends the price updater service to track the latest known good price for each currency, so that we can avoid ever serving responses with bad price data.