### PR TITLE
[accelerator] use unique wording for acceleration confirmation

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -572,22 +572,14 @@
     <div class="row mb-1 text-center">
       <div class="col-sm">
         <h1 style="font-size: larger;"><ng-content select="[slot='accelerated-title']"></ng-content>
-          @if (accelerationResponse) {
-            <span class="default-slot" i18n="accelerator.success-message">Your transaction is being accelerated!</span>
-          } @else {
-            <span class="default-slot" i18n="accelerator.success-message-third-party">Transaction is already being accelerated!</span>
-          }
+          <span class="default-slot" i18n="accelerator.success-message">Transaction is being accelerated!</span>
         </h1>
       </div>
     </div>
     <div class="row text-center mt-1">
       <div class="col-sm">
         <div class="d-flex flex-row justify-content-center align-items-center">
-          @if (accelerationResponse) {        
-            <span i18n="accelerator.confirmed-acceleration-with-miners">Your transaction has been accepted for acceleration by our mining pool partners.</span>
-          } @else {
-            <span i18n="accelerator.confirmed-acceleration-with-miners-third-party">Transaction has already been accepted for acceleration by our mining pool partners.</span>
-          }
+          <span i18n="accelerator.confirmed-acceleration-with-miners">Transaction has been accepted for acceleration by our mining pool partners.</span>
         </div>
         @if (accelerationResponse?.receiptUrl) {
           <div class="d-flex flex-row justify-content-center align-items-center">

--- a/frontend/src/app/components/tracker/tracker.component.html
+++ b/frontend/src/app/components/tracker/tracker.component.html
@@ -141,7 +141,7 @@
             <div class="progress-icon">
               <fa-icon [icon]="['fas', 'wand-magic-sparkles']" [fixedWidth]="true"></fa-icon>
             </div>
-            <span class="explainer" i18n="tracker.explain.accelerated">Your transaction has been accelerated</span>
+            <span class="explainer" i18n="tracker.explain.accelerated">Transaction has been accelerated</span>
             @if (paymentReceiptUrl) {
               <span class="explainer"><a [href]="paymentReceiptUrl" target="_blank" i18n="accelerator.receipt-label">Get a receipt.</a></span>
             }


### PR DESCRIPTION
We currently have two slightly different sentence to let the user know a transaction is being accelerated.

The initial idea was to show a more personal message when someone is accelerating a transaction using the words `Your` or `already` based on whether the user actually triggered the acceleration or not.

But this is very buggy (probably because the transaction component get the acceleration info before the acceleration checkout gets the acceleration confirmation?).

So most of the time we show the user the wrong message and to avoid this I want to simply use the same message for all situation.