### PR TITLE
display stales in blockchain bar

### DIFF
--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.html
@@ -17,9 +17,22 @@
         <a draggable="false" [routerLink]="[getHref(i, block) | relativeUrl]" [state]="{ data: { block: block } }"
           class="blockLink" [ngClass]="{'disabled': (this.stateService.blockScrolling$ | async)}">&nbsp;</a>
         <div *ngIf="!minimal" [attr.data-cy]="'bitcoin-block-' + i + '-height'" class="block-height">
-          <a [routerLink]="[getHref(i, block) | relativeUrl]" [state]="{ data: { block: block } }">{{ block.height
+          <a [routerLink]="[getHref(i, block) | relativeUrl]" [state]="{ data: { block: block } }" class="block-height-link">{{ block.height
             }}</a>
         </div>
+        @if (!minimal && block?.extras?.orphans?.length > 0) {
+          <ng-container *ngFor="let orphan of block.extras.orphans.slice(0, 3); let j = index">
+            <div
+              class="stale-ghost"
+              [style.--stale-index]="j"
+              [routerLink]="['/block' | relativeUrl, orphan.hash]"
+              [ngbTooltip]="'stale block ' + orphan.hash.slice(0, 4) + '...' + orphan.hash.slice(-4)"
+              [placement]="'top'"
+              [container]="'body'"
+              [autoClose]="'outside'"
+            ></div>
+          </ng-container>
+        }
         <div class="block-body">
           <ng-container *ngIf="!minimal">
             <div *ngIf="block?.extras; else emptyfees" [attr.data-cy]="'bitcoin-block-offset=' + offset + '-index-' + i + '-fees'" class="fees">

--- a/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
+++ b/frontend/src/app/components/blockchain-blocks/blockchain-blocks.component.scss
@@ -111,6 +111,11 @@
   width: 100%;
   left: -12px;
   z-index: 1;
+  pointer-events: none;
+}
+
+.block-height-link {
+  pointer-events: all;
 }
 
 .bitcoin-block::after {
@@ -137,6 +142,48 @@
   transform: skewY(50deg);
   transform-origin: top;
 }
+
+.bitcoin-block .stale-ghost {
+  position: absolute;
+  --stale-index: 0;
+  top: calc(-1 * ((var(--stale-index) * 0.144) + 0.24) * var(--block-size));
+  left: calc(-1 * ((var(--stale-index) * 0.12) + 0.20) * var(--block-size));
+  width: var(--block-size);
+  height: var(--block-size);
+  z-index: calc(-1 * (var(--stale-index) + 1));
+  opacity: 0.5;
+  cursor: pointer;
+}
+
+.bitcoin-block .stale-ghost::after {
+  content: '';
+  width: var(--block-size);
+  height: calc(0.096 * var(--block-size));
+  position:absolute;
+  top: calc(-0.096 * var(--block-size));
+  left: calc(-0.08 * var(--block-size));
+  background-color: #232838;
+  transform:skew(40deg);
+  transform-origin:top;
+}
+
+.bitcoin-block .stale-ghost::before {
+  content: '';
+  width: calc(0.08 * var(--block-size));
+  height: var(--block-size);
+  position: absolute;
+  top: calc(-0.048 * var(--block-size));
+  left: calc(-0.08 * var(--block-size));
+  background-color: #191c27;
+
+  transform: skewY(50deg);
+  transform-origin: top;
+}
+
+.bitcoin-block .stale-ghost:hover {
+  opacity: 1;
+}
+
 
 .bitcoin-block.placeholder-block::after {
   content: none;


### PR DESCRIPTION
This PR extends the blockchain bar to display & link to stale blocks, visualized as additional subtle "ghost" blocks extending behind the corresponding block height:

https://github.com/user-attachments/assets/05581e40-c20f-4d0e-b5d6-c98ea4261dc2

If there are many stale blocks at the same height (e.g. on testnet4), only the first three will be displayed.

Lists of stale blocks at each height are already included in `BlockExtended` blocks served via the websocket and backend APIs, so this is only a frontend change.
