### PR TITLE
[ONBTC] mobile view on onbtc wallet page

### DIFF
--- a/frontend/src/app/components/addresses-treemap/addresses-treemap.component.ts
+++ b/frontend/src/app/components/addresses-treemap/addresses-treemap.component.ts
@@ -75,6 +75,7 @@ export class AddressesTreemap implements OnChanges {
           progressive: 100,
           tooltip: {
             show: true,
+            confine: true,
             backgroundColor: 'rgba(17, 19, 31, 1)',
             borderRadius: 4,
             shadowColor: 'rgba(0, 0, 0, 0.5)',

--- a/frontend/src/app/components/wallet/wallet.component.html
+++ b/frontend/src/app/components/wallet/wallet.component.html
@@ -12,8 +12,8 @@
         <div class="col-md">
           <table class="table table-borderless table-striped address-table">
             <tbody>
-              <tr class="addresses-row">
-                <td class="addresses-label" i18n="address.number-addresses">Addresses</td>
+              <tr>
+                <td i18n="address.number-addresses">Addresses</td>
                 <td *ngIf="addressStrings.length" class="address-list">
                   <app-truncate [text]="addressStrings[0]" [lastChars]="8" [link]="['/address/' | relativeUrl, addressStrings[0]]"></app-truncate>
                   <ng-container *ngIf="addressStrings.length > 1">

--- a/frontend/src/app/components/wallet/wallet.component.scss
+++ b/frontend/src/app/components/wallet/wallet.component.scss
@@ -46,31 +46,6 @@
   max-width: 200px;
 }
 
-@media (max-width: 575.98px) {
-  .address-table tr {
-    display: block;
-
-    td {
-      display: block;
-      width: 100%;
-    }
-
-    td:first-child {
-      padding-bottom: 0.25rem;
-      font-weight: 600;
-    }
-
-    td:last-child {
-      padding-top: 0;
-      text-align: left;
-    }
-  }
-
-  .address-table tr.addresses-row .address-list {
-    max-width: none;
-  }
-}
-
 h1 {
   margin: 0px;
   padding: 0px;


### PR DESCRIPTION
### Summary

improves the mobile layout of the wallet stats table and addresses treemap by adjusting their structure for better responsiveness and readability on small screens

### Result

on mobile devices:

table rows are displayed in a stacked (vertical) layout instead of side by side
the addresses treemap is positioned below the table
the treemap now spans the full screen width

screenshot (iphone 12 pro):

<img width="384" height="833" alt="Screenshot_20260224_231847" src="https://github.com/user-attachments/assets/802eda86-61f1-4fb4-8da2-96b3dea04d5e" />

fixes: #6339 
 