### PR TITLE
[price] remove bitfinex JPY feed

### DIFF
--- a/backend/src/tasks/price-feeds/bitfinex-api.ts
+++ b/backend/src/tasks/price-feeds/bitfinex-api.ts
@@ -3,7 +3,7 @@ import priceUpdater, { PriceFeed, PriceHistory } from '../price-updater';
 
 class BitfinexApi implements PriceFeed {
   public name: string = 'Bitfinex';
-  public currencies: string[] = ['USD', 'EUR', 'GPB'];
+  public currencies: string[] = ['USD', 'EUR', 'GBP'];
 
   public url: string = 'https://api.bitfinex.com/v1/pubticker/BTC';
   public urlHist: string = 'https://api-pub.bitfinex.com/v2/candles/trade:{GRANULARITY}:tBTC{CURRENCY}/hist';


### PR DESCRIPTION
This has been bothering me for a while https://www.bitfinex.com/posts/1155

```
Jan  6 12:52:12 [23170] WARN: Could not connect to https://api.bitfinex.com/v1/pubticker/BTCJPY (Attempt 1/1). Reason: Request failed with status code 400
Jan  6 12:52:12 [23170] ERR: Could not connect to https://api.bitfinex.com/v1/pubticker/BTCJPY. All 1 attempts failed
```