### PR TITLE
feat: suggested child fee rate for cpfp

### DIFF
--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -228,7 +228,15 @@
 <ng-template #feeRateRow>
   @if (!isLoadingTx) {
     <tr>
-      <td i18n="transaction.fee-rate|Transaction fee rate">Fee rate</td>
+      <td>
+        <span i18n="transaction.fee-rate|Transaction fee rate">Fee rate</span>
+        @if (!tx?.status?.confirmed && recommendedChildFeeRate) {
+          <fa-icon class="info-badges ml-1" [icon]="['fas', 'angles-up']" style="color:gray" [fixedWidth]="true" 
+                   i18n-ngbTooltip="tx-details.recommended.fee.rate.child|Tooltip recommended fee rate child" 
+                   ngbTooltip="A child ~140 vBytes transaction must pay ~{{ recommendedChildFeeRate }} sat/vB to bump this transaction to high priority" 
+                   placement="bottom"></fa-icon>
+        }
+      </td>
       <td>
         <app-fee-rate [fee]="tx.feePerVsize"></app-fee-rate>
         @if (tx?.status?.confirmed && tx.fee && !hasEffectiveFeeRate && !accelerationInfo) {

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.ts
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.ts
@@ -30,6 +30,7 @@ export class TransactionDetailsComponent implements OnInit {
   @Input() hasEffectiveFeeRate: boolean;
   @Input() cpfpInfo: CpfpInfo;
   @Input() hasCpfp: boolean;
+  @Input() recommendedChildFeeRate: number | null = null;
   @Input() accelerationInfo: Acceleration;
   @Input() acceleratorAvailable: boolean;
   @Input() accelerateCtaType: string;

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -68,6 +68,7 @@
       [hasEffectiveFeeRate]="hasEffectiveFeeRate"
       [cpfpInfo]="cpfpInfo"
       [hasCpfp]="hasCpfp"
+      [recommendedChildFeeRate]="recommendedChildFeeRate$ | async"
       [accelerationInfo]="accelerationInfo"
       [replaced]="replaced"
       [isCached]="isCached"


### PR DESCRIPTION
### Description
This PR introduces a new feature decribed in issue #4273 to help users bump their unconfirmed transactions by calculating and displaying the fee rate a child pays for parent transaction needs to reach high priority.

### Motivation
Currently users who want to accelerate their tx with CPFP have to manually calculate the fee rate needed for the child tx.

### Key changes

- Added a calculation logic into the transaction component to determine the fee rate required for a standard 140 vB child transaction.
- The indicator is not shown if the transaction is in block 0 (next block).
- An icon is shown next to fee rate, on tooltip the user can see "A child ~140 vBytes transaction must pay x sats/vBytes to bump this transaction to high priority"

### Video

https://github.com/user-attachments/assets/a055ea31-3c32-407a-ae8a-f49b30b6a259