### PR TITLE
[axios] bump timeouts from 10000 ms to 20000 ms

### DIFF
--- a/backend/src/utils/axios-query.ts
+++ b/backend/src/utils/axios-query.ts
@@ -18,7 +18,7 @@ export async function query(path, throwOnFail: boolean = false): Promise<object 
    headers: {
      'User-Agent': (config.MEMPOOL.USER_AGENT === 'mempool') ? `mempool/v${backendInfo.getBackendInfo().version}` : `${config.MEMPOOL.USER_AGENT}`
    },
-   timeout: config.SOCKS5PROXY.ENABLED ? 30000 : 10000
+   timeout: config.SOCKS5PROXY.ENABLED ? 30000 : 20000
  };
  let retry = 0;
  let lastError: any = null;


### PR DESCRIPTION
This `query` wrapper is only used for fetching the prices