### PR TITLE
Support utxo bubble graph on electrum backends

### DIFF
--- a/frontend/src/app/components/address/address.component.html
+++ b/frontend/src/app/components/address/address.component.html
@@ -108,7 +108,7 @@
       </div>
     </ng-container>
 
-    <ng-container *ngIf="(stateService.backend$ | async) === 'esplora' && address && utxos && utxos.length > 2">
+    <ng-container *ngIf="address && utxos && utxos.length > 2">
       <br>
       <div class="title-tx">
         <h2 class="text-left" i18n="address.unspent-outputs">Unspent Outputs</h2>

--- a/frontend/src/app/components/address/address.component.ts
+++ b/frontend/src/app/components/address/address.component.ts
@@ -221,7 +221,7 @@ export class AddressComponent implements OnInit, OnDestroy {
             address.is_pubkey
               ? this.electrsApiService.getScriptHashTransactions$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
               : this.electrsApiService.getAddressTransactions$(address.address),
-            (utxoCount > 2 && utxoCount <= 500 ? (address.is_pubkey
+            ((utxoCount > 2 && utxoCount <= 500) || this.address.electrum ? (address.is_pubkey
               ? this.electrsApiService.getScriptHashUtxos$((address.address.length === 66 ? '21' : '41') + address.address + 'ac')
               : this.electrsApiService.getAddressUtxos$(address.address)) : of(null)).pipe(
                 catchError(() => {


### PR DESCRIPTION
This PR uses the newly added `/api/address/:address/utxo` in electrum backend to display the utxo bubble graph on the address page:

<img width="700" height="644" alt="Screenshot 2025-10-14 at 12 31 07" src="https://github.com/user-attachments/assets/ab092ac7-88bd-42ac-89b6-3ea59e5316d0" />

I didn't set an upper limit on the UTXO count for fetching from the endpoint because on electrum backend we can't know the UTXO count before actually querying them, and there is no point trying to predict it based on transaction count. Also if there are too many utxos for a given address, there's a good chance that the /api/address/:address call will fail anyway on electrum backend.