### PR TITLE
[accelerator] show referral code when activated

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -244,8 +244,12 @@
                     </tr>
                   </ng-container>
 
-                  <tr class="group-first group-last" style="border-top: 1px dashed grey">
-                    <td class="item"></td>
+                  <tr class="group-first group-last dashed-top">
+                    <td class="item" style="vertical-align:middle">
+                      @if (referralCode) {
+                        <ng-container *ngTemplateOutlet="referralCodeDisplay; context: {referralCode: referralCode}"></ng-container>
+                      }
+                    </td>
                     <td colspan="2">
                       <div class="d-flex">
                         <ng-container *ngTemplateOutlet="accelerateButton"></ng-container>
@@ -318,10 +322,8 @@
         <div>
           <div class="row summary-row">
             <div>
-              <div class="mb-2">
-                <div class="d-flex flex-column" for="accel">
-                  <ng-container *ngTemplateOutlet="accelerateOption; context: {etaInfo}"></ng-container>
-                </div>
+              <div class="d-flex flex-column" for="accel">
+                <ng-container *ngTemplateOutlet="accelerateOption; context: {etaInfo}"></ng-container>
               </div>
             </div>
             <div class="pie d-none d-lg-flex">
@@ -641,3 +643,9 @@
 </ng-template>
 
 <ng-template #prioritizedBy let-i i18n="accelerator.hashrate-percentage-description">Your transaction will be prioritized by up to <strong>{{ i | number : '1.1-1' }}%</strong> of miners.</ng-template>
+
+<ng-template #referralCodeDisplay let-referralCode="referralCode">
+  <div class="small font-italic">
+    <span i18n="accelerator.using-referral-code">Using referral code</span>&nbsp;<span class="badge badge-secondary">{{ referralCode }}</span>
+  </div>
+</ng-template>


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/6227

When an accelerator referral code is active in local storage, we now display it in the details view.

I also tweaked some unrelated alignment issue I noticed _(some hard to read inline code has been split into multiple lines)_

<img width="4066" height="2020" alt="Screenshot 2026-02-19 at 11-09-03 Transaction ca79302a13593b4fbf7375a4082ac40cebb4f5e58610d772a130bdb5b491ba3b - mempool - Bitcoin Explorer" src="https://github.com/user-attachments/assets/703e8b65-92be-462d-b3ec-1d3aa399a6d0" />


--- 

**Accelerate Checkout UI Enhancements:**

* Added a new section to display the referral code in the summary row, using a dedicated `referralCodeDisplay` template for clearer visibility. [[1]](diffhunk://#diff-15906d96be0946bd51135ba6dd4e62ef8fa81778dbfe9dfd2d92e2722ae98c5aL247-R252) [[2]](diffhunk://#diff-15906d96be0946bd51135ba6dd4e62ef8fa81778dbfe9dfd2d92e2722ae98c5aR649-R654)
* Improved layout and alignment for the "accelerate to" and "customize" buttons by wrapping them in a flex container, ensuring consistent spacing and alignment.
