### PR TITLE
PoC tool for generating transaction message commitment

### DIFF
--- a/frontend/src/app/components/taproot-address-scripts/taproot-address-scripts.component.ts
+++ b/frontend/src/app/components/taproot-address-scripts/taproot-address-scripts.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { EChartsOption } from '@app/graphs/echarts';
 import { ScriptInfo } from '@app/shared/script.utils';
-import { computeLeafHash, taggedHash, taprootAddressToOutputKey } from '@app/shared/transaction.utils';
+import { computeLeafHash, taggedHash, addressToScriptPubKey } from '@app/shared/transaction.utils';
 import { StateService } from '@app/services/state.service';
 import { AsmStylerPipe } from '@app/shared/pipes/asm-styler/asm-styler.pipe';
 import { RelativeUrlPipe } from '@app/shared/pipes/relative-url/relative-url.pipe';
@@ -117,7 +117,7 @@ export class TaprootAddressScriptsComponent implements OnChanges {
     // Expand the tree to include public key, internal key and merkle root
     const internalKeyNode = scripts[0].taprootInfo.scriptPath.internalKey;
     const merkleRootNode = treeStructure.length > 0 ? treeStructure[0].keys().next().value : leaves.keys().next().value;
-    const outputKeyNode = taprootAddressToOutputKey(this.address).outputKey;
+    const outputKeyNode = addressToScriptPubKey(this.address, this.stateService.network || '').scriptPubKey.slice(4);
     treeStructure.unshift(new Map<string, [string, string]>());
     treeStructure[0].set(outputKeyNode, [internalKeyNode, merkleRootNode]);
     this.depth++;

--- a/frontend/src/app/components/verify-address/verify-address.component.html
+++ b/frontend/src/app/components/verify-address/verify-address.component.html
@@ -1,0 +1,106 @@
+<div class="container-xl">
+  <h1 class="text-left" i18n="shared.verify-address|Verify Address Ownership">Verify Address Ownership</h1>
+
+  <div class="row">
+    <div class="col">
+      <form [formGroup]="verifyAddressForm">
+        <div class="mb-3">
+          <label for="address" class="form-label">
+            <strong i18n="shared.address|Address">Address</strong>
+            <span placement="bottom" class="badge badge-primary ml-2" *ngIf="addressType">
+              <app-address-type [address]="addressType"></app-address-type>
+            </span>
+          </label>
+          <input type="text" id="address" class="form-control" [class.is-invalid]="addressControl?.invalid && addressControl?.touched" formControlName="address" placeholder="bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l">
+          <div class="invalid-feedback" *ngIf="addressControl?.invalid && addressControl?.touched" i18n="verify-address.invalid-address|Unsupported or invalid address">Unsupported or invalid address</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="spk" class="form-label"><strong i18n="verify-address.spk|SPK">ScriptPubKey (Hex)</strong></label>
+          <input type="text" id="spk" class="form-control" [class.is-invalid]="spkControl?.invalid && spkControl?.touched" formControlName="spk" placeholder="00142b05d564e6a7a33c087f16e0f730d1440123799d">
+        </div>
+
+        <div class="mb-3">
+          <label for="message" class="form-label"><strong i18n="verify-address.message|Message">Message</strong></label>
+          <textarea id="message" class="form-control" [class.is-invalid]="messageControl?.invalid && messageControl?.touched" formControlName="message" rows="1" placeholder="Address verification for Mempool Treasury Dashboard"></textarea>
+        </div>
+
+        <div class="row mb-1">
+          <div class="col-12 col-sm-6 col-md-3 order-3 order-md-1 mt-3 mt-md-0">
+            <label for="feeRate" class="form-label"><strong i18n="verify-address.fee-rate|Fee rate input label">Fee rate (sat/vB)</strong></label>
+            <input type="number" id="feeRate" class="form-control" min="0" formControlName="feeRate" [placeholder]="priorityFeeRate || 1">
+          </div>
+          <div class="col-12 col-sm-6 col-md-3 order-1 order-md-2">
+            <label for="sequence" class="form-label"><strong i18n="verify-address.input-sequence|Input sequence input label">Input Sequence</strong></label>
+            <input type="number" id="sequence" class="form-control" min="0" max="4294967295" formControlName="sequence">
+          </div>
+          <div class="col-12 col-sm-6 col-md-3 order-2 order-md-3">
+            <label for="locktime" class="form-label"><strong i18n="verify-address.timelock|Timelock input label">Timelock</strong></label>
+            <input type="number" id="locktime" class="form-control" min="0" max="4294967295" formControlName="locktime">
+          </div>
+          <div class="col-12 col-sm-6 col-md-3 order-4 order-md-4 mt-3 mt-md-0" *ngIf="showFallbackFee">
+            <label for="fallbackFee" class="form-label"><strong i18n="verify-address.fallback-fee|Fallback fee input label">Fallback fee (sats)</strong></label>
+            <input type="number" id="fallbackFee" class="form-control" min="0" formControlName="fallbackFee" placeholder="1000">
+          </div>
+        </div>
+
+        <div class="row mb-1" *ngIf="showFallbackFee">
+          <div class="col-12 text-right">
+            <small class="form-text text-muted" i18n="verify-address.fallback-fee-help|Fallback fee helper text">Provide a fallback fee if the finalized transaction size can't be estimated reliably (hidden scripts in P2SH, P2WSH, or P2TR).</small>
+          </div>
+        </div>
+
+        <div class="mb-1 mt-3">
+          <label class="form-label">
+            <strong>UTXO</strong>
+          </label>
+          <div *ngIf="isLoadingUtxos" class="spinner-border spinner-border-sm text-light ml-2" role="status"></div>
+          <div *ngIf="utxosError" class="text-danger small">{{ utxosError }}</div>
+          <div class="row g-2 utxo-grid" *ngIf="!isLoadingUtxos && utxos.length">
+            <label class="col-12 col-sm-6 col-md-3 utxo-item" *ngFor="let utxo of utxos | slice:0:8">
+              <input class="utxo-input" type="radio" [value]="utxo.txid + ':' + utxo.vout" formControlName="utxo" (change)="selectUtxo(utxo)">
+              <span class="utxo-option">
+                <div class="utxo-amount"><strong>{{ utxo.value | number }}</strong> <span class="symbol">sats</span></div>
+                <small class="text-muted d-block">{{ utxo.txid | slice:0:8 }}...:{{ utxo.vout }}</small>
+              </span>
+            </label>
+          </div>
+          <div class="row mb-3" *ngIf="utxos.length > 8">
+            <div class="col-12 text-right"><small class="form-text text-muted">+{{ utxos.length - 8 }} more</small></div>
+          </div>
+        </div>
+
+        <div class="mb-3">
+          <button type="button" class="btn btn-primary me-2" [disabled]="!canGenerate()" (click)="generatePsbt()">
+            <span i18n="verify-address.generate-psbt">Generate PSBT</span>
+          </button>
+          <div *ngIf="isGeneratingPsbt" class="spinner-border spinner-border-sm text-light ml-2" role="status" aria-hidden="true"></div>
+        </div>
+
+        <div *ngIf="generateError" class="alert alert-danger" role="alert">{{ generateError }}</div>
+
+        <div *ngIf="generatedPsbt" class="mb-3">
+          <div class="input-group info-group">
+            <input type="text" class="form-control" style="background-color: var(--secondary)" [value]="generatedPsbt">
+            <div class="input-group-append">
+              <button class="btn btn-outline-secondary" type="button">
+                <app-clipboard [text]="generatedPsbt" [leftPadding]="false"></app-clipboard>
+              </button>
+              <span class="btn btn-outline-secondary qrSpan" (mouseover)="showQR = true" (mouseout)="showQR = false" (pointerdown)="showQR = true">
+                <fa-icon [icon]="['fas', 'qrcode']" [fixedWidth]="true" [style.font-size]="'12px'"></fa-icon>
+                <div class="qr-wrapper" [hidden]="!showQR">
+                  <app-qrcode [size]="300" [data]="generatedPsbt"></app-qrcode>
+                </div>
+              </span>
+              <button class="btn btn-primary" type="button" (click)="navigateToPreview()" i18n="shared.Preview">Preview</button>
+            </div>
+          </div>
+          <small class="form-text text-warning" i18n="verify-address.verify-transaction-warning">Double check that this transaction sends the funds back to the provided address before signing</small>
+        </div>
+        <div class="mt-4" *ngIf="generatedPsbt">
+          <div><button type="button" class="btn btn-secondary" (click)="cancel()" i18n="shared.reset">Reset</button></div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/verify-address/verify-address.component.scss
+++ b/frontend/src/app/components/verify-address/verify-address.component.scss
@@ -1,0 +1,57 @@
+.qr-wrapper {
+  position: absolute;
+  top: 30px;
+  right: 0px;
+  border: solid 10px var(--active-bg);
+  border-radius: 5px;
+  background-color: #fff;
+  padding: 10px;
+  padding-bottom: 5px;
+  display: block;
+  z-index: 99;
+}
+
+.qrSpan {
+  position: relative;
+  cursor: pointer;
+  color: #fff;
+}
+
+.utxo-grid label {
+  cursor: pointer;
+}
+
+.utxo-item {
+  position: relative;
+}
+
+.utxo-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.utxo-option {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--active-bg);
+  border-radius: 6px;
+  background-color: var(--secondary);
+  color: inherit;
+  width: 100%;
+  height: 100%;
+}
+
+.utxo-input:checked + .utxo-option {
+  border-color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 12%, var(--secondary));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 65%, transparent);
+}
+
+.utxo-amount .symbol {
+  margin-left: 4px;
+}

