### PR TITLE
[liquid] fix peg db table truncations

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -1182,13 +1182,14 @@ class DatabaseMigration {
     // reindex liquid federation addresses and txos, and add hardcoded federation addresses
     // (safe to make this conditional on the network since it doesn't change the database schema)
     if (databaseSchemaVersion < 105 && config.MEMPOOL.NETWORK === 'liquid') {
-      await this.$executeQuery('DELETE FROM elements_pegs WHERE block > 3729730');
-      await this.$executeQuery('DELETE FROM federation_txos WHERE blocknumber > 933800');
+      await this.$executeQuery('DELETE FROM elements_pegs WHERE block > 3686608');
+      await this.$executeQuery('DELETE FROM federation_txos WHERE blocknumber > 929701');
       // Hardcoded federation addresses
       await this.$executeQuery(`INSERT IGNORE INTO federation_addresses (bitcoinaddress) VALUES ('3G6neksSBMp51kHJ2if8SeDUrzT8iVETWT')`);
       await this.$executeQuery(`INSERT IGNORE INTO federation_addresses (bitcoinaddress) VALUES ('bc1qwnevjp8nsq7adu3hxlvdvslrf242q4vuavfg0y929jp2zntp3vgq7cq6z2')`);
-      await this.$executeQuery(`UPDATE state SET number = 3729730 WHERE name = 'last_elements_block';`);
-      await this.$executeQuery(`UPDATE state SET number = 933800 WHERE name = 'last_bitcoin_block_audit';`);
+      await this.$executeQuery(`UPDATE federation_txos SET lastblockupdate = 929700 WHERE unspent = 1;`);
+      await this.$executeQuery(`UPDATE state SET number = 3686608 WHERE name = 'last_elements_block';`);
+      await this.$executeQuery(`UPDATE state SET number = 929700 WHERE name = 'last_bitcoin_block_audit';`);
       await this.updateToSchemaVersion(105);
     }
   }

--- a/backend/src/api/liquid/elements-parser.ts
+++ b/backend/src/api/liquid/elements-parser.ts
@@ -255,7 +255,7 @@ class ElementsParser {
           // Check that the UTXO was not already added in the DB by previous scans
           const [rows_check] = await DB.query(`SELECT txid FROM federation_txos WHERE txid = ? AND txindex = ?`, [tx.txid, output.n]) as any[];
           if (rows_check.length === 0) {
-            const timelock = output.scriptPubKey.address === federationChangeAddresses[0] ? 4032 : 2016; // P2WSH change address has a 4032 timelock, P2SH change address has a 2016 timelock
+            const timelock = output.scriptPubKey.address === federationChangeAddresses[1] ? 2016 : 4032; // hardcode timelock for 3EiAcrzq... This will be addressed better in the future
             const query_utxos = `INSERT INTO federation_txos (txid, txindex, bitcoinaddress, amount, blocknumber, blocktime, unspent, lastblockupdate, lasttimeupdate, timelock, expiredAt, emergencyKey, pegtxid, pegindex, pegblocktime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
             const params_utxos: (string | number)[] = [tx.txid, output.n, output.scriptPubKey.address, output.value * 100000000, block.height, block.time, 1, block.height, 0, timelock, 0, 0, '', 0, 0];
             await DB.query(query_utxos, params_utxos);


### PR DESCRIPTION
_(NOTE: requires restoring the database to before the migration to previous schema version 105)_

change the latest liquid database migration to truncate indexed peg data much less aggressively.

instead of truncating the whole tables, deletes entries in `elements_pegs` newer than liquid mainnet block 3729730, and in `federation_txos` newer than bitcoin mainnet block 933800 (shortly before the first transactions involving the new federation addresses).