### PR TITLE
Trigger hashrate weekly reindexing when mining pools are updated

### DIFF
--- a/backend/src/api/mining/mining.ts
+++ b/backend/src/api/mining/mining.ts
@@ -218,7 +218,7 @@ class Mining {
     const now = new Date();
 
     // Run only if:
-    // * this.lastWeeklyHashrateIndexingDate is set to null (node backend restart, reorg)
+    // * this.lastWeeklyHashrateIndexingDate is set to null (node backend restart, reorg, or re-indexing was requested after mining pools update)
     // * we started a new week (around Monday midnight)
     const runIndexing = this.lastWeeklyHashrateIndexingDate === null ||
       now.getUTCDay() === 1 && this.lastWeeklyHashrateIndexingDate !== now.getUTCDate();
@@ -334,6 +334,7 @@ class Mining {
       logger.notice(`hashrates will now be re-indexed`);
       await database.query(`TRUNCATE hashrates`);
       this.lastHashrateIndexingDate = 0;
+      this.lastWeeklyHashrateIndexingDate = null;
       this.reindexHashrateRequested = false;
     }
 


### PR DESCRIPTION
Currently, when the backend automatically updates mining pools from github, it truncates the `hashrates` table but does not trigger a reindex of the weekly data. As a result weekly hashrates are missing until either the backend is restarted or the scheduled reindex runs the following Monday, and during this time APIs relying on that like  `/mining/hashrate/pools/:interval` are broken.

This PR fixes the issue by triggering weekly data indexing whenever mining pools are updated.