### PR TITLE
hotfix for qs breaking query param change

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -143,17 +143,14 @@ class BitcoinRoutes {
   }
 
   private getTransactionTimes(req: Request, res: Response) {
-    if (!Array.isArray(req.query.txId)) {
-      handleError(req, res, 500, 'Not an array');
+    if (!req.query.txId || typeof req.query.txId !== 'object') {
+      handleError(req, res, 500, 'invalid txId format');
       return;
     }
     const txIds: string[] = [];
-    for (const _txId in req.query.txId) {
-      if (typeof req.query.txId[_txId] === 'string') {
-        const txid = req.query.txId[_txId].toString();
-        if (TXID_REGEX.test(txid)) {
-          txIds.push(txid);
-        }
+    for (const txid of Object.values(req.query.txId)) {
+      if (typeof txid === 'string' && TXID_REGEX.test(txid)) {
+        txIds.push(txid);
       }
     }
 

--- a/backend/src/api/explorer/channels.routes.ts
+++ b/backend/src/api/explorer/channels.routes.ts
@@ -78,17 +78,14 @@ class ChannelsRoutes {
 
   private async $getChannelsByTransactionIds(req: Request, res: Response): Promise<void> {
     try {
-      if (!Array.isArray(req.query.txId)) {
-        handleError(req, res, 400, 'Not an array');
+      if (!req.query.txId || typeof req.query.txId !== 'object') {
+        handleError(req, res, 400, 'invalid txId format');
         return;
       }
       const txIds: string[] = [];
-      for (const _txId in req.query.txId) {
-        if (typeof req.query.txId[_txId] === 'string') {
-          const txid = req.query.txId[_txId].toString();
-          if (TXID_REGEX.test(txid)) {
-            txIds.push(txid);
-          }
+      for (const txid of Object.values(req.query.txId)) {
+        if (typeof txid === 'string' && TXID_REGEX.test(txid)) {
+          txIds.push(txid);
         }
       }
       const channels = await channelsApi.$getChannelsByTransactionId(txIds);


### PR DESCRIPTION
qs patch version 6.14.0 -> 6.14.1 (dependency via express) introduces a breaking change in query param array parsing, where `x[]=...` type params that were previously parsed as arrays are now parsed as numerically-indexed objects for some reason.

this PR implements support for accepting such params in either format.