### PR TITLE
Prevent accumulation of scheduled indexing runs

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -170,6 +170,9 @@ class Indexer {
       return;
     }
 
+    this.runIndexer = false;
+    this.indexerRunning = true;
+
     if (config.FIAT_PRICE.ENABLED) {
       try {
         await priceUpdater.$run();
@@ -183,9 +186,6 @@ class Indexer {
     if (blockchainInfo.blocks !== blockchainInfo.headers) {
       return;
     }
-
-    this.runIndexer = false;
-    this.indexerRunning = true;
 
     logger.debug(`Running mining indexer`);
 


### PR DESCRIPTION
I've noticed that after the backend has been running for a few weeks, the indexing task restarts immediately after it finished, instead of waiting the intended one hour:

```
Nov 9 00:36:38 [1098747] DEBUG: Running mining indexer
...
Nov 9 00:38:19 [1098747] DEBUG: Indexing completed. Next run planned at Sun, 09 Nov 2025 01:38:19 GMT
...
Nov 9 00:38:40 [1098747] DEBUG: Running mining indexer
```

It's probably because of uncleared timers accumulating over time for some reason. This PR clears any potential timer when a reindex is scheduled.