### PR TITLE
freebsd version

### DIFF
--- a/backend/src/api/backend-info.ts
+++ b/backend/src/api/backend-info.ts
@@ -30,6 +30,7 @@ class BackendInfo {
       lightning: config.LIGHTNING.ENABLED,
       backend: config.MEMPOOL.BACKEND,
       coreVersion: '?',
+      osVersion: `${os.type()} ${os.release()}`,
     };
 
     this.timer = setInterval(async () => {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -30,6 +30,7 @@ interface FailoverHost {
     electrs?: string,
     ssr?: string,
     core?: string,
+    os?: string,
     lastUpdated: number,
   }
 }
@@ -323,6 +324,9 @@ class FailoverRouter {
       }
       if (response.data?.coreVersion) {
         host.hashes.core = response.data.coreVersion;
+      }
+      if (response.data?.osVersion) {
+        host.hashes.os = response.data.osVersion;
       }
     } catch (e) {
       // failed to get backend build hash - do nothing

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -505,6 +505,7 @@ export interface IBackendInfo {
   version: string;
   lightning: boolean;
   coreVersion: string;
+  osVersion: string;
   backend: 'esplora' | 'electrum' | 'none';
 }
 

--- a/frontend/src/app/components/server-health/server-health.component.html
+++ b/frontend/src/app/components/server-health/server-health.component.html
@@ -25,6 +25,7 @@
             <th class="electrs hash">Electrs</th>
             <th class="ssr hash">SSR</th>
             <th class="core">Core</th>
+            <th class="os">OS</th>
           </tr>
           <tr *ngFor="let host of hosts; let i = index; trackBy: trackByFn">
             <td class="rank">{{ i + 1 }}</td>
@@ -34,13 +35,13 @@
             <td class="rtt only-small">{{ (host.rtt / 1000) | number : '1.1-1' }} {{ host.rtt == null ? '' : 's'}} {{ !host.checked ? '⏳' : (host.unreachable ? '🔥' : '✅') }}</td>
             <td class="rtt only-large">{{ host.rtt | number : '1.0-0' }} {{ host.rtt == null ? '' : 'ms'}} {{ !host.checked ? '⏳' : (host.unreachable ? '🔥' : '✅') }}</td>
             <td class="height">{{ host.latestHeight }} {{ !host.checked ? '⏳' : (host.outOfSync ? '🚫' : (host.latestHeight && host.latestHeight < maxHeight ? '🟧' : '✅')) }}</td>
-            <ng-container *ngFor="let type of ['hybrid', 'frontend', 'backend', 'electrs', 'ssr', 'core']">
-              <td class="{{type}}" [class.hash]="type !== 'core'" [style.background-color]="colors[host.host][type]">
-                @if (type !== 'core' && host.hashes?.[type]) {
+            <ng-container *ngFor="let type of ['hybrid', 'frontend', 'backend', 'electrs', 'ssr', 'core', 'os']">
+              <td class="{{type}}" [class.hash]="type !== 'core' && type !== 'os'" [style.background-color]="colors[host.host][type]">
+                @if (type !== 'core' && type !== 'os' && host.hashes?.[type]) {
                   <a [style.color]="'white'" href="https://github.com/mempool/{{repoMap[type]}}/commit/{{ host.hashes[type] }}" target="_blank">{{ host.hashes[type].slice(0, 8) || '?' }}</a>
                 } @else if (host.hashes?.[type]) {
                   <span [style.color]="'white'" class="only-large" style="font-size: 10px;">{{ host.hashes[type] || '?' }}</span>
-                  <span [style.color]="'white'" class="only-small" style="font-size: 10px;">{{ host.hashes[type]?.slice(9) || '?' }}</span>
+                  <span [style.color]="'white'" class="only-small" style="font-size: 10px;">{{ shortenVersion(host.hashes[type]) || '?' }}</span>
                 } @else {
                   <span>?</span>
                 }

--- a/frontend/src/app/components/server-health/server-health.component.scss
+++ b/frontend/src/app/components/server-health/server-health.component.scss
@@ -13,10 +13,12 @@
     margin: auto;
     padding: 1em;
     background: var(--box-bg);
+    overflow-x: auto;
   }
 
   .status-table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
 
     td, th {
       padding: 0.25em;
@@ -45,6 +47,7 @@
       &.host {
         width: 100%;
         max-width: 0;
+        min-width: 130px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -154,6 +154,7 @@ export interface HealthCheckHost {
     hybrid?: string;
     ssr?: string;
     core?: string;
+    os?: string;
   };
 }
 


### PR DESCRIPTION
_(includes #6217)_

adds OS version to the backend-info API endpoint, gathers it in the tomahawk monitoring system, and adds it to the server health table (color-coded like the Core version column)

also makes the server health table horizontally scrollable where necessary to better fit the new columns.