--- a/frontend/src/app/components/verify-address/verify-address.component.ts
+++ b/frontend/src/app/components/verify-address/verify-address.component.ts
@@ -1,0 +1,320 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Subject, firstValueFrom } from 'rxjs';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { StateService } from '@app/services/state.service';
+import { ElectrsApiService } from '@app/services/electrs-api.service';
+import { RelativeUrlPipe } from '@app/shared/pipes/relative-url/relative-url.pipe';
+import { AddressTypeInfo } from '../../shared/address-utils';
+import { addressToScriptPubKey, scriptPubKeyToAddress, createMessageSigningPsbt } from '../../shared/transaction.utils';
+import { Utxo } from '@interfaces/electrs.interface';
+import { Recommendedfees } from '@interfaces/websocket.interface';
+
+@Component({
+  selector: 'app-verify-address',
+  templateUrl: './verify-address.component.html',
+  styleUrls: ['./verify-address.component.scss'],
+  standalone: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VerifyAddressComponent implements OnInit, OnDestroy {
+  network: string = '';
+  verifyAddressForm: UntypedFormGroup;
+  addressType: AddressTypeInfo | null = null;
+  showFallbackFee = false;
+  generatedPsbt: string = '';
+  isUpdatingFields = false;
+  showQR: boolean = false;
+  utxos: Utxo[] = [];
+  isLoadingUtxos = false;
+  isGeneratingPsbt = false;
+  utxosError = '';
+  selectedUtxoKey = '';
+  priorityFeeRate = 0;
+  generateError = '';
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    public stateService: StateService,
+    private electrsApiService: ElectrsApiService,
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private relativeUrlPipe: RelativeUrlPipe,
+    private cd: ChangeDetectorRef,
+  ) {
+    this.network = this.stateService.network || '';
+
+    this.verifyAddressForm = this.formBuilder.group({
+      address: ['', [this.addressValidator.bind(this)]],
+      spk: ['', [Validators.required, this.hexValidator.bind(this)]],
+      message: ['', [Validators.required, Validators.minLength(1)]],
+      feeRate: [null, [Validators.min(0)]],
+      fallbackFee: [null, [Validators.min(0)]],
+      sequence: [0, [Validators.min(0), Validators.max(0xffffffff)]],
+      locktime: [0, [Validators.min(0), Validators.max(0xffffffff)]],
+      utxo: ['', [Validators.required]],
+    });
+
+    this.setupFieldSynchronization();
+  }
+
+  ngOnInit(): void {
+    this.stateService.networkChanged$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((network) => {
+        this.network = network;
+        this.resetUtxos();
+      });
+
+    this.stateService.recommendedFees$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((fees: Recommendedfees) => this.priorityFeeRate = fees?.fastestFee || 0);
+
+    this.addressControl?.valueChanges
+      .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(() => this.tryFetchUtxos());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  setupFieldSynchronization(): void {
+    this.addressControl?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(address => {
+        if (this.isUpdatingFields) {
+          return;
+        }
+        this.isUpdatingFields = true;
+
+        try {
+          const normalizedAddress = (address || '').trim();
+          const { scriptPubKey } = addressToScriptPubKey(normalizedAddress, this.network || '');
+          if (scriptPubKey && this.spkControl?.value !== scriptPubKey) {
+            this.spkControl?.setValue(scriptPubKey, { emitEvent: false });
+          } else if (scriptPubKey === null) {
+            this.spkControl?.setValue('', { emitEvent: false });
+          }
+        } catch (error) {
+          console.warn('Error converting address to scriptPubKey:', error);
+        } finally {
+          this.isUpdatingFields = false;
+        }
+      });
+
+    this.spkControl?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(spk => {
+        if (this.isUpdatingFields) {
+          return;
+        }
+        this.isUpdatingFields = true;
+
+        try {
+          const normalizedSpk = (spk || '').trim();
+          const { address } = scriptPubKeyToAddress(normalizedSpk, this.network || '');
+
+          if (address && this.addressControl?.value !== address) {
+            this.addressControl?.setValue(address, { emitEvent: false });
+          } else if (address === null) {
+            this.addressControl?.setValue('', { emitEvent: false });
+          }
+        } catch (error) {
+          console.warn('Error converting scriptPubKey to address:', error);
+        } finally {
+          this.isUpdatingFields = false;
+        }
+      });
+  }
+
+  addressValidator(control: any) {
+    if (!control.value) {
+      this.addressType = null;
+      this.showFallbackFee = false;
+      return null;
+    }
+
+    const value = (control.value || '').trim();
+    const addressTypeInfo = new AddressTypeInfo(this.network || '', value);
+    this.showFallbackFee = ['p2sh', 'v0_p2wsh', 'v1_p2tr'].includes(addressTypeInfo.type);
+    this.addressType = addressTypeInfo;
+    if (this.addressType.type !== 'unknown') {
+      return null;
+    }
+    this.addressType = null;
+    this.showFallbackFee = false;
+    return { invalidAddress: true };
+  }
+
+  hexValidator(control: any) {
+    if (!control.value) {
+      return { required: true };
+    }
+
+    const hexRegex = /^[0-9a-fA-F]+$/;
+    const value = control.value.trim();
+
+    if (!hexRegex.test(value) || value.length % 2 !== 0) {
+      return { invalidHex: true };
+    }
+
+    return null;
+  }
+
+  get addressControl() {
+    return this.verifyAddressForm.get('address');
+  }
+
+  get spkControl() {
+    return this.verifyAddressForm.get('spk');
+  }
+
+  get messageControl() {
+    return this.verifyAddressForm.get('message');
+  }
+
+  get feeRateControl() {
+    return this.verifyAddressForm.get('feeRate');
+  }
+
+  get fallbackFeeControl() {
+    return this.verifyAddressForm.get('fallbackFee');
+  }
+
+  get sequenceControl() {
+    return this.verifyAddressForm.get('sequence');
+  }
+
+  get locktimeControl() {
+    return this.verifyAddressForm.get('locktime');
+  }
+
+  get utxoControl() {
+    return this.verifyAddressForm.get('utxo');
+  }
+
+  private tryFetchUtxos(): void {
+    const address = this.addressControl?.value?.trim();
+    if (!address || this.addressControl?.invalid || this.spkControl?.invalid) {
+      this.resetUtxos();
+      return;
+    }
+
+    this.fetchUtxos(address);
+  }
+
+  private fetchUtxos(address: string): void {
+    this.isLoadingUtxos = true;
+    this.utxosError = '';
+    this.cd.markForCheck();
+
+    this.electrsApiService.getAddressUtxos$(address)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (utxos: Utxo[]) => {
+          this.isLoadingUtxos = false;
+          this.utxos = (utxos || []).sort((a, b) => b.value - a.value);
+          this.utxosError = this.utxos.length ? '' : 'This address has no UTXOs.';
+
+          if (this.utxos.length) {
+            this.selectUtxo(this.utxos[0]);
+          } else {
+            this.selectedUtxoKey = '';
+            this.utxoControl?.reset('');
+          }
+          this.cd.markForCheck();
+        },
+        error: (error) => {
+          console.error(error);
+          this.isLoadingUtxos = false;
+          this.utxos = [];
+          this.utxosError = 'Unable to fetch UTXOs for this address: ' + (error?.message || 'Unknown error.');
+          this.cd.markForCheck();
+        }
+      });
+  }
+
+  selectUtxo(utxo: Utxo): void {
+    const key = `${utxo.txid}:${utxo.vout}`;
+    this.selectedUtxoKey = key;
+    this.utxoControl?.setValue(key);
+    this.cd.markForCheck();
+  }
+
+  private resetUtxos(): void {
+    this.utxos = [];
+    this.utxosError = '';
+    this.selectedUtxoKey = '';
+    this.isLoadingUtxos = false;
+    this.utxoControl?.reset('');
+    this.cd.markForCheck();
+  }
+
+  private getSelectedUtxo(): Utxo | undefined {
+    const key = this.utxoControl?.value || this.selectedUtxoKey;
+    if (!key) {
+      return undefined;
+    }
+    const [txid, voutStr] = key.split(':');
+    return this.utxos.find((utxo) => utxo.txid === txid && utxo.vout === Number(voutStr));
+  }
+
+  canGenerate(): boolean {
+    return !!this.addressType
+      && !!this.getSelectedUtxo()
+      && this.spkControl?.valid
+      && this.messageControl?.valid
+      && this.utxoControl?.valid
+      && !this.isLoadingUtxos
+      && !this.isGeneratingPsbt
+  }
+
+  async generatePsbt(): Promise<void> {
+    this.generatedPsbt = '';
+    this.generateError = '';
+    this.isGeneratingPsbt = true;
+    this.cd.markForCheck();
+
+    try {
+      const result = createMessageSigningPsbt(
+        this.getSelectedUtxo(),
+        this.spkControl?.value?.trim() || '',
+        this.addressType.type,
+        this.addressControl?.value?.trim() || '',
+        this.messageControl?.value?.trim() || '',
+        this.feeRateControl?.value ?? this.priorityFeeRate ?? 1,
+        this.fallbackFeeControl?.value ?? 1000,
+        this.sequenceControl?.value ?? 0xffffffff,
+        this.locktimeControl?.value ?? 0,
+        await firstValueFrom(this.electrsApiService.getTransactionHex$(this.getSelectedUtxo().txid))
+      );
+
+      this.generatedPsbt = result;
+    } catch (error: any) {
+      console.error(error);
+      this.generateError = 'Can not build transaction' + (error?.message ? ': ' + error.message : '.');
+    } finally {
+      this.isGeneratingPsbt = false;
+      this.cd.markForCheck();
+    }
+  }
+
+  navigateToPreview(): void {
+    if (!this.generatedPsbt) {
+      return;
+    }
+    const fragment = new URLSearchParams({ offline: 'true', tx: this.generatedPsbt }).toString();
+    const previewPath = this.relativeUrlPipe.transform('/tx/preview');
+    const url = this.router.serializeUrl(this.router.createUrlTree([previewPath], { fragment: fragment }));
+    window.open(url, '_blank');
+  }
+
+  cancel(): void {
+    this.generatedPsbt = '';
+    this.generateError = '';
+  }
+}

