### PR TITLE
[UI] search result show twice the same link (duplicated result) 

### DIFF
--- a/frontend/src/app/components/search-form/search-form.component.ts
+++ b/frontend/src/app/components/search-form/search-form.component.ts
@@ -219,7 +219,7 @@ export class SearchFormComponent implements OnInit {
             blockHash: matchesBlockHash,
             address: matchesAddress,
             publicKey: publicKey,
-            addresses: matchesAddress && addressPrefixSearchResults.length === 1 && searchText === addressPrefixSearchResults[0] ? [] : addressPrefixSearchResults, // If there is only one address and it matches the search text, don't show it in the dropdown
+            addresses: matchesAddress && addressPrefixSearchResults.length === 1 && addressPrefixSearchResults[0].startsWith(searchText) ? [] : addressPrefixSearchResults, // If there is only one address and it matches the search text, don't show it in the dropdown
             otherNetworks: otherNetworks,
             nodes: lightningResults.nodes,
             channels: lightningResults.channels,


### PR DESCRIPTION
## Description
Fixes duplicate address display in search results when searching by address prefix.

## Problem
When searching for an address by prefix, the search dropdown was showing the same address twice:
1. Once under "[Network] Address" (exact match section)
2. Again under "[Network] Addresses" (prefix search results section)

This occurred because the existing logic only checked for exact string equality (`searchText === addressPrefixSearchResults[0]`), which failed when the search text was a prefix of the full address.

## Solution
Updated the duplicate detection logic to use `startsWith()` instead of strict equality:
```typescript
// Before
addresses: matchesAddress && addressPrefixSearchResults.length === 1 && searchText === addressPrefixSearchResults[0] ? [] : addressPrefixSearchResults

// After
addresses: matchesAddress && addressPrefixSearchResults.length === 1 && addressPrefixSearchResults[0].startsWith(searchText) ? [] : addressPrefixSearchResults
```

Now when there's only one address result that starts with the search text, it's only shown once in the "Address" section, and the "Addresses" section is hidden.

<table>
<tr>
<td width="50%" valign="top">

**Before**

<img width="380" alt="Screenshot 2026-02-09 234430" src="https://github.com/user-attachments/assets/87cba093-c8f0-40fd-a55c-6fd9eff14e06" />

Duplicate address shown in both sections

</td>
<td width="50%" valign="top">

**After**

<img width="377" alt="Screenshot 2026-02-09 234456" src="https://github.com/user-attachments/assets/fefea5c0-3edb-4ae2-a690-7110f8ebf9b7" />

Single address shown only once

</td>
</tr>
</table>



fix: https://github.com/mempool/mempool/issues/5709
