### PR TITLE
stale block UI fixes

### DIFF
--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -525,15 +525,33 @@
         <td i18n="block.total-fees|Total fees in a block">Total fees</td>
         <td>
           <app-amount [satoshis]="staleStats.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
+          @if (staleStats.feeDelta && (canonicalStats.feeDelta >= 100 || canonicalStats.feeDelta <= -100)) {
+            <span class="difference" [class.positive]="staleStats.feeDelta > 0" [class.negative]="staleStats.feeDelta <= 0">
+              {{ staleStats.feeDelta > 0 ? '+' : '' }}{{ (staleStats.feeDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
         </td>
       </tr>
       <tr>
         <td i18n="block.weight">Weight</td>
-        <td [innerHTML]="'&lrm;' + (staleStats.totalWeight | wuBytes: 2)"></td>
+        <td>
+          <span [innerHTML]="'&lrm;' + (staleStats.totalWeight | wuBytes: 2)"></span>
+          @if (staleStats.weightDelta && (canonicalStats.weightDelta >= 100 || canonicalStats.weightDelta <= -100)) {
+            <span class="difference" [class.positive]="staleStats.weightDelta > 0" [class.negative]="staleStats.weightDelta <= 0">
+              {{ staleStats.weightDelta > 0 ? '+' : '' }}{{ (staleStats.weightDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
+        </td>
       </tr>
       <tr>
         <td i18n="mempool-block.transactions">Transactions</td>
-        <td>{{ staleStats.txCount || 0 }}</td>
+        <td>{{ staleStats.txCount || 0 }}
+          @if (staleStats.txDelta && (canonicalStats.txDelta >= 100 || canonicalStats.txDelta <= -100)) {
+            <span class="difference" [class.positive]="staleStats.txDelta > 0" [class.negative]="staleStats.txDelta <= 0">
+              {{ staleStats.txDelta > 0 ? '+' : '' }}{{ (staleStats.txDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
+        </td>
       </tr>
     </tbody>
   </table>
@@ -546,27 +564,33 @@
         <td i18n="block.total-fees|Total fees in a block">Total fees</td>
         <td class="text-wrap">
           <app-amount [satoshis]="canonicalStats.totalFees" digitsInfo="1.2-3" [noFiat]="true"></app-amount>
-          <span *ngIf="canonicalStats.feeDelta" class="difference" [class.positive]="canonicalStats.feeDelta > 0" [class.negative]="canonicalStats.feeDelta <= 0">
-            {{ canonicalStats.feeDelta > 0 ? '+' : '' }}{{ (canonicalStats.feeDelta * 100) | amountShortener: 2 }}%
-          </span>
+          @if (canonicalStats.feeDelta && canonicalStats.feeDelta < 100 && canonicalStats.feeDelta > -100) {
+            <span class="difference" [class.positive]="canonicalStats.feeDelta > 0" [class.negative]="canonicalStats.feeDelta <= 0">
+              {{ canonicalStats.feeDelta > 0 ? '+' : '' }}{{ (canonicalStats.feeDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
         </td>
       </tr>
       <tr>
         <td i18n="block.weight">Weight</td>
-        <td [innerHTML]>
+        <td>
           <span [innerHTML]="'&lrm;' + (canonicalStats.totalWeight | wuBytes: 2)"></span>
-          <span *ngIf="canonicalStats.weightDelta" class="difference" [class.positive]="canonicalStats.weightDelta > 0" [class.negative]="canonicalStats.weightDelta <= 0">
-            {{ canonicalStats.weightDelta > 0 ? '+' : '' }}{{ (canonicalStats.weightDelta * 100) | amountShortener: 2 }}%
-          </span>
+          @if (canonicalStats.weightDelta && canonicalStats.weightDelta < 100 && canonicalStats.weightDelta > -100) {
+            <span class="difference" [class.positive]="canonicalStats.weightDelta > 0" [class.negative]="canonicalStats.weightDelta <= 0">
+              {{ canonicalStats.weightDelta > 0 ? '+' : '' }}{{ (canonicalStats.weightDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
         </td>
       </tr>
       <tr>
         <td i18n="mempool-block.transactions">Transactions</td>
         <td>
           {{ canonicalStats.txCount || 0 }}
-          <span *ngIf="canonicalStats.txDelta" class="difference" [class.positive]="canonicalStats.txDelta > 0" [class.negative]="canonicalStats.txDelta <= 0">
-            {{ canonicalStats.txDelta > 0 ? '+' : '' }}{{ (canonicalStats.txDelta * 100) | amountShortener: 2 }}%
-          </span>
+          @if (canonicalStats.txDelta && canonicalStats.txDelta < 100 && canonicalStats.txDelta > -100) {
+            <span class="difference" [class.positive]="canonicalStats.txDelta > 0" [class.negative]="canonicalStats.txDelta <= 0">
+              {{ canonicalStats.txDelta > 0 ? '+' : '' }}{{ (canonicalStats.txDelta * 100) | amountShortener: 2 }}%
+            </span>
+          }
         </td>
       </tr>
     </tbody>

--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -689,13 +689,13 @@ export class BlockComponent implements OnInit, OnDestroy {
     this.staleStats.totalWeight = Math.min(this.staleStats.totalWeight, 4_000_000);
     this.canonicalStats.totalWeight = Math.min(this.canonicalStats.totalWeight, 4_000_000);
 
-    this.staleStats.feeDelta = this.staleStats.totalFees > 0 ? (this.staleStats.totalFees - this.canonicalStats.totalFees) / this.staleStats.totalFees : 0;
-    this.staleStats.weightDelta = this.staleStats.totalWeight > 0 ? (this.staleStats.totalWeight - this.canonicalStats.totalWeight) / this.staleStats.totalWeight : 0;
-    this.staleStats.txDelta = this.staleStats.txCount > 0 ? (this.staleStats.txCount - this.canonicalStats.txCount) / this.staleStats.txCount : 0;
+    this.staleStats.feeDelta = this.canonicalStats.totalFees > 0 ? (this.staleStats.totalFees - this.canonicalStats.totalFees) / this.canonicalStats.totalFees : (this.canonicalStats.totalFees > 0 ? Infinity : -Infinity);
+    this.staleStats.weightDelta = this.canonicalStats.totalWeight > 0 ? (this.staleStats.totalWeight - this.canonicalStats.totalWeight) / this.canonicalStats.totalWeight : (this.canonicalStats.totalWeight > 0 ? Infinity : -Infinity);
+    this.staleStats.txDelta = this.canonicalStats.txCount > 0 ? (this.staleStats.txCount - this.canonicalStats.txCount) / this.canonicalStats.txCount : (this.canonicalStats.txCount > 0 ? Infinity : -Infinity);
 
-    this.canonicalStats.feeDelta = this.canonicalStats.totalFees > 0 ? (this.canonicalStats.totalFees - this.staleStats.totalFees) / this.canonicalStats.totalFees : 0;
-    this.canonicalStats.weightDelta = this.canonicalStats.totalWeight > 0 ? (this.canonicalStats.totalWeight - this.staleStats.totalWeight) / this.canonicalStats.totalWeight : 0;
-    this.canonicalStats.txDelta = this.canonicalStats.txCount > 0 ? (this.canonicalStats.txCount - this.staleStats.txCount) / this.canonicalStats.txCount : 0;
+    this.canonicalStats.feeDelta = this.staleStats.totalFees > 0 ? (this.canonicalStats.totalFees - this.staleStats.totalFees) / this.staleStats.totalFees : (this.staleStats.totalFees > 0 ? Infinity : -Infinity);
+    this.canonicalStats.weightDelta = this.staleStats.totalWeight > 0 ? (this.canonicalStats.totalWeight - this.staleStats.totalWeight) / this.staleStats.totalWeight : (this.staleStats.totalWeight > 0 ? Infinity : -Infinity);
+    this.canonicalStats.txDelta = this.staleStats.txCount > 0 ? (this.canonicalStats.txCount - this.staleStats.txCount) / this.staleStats.txCount : (this.staleStats.txCount > 0 ? Infinity : -Infinity);
   }
 
   setupBlockAudit(): void {


### PR DESCRIPTION
This PR fixes a few minor UI bugs in the new stale blocks comparison view:
 - Moves the "Why is this block empty" banner to the correct position when a stale block is empty.
 - Fixes the "total fees" for canonical blocks to use the correct variable
 - Mitigates an issue caused by vsize rounding in the "weight" field for both stale & canonical blocks
 - Fixes incorrect relative block total stat differences (was using the wrong denominator)
 - Makes relative total stat differences more legible (switches which side they're displayed on when the differences are very large)
    - e.g. displays -99.9% on smaller value instead of +314.15k% on the larger value
    
Before:
<img width="993" height="667" alt="Screenshot 2025-10-13 at 9 11 46 AM" src="https://github.com/user-attachments/assets/024519e2-40ee-4e1c-9573-21edb93ed733" />

After:
<img width="993" height="667" alt="Screenshot 2025-10-13 at 9 20 51 AM" src="https://github.com/user-attachments/assets/996c7e18-b402-4dd7-b7d3-0b09001921c2" />
