### PR TITLE
softsimon theme primary color fix

### DIFF
--- a/frontend/src/theme-softsimon.scss
+++ b/frontend/src/theme-softsimon.scss
@@ -18,7 +18,7 @@ $gray-700: $fg;
 
 $nav-tabs-link-active-bg: $active-bg;
 
-$primary: #105fb0;
+$primary: #007cfa;
 $secondary: #2d3348;
 $tertiary: #653b9c;
 $success: #1a9436;


### PR DESCRIPTION
Correcting a bootstrap primary color in the softsimon theme that was making the toggle states difficult to interpret.

| Before | After |
|----------|----------|
|  <img width="204" height="53" alt="Screenshot 2025-12-17 at 21 50 18" src="https://github.com/user-attachments/assets/216d3c70-1c53-4280-b0b0-35144c5ea83d" /> | <img width="202" height="49" alt="Screenshot 2025-12-17 at 21 50 39" src="https://github.com/user-attachments/assets/ade66b48-3b22-485f-8b44-69e8c99a7a1a" />  |