### PR TITLE
fix electrum /scripthash/.../utxo

### DIFF
--- a/backend/src/api/bitcoin/electrum-api.ts
+++ b/backend/src/api/bitcoin/electrum-api.ts
@@ -165,7 +165,8 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
     if (!addressInfo || !addressInfo.isvalid) {
       return [];
     }
-    return await this.$getScriptHashUtxos(addressInfo.scriptPubKey);
+    const scripthash = this.encodeScriptHash(addressInfo.scriptPubKey);
+    return this.$getScriptHashUtxos(scripthash);
   }
 
   async $getScriptHashTransactions(scripthash: string, lastSeenTxId?: string): Promise<IEsploraApi.Transaction[]> {
@@ -240,7 +241,7 @@ class BitcoindElectrsApi extends BitcoinApi implements AbstractBitcoinApi {
   }
 
   private $getScriptHashUnspent(scriptHash: string): Promise<IElectrumApi.ScriptHashUtxos[]> {
-    return this.electrumClient.blockchainScripthash_listunspent(this.encodeScriptHash(scriptHash));
+    return this.electrumClient.blockchainScripthash_listunspent(scriptHash);
   }
 
   async $getTransactionMerkleProof(txId: string): Promise<IEsploraApi.MerkleProof> {


### PR DESCRIPTION
Follow-up to #5959, fixing the `/scripthash/:scripthash/utxo` endpoint on electrum backends.

#### Testing:
Confirm that both scripthash and address `/utxo` endpoints now return non-empty results when running an electrum backend.

e.g:
/api/scripthash/3318537dfb3135df9f3d950dbdf8a7ae68dd7c7dfef61ed17963ff80f3850474/utxo
and
/api/address/bc1qjykfxt9lgkpr0chrt9ey7xj7hn77e8x4jtpeje/utxo

