### PR TITLE
[enterprise] add support for testnets in enterprise landing page

### DIFF
--- a/frontend/src/app/components/master-page/master-page.component.html
+++ b/frontend/src/app/components/master-page/master-page.component.html
@@ -116,7 +116,7 @@
         </a>
       </li>
       <li class="nav-item" routerLinkActive="active" id="btn-enterprise" *ngIf="officialMempoolSpaceBuild">
-        <a class="nav-link" [routerLink]="['/enterprise' | relativeUrl ]" (click)="collapse()">
+        <a class="nav-link" [routerLink]="['/enterprise']" [queryParams]="{network: network.val.length ? network.val : null}" (click)="collapse()">
           <div class="svg-wrapper"><app-svg-images name="nav-enterprise" width="21.59" height="100%"></app-svg-images></div>
         </a>
       </li>

--- a/frontend/src/app/docs/api-docs/api-docs-nav.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs-nav.component.html
@@ -1,6 +1,10 @@
 <div id="enterprise-cta-desktop" *ngIf="officialMempoolInstance">
   <p>Get higher API limits with Mempool Enterprise®</p>
-  <a class="btn btn-small btn-purple" [href]="[ isMempoolSpaceBuild ? '/enterprise' : 'https://mempool.space/enterprise']" [target]="isMempoolSpaceBuild ? '' : 'blank'">More Info <fa-icon [icon]="['fas', 'angle-right']"></fa-icon></a>
+  @if (isMempoolSpaceBuild) {
+    <a class="btn btn-small btn-purple" routerLink="/enterprise" [queryParams]="{network: network.val.length ? network.val : null}">More Info <fa-icon [icon]="['fas', 'angle-right']"></fa-icon></a>
+  } @else {
+    <a class="btn btn-small btn-purple" [href]="['https://mempool.space/enterprise' + (network.val.length ? `?network=${network.val}` : '')]" [target]="'blank'">More Info <fa-icon [icon]="['fas', 'angle-right']"></fa-icon></a>
+  }
 </div>
 <div *ngFor="let item of tabData">
   <p *ngIf="( item.type === 'category' ) && ( item.showConditions.indexOf(network.val) > -1 ) && ( !item.hasOwnProperty('options') || ( item.hasOwnProperty('options') && item.options.hasOwnProperty('officialOnly') && item.options.officialOnly && officialMempoolInstance ))">{{ item.title }}</p>

--- a/frontend/src/app/docs/api-docs/api-docs-nav.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-nav.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Env, StateService } from '@app/services/state.service';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { restApiDocsData, wsApiDocsData, electrumApiDocsData } from '@app/docs/api-docs/api-docs-data';
 import { faqData } from '@app/docs/api-docs/api-docs-data';


### PR DESCRIPTION
This pull request updates the navigation link for the Enterprise section to include the current network as a query parameter when navigating. This ensures that the selected network context is preserved when users access the Enterprise page.

- Navigation update:
  * In `master-page.component.html`, the Enterprise navigation link now appends the current network value as a query parameter if not on mainnet already