--- a/frontend/src/app/master-page.module.ts
+++ b/frontend/src/app/master-page.module.ts
@@ -17,6 +17,7 @@ import { ServerStatusComponent } from '@components/server-health/server-status.c
 import { FaucetComponent } from '@components/faucet/faucet.component';
 import { SimpleProofWidgetComponent } from '@components/simpleproof-widget/simpleproof-widget.component';
 import { SimpleProofCuboWidgetComponent } from '@components/simpleproof-widget/simpleproof-cubo-widget.component';
+import { VerifyAddressComponent } from '@components/verify-address/verify-address.component';
 
 const browserWindow = window || {};
 // @ts-ignore
@@ -116,6 +117,10 @@ const routes: Routes = [
         path: 'tools/calculator',
         component: CalculatorComponent
       },
+      {
+        path: 'verify',
+        component: VerifyAddressComponent,
+      }
     ],
   }
 ];

--- a/frontend/src/app/services/electrs-api.service.ts
+++ b/frontend/src/app/services/electrs-api.service.ts
@@ -81,6 +81,10 @@ export class ElectrsApiService {
     return this.httpClient.get<Transaction>(this.apiBaseUrl + this.apiBasePath + '/api/tx/' + txId);
   }
 
+  getTransactionHex$(txId: string): Observable<string> {
+    return this.httpClient.get(this.apiBaseUrl + this.apiBasePath + '/api/tx/' + txId + '/hex', { responseType: 'text' });
+  }
+
   getRecentTransaction$(): Observable<Recent[]> {
     return this.httpClient.get<Recent[]>(this.apiBaseUrl + this.apiBasePath + '/api/mempool/recent');
   }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -112,6 +112,7 @@ import { PendingStatsComponent } from '@components/acceleration/pending-stats/pe
 import { AccelerationStatsComponent } from '@components/acceleration/acceleration-stats/acceleration-stats.component';
 import { AccelerationSparklesComponent } from '@components/acceleration/sparkles/acceleration-sparkles.component';
 import { OrdDataComponent } from '@components/ord-data/ord-data.component';
