### PR TITLE
Enable the mariadb auto upgrade process

### DIFF
--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -8,6 +8,7 @@ services:
       MYSQL_USER: "mempool_test"
       MYSQL_PASSWORD: "mempool_test"
       MYSQL_ROOT_PASSWORD: "admin"
+      MARIADB_AUTO_UPGRADE: "1"
     ports:
       - "33306:3306"
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       MYSQL_USER: "mempool"
       MYSQL_PASSWORD: "mempool"
       MYSQL_ROOT_PASSWORD: "admin"
+      MARIADB_AUTO_UPGRADE: "1"
     image: mariadb:10.5.21
     user: "1000:1000"
     restart: on-failure


### PR DESCRIPTION
Enabling auto db upgrade ahead of the mariadb version bump

https://hub.docker.com/_/mariadb#mariadb_auto_upgrade