### PR TITLE
feat: add showDetails query param and toggle for tx metadata

### DIFF
--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -180,7 +180,7 @@
 
       <div class="title-buttons">
         <button *ngIf="!flowEnabled" type="button" class="btn btn-outline-info flow-toggle btn-sm" (click)="toggleGraph()" i18n="show-diagram">Show diagram</button>
-        <button type="button" class="btn btn-outline-info btn-sm" (click)="txList.toggleDetails()" i18n="transaction.details|Transaction Details">Details</button>
+        <button type="button" class="btn btn-outline-info btn-sm" (click)="toggleDetailsFromTxPage()" i18n="transaction.details|Transaction Details">Details</button>
       </div>
     </div>
 

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -532,6 +532,12 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
+  setDetailsOpen(open: boolean): void {
+    if (open !== this.showDetails$.value) {
+      this.toggleDetails();
+    }
+  }
+
   loadMoreInputs(tx: Transaction): void {
     if (!tx['@vinLoaded'] && !this.txPreview) {
       this.electrsApiService.getTransaction$(tx.txid)


### PR DESCRIPTION
Following the existing showFlow architectural pattern, I have implemented a way to toggle the visibility of the “Details” section:

URL parameter support: handling of the query parameter ?showDetails=true/false has been added. This allows direct control of the user interface state via the URL.

State management: a new hideDetails state has been integrated into StateService.

Persistence: The user preference is saved in localStorage under the key details-preference, ensuring that the user interface remembers your choice across sessions.

User interface integration: A Show Details/Hide Details toggle button has been added to the transaction header area (next to the Show Diagram button) for easy access.

Since there wasn't much information about the visual aspect of the issue, I am ready to make any necessary changes that may be required.

Closes #6059