### PR TITLE
Fix bowtie tooltip output on electrum backend

### DIFF
--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -56,7 +56,7 @@
             </ng-container>
           </span>
           <span *ngSwitchCase="'output'">
-            <ng-container *ngIf="line.blockHeight && line?.spent">
+            <ng-container *ngIf="(stateService.backend$ | async) === 'esplora' && line.blockHeight && line?.spent">
               <ng-container *ngIf="line?.status?.block_height; else noBlockHeight">
                 <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: line?.status?.block_height - line.blockHeight, connector: false}"></ng-container>
               </ng-container>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.ts
@@ -54,7 +54,7 @@ export class TxBowtieGraphTooltipComponent implements OnChanges {
 
   constructor(
     private priceService: PriceService,
-    private stateService: StateService,
+    public stateService: StateService,
     private apiService: ApiService,
   ) {}
 


### PR DESCRIPTION
Electrum doesn’t expose the spending outpoint’s block height, so the bowtie tooltip shows wrong data ("spent 33 blocks later" which is just the distance to the tip):

<img width="372" height="477" alt="Screenshot 2025-11-20 at 13 58 54" src="https://github.com/user-attachments/assets/2affc198-f1f7-481b-9e9e-57da8f1f4c05" />

This PR simply hides that block-age detail on the output tooltip when electrum is used as backend.