### PR TITLE
feat: implement Solution 1 from issue #3778 to improve block list dra…

### DIFF
--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -114,3 +114,10 @@
     direction: rtl;
   }
 }
+.blocks-wrapper {
+  cursor: grab;
+}
+
+.blocks-wrapper:active {
+  cursor: grabbing;
+}


### PR DESCRIPTION
## Description
This Pull Request implements **Solution 1** proposed in [issue #3778](https://github.com/mempool/mempool/issues/3778), where it was identified that it wasn't clear to users that the block list could be dragged horizontally on desktop devices.

The change consists of adding the `grab` cursor to the `.blocks-wrapper` container, which changes to `grabbing` when the user clicks and drags. This improves the user experience by providing a clear visual cue that the block list is draggable.

## Changes made
- Added `cursor: grab` to `.blocks-wrapper`.

- Added `cursor: grabbing` to the `:active` state of `.blocks-wrapper`.

## Screenshots
Attached is a recording showing the cursor before and after the change:

https://github.com/user-attachments/assets/b68fca7e-6781-4977-8091-3b0e8d1560bc

## Additional Context
This change follows UX best practices for drag-and-drop interactions and does not affect the site's design or performance.