### PR TITLE
Tag only release Docker builds as latest

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -117,10 +117,10 @@ jobs:
 
   tag-latest:
     needs: build
-    if: ${{ needs.build.result == 'success' }}
+    if: ${{ needs.build.result == 'success' && !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Tag images as latest
+    name: Tag release build as latest
     strategy:
       matrix:
         service:
@@ -145,7 +145,7 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Tag multi-arch image as latest for ${{ matrix.service }}
+      - name: Tag as latest for ${{ matrix.service }}
         run: |
           docker buildx imagetools create \
             --tag ${{ secrets.DOCKER_HUB_USER }}/${{ matrix.service }}:latest \


### PR DESCRIPTION
Improve the Docker tagging workflow so that tags that don't have any dashes (i.e, v3.3.0-rc1) are not tagged as `latest`.

Dev build:
<img width="1216" height="563" alt="Screenshot 2025-10-17 at 10 28 45 PM" src="https://github.com/user-attachments/assets/6d929e73-2cee-4e28-bf06-7599ece346a5" />

Release build:

<img width="1054" height="552" alt="Screenshot 2025-10-17 at 10 28 27 PM" src="https://github.com/user-attachments/assets/8441387f-2edb-4d4c-b049-cb31179b59fb" />

Dockerhub images (backend and frontend):


<img width="379" height="756" alt="Screenshot 2025-10-17 at 10 22 05 PM" src="https://github.com/user-attachments/assets/05365eba-bd4d-41a1-a8ec-7a7aee1ff79e" />
<img width="305" height="745" alt="Screenshot 2025-10-17 at 10 21 52 PM" src="https://github.com/user-attachments/assets/ad923461-5a14-4177-b191-5dac24cd20b5" />
