### PR TITLE
Compare stale blocks

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -11,8 +11,8 @@ export interface AbstractBitcoinApi {
   $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof>;
   $getBlockHeightTip(): Promise<number>;
   $getBlockHashTip(): Promise<string>;
-  $getTxIdsForBlock(hash: string): Promise<string[]>;
-  $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]>;
+  $getTxIdsForBlock(hash: string, fallbackToCore?: boolean): Promise<string[]>;
+  $getTxsForBlock(hash: string, fallbackToCore?: boolean): Promise<IEsploraApi.Transaction[]>;
   $getBlockHash(height: number): Promise<string>;
   $getBlockHeader(hash: string): Promise<string>;
   $getBlock(hash: string): Promise<IEsploraApi.Block>;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -117,6 +117,12 @@ class BitcoinApi implements AbstractBitcoinApi {
     const transactions: IEsploraApi.Transaction[] = [];
     for (const tx of verboseBlock.tx) {
       const converted = await this.$convertTransaction(tx, true, false, verboseBlock.confirmations === -1);
+      converted.status = {
+        confirmed: true,
+        block_height: verboseBlock.height,
+        block_hash: hash,
+        block_time: verboseBlock.time,
+      };
       transactions.push(converted);
     }
     return transactions;

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -107,16 +107,16 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.getBestBlockHash();
   }
 
