### PR TITLE
[liquid] use bitcoin esplora for peg parsing queries

### DIFF
--- a/backend/mempool-config.sample.json
+++ b/backend/mempool-config.sample.json
@@ -64,6 +64,9 @@
     "FALLBACK": [],
     "MAX_BEHIND_TIP": 2
   },
+  "SECOND_ESPLORA": {
+    "UNIX_SOCKET_PATH": "/tmp/esplora-bitcoin-mainnet"
+  },
   "SECOND_CORE_RPC": {
     "HOST": "127.0.0.1",
     "PORT": 8332,

--- a/backend/src/api/bitcoin/esplora-second-api.ts
+++ b/backend/src/api/bitcoin/esplora-second-api.ts
@@ -1,0 +1,89 @@
+import config from '../../config';
+import axios from 'axios';
+import http from 'http';
+import { IEsploraApi } from './esplora-api.interface';
+import logger from '../../logger';
+
+class EsploraSecondApi {
+  private requestConnection = axios.create({
+    httpAgent: new http.Agent({ keepAlive: true })
+  });
+
+  private async $query<T>(method: 'get' | 'post', path: string, data?: any, responseType = 'json'): Promise<T> {
+    let axiosConfig: any;
+    let url: string;
+
+    if (config.SECOND_ESPLORA.UNIX_SOCKET_PATH) {
+      axiosConfig = { socketPath: config.SECOND_ESPLORA.UNIX_SOCKET_PATH, timeout: config.SECOND_ESPLORA.REQUEST_TIMEOUT, responseType };
+      url = 'http://api' + path;
+    } else {
+      axiosConfig = { timeout: config.SECOND_ESPLORA.REQUEST_TIMEOUT, responseType };
+      url = config.SECOND_ESPLORA.REST_API_URL + path;
+    }
+
+    try {
+      const response = method === 'post'
+        ? await this.requestConnection.post<T>(url, data, axiosConfig)
+        : await this.requestConnection.get<T>(url, axiosConfig);
+      return response.data;
+    } catch (e: any) {
+      logger.warn(`Second esplora request failed: ${url}`);
+      logger.warn(e instanceof Error ? e.message : e);
+      throw e;
+    }
+  }
+
+  async $getRawTransaction(txId: string): Promise<IEsploraApi.Transaction> {
+    return this.$query<IEsploraApi.Transaction>('get', '/tx/' + txId);
+  }
+
+  async $getTransactionHex(txId: string): Promise<string> {
+    return this.$query<string>('get', '/tx/' + txId + '/hex');
+  }
+
+  async $getBlockHeightTip(): Promise<number> {
+    return this.$query<number>('get', '/blocks/tip/height');
+  }
+
+  async $getBlockHashTip(): Promise<string> {
+    return this.$query<string>('get', '/blocks/tip/hash');
+  }
+
+  async $getBlockHash(height: number): Promise<string> {
+    return this.$query<string>('get', '/block-height/' + height);
+  }
+
+  async $getBlock(hash: string): Promise<IEsploraApi.Block> {
+    return this.$query<IEsploraApi.Block>('get', '/block/' + hash);
+  }
+
+  async $getBlockHeader(hash: string): Promise<string> {
+    return this.$query<string>('get', '/block/' + hash + '/header');
+  }
+
+  async $getTxIdsForBlock(hash: string): Promise<string[]> {
+    return this.$query<string[]>('get', '/block/' + hash + '/txids');
+  }
+
+  async $getTxsForBlock(hash: string): Promise<IEsploraApi.Transaction[]> {
+    return this.$query<IEsploraApi.Transaction[]>('get', '/internal/block/' + hash + '/txs');
+  }
+
+  async $getAddress(address: string): Promise<IEsploraApi.Address> {
+    return this.$query<IEsploraApi.Address>('get', '/address/' + address);
+  }
+
+  async $getAddressUtxos(address: string): Promise<IEsploraApi.UTXO[]> {
+    return this.$query<IEsploraApi.UTXO[]>('get', '/address/' + address + '/utxo');
+  }
+
+  async $getOutspend(txId: string, vout: number): Promise<IEsploraApi.Outspend> {
+    return this.$query<IEsploraApi.Outspend>('get', '/tx/' + txId + '/outspend/' + vout);
+  }
+
+  async $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]> {
+    return this.$query<IEsploraApi.Outspend[]>('get', '/tx/' + txId + '/outspends');
+  }
+}
+
+export default new EsploraSecondApi();

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -54,6 +54,11 @@ interface IConfig {
     FALLBACK: string[];
     MAX_BEHIND_TIP: number;
   };
+  SECOND_ESPLORA: {
+    REST_API_URL: string;
+    UNIX_SOCKET_PATH: string | void | null;
+    REQUEST_TIMEOUT: number;
+  };
   LIGHTNING: {
     ENABLED: boolean;
     BACKEND: 'lnd' | 'cln' | 'ldk';
@@ -225,6 +230,11 @@ const defaults: IConfig = {
     'FALLBACK': [],
     'MAX_BEHIND_TIP': 2,
   },
+  'SECOND_ESPLORA': {
+    'REST_API_URL': 'http://127.0.0.1:3000',
+    'UNIX_SOCKET_PATH': null,
+    'REQUEST_TIMEOUT': 10000,
+  },
   'ELECTRUM': {
     'HOST': '127.0.0.1',
     'PORT': 3306,
@@ -347,6 +357,7 @@ const defaults: IConfig = {
 class Config implements IConfig {
   MEMPOOL: IConfig['MEMPOOL'];
   ESPLORA: IConfig['ESPLORA'];
+  SECOND_ESPLORA: IConfig['SECOND_ESPLORA'];
   ELECTRUM: IConfig['ELECTRUM'];
   CORE_RPC: IConfig['CORE_RPC'];
   SECOND_CORE_RPC: IConfig['SECOND_CORE_RPC'];
@@ -370,6 +381,7 @@ class Config implements IConfig {
     const configs = this.merge(configFromFile, defaults);
     this.MEMPOOL = configs.MEMPOOL;
     this.ESPLORA = configs.ESPLORA;
+    this.SECOND_ESPLORA = configs.SECOND_ESPLORA;
     this.ELECTRUM = configs.ELECTRUM;
     this.CORE_RPC = configs.CORE_RPC;
     this.SECOND_CORE_RPC = configs.SECOND_CORE_RPC;

--- a/production/mempool-config.liquid.json
+++ b/production/mempool-config.liquid.json
@@ -70,6 +70,9 @@
       "http://node206.tk7.mempool.space:3001"
     ]
   },
+  "SECOND_ESPLORA": {
+    "UNIX_SOCKET_PATH": "/bitcoin/socket/esplora-bitcoin-mainnet"
+  },
   "DATABASE": {
     "ENABLED": true,
     "HOST": "127.0.0.1",

--- a/production/mempool-config.liquidtestnet.json
+++ b/production/mempool-config.liquidtestnet.json
@@ -70,6 +70,9 @@
       "http://node206.tk7.mempool.space:3004"
     ]
   },
+  "SECOND_ESPLORA": {
+    "UNIX_SOCKET_PATH": "/bitcoin/socket/esplora-bitcoin-testnet"
+  },
   "DATABASE": {
     "ENABLED": true,
     "HOST": "127.0.0.1",


### PR DESCRIPTION
Adds support for querying a bitcoin mempool/electrs instance from Liquid backends, and uses it for some requests during Liquid peg parsing.