### PR TITLE
Ignore draft PRs for review and add issues automatically

### DIFF
--- a/.github/workflows/project-review-status.yml
+++ b/.github/workflows/project-review-status.yml
@@ -11,7 +11,7 @@ on:
     types: [opened]
 
 jobs:
-  update-project-status:
+  manage-project-board:
     runs-on: ubuntu-latest
     steps:
       - name: Update Project Board


### PR DESCRIPTION
Per discussion with @orangesurf, I suggested that draft PRs should not be moved automatically as they are not ready for review.

This PR also implements a requested improvement to add newly created issues to the board.