### PR TITLE
Don't show overpaid fee rating in sub-sat blocks

### DIFF
--- a/frontend/src/app/components/tx-fee-rating/tx-fee-rating.component.ts
+++ b/frontend/src/app/components/tx-fee-rating/tx-fee-rating.component.ts
@@ -58,8 +58,8 @@ export class TxFeeRatingComponent implements OnInit, OnChanges, OnDestroy {
     const feePervByte = this.tx.effectiveFeePerVsize || this.tx.fee / (this.tx.weight / 4);
     this.medianFeeNeeded = block?.extras?.medianFee;
 
-    // Block not filled
-    if (block.weight < this.stateService.env.BLOCK_WEIGHT_UNITS * 0.95) {
+    // Block not filled or sub-sat median fee
+    if (block.weight < this.stateService.env.BLOCK_WEIGHT_UNITS * 0.95 || this.medianFeeNeeded < 1) {
       this.medianFeeNeeded = 1;
     }
 


### PR DESCRIPTION
This PR overrides the block median fee to at least 1 sat/vB for fee rating calculation so that we don't show 'Overpaid' fee rating on sub-sat blocks.