### PR TITLE
Allow the frontend Docker container to override the proxied services URL

### DIFF
--- a/docker/frontend/entrypoint.sh
+++ b/docker/frontend/entrypoint.sh
@@ -6,8 +6,8 @@ __MEMPOOL_FRONTEND_HTTP_PORT__=${FRONTEND_HTTP_PORT:=8080}
 __PROXIED_SERVICES__=${PROXIED_SERVICES:=false}
 __PROXIED_SERVICES_HOST__=${PROXIED_SERVICES_HOST:=https://mempool.space}
 
-if [ "${PROXIED_SERVICES}" = "true" ]; then
-  sed -i "s|proxy_pass https://mempool.space;|proxy_pass ${PROXIED_SERVICES_HOST};|g" /etc/nginx/conf.d/nginx-mempool.conf
+if [ "${__PROXIED_SERVICES__}" = "true" ]; then
+  sed -i "s|proxy_pass https://mempool.space;|proxy_pass ${__PROXIED_SERVICES_HOST__};|g" /etc/nginx/conf.d/nginx-mempool.conf
 fi
 
 sed -i "s/__MEMPOOL_BACKEND_MAINNET_HTTP_HOST__/${__MEMPOOL_BACKEND_MAINNET_HTTP_HOST__}/g" /etc/nginx/conf.d/nginx-mempool.conf


### PR DESCRIPTION
Making @nymkappa's life easier. 

He was like `(╯°□°）╯︵ ┻━┻` now he'll be like `┬─┬﻿ ノ( ゜-゜ノ)`

```
  web:
    environment:
      FRONTEND_HTTP_PORT: "8080"
      BACKEND_MAINNET_HTTP_HOST: "api"
      PROXIED_SERVICES: "true"
      PROXIED_SERVICES_HOST: "http://yolo.space"
```

Will patch `/etc/nginx/conf.d/nginx-mempool.conf` with

```
	location /api/v1/services {
		proxy_pass https://yolo.space;
	}
```