+import { VerifyAddressComponent } from '../components/verify-address/verify-address.component';
 
 import { BlockViewComponent } from '@components/block-view/block-view.component';
 import { EightBlocksComponent } from '@components/eight-blocks/eight-blocks.component';
@@ -256,6 +257,7 @@ import { GithubLogin } from '@components/github-login.component/github-login.com
     TwitterLogin,
     GithubLogin,
     BitcoinInvoiceComponent,
+    VerifyAddressComponent,
   ],
   imports: [
     CommonModule,
@@ -397,6 +399,7 @@ import { GithubLogin } from '@components/github-login.component/github-login.com
     GithubLogin,
     BitcoinInvoiceComponent,
     BitcoinsatoshisPipe,
+    VerifyAddressComponent,
 
     MempoolBlockOverviewComponent,
     ClockchainComponent,


### PR DESCRIPTION
This PR is a proof of concept for generating a transaction that commits a message to an OP_RETURN output. The flow is:

- navigate to https://mempool.space/verify
- enter the address to be verified; the address UTXOs are fetched and displayed
- enter the message to embed in the OP_RETURN
- optionally select: 
  - UTXO to spend
  - fee rate*
  - sequence number of the input
  - transaction lock time
- click `Generate PSBT`
- PSBT is displayed and can be copied, shown as a QR code, or previewed, then signed using an external wallet

https://github.com/user-attachments/assets/9cade27d-60f4-4aae-a170-eb57e2c0d1c5

**Note***: For script-hash or Taproot addresses, the final transaction weight depends on the signature and witness data, which cannot be determined before signing so we can't use the fee rate to compute the fee. In this case the user is prompted to specify the absolute fee directly:

<img width="939" height="432" alt="Screenshot 2026-01-16 at 17 36 14" src="https://github.com/user-attachments/assets/a0305eb4-3608-487d-b44f-c2af2f26ded1" />