-  $getTxIdsForBlock(hash: string): Promise<string[]> {
+  $getTxIdsForBlock(hash: string, fallbackToCore = false): Promise<string[]> {
     return this.bitcoindClient.getBlock(hash, 1)
       .then((rpcBlock: IBitcoinApi.Block) => rpcBlock.tx);
   }
 
-  async $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]> {
+  async $getTxsForBlock(hash: string, fallbackToCore = false): Promise<IEsploraApi.Transaction[]> {
     const verboseBlock: IBitcoinApi.VerboseBlock = await this.bitcoindClient.getBlock(hash, 2);
     const transactions: IEsploraApi.Transaction[] = [];
     for (const tx of verboseBlock.tx) {
-      const converted = await this.$convertTransaction(tx, true);
+      const converted = await this.$convertTransaction(tx, true, false, verboseBlock.confirmations === -1);
       transactions.push(converted);
     }
     return transactions;
@@ -269,7 +269,7 @@ class BitcoinApi implements AbstractBitcoinApi {
     return this.bitcoindClient.getNetworkHashPs(120, blockHeight);
   }
 
-  protected async $convertTransaction(transaction: IBitcoinApi.Transaction, addPrevout: boolean, lazyPrevouts = false): Promise<IEsploraApi.Transaction> {
+  protected async $convertTransaction(transaction: IBitcoinApi.Transaction, addPrevout: boolean, lazyPrevouts = false, allowMissingPrevouts = false): Promise<IEsploraApi.Transaction> {
     let esploraTransaction: IEsploraApi.Transaction = {
       txid: transaction.txid,
       version: transaction.version,
@@ -318,7 +318,13 @@ class BitcoinApi implements AbstractBitcoinApi {
     }
 
     if (addPrevout) {
-      esploraTransaction = await this.$calculateFeeFromInputs(esploraTransaction, false, lazyPrevouts);
+      try {
+        esploraTransaction = await this.$calculateFeeFromInputs(esploraTransaction, false, lazyPrevouts);
+      } catch (e) {
+        if (!allowMissingPrevouts) {
+          throw e;
+        }
+      }
     } else if (!transaction.confirmations) {
       esploraTransaction = await this.$appendMempoolFeeData(esploraTransaction);
     }

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -94,6 +94,19 @@ class ChainTips {
     return this.chainTips;
   }
 
+  clearOrphanCacheAboveHeight(height: number): void {
+    for (const h in this.orphansByHeight) {
+      if (Number(h) > height) {
+        const orphans = this.orphansByHeight[h];
+        delete this.orphansByHeight[h];
+        for (const o of orphans) {
+          delete this.orphanedBlocks[o.hash];
+          delete this.blockCache[o.hash];
+        }
+      }
+    }
+  }
+
   public isOrphaned(hash: string): boolean {
     return !!this.orphanedBlocks[hash] || this.blockCache[hash]?.status === 'valid-fork' || this.blockCache[hash]?.status === 'valid-headers';
   }

--- a/backend/src/api/pools-parser.ts
+++ b/backend/src/api/pools-parser.ts
@@ -122,10 +122,8 @@ class PoolsParser {
     // refresh the in-memory block cache with the reindexed data
     if (clearCache) {
       for (const block of blocks.getBlocks()) {
-        const reindexedBlock = await blocks.$indexBlock(block.height);
-        if (reindexedBlock.id === block.id) {
-          block.extras.pool = reindexedBlock.extras.pool;
-        }
+        const reindexedBlock = await blocks.$indexBlock(block.id);
+        block.extras.pool = reindexedBlock.extras.pool;
       }
       // update persistent cache with the reindexed data
       diskCache.$saveCacheToDisk();

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -60,6 +60,7 @@ interface DatabaseBlock {
   utxoSetSize: number;
   totalInputAmt: number;
   firstSeen: number;
+  stale: boolean;
 }
 
 const BLOCK_DB_FIELDS = `
@@ -104,7 +105,8 @@ const BLOCK_DB_FIELDS = `
   blocks.utxoset_change AS utxoSetChange,
   blocks.utxoset_size AS utxoSetSize,
   blocks.total_input_amt AS totalInputAmt,
-  UNIX_TIMESTAMP(blocks.first_seen) AS firstSeen
+  UNIX_TIMESTAMP(blocks.first_seen) AS firstSeen,
+  blocks.stale
 `;
 
 class BlocksRepository {
@@ -128,7 +130,8 @@ class BlocksRepository {
         coinbase_signature, utxoset_size,             utxoset_change,    avg_tx_size,
         total_inputs,       total_outputs,            total_input_amt,   total_output_amt,
         fee_percentiles,    segwit_total_txs,         segwit_total_size, segwit_total_weight,
-        median_fee_amt,     coinbase_signature_ascii, definition_hash,   index_version
+        median_fee_amt,     coinbase_signature_ascii, definition_hash,   index_version,
+        stale
       ) VALUE (
         ?, ?, FROM_UNIXTIME(?), ?,
         ?, ?, ?, ?,
@@ -139,7 +142,8 @@ class BlocksRepository {
         ?, ?, ?, ?,
         ?, ?, ?, ?,
         ?, ?, ?, ?,
-        ?, ?, ?, ?
+        ?, ?, ?, ?,
+        ?
       )`;
 
       const poolDbId = await PoolsRepository.$getPoolByUniqueId(block.extras.pool.id);
@@ -187,13 +191,23 @@ class BlocksRepository {
         block.extras.medianFeeAmt,
         truncatedCoinbaseSignatureAscii,
         poolsUpdater.currentSha,
-        BlocksRepository.version
+        BlocksRepository.version,
+        (block.stale ? 1 : 0),
       ];
 
       await DB.query(query, params);
     } catch (e: any) {
-      if (e.errno === 1062) { // ER_DUP_ENTRY - This scenario is possible upon node backend restart
-        logger.debug(`$saveBlockInDatabase() - Block ${block.height} has already been indexed, ignoring`, logger.tags.mining);
+      if (e.errno === 1062) { // ER_DUP_ENTRY - This scenario is possible upon node backend restart or if a stale block is reconnected
+        if (!block.stale) {
+          logger.debug(`$saveBlockInDatabase() - Block ${block.height} has already been indexed, setting as canonical`, logger.tags.mining);
+          try {
+            await this.$setCanonicalBlockAtHeight(block.id, block.height);
+          } catch (e: any) {
+            logger.err(`Cannot set canonical block at height ${block.height}. Reason: ` + (e instanceof Error ? e.message : e));
+          }
+        } else {
+          logger.debug(`$saveBlockInDatabase() - Block ${block.height} has already been indexed, ignoring`, logger.tags.mining);
+        }
       } else {
         logger.err('Cannot save indexed block into db. Reason: ' + (e instanceof Error ? e.message : e), logger.tags.mining);
         throw e;
@@ -266,7 +280,7 @@ class BlocksRepository {
       const [rows]: any[] = await DB.query(`
         SELECT height
         FROM blocks
-        WHERE height <= ? AND height >= ?
+        WHERE height <= ? AND height >= ? AND stale = 0
         ORDER BY height DESC;
       `, [startHeight, endHeight]);
 
@@ -292,7 +306,7 @@ class BlocksRepository {
     let query = `SELECT count(height) as count, pools.id as poolId
       FROM blocks
       JOIN pools on pools.id = blocks.pool_id
-      WHERE tx_count = 1`;
+      WHERE tx_count = 1 AND stale = 0`;
 
     if (poolId) {
       query += ` AND pool_id = ?`;
@@ -335,20 +349,16 @@ class BlocksRepository {
 
     const params: any[] = [];
     let query = `SELECT count(height) as blockCount
-      FROM blocks`;
+      FROM blocks 
+      WHERE stale = 0`;
 
     if (poolId) {
-      query += ` WHERE pool_id = ?`;
+      query += ` AND pool_id = ?`;
       params.push(poolId);
     }
 
     if (interval) {
-      if (poolId) {
-        query += ` AND`;
-      } else {
-        query += ` WHERE`;
-      }
-      query += ` blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+      query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
     try {
@@ -372,19 +382,15 @@ class BlocksRepository {
     let query = `SELECT
       count(height) as blockCount,
       max(height) as lastBlockHeight
-      FROM blocks`;
+      FROM blocks
+      WHERE stale = 0`;
 
     if (poolId) {
-      query += ` WHERE pool_id = ?`;
+      query += ` AND pool_id = ?`;
       params.push(poolId);
     }
 
-    if (poolId) {
-      query += ` AND`;
-    } else {
-      query += ` WHERE`;
-    }
-    query += ` blockTimestamp BETWEEN FROM_UNIXTIME('${from}') AND FROM_UNIXTIME('${to}')`;
+    query += ` AND blockTimestamp BETWEEN FROM_UNIXTIME('${from}') AND FROM_UNIXTIME('${to}')`;
 
     try {
       const [rows] = await DB.query(query, params);
@@ -402,7 +408,7 @@ class BlocksRepository {
     const params: any[] = [];
     let query = `SELECT count(height) as blockCount
       FROM blocks
-      WHERE height <= ${startHeight} AND height >= ${endHeight}`;
+      WHERE height <= ${startHeight} AND height >= ${endHeight} AND stale = 0`;
 
     try {
       const [rows] = await DB.query(query, params);
@@ -422,7 +428,7 @@ class BlocksRepository {
       SELECT AVG(blocks_audits.match_rate) AS avg_match_rate
       FROM blocks
       JOIN blocks_audits ON blocks.height = blocks_audits.height
-      WHERE blocks.pool_id = ?
+      WHERE blocks.pool_id = ? AND stale = 0
     `;
     params.push(poolId);
 
@@ -446,7 +452,7 @@ class BlocksRepository {
     const query = `
       SELECT sum(reward) as total_reward
       FROM blocks
-      WHERE blocks.pool_id = ?
+      WHERE blocks.pool_id = ? AND stale = 0
     `;
     params.push(poolId);
 
@@ -468,6 +474,7 @@ class BlocksRepository {
   public async $oldestBlockTimestamp(): Promise<number> {
     const query = `SELECT UNIX_TIMESTAMP(blockTimestamp) as blockTimestamp
       FROM blocks
+      WHERE stale = 0
       ORDER BY height
       LIMIT 1;`;
 
@@ -499,7 +506,7 @@ class BlocksRepository {
       SELECT ${BLOCK_DB_FIELDS}
       FROM blocks
       JOIN pools ON blocks.pool_id = pools.id
-      WHERE pool_id = ?`;
+      WHERE pool_id = ? AND stale = 0`;
     params.push(pool.id);
 
     if (startHeight !== undefined) {
@@ -534,7 +541,7 @@ class BlocksRepository {
         SELECT ${BLOCK_DB_FIELDS}
         FROM blocks
         JOIN pools ON blocks.pool_id = pools.id
-        WHERE blocks.height = ?`,
+        WHERE blocks.height = ? AND stale = 0`,
         [height]
       );
 
@@ -550,11 +557,35 @@ class BlocksRepository {
   }
 
   /**
+   * Get one block by hash
+   */
+  public async $getBlockByHash(hash: string): Promise<BlockExtended | null> {
+    try {
+      const [rows]: any[] = await DB.query(`
+        SELECT ${BLOCK_DB_FIELDS}
+        FROM blocks
+        JOIN pools ON blocks.pool_id = pools.id
+        WHERE blocks.hash = ?`,
+        [hash]
+      );
+
+      if (rows.length <= 0) {
+        return null;
+      }
+
+      return await this.formatDbBlockIntoExtendedBlock(rows[0] as DatabaseBlock);
+    } catch (e) {
+      logger.err(`Cannot get indexed block ${hash}. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
    * Return blocks difficulty
    */
   public async $getBlocksDifficulty(): Promise<object[]> {
     try {
-      const [rows]: any[] = await DB.query(`SELECT UNIX_TIMESTAMP(blockTimestamp) as time, height, difficulty, bits FROM blocks ORDER BY height ASC`);
+      const [rows]: any[] = await DB.query(`SELECT UNIX_TIMESTAMP(blockTimestamp) as time, height, difficulty, bits FROM blocks WHERE stale = 0 ORDER BY height ASC`);
       return rows;
     } catch (e) {
       logger.err('Cannot get blocks difficulty list from the db. Reason: ' + (e instanceof Error ? e.message : e));
@@ -573,7 +604,7 @@ class BlocksRepository {
     try {
       // Get first block at or after the given timestamp
       const query = `SELECT height, hash, blockTimestamp as timestamp FROM blocks
-        WHERE blockTimestamp <= FROM_UNIXTIME(?)
+        WHERE blockTimestamp <= FROM_UNIXTIME(?) AND stale = 0
         ORDER BY blockTimestamp DESC
         LIMIT 1`;
       const params = [timestamp];
@@ -602,6 +633,7 @@ class BlocksRepository {
         SELECT MIN(height) as startBlock, MAX(height) as endBlock, SUM(reward) as totalReward, SUM(fees) as totalFee, SUM(tx_count) as totalTx
         FROM
           (SELECT height, reward, fees, tx_count FROM blocks
+          WHERE stale = 0
           ORDER by height DESC
           LIMIT ?) as sub`;
 
@@ -686,12 +718,13 @@ class BlocksRepository {
         FROM blocks
         JOIN blocks_prices on blocks_prices.height = blocks.height
         JOIN prices on prices.id = blocks_prices.price_id
+        WHERE stale = 0
       `;
 
       if (interval !== null) {
-        query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+        query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
       } else if (timespan) {
-        query += ` WHERE blockTimestamp BETWEEN FROM_UNIXTIME(${timespan.from}) AND FROM_UNIXTIME(${timespan.to})`;
+        query += ` AND blockTimestamp BETWEEN FROM_UNIXTIME(${timespan.from}) AND FROM_UNIXTIME(${timespan.to})`;
       }
 
       query += ` GROUP BY UNIX_TIMESTAMP(blockTimestamp) DIV ${div}`;
@@ -717,10 +750,11 @@ class BlocksRepository {
         FROM blocks
         JOIN blocks_prices on blocks_prices.height = blocks.height
         JOIN prices on prices.id = blocks_prices.price_id
+        WHERE stale = 0
       `;
 
       if (interval !== null) {
-        query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+        query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
       }
 
       query += ` GROUP BY UNIX_TIMESTAMP(blockTimestamp) DIV ${div}`;
@@ -748,10 +782,11 @@ class BlocksRepository {
         CAST(AVG(JSON_EXTRACT(fee_span, '$[4]')) as INT) as avgFee_75,
         CAST(AVG(JSON_EXTRACT(fee_span, '$[5]')) as INT) as avgFee_90,
         CAST(AVG(JSON_EXTRACT(fee_span, '$[6]')) as INT) as avgFee_100
-      FROM blocks`;
+      FROM blocks
+      WHERE stale = 0`;
 
       if (interval !== null) {
-        query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+        query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
       }
 
       query += ` GROUP BY UNIX_TIMESTAMP(blockTimestamp) DIV ${div}`;
@@ -773,10 +808,11 @@ class BlocksRepository {
         CAST(AVG(height) as INT) as avgHeight,
         CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
         CAST(AVG(size) as INT) as avgSize
-      FROM blocks`;
+      FROM blocks
+      WHERE stale = 0`;
 
       if (interval !== null) {
-        query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+        query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
       }
 
       query += ` GROUP BY UNIX_TIMESTAMP(blockTimestamp) DIV ${div}`;
@@ -798,10 +834,11 @@ class BlocksRepository {
         CAST(AVG(height) as INT) as avgHeight,
         CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
         CAST(AVG(weight) as INT) as avgWeight
-      FROM blocks`;
+      FROM blocks
+      WHERE stale = 0`;
 
       if (interval !== null) {
-        query += ` WHERE blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+        query += ` AND blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
       }
 
       query += ` GROUP BY UNIX_TIMESTAMP(blockTimestamp) DIV ${div}`;
@@ -816,11 +853,12 @@ class BlocksRepository {
 
   /**
    * Get a list of blocks that have been indexed
+   * (includes stale blocks)
    */
-  public async $getIndexedBlocks(): Promise<{ height: number, hash: string }[]> {
+  public async $getIndexedBlocks(): Promise<{ height: number, hash: string, stale: boolean }[]> {
     try {
-      const [rows] = await DB.query(`SELECT height, hash FROM blocks ORDER BY height DESC`) as RowDataPacket[][];
-      return rows as { height: number, hash: string }[];
+      const [rows] = await DB.query(`SELECT height, hash, stale FROM blocks ORDER BY height DESC`) as RowDataPacket[][];
+      return rows as { height: number, hash: string, stale: boolean }[];
     } catch (e) {
       logger.err('Cannot generate block size and weight history. Reason: ' + (e instanceof Error ? e.message : e));
       throw e;
@@ -865,7 +903,7 @@ class BlocksRepository {
    */
   public async $getOldestConsecutiveBlock(): Promise<any> {
     try {
-      const [rows]: any = await DB.query(`SELECT height, UNIX_TIMESTAMP(blockTimestamp) as timestamp, difficulty, bits FROM blocks ORDER BY height DESC`);
+      const [rows]: any = await DB.query(`SELECT height, UNIX_TIMESTAMP(blockTimestamp) as timestamp, difficulty, bits FROM blocks WHERE stale = 0 ORDER BY height DESC`);
       for (let i = 0; i < rows.length - 1; ++i) {
         if (rows[i].height - rows[i + 1].height > 1) {
           return rows[i];
@@ -929,7 +967,7 @@ class BlocksRepository {
         SELECT height, hash
         FROM blocks
         WHERE height >= ${minHeight} AND height <= ${maxHeight} AND
-          (utxoset_size IS NULL OR total_input_amt IS NULL)
+          (utxoset_size IS NULL OR total_input_amt IS NULL) AND stale = 0
       `);
       return blocks;
     } catch (e) {
@@ -940,6 +978,7 @@ class BlocksRepository {
 
   /**
    * Get all indexed blocks with missing coinbase addresses
+   * (includes stale blocks)
    */
   public async $getBlocksWithoutCoinbaseAddresses(): Promise<any> {
     try {
@@ -1047,6 +1086,34 @@ class BlocksRepository {
       );
     } catch (e) {
       logger.err(`Cannot update block first seen time. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
+   * Change which block at a height belongs to the canonical chain
+   * 
+   * @param hash
+   * @param height
+   */
+  public async $setCanonicalBlockAtHeight(hash: string | null, height: number): Promise<void> {
+    try {
+      // do this first, so that we fail if the block hasn't actually been indexed yet
+      if (hash) {
+        await DB.query(`
+          UPDATE blocks SET stale = 0
+          WHERE hash = ?`,
+          [hash]
+        );
+      }
+      // all other blocks at this height must be stale
+      await DB.query(`
+        UPDATE blocks SET stale = 1
+        WHERE height = ? AND hash != ?`,
+        [height, hash ?? '']
+      );
+    } catch (e) {
+      logger.err(`Cannot set canonical block at height. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1,4 +1,4 @@
-import bitcoinApi from '../api/bitcoin/bitcoin-api-factory';
+import bitcoinApi, { bitcoinCoreApi } from '../api/bitcoin/bitcoin-api-factory';
 import { BlockExtended, BlockExtension, BlockPrice, EffectiveFeeStats } from '../mempool.interfaces';
 import DB from '../database';
 import logger from '../logger';
@@ -1201,11 +1201,10 @@ class BlocksRepository {
     {
       extras.feePercentiles = await BlocksSummariesRepository.$getFeePercentilesByBlockId(dbBlk.id);
       if (extras.feePercentiles === null) {
-
         let summary;
         let summaryVersion = 0;
         if (config.MEMPOOL.BACKEND === 'esplora') {
-          const txs = (await bitcoinApi.$getTxsForBlock(dbBlk.id)).map(tx => transactionUtils.extendTransaction(tx));
+          const txs = (await bitcoinApi.$getTxsForBlock(dbBlk.id, dbBlk.stale)).map(tx => transactionUtils.extendTransaction(tx));
           summary = blocks.summarizeBlockTransactions(dbBlk.id, dbBlk.height, txs);
           summaryVersion = 1;
         } else {

--- a/backend/src/repositories/PoolsRepository.ts
+++ b/backend/src/repositories/PoolsRepository.ts
@@ -45,10 +45,11 @@ class PoolsRepository {
       FROM blocks
       JOIN pools on pools.id = pool_id
       LEFT JOIN blocks_audits ON blocks_audits.height = blocks.height
+      WHERE blocks.stale = 0
     `;
 
     if (interval) {
-      query += ` WHERE blocks.blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
+      query += ` AND blocks.blockTimestamp BETWEEN DATE_SUB(NOW(), INTERVAL ${interval}) AND NOW()`;
     }
 
     query += ` GROUP BY pool_id
@@ -70,6 +71,7 @@ class PoolsRepository {
     const query = `SELECT COUNT(height) as blockCount, pools.id as poolId, pools.name as poolName
       FROM pools
       LEFT JOIN blocks on pools.id = blocks.pool_id AND blocks.blockTimestamp BETWEEN FROM_UNIXTIME(?) AND FROM_UNIXTIME(?)
+      WHERE blocks.stale = 0
       GROUP BY pools.id`;
 
     try {

--- a/frontend/src/app/components/block-overview-graph/tx-view.ts
+++ b/frontend/src/app/components/block-overview-graph/tx-view.ts
@@ -33,8 +33,8 @@ export default class TxView implements TransactionStripped {
   flags: number;
   bigintFlags?: bigint | null = 0b00000100_00000000_00000000_00000000n;
   time?: number;
-  status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'added_prioritized' | 'prioritized' | 'added_deprioritized' | 'deprioritized' | 'censored' | 'selected' | 'rbf' | 'accelerated';
-  context?: 'projected' | 'actual';
+  status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'added_prioritized' | 'prioritized' | 'added_deprioritized' | 'deprioritized' | 'censored' | 'selected' | 'rbf' | 'accelerated' | 'matched' | 'unmatched';
+  context?: 'projected' | 'actual' | 'stale' | 'canonical';
   scene?: BlockScene;
 
   initialised: boolean;

--- a/frontend/src/app/components/block-overview-graph/utils.ts
+++ b/frontend/src/app/components/block-overview-graph/utils.ts
@@ -171,6 +171,12 @@ export function defaultColorFunction(
       } else {
         return levelColor;
       }
+    case 'unmatched':
+      if (tx.context === 'stale') {
+        return auditColors.censored;
+      } else {
+        return auditColors.added;
+      }
     default:
       if (tx.acc) {
         return auditColors.accelerated;

--- a/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
+++ b/frontend/src/app/components/block-overview-tooltip/block-overview-tooltip.component.html
@@ -87,6 +87,8 @@
             <span *ngSwitchCase="'selected'" class="badge badge-warning" i18n="transaction.audit.marginal">Marginal fee rate</span>
             <span *ngSwitchCase="'rbf'" class="badge badge-warning" i18n="tx-features.tag.conflict|Conflict">Conflict</span>
             <span *ngSwitchCase="'accelerated'" class="badge badge-accelerated" i18n="transaction.audit.accelerated">Accelerated</span>
+            <span *ngSwitchCase="'matched'" class="badge badge-success" i18n="transaction.audit.match">Match</span>
+            <span *ngSwitchCase="'unmatched'" class="badge badge-warning" i18n="transaction.audit.no-match">No Match</span>
           </ng-container>
         </td>
       </tr>

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -6,8 +6,12 @@
       <app-truncate [text]="block.canonical" [lastChars]="12" [link]="['/block/' | relativeUrl, block.canonical]" [maxWidth]="480"></app-truncate>
     </div>
     <h1>
-      <ng-container *ngIf="blockHeight == null || blockHeight > 0; else genesis" i18n="shared.block-title">Block</ng-container>
-      <ng-template #genesis i18n="@@2303359202781425764">Genesis</ng-template>
+      @if (!block?.stale) {
+        <ng-container *ngIf="blockHeight == null || blockHeight > 0; else genesis" i18n="shared.block-title">Block</ng-container>
+        <ng-template #genesis i18n="@@2303359202781425764">Genesis</ng-template>
+      } @else {
+        <ng-container i18n="shared.stale-block-title">Stale Block</ng-container>
+      }
       <span class="next-previous-blocks">
         <a *ngIf="showNextBlocklink" class="nav-arrow next" [routerLink]="['/block/' | relativeUrl, nextBlockHeight]" (click)="navigateToNextBlock()" i18n-ngbTooltip="Next Block" ngbTooltip="Next Block" placement="bottom">
           <fa-icon [icon]="['fas', 'angle-left']" [fixedWidth]="true"></fa-icon>
@@ -92,21 +96,21 @@
               <tr>
                 <td colspan="2"><span class="skeleton-loader"></span></td>
               </tr>
-              <tr *ngIf="showAudit">
+              <tr *ngIf="showComparison">
                 <td colspan="2"><span class="skeleton-loader"></span></td>
               </tr>
             </ng-template>
-            <ng-container *ngIf="isMobile || (webGlEnabled && !showAudit); then restOfTable;"></ng-container>
+            <ng-container *ngIf="isMobile || (webGlEnabled && !showComparison); then restOfTable;"></ng-container>
           </tbody>
         </table>
       </div>
-      <div class="col-sm" [class.graph-col]="webGlEnabled && !showAudit">
-        <table class="table table-borderless table-striped" *ngIf="!isMobile && !(webGlEnabled && !showAudit)">
+      <div class="col-sm" [class.graph-col]="webGlEnabled && !showComparison">
+        <table class="table table-borderless table-striped" *ngIf="!isMobile && !(webGlEnabled && !showComparison)">
           <tbody>
             <ng-container *ngTemplateOutlet="restOfTable"></ng-container>
           </tbody>
         </table>
-        <div class="col-sm chart-container" *ngIf="webGlEnabled && !showAudit">
+        <div class="col-sm chart-container" *ngIf="webGlEnabled && !showComparison">
           <app-block-overview-graph
             #blockGraphActual
             [isLoading]="!stateService.isBrowser || isLoadingOverview"
@@ -220,47 +224,89 @@
     </ng-template>
   </ng-template>
 
-  <ng-container *ngIf="showAudit">
+  <ng-container *ngIf="showComparison">
     <span id="overview"></span>
     <br>
   </ng-container>
 
   <!-- VISUALIZATIONS -->
-  <div class="box" *ngIf="!error && webGlEnabled && showAudit">
-    <div class="nav nav-tabs" *ngIf="isMobile && showAudit">
-      <a class="nav-link" [class.active]="mode === 'projected'"
-        fragment="projected" (click)="changeMode('projected')"><ng-container i18n="block.expected">Expected</ng-container></a>
-      <a class="nav-link" [class.active]="mode === 'actual'" i18n="block.actual"
-        fragment="actual" (click)="changeMode('actual')">Actual</a>
-    </div>
+  <div class="box" *ngIf="!error && webGlEnabled && showComparison">
+    @if (block?.stale) {
+      <div class="nav nav-tabs" *ngIf="isMobile">
+        <a class="nav-link" [class.active]="mode === 'stale'"
+          fragment="stale" (click)="changeMode('stale')"><ng-container i18n="block.stale">Stale</ng-container></a>
+        <a class="nav-link" [class.active]="mode === 'actual'" i18n="block.actual"
+          fragment="actual" (click)="changeMode('actual')">Winning</a>
+      </div>
+    } @else {
+      <div class="nav nav-tabs" *ngIf="isMobile && showAudit">
+        <a class="nav-link" [class.active]="mode === 'projected'"
+          fragment="projected" (click)="changeMode('projected')"><ng-container i18n="block.expected">Expected</ng-container></a>
+        <a class="nav-link" [class.active]="mode === 'actual'" i18n="block.actual"
+          fragment="actual" (click)="changeMode('actual')">Actual</a>
+      </div>
+    }
     <div class="row">
       <div class="col-sm audit-col" [class.mobile]="isMobile">
-        <h3 class="block-subtitle" *ngIf="!isMobile"><ng-container i18n="block.expected-block">Expected Block</ng-container></h3>
+        @if (block?.stale && !showAudit) {
+          <h3 class="block-subtitle" *ngIf="!isMobile">
+            <ng-container i18n="block.stale-block">Stale Block</ng-container>
+            @if (block?.extras?.pool) {
+              <img class="pool-logo large" [src]="'/resources/mining-pools/' + block?.extras?.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + block?.extras?.pool.name + ' mining pool'">
+              <span class="pool-name">{{ block?.extras?.pool.name }}</span>
+            }
+          </h3>
+        } @else {
+          <h3 class="block-subtitle" *ngIf="!isMobile"><ng-container i18n="block.expected-block">Expected Block</ng-container></h3>
+        }
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphProjected [isLoading]="!stateService.isBrowser || isLoadingOverview" [resolution]="86"
-            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" [auditHighlighting]="showAudit"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit"
+            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" [auditHighlighting]="showComparison"
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="!isMobile && !showAudit && !block?.stale"
             [showFilters]="true" [excludeFilters]="['replacement']" [relativeTime]="block?.timestamp"></app-block-overview-graph>
           <ng-container *ngIf="!isMobile || mode !== 'actual'; else emptyBlockInfo"></ng-container>
         </div>
         <ng-container *ngIf="network !== 'liquid'">
           <ng-template [ngIf]="!isLoadingOverview" [ngIfElse]="loadingDetailsSkeletons">
-            <ng-container *ngTemplateOutlet="isMobile && mode === 'actual' ? actualDetails : expectedDetails"></ng-container>
+            @if (block?.stale && !showAudit) {
+              <ng-container *ngTemplateOutlet="isMobile && mode === 'actual' ? canonicalDetails : staleDetails"></ng-container>
+            } @else {
+              <ng-container *ngTemplateOutlet="isMobile && mode === 'actual' ? actualDetails : expectedDetails"></ng-container>
+            }
           </ng-template>
         </ng-container>
       </div>
       <div class="col-sm audit-col" *ngIf="!isMobile">
-        <h3 class="block-subtitle actual" *ngIf="!isMobile"><ng-container i18n="block.actual-block">Actual Block</ng-container><a class="info-link" [routerLink]="['/docs/faq' | relativeUrl ]" fragment="how-do-block-audits-work"><fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></a></h3>
+        <h3 class="block-subtitle actual" *ngIf="!isMobile">
+          @if (block?.stale) {
+            @if (showAudit) {
+              <ng-container i18n="block.winning-block">Stale Block</ng-container>
+            } @else {
+              <ng-container i18n="block.stale-block">Winning Block</ng-container>
+              @if (canonicalBlock?.extras?.pool) {
+                <img class="pool-logo large" [src]="'/resources/mining-pools/' + canonicalBlock?.extras?.pool.slug + '.svg'" onError="this.src = '/resources/mining-pools/default.svg'" [alt]="'Logo of ' + canonicalBlock?.extras?.pool.name + ' mining pool'">
+                <span class="pool-name">{{ canonicalBlock?.extras?.pool.name }}</span>
+              }
+            }
+          } @else {
+            <ng-container i18n="block.actual-block">Actual Block</ng-container>
+            <a class="info-link" [routerLink]="['/docs/faq' | relativeUrl ]" fragment="how-do-block-audits-work"><fa-icon [icon]="['fas', 'info-circle']" [fixedWidth]="true"></fa-icon></a>
+          }
+        </h3>
         <div class="block-graph-wrapper">
           <app-block-overview-graph #blockGraphActual [isLoading]="!stateService.isBrowser || isLoadingOverview" [resolution]="86"
-            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"  [auditHighlighting]="showAudit"
-            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit"
+            [blockLimit]="stateService.blockVSize" [orientation]="'top'" [flip]="false" [mirrorTxid]="hoverTx" mode="mined"  [auditHighlighting]="showComparison"
+            (txClickEvent)="onTxClick($event)" (txHoverEvent)="onTxHover($event)" [unavailable]="isMobile && !showAudit && !block?.stale"
             [showFilters]="true" [excludeFilters]="['replacement']" [relativeTime]="block?.timestamp"></app-block-overview-graph>
           <ng-container *ngTemplateOutlet="emptyBlockInfo"></ng-container>
         </div>
         <ng-container *ngIf="network !== 'liquid'">
           <ng-template [ngIf]="!isLoadingOverview" [ngIfElse]="loadingDetailsSkeletons">
-            <ng-container *ngTemplateOutlet="actualDetails"></ng-container>
+            @if (block?.stale && !showAudit) {
+              <ng-container *ngTemplateOutlet="canonicalDetails"></ng-container>
+            } @else {
+              <ng-container *ngTemplateOutlet="actualDetails"></ng-container>
+            }
           </ng-template>
         </ng-container>
       </div>
@@ -333,7 +379,9 @@
     </div>
 
     @defer (on viewport) {
+      @if (!block?.stale) {
       <app-block-transactions [paginationMaxSize]="paginationMaxSize" [block$]="block$" [txCount]="block.tx_count" [timestamp]="block.timestamp" [blockHash]="blockHash" [previousBlockHash]="block.previousblockhash" (blockReward)="updateBlockReward($event)"></app-block-transactions>
+      }
     } @placeholder {
       <div>
         <div class="block-tx-title">
@@ -440,6 +488,61 @@
           {{ block.tx_count }}
           <span *ngIf="blockAudit.txDelta" class="difference" [class.positive]="blockAudit.txDelta <= 0" [class.negative]="blockAudit.txDelta > 0">
             {{ blockAudit.txDelta < 0 ? '+' : '' }}{{ (-blockAudit.txDelta * 100) | amountShortener: 2 }}%
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</ng-template>
+
+<ng-template #staleDetails>
+  <table *ngIf="block && staleStats" class="table table-borderless table-striped audit-details-table">
+    <tbody>
+      <tr>
+        <td i18n="block.total-fees|Total fees in a block">Total fees</td>
+        <td>
+          <app-amount [satoshis]="staleStats.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
+        </td>
+      </tr>
+      <tr>
+        <td i18n="block.weight">Weight</td>
+        <td [innerHTML]="'&lrm;' + (staleStats.totalWeight | wuBytes: 2)"></td>
+      </tr>
+      <tr>
+        <td i18n="mempool-block.transactions">Transactions</td>
+        <td>{{ staleStats.txCount || 0 }}</td>
+      </tr>
+    </tbody>
+  </table>
+</ng-template>
+
+<ng-template #canonicalDetails>
+  <table *ngIf="block && canonicalTransactions && canonicalStats" class="table table-borderless table-striped audit-details-table">
+    <tbody>
+      <tr>
+        <td i18n="block.total-fees|Total fees in a block">Total fees</td>
+        <td class="text-wrap">
+          <app-amount [satoshis]="block.extras.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
+          <span *ngIf="canonicalStats.feeDelta" class="difference" [class.positive]="canonicalStats.feeDelta > 0" [class.negative]="canonicalStats.feeDelta <= 0">
+            {{ canonicalStats.feeDelta > 0 ? '+' : '' }}{{ (canonicalStats.feeDelta * 100) | amountShortener: 2 }}%
+          </span>
+        </td>
+      </tr>
+      <tr>
+        <td i18n="block.weight">Weight</td>
+        <td [innerHTML]>
+          <span [innerHTML]="'&lrm;' + (canonicalStats.totalWeight | wuBytes: 2)"></span>
+          <span *ngIf="canonicalStats.weightDelta" class="difference" [class.positive]="canonicalStats.weightDelta > 0" [class.negative]="canonicalStats.weightDelta <= 0">
+            {{ canonicalStats.weightDelta > 0 ? '+' : '' }}{{ (canonicalStats.weightDelta * 100) | amountShortener: 2 }}%
+          </span>
+        </td>
+      </tr>
+      <tr>
+        <td i18n="mempool-block.transactions">Transactions</td>
+        <td>
+          {{ canonicalStats.txCount || 0 }}
+          <span *ngIf="canonicalStats.txDelta" class="difference" [class.positive]="canonicalStats.txDelta > 0" [class.negative]="canonicalStats.txDelta <= 0">
+            {{ canonicalStats.txDelta > 0 ? '+' : '' }}{{ (canonicalStats.txDelta * 100) | amountShortener: 2 }}%
           </span>
         </td>
       </tr>

--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -92,6 +92,12 @@ h1 {
   position: relative;
   top: -1px;
   margin-right: 2px;
+
+  &.large {
+    width: 30px;
+    height: 30px;
+    margin: 0 0.3em;
+  }
 }
 
 .row {

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -244,8 +244,8 @@ export interface TransactionStripped {
   acc?: boolean;
   flags?: number | null;
   time?: number;
-  status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'added_prioritized' | 'prioritized' | 'added_deprioritized' | 'deprioritized' | 'censored' | 'selected' | 'rbf' | 'accelerated';
-  context?: 'projected' | 'actual';
+  status?: 'found' | 'missing' | 'sigop' | 'fresh' | 'freshcpfp' | 'added' | 'added_prioritized' | 'prioritized' | 'added_deprioritized' | 'deprioritized' | 'censored' | 'selected' | 'rbf' | 'accelerated' | 'matched' | 'unmatched';
+  context?: 'projected' | 'actual' | 'stale' | 'canonical';
 }
 
 export interface RbfTransaction extends TransactionStripped {


### PR DESCRIPTION
_(builds on #6030)_

This PR extends #6030 to add a feature to the `/block` page to visualize the differences between a stale block and the winning canonical block:

<img width="2400" height="3268" alt="localhost_4200_block_000000000000000000000cdf5d7f499305261f6fadab837f94a3e5acb28795b8 (2)" src="https://github.com/user-attachments/assets/d6e3fd6d-a46e-4f98-961a-dc9206ff6734" />


If an audit is available for the stale block, the audit toggle still works as usual, with some minor UI changes to make it clear the block is stale (although for stale blocks, the page defaults to the new comparison view):

<img width="2400" height="3268" alt="localhost_4200_block_000000000000000000000cdf5d7f499305261f6fadab837f94a3e5acb28795b8 (1)" src="https://github.com/user-attachments/assets/c184ecdf-48ba-4762-bdfb-e2dbce0ac940" />
