### PR TITLE
address poisoning detection fixes

### DIFF
--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -280,12 +280,18 @@ function fuzzyPrefixMatch(a: string, b: string, rtl: boolean = false): { score: 
     b = b.split('').reverse().join('');
   }
 
+  let discounted = false;
   while (ai < a.length && bi < b.length && !done) {
     if (a[ai] === b[bi]) {
       // matching characters
       prefixA += a[ai];
       prefixB += b[bi];
-      score++;
+      if (discounted) {
+        score += 0.5;
+      } else {
+        score ++;
+      }
+      discounted = false;
       ai++;
       bi++;
     } else if (!gap) {
@@ -312,6 +318,7 @@ function fuzzyPrefixMatch(a: string, b: string, rtl: boolean = false): { score: 
         bi++;
       }
       gap = true;
+      discounted = true;
     } else {
       done = true;
     }

--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -264,7 +264,7 @@ export type AddressSimilarityResult =
   | { status: 'incomparable' }
   | AddressSimilarity;
 
-export const ADDRESS_SIMILARITY_THRESHOLD = 10_000_000; // 1 false positive per ~10 million comparisons
+export const ADDRESS_SIMILARITY_THRESHOLD = 1_000_000; // 1 false positive per ~1 million comparisons
 
 function fuzzyPrefixMatch(a: string, b: string, rtl: boolean = false): { score: number, matchA: string, matchB: string } {
   let score = 0;

--- a/frontend/src/app/shared/address-utils.ts
+++ b/frontend/src/app/shared/address-utils.ts
@@ -347,7 +347,7 @@ export function compareAddressInfo(a: AddressTypeInfo, b: AddressTypeInfo): Addr
   const left = fuzzyPrefixMatch(a.address, b.address);
   const right = fuzzyPrefixMatch(a.address, b.address, true);
   // depending on address type, some number of matching prefix characters are guaranteed
-  const prefixScore = isBase58 ? 1 : ADDRESS_PREFIXES[a.network || 'mainnet'].bech32.length;
+  const prefixScore = isBase58 ? 1 : (ADDRESS_PREFIXES[a.network || 'mainnet'].bech32.length + 1);
 
   // add the two scores together
   const totalScore = left.score + right.score - prefixScore;


### PR DESCRIPTION
This PR adjusts the address poisoning similarity detection heuristics to improve the false positive & false negative rates:
 - exclude the witness version character from bech32(m) address prefix matches (which was artificially inflating the similarity score of bech32(m) addresses)
 - dynamically adjust the score threshold based on the number of comparisons to account for the birthday problem effect, so that each transaction has a similar chance of producing a false positive result.
 - slightly discount the contribution of imperfectly matching prefixes/postfixes to the similarity score (so that e.g. `bc1qxxyx... <-> bc1qxxzx...` is considered less similar than `bc1qxxx... <-> bc1qxxx...`)
 - change the similarity threshold from 1-in-10-million *comparisons* to a 1-in-1-million *transactions* random false positive rate.
 
---
 
Test transactions:
| | Type | Before | After |
|-|-|-|-|
| [tx](https://mempool.space/tx/26d146d63a834f3108f52b6fed1090a8adc84c152465494e9ed13736ecc5c6d0) | not very similar bech32(m) addresses | false positive | no warning |
| [tx](https://mempool.space/tx/777b7c7bae8489668244ef20d9842c449c8b44f5f5e89748cbd2c132046dc74a) | many alphabetically sorted outputs | many false positives | no warning |
| [tx](https://mempool.space/tx/036641c1461928126815b001b536c1cb8fa702a1156e159295ff420355f72e8b) | large batch withdrawal | false positive | no warning |
| [tx](https://mempool.space/tx/eb692afae43f8246f1b60657271d37e4a4ab183ae542aa7452fa49b2359cf839) | actual address poisoning attack | warning displayed | warning displayed |
| all spends of outputs created in [tx](https://mempool.space/tx/7e9fc6393f24e6d574bfce8c19aac20c1be3c5171a818afb9701483cd3eb5c30) | actual address poisoning attacks | warning displayed for every child transaction | warning displayed for every child transaction |

---
 
The PR also fixes a bug in the similar address group construction, which prevented matching addresses from being correctly color-coded, e.g:
https://mempool.space/tx/4d2127a5c020569648912e1fc192e09822b24369b57081dd50bcb0f6ca71c159 (false positives due to vanity addresses, but this illustrates the point)

| Before | After |
|-|-|
| <img width="516" height="346" alt="Screenshot 2025-10-04 at 2 10 28 PM" src="https://github.com/user-attachments/assets/9874c9ed-644f-4d66-8ee6-f106d17a824a" /> | <img width="516" height="346" alt="Screenshot 2025-10-04 at 2 10 08 PM" src="https://github.com/user-attachments/assets/3a856424-fd88-43bb-b550-2d568c140da5" /> |
| random colors | similar addresses in matching colors |


