### PR TITLE
Improve tooltip message for number of scripts in Taproot tree

### DIFF
--- a/frontend/src/app/components/taproot-address-scripts/taproot-address-scripts.component.ts
+++ b/frontend/src/app/components/taproot-address-scripts/taproot-address-scripts.component.ts
@@ -326,9 +326,18 @@ export class TaprootAddressScriptsComponent implements OnChanges {
 
           let hiddenScriptsMessage = '';
           if (node.tooltip[0].label === 'Hash') {
+            const remaining = 128 - (node.depth ?? 0);
+            let upperBoundHtml: string;
+            if (remaining === 0) {
+              upperBoundHtml = '1';
+            } else if (remaining <= 39) {
+              upperBoundHtml = (2 ** remaining).toLocaleString();
+            } else {
+              upperBoundHtml = `2<sup style="font-size: 0.85em;">${remaining}</sup>`;
+            }
             hiddenScriptsMessage = `
               <div style="margin-top: 8px; color: #888; font-size: 11px; line-height: 1.3; font-style: italic; border-top: 1px solid #333; padding-top: 6px; word-break: break-word; white-space: normal">
-                This node might commit to one or more scripts that have not been revealed yet.
+                This node might commit to ${upperBoundHtml === '1' ? 'exactly 1 script' : `at most ${upperBoundHtml} scripts`}.
               </div>`;
           }
 


### PR DESCRIPTION
This PR improves the tooltip message in the Taproot tree by specifying the number of potential spending scripts that can be committed.

See on address `bc1pkat977l0gah06kr7cswwj5cnq26cfmk66ul6y987v39nrswkztyqy5d8jt`:

<img width="631" height="345" alt="Screenshot 2025-09-09 at 18 53 33" src="https://github.com/user-attachments/assets/426c3fdb-2805-4a40-89f5-24d22d930978" />

<br>
<br>

<img width="631" height="435" alt="Screenshot 2025-09-09 at 18 53 57" src="https://github.com/user-attachments/assets/8178adea-ee0a-48a8-8513-e3c3fa8f7a0d" />

<br>
<br>

<img width="631" height="201" alt="Screenshot 2025-09-09 at 18 56 23" src="https://github.com/user-attachments/assets/4bf0e1bb-6bf5-4a0e-a600-103bcb9229b2" />
