### PR TITLE
feat: enhance first mempool block design for better visibility

### DIFF
--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -320,3 +320,27 @@ h1 {
     }
   }
 }
+
+
+div#mempool-block-7.bitcoin-block.text-center.mempool-block.ng-tns-c41619706-0.ng-star-inserted::before {
+  content: "";
+  position: absolute;
+  top: -15px;
+  left: -26.5px;
+  width: 20%;
+  height: 123px;
+  background: repeating-linear-gradient(90deg, #ED7D39, #ED7D39 2px, transparent 10px, transparent 10px);
+  z-index: -1;
+}
+
+
+div#mempool-block-7.bitcoin-block.text-center.mempool-block.ng-tns-c41619706-0.ng-star-inserted::after {
+  content: "";
+  position: absolute;
+  top: -31px;
+  left: -28px;
+  width: 127px;
+  height: 25%;
+  background: repeating-linear-gradient(180deg, #ED7D39, #ED7D39 2px, transparent 12px, transparent 1px);
+  z-index: -1;
+}


### PR DESCRIPTION
## Description
This Pull Request addresses the issue described in issue #4569, where users were mistaking the first block (containing the entire mempool) for a regular block. To resolve this, visual styles have been added to the `#mempool-block-7` block using `::before` and `::after` pseudo-elements to improve its visibility and clearly distinguish it from other blocks.

## Changes Made
- Styles were added to the `::before` and `::after` pseudo-elements of the `#mempool-block-7.bitcoin-block.text-center.mempool-block` block to create a stacking visual effect.

- The colors and sizes used are just an example and can be adjusted according to the team's preferences.

## Screenshots
Attached are screenshots showing the block's design before and after the change:

**Before:**
<img width="1341" height="596" alt="Before" src="https://github.com/user-attachments/assets/3a96f9ad-cae0-4d6f-8fc0-52df74c57473" />


**After:**
<img width="1351" height="600" alt="After (2)" src="https://github.com/user-attachments/assets/66ae7230-9e24-4b6f-92ef-7b9e1c39e6e6" />
