### PR TITLE
feat(dashboard): add tooltips to external link icons

### DIFF
--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -20,7 +20,7 @@
           <a class="title-link mb-0" style="margin-top: -2px" href="" [routerLink]="['/mempool-block/0' | relativeUrl]">
             <h5 class="card-title d-inline"><span>Mempool Goggles&trade;</span> : {{ goggleCycle[goggleIndex].name }}</h5>
             <span>&nbsp;</span>
-            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)"></fa-icon>
+            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)" title="View details"></fa-icon>
           </a>
           <div class="quick-filter">
             <div class="btn-group btn-group-toggle">
@@ -64,7 +64,7 @@
           <a class="title-link" href="" [routerLink]="['/rbf' | relativeUrl]">
             <h5 class="card-title d-inline" i18n="dashboard.recent-rbf-replacements">Recent Replacements</h5>
             <span>&nbsp;</span>
-            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)"></fa-icon>
+            <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)" title="View details"></fa-icon>
           </a>
           <table class="table lastest-replacements-table">
             <thead>
@@ -98,7 +98,7 @@
             <a class="title-link" href="" [routerLink]="['/blocks' | relativeUrl]">
               <h5 class="card-title d-inline" i18n="dashboard.recent-blocks">Recent Blocks</h5>
               <span>&nbsp;</span>
-              <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)"></fa-icon>
+              <fa-icon [icon]="['fas', 'external-link-alt']" [fixedWidth]="true" style="vertical-align: text-top; font-size: 13px; color: var(--title-fg)" title="View details"></fa-icon>
             </a>
             <table class="table lastest-blocks-table">
               <thead>


### PR DESCRIPTION
### Summary

This pull request adds native browser tooltips to external link icons in the dashboard.

### Motivation

Some dashboard links are represented only by icons, which can make their behavior unclear for users.
Adding tooltips improves usability and accessibility by making the clickable action explicit.

### Scope of Changes

- Added a `title` attribute to external link icons in the dashboard
- No visual layout or functional behavior was modified

### Notes

This change is intentionally minimal and low-risk, focusing only on UX and accessibility improvements.
