### PR TITLE
unsquish cobranded logos

### DIFF
--- a/frontend/src/app/components/master-page/master-page.component.scss
+++ b/frontend/src/app/components/master-page/master-page.component.scss
@@ -200,9 +200,9 @@ nav {
 }
 
 .subdomain_logo {
-  height: 35px;
+  max-height: 35px;
   overflow: clip;
-  max-width: 140px;
+  max-width: 100%;
   margin: auto;
   align-self: center;
   .rounded {
@@ -210,7 +210,7 @@ nav {
   }
 
   &.custom_logo {
-    height: 48px;
+    max-height: 48px;
     margin-right: 1em;
   }
  
@@ -219,7 +219,7 @@ nav {
   }
 
   &.custom_logo.mobile_logo {
-    height: 42px;
+    max-height: 42px;
   }
 }
 


### PR DESCRIPTION
before:
<img width="481" height="175" alt="Screenshot 2026-01-19 at 6 05 46 AM" src="https://github.com/user-attachments/assets/3ad3168a-e12f-4371-9cd1-79d85cf0874b" />

after:
<img width="481" height="175" alt="Screenshot 2026-01-19 at 6 05 40 AM" src="https://github.com/user-attachments/assets/d04f75b1-b0c6-4437-ba99-ab64ae62b002" />
