### PR TITLE
hotfix difficulty adjustment bug

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -974,6 +974,7 @@ class Blocks {
         await this.updateQuarterEpochBlockTime();
       } else {
         this.currentBlockHeight++;
+        await this.updateQuarterEpochBlockTime();
         logger.debug(`New block found (#${this.currentBlockHeight})!`);
       }
 


### PR DESCRIPTION
restore missing line needed for the rolling window difficulty adjustment calculation lost during a rebase in [commit cd2119e8](https://github.com/mempool/mempool/commit/cd2119e89b2fecc6609b30cd44985ab58b4b7465#diff-dda16494bf113d0b9a4354b756c136af07538b5910a1babc41d4f3caa13c4bacL975-L1011)

without this, the "quarterEpochBlockTime" gets stuck in the past, which makes the difficulty adjustment calculation think the last 503 blocks were exceptionally slow during the first quarter of a new difficulty adjustment epoch.

(note that the quarterEpochBlockTime is set correctly *once* on startup, so the bug takes a while to manifest)

Before:
<img width="557" height="161" alt="Screenshot 2025-10-16 at 9 23 00 AM" src="https://github.com/user-attachments/assets/9a603089-797c-4820-8e2b-d4735a7df6d0" />


After:
<img width="557" height="161" alt="Screenshot 2025-10-16 at 9 23 06 AM" src="https://github.com/user-attachments/assets/7fd9c546-55ab-4e6c-af7d-94178a568784" />

