### PR TITLE
Stale UX suggestions

### DIFF
--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -8,7 +8,7 @@
     <ng-container *ngIf="chainTips$ | async as chainTips">
       <div *ngFor="let chainTip of chainTips" class="chain-tip">
         <p class="info">
-          <span class="height"><a [routerLink]="['/block', chainTip.height]">{{ chainTip.height }}</a></span>
+          <span class="height"><a [routerLink]="['/block', chainTip.canonical?.id || chainTip.height]">{{ chainTip.height }}</a></span>
           <span class="badges">
             <span class="type" [ngSwitch]="chainTip.status">
               <span *ngSwitchCase="'headers-only'" class="badge badge-info" i18n="chain-tips.headers-only">Headers Only</span>


### PR DESCRIPTION
Just some suggestions. Feel free to reject.

* Block height is now a link with the same recognisable color as block heights on the blockchain
* Use "Stale" and "Winning" with colorful tags making it more clear and remove "Block" because it should be assumed below is a block

<img width="1026" height="354" alt="Screenshot 2025-10-13 at 13 20 50" src="https://github.com/user-attachments/assets/8c571597-b10f-4039-80d4-95a19ab480fe" />
