### PR TITLE
[Docs] Add API - Accelerator documentation tab

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs-data.ts
+++ b/frontend/src/app/docs/api-docs/api-docs-data.ts
@@ -11951,40 +11951,50 @@ export const restApiDocsData = [
   },
   {
     type: 'category',
-    category: 'accelerator-public',
-    fragment: 'accelerator-public',
-    title: 'Accelerator (Public)',
+    category: 'accelerator',
+    fragment: 'accelerator',
+    title: 'Accelerator',
     showConditions: [''],
-    options: { officialOnly: true },
+    options: { officialOnly: true }
   },
   {
-    options: { officialOnly: true },
     type: 'endpoint',
-    category: 'accelerator-public',
-    httpRequestMethod: 'POST',
-    fragment: 'accelerator-estimate',
-    title: 'POST Calculate Estimated Costs',
-    description: {
-      default: '<p>Returns estimated costs to accelerate a transaction. Optionally set the <code>X-Mempool-Auth</code> header to get customized estimation.</p>'
-    },
-    urlString: '/v1/services/accelerator/estimate',
+    category: 'accelerator',
+    fragment: 'accelerator-api',
+    title: 'Accelerator API',
     showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/accelerator/estimate`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29'],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `{
+    options: { officialOnly: true },
+    description: {
+      default: '<p>See the dedicated <a href="/docs/api/accelerator">Accelerator API</a> page for all accelerator endpoints including public, pro, and auto-acceleration APIs.</p>'
+    },
+  },
+];
+
+const accAuthHeaderDesc = 'Required header. Your API key &mdash; generate one at <a href="https://mempool.space/services/account/api-key" target="_blank">Account &gt; API Key</a> (select &ldquo;Authenticated API&rdquo;)';
+const accReferralCodeDesc = 'Optional. Your <a href="https://mempool.space/services/accelerator/commission">partner referral code</a> &mdash; earn a commission on every acceleration. Currently available to invited partners only.';
+
+export const acceleratorDocsData = [
+  // ── PUBLIC TAB ──────────────────────────────────────────────
+  {
+    tab: 'public',
+    cardPosition: 'primary',
+    cardOrder: 0,
+    cardOptional: true,
+    cardTitle: 'Get Estimate',
+    cardSummary: 'Returns a cost breakdown including the fee needed to boost to your target fee rate and the service fee.',
+    fragment: 'pub-estimate',
+    httpRequestMethod: 'POST',
+    urlString: '/v1/services/accelerator/estimate',
+    description: 'Returns estimated costs to accelerate a transaction. Optionally set the <code>X-Mempool-Auth</code> header to get customized estimation.',
+    params: [
+      { name: 'txInput', description: 'The txid of the transaction to accelerate' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/accelerator/estimate \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -d "txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29"`,
+    response: `{
   "txSummary": {
-    "txid": "ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29",
+    "txid": "ee13ebb9...b2dc29",
     "effectiveVsize": 154,
     "effectiveFee": 154,
     "ancestorCount": 1
@@ -11995,236 +12005,268 @@ export const restApiDocsData = [
   "userBalance": 0,
   "mempoolBaseFee": 50000,
   "vsizeFee": 0,
-  "pools": [
-    111,
-    102,
-    112,
-    142,
-    115
-  ],
+  "pools": [111, 102, 112, 142, 115],
   "options": [
-    {
-      "fee": 1500
-    },
-    {
-      "fee": 3000
-    },
-    {
-      "fee": 12500
-    }
+    { "fee": 1500 },
+    { "fee": 3000 },
+    { "fee": 12500 }
   ],
   "hasAccess": false,
   "availablePaymentMethods": {
-    "bitcoin": {
-      "enabled": true,
-      "min": 1000,
-      "max": 10000000
-    },
-    "cashapp": {
-      "enabled": true,
-      "min": 10,
-      "max": 200
-    }
+    "bitcoin": { "enabled": true, "min": 1000, "max": 10000000 },
+    "cashapp": { "enabled": true, "min": 10, "max": 200 }
   },
   "unavailable": false
 }`,
-        },
-      }
-    }
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-public',
+    tab: 'public',
+    cardPosition: 'primary',
+    cardOrder: 1,
+    cardOptional: false,
+    cardTitle: 'Accelerate',
+    cardSummary: 'Submit a transaction to accelerate and receive a Lightning invoice. Pay the invoice to start acceleration.',
+    fragment: 'pub-accelerate',
     httpRequestMethod: 'POST',
-    fragment: 'accelerator-get-invoice',
-    title: 'POST Generate Acceleration Invoice',
-    description: {
-      default: '<p>Request a LN invoice to accelerate a transaction.</p>'
-    },
     urlString: '/v1/services/payments/bitcoin',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/payments/bitcoin`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['product=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29&amount=12500'],
-          headers: '',
-          response: `[
+    description: 'Request a Lightning invoice to accelerate a transaction. Pay the returned invoice to start acceleration.',
+    params: [
+      { name: 'product', description: 'The txid of the transaction to accelerate' },
+      { name: 'amount', description: 'Amount in sats. The estimate endpoint returns low, medium, and high priority suggestions in <code>options[].fee</code>, but you can set any value' },
+      { name: 'referralCode', description: accReferralCodeDesc, badge: 'Beta' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/payments/bitcoin \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -d "product=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29" \\
+  -d "amount=12500" \\
+  -d "referralCode=IWzhmhR7"`,
+    response: `[
   {
     "btcpayInvoiceId": "4Ww53d7VgSa596jmCFufe7",
     "btcDue": "0.000625",
     "addresses": {
-      "BTC": "bc1qcvqx2kr5mktd7gvym0atrrx0sn27mwv5kkghl3m78kegndm5t8ksvcqpja",
+      "BTC": "bc1qcvqx2kr5mkt...",
       "BTC_LNURLPAY": null,
-      "BTC_LightningLike": "lnbc625u1pngl0wzpp56j7cqghsw2y5q7vdu9shmpxgpzsx4pqra4wcm9vdnvqegutplk2qdxj2pskjepqw3hjqnt9d4cx7mmvypqkxcm9d3jhyct5daezq2z0wfjx2u3qf9zr5grpvd3k2mr9wfshg6t0dckk2ef3xdjkyc3e8ymrxv3nxumkxvf4vvungwfcxqen2dmxxcmngepj8q6kzce5xyengdfjxq6nqvpnx9jkzdnyvdjrxefevgexgcej8yknzdejxqmrjd3jx5mrgdpj9ycqzpuxqrpr5sp58593dzj2uauaj3afa7x47qeam8k9yyqrh9qasj2ssdzstew6qv3q9qxpqysgqj8qshfkxmj0gfkly5xfydysvsx55uhnc6fgpw66uf6hl8leu07454axe2kq0q788yysg8guel2r36d6f75546nkhmdcmec4mmlft8dsq62rnsj"
+      "BTC_LightningLike": "lnbc625u1pngl0wz..."
     }
   }
 ]`,
-        },
-      }
-    }
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-public',
+    tab: 'public',
+    cardPosition: 'primary',
+    cardOrder: 2,
+    cardOptional: true,
+    cardTitle: 'Check Status',
+    cardSummary: 'Returns all transactions currently being accelerated. Use this to confirm your acceleration is active.',
+    fragment: 'pub-pending',
     httpRequestMethod: 'GET',
-    fragment: 'accelerator-pending',
-    title: 'GET Pending Accelerations',
-    description: {
-      default: '<p>Returns all transactions currently being accelerated.</p>'
-    },
     urlString: '/v1/services/accelerator/accelerations',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/accelerations`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: '',
-          response: `[
+    description: 'Returns all transactions currently being accelerated.',
+    params: [],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/accelerations`,
+    response: `[
   {
-    "txid": "8a183c8ae929a2afb857e7f2acd440aaefdf2797f8f7eab1c5f95ff8602abc81",
+    "txid": "8a183c8ae929...abc81",
     "added": 1707558316,
     "feeDelta": 3500,
     "effectiveVsize": 111,
     "effectiveFee": 1671,
-    "pools": [
-      111
-    ]
-  },
-  {
-    "txid": "6097f295e21bdd8d725bd8d9ad4dd72b05bd795dc648bfef52150a9b2b7f7a45",
-    "added": 1707560464,
-    "feeDelta": 60000,
-    "effectiveVsize": 812,
-    "effectiveFee": 7790,
-    "pools": [
-      111
-    ]
+    "pools": [111]
   }
 ]`,
-        },
-      }
-    }
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-public',
+    tab: 'public',
+    cardPosition: 'secondary',
+    cardOrder: 0,
+    cardOptional: false,
+    cardTitle: 'Acceleration History',
+    cardSummary: '',
+    fragment: 'pub-history',
     httpRequestMethod: 'GET',
-    fragment: 'accelerator-public-history',
-    title: 'GET Acceleration History',
-    description: {
-      default: `<p>Returns all past accelerated transactions.
-      Filters can be applied:<ul>
-      <li><code>status</code>: <code>all</code>, <code>requested</code>, <code>accelerating</code>, <code>mined</code>, <code>completed</code>, <code>failed</code></li>
-      <li><code>timeframe</code>: <code>24h</code>, <code>3d</code>, <code>1w</code>, <code>1m</code>, <code>3m</code>, <code>6m</code>, <code>1y</code>, <code>2y</code>, <code>3y</code>, <code>4y</code>, <code>all</code></li>
-      <li><code>minedByPoolUniqueId</code>: any id from <a target="_blank" href="https://github.com/mempool/mining-pools/blob/master/pools-v2.json">pools-v2.json</a>
-      <li><code>blockHash</code>: a block hash</a>
-      <li><code>blockHeight</code>: a block height</a>
-      <li><code>page</code>: the requested page number if using pagination <i>(min: 1)</i></a>
-      <li><code>pageLength</code>: the page lenght if using pagination <i>(min: 1, max: 50)</i></a>
-      <li><code>from</code>: unix timestamp (<i>overrides <code>timeframe</code></i>)</a>
-      <li><code>to</code>: unix timestamp (<i>overrides <code>timeframe</code></i>)</a>
-      </ul></p>`
-    },
     urlString: '/v1/services/accelerator/accelerations/history',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/accelerations/history?blockHash=00000000000000000000482f0746d62141694b9210a813b97eb8445780a32003`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: '',
-          response: `[
+    description: 'Returns all past accelerated transactions. Supports filtering by status, timeframe, pool, block, and pagination.',
+    params: [
+      { name: 'status', description: 'Optional. <code>all</code>, <code>requested</code>, <code>accelerating</code>, <code>mined</code>, <code>completed</code>, <code>failed</code>' },
+      { name: 'timeframe', description: 'Optional. <code>24h</code>, <code>3d</code>, <code>1w</code>, <code>1m</code>, <code>3m</code>, <code>6m</code>, <code>1y</code>, <code>2y</code>, <code>3y</code>, <code>4y</code>, <code>all</code>' },
+      { name: 'blockHash', description: 'Optional. Filter by block hash' },
+      { name: 'blockHeight', description: 'Optional. Filter by block height' },
+      { name: 'page', description: 'Optional. Page number (min 1)' },
+      { name: 'pageLength', description: 'Optional. Results per page (min 1, max 50)' },
+    ],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/accelerations/history?blockHash=00000000000000000000482f0746d62141694b9210a813b97eb8445780a32003`,
+    response: `[
   {
-    "txid": "f829900985aad885c13fb90555d27514b05a338202c7ef5d694f4813ad474487",
+    "txid": "f829900985aa...d474487",
     "status": "completed_provisional",
     "added": 1728111527,
     "lastUpdated": 1728112113,
     "effectiveFee": 1385,
     "effectiveVsize": 276,
     "feeDelta": 3000,
-    "blockHash": "00000000000000000000cde89e34036ece454ca2d07ddd7f71ab46307ca87423",
+    "blockHash": "00000000...ca87423",
     "blockHeight": 864248,
     "bidBoost": 65,
-    "boostVersion": "v2",
-    "pools": [
-      111,
-      115,
-    ],
+    "pools": [111, 115],
     "minedByPoolUniqueId": 115
   }
 ]`,
-        },
-      }
-    }
+  },
+
+  // ── PRO TAB ─────────────────────────────────────────────────
+  {
+    tab: 'pro',
+    cardPosition: 'primary',
+    cardOrder: 0,
+    cardOptional: false,
+    cardTitle: 'Top Up',
+    cardSummary: 'Add credit to your account via Lightning.',
+    fragment: 'pro-topup',
+    httpRequestMethod: 'POST',
+    urlString: '/v1/services/payments/bitcoin/top-up',
+    description: 'Request a Lightning invoice to add credit to your account balance for use with Pro accelerations.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+      { name: 'amount', description: 'Amount in sats to top up' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/payments/bitcoin/top-up \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -H "X-Mempool-Auth: YOUR_API_KEY" \\
+  -d "amount=1000000"`,
+    response: `{
+  "btcpayInvoiceId": "NS9aqa5PUW2MNnSazaFnX3",
+  "btcDue": "0.01",
+  "addresses": {
+    "BTC-LN": "lnbc10m1p5eaat...",
+    "BTC": "bc1qrvwcm825qa...",
+    "BTC-LNURL": null
+  },
+  "expirationTime": 1772026108
+}`,
   },
   {
-    type: 'category',
-    category: 'accelerator-private',
-    fragment: 'accelerator-private',
-    title: 'Accelerator (Authenticated)',
-    showConditions: [''],
-    options: { officialOnly: true },
+    tab: 'pro',
+    cardPosition: 'primary',
+    cardOrder: 1,
+    cardOptional: false,
+    cardTitle: 'Accelerate',
+    cardSummary: 'Accelerate a transaction using your account credit. Specify a max bid &mdash; you only pay what\'s needed.',
+    fragment: 'pro-accelerate',
+    httpRequestMethod: 'POST',
+    urlString: '/v1/services/accelerator/accelerate',
+    description: 'Sends a request to accelerate a transaction using account credit.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+      { name: 'txInput', description: 'The txid of the transaction to accelerate' },
+      { name: 'userBid', description: 'Maximum bid in sats' },
+      { name: 'referralCode', description: accReferralCodeDesc, badge: 'Beta' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/accelerator/accelerate \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -H "X-Mempool-Auth: YOUR_API_KEY" \\
+  -d "txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29" \\
+  -d "userBid=21000000" \\
+  -d "referralCode=IWzhmhR7"`,
+    response: `HTTP/1.1 200 OK`,
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
+    tab: 'pro',
+    cardPosition: 'primary',
+    cardOrder: 2,
+    cardOptional: true,
+    cardTitle: 'Cancel',
+    cardSummary: 'Cancel an active acceleration that is in <code>accelerating</code> status.',
+    fragment: 'pro-cancel',
+    httpRequestMethod: 'POST',
+    urlString: '/v1/services/accelerator/cancel',
+    description: 'Cancel an acceleration in the <code>accelerating</code> status. Retrieve eligible acceleration <code>id</code> using the history endpoint.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+      { name: 'id', description: 'The acceleration ID to cancel' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/accelerator/cancel \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -H "X-Mempool-Auth: YOUR_API_KEY" \\
+  -d "id=42"`,
+    response: `HTTP/1.1 200 OK`,
+  },
+  {
+    tab: 'pro',
+    cardPosition: 'secondary',
+    cardOrder: 0,
+    cardOptional: false,
+    cardTitle: 'Acceleration History',
+    cardSummary: '',
+    fragment: 'pro-history',
     httpRequestMethod: 'GET',
-    fragment: 'accelerator-top-up-history',
-    title: 'GET Top Up History',
-    description: {
-      default: '<p>Returns a list of top ups the user has made as prepayment for the accelerator service.</p>'
-    },
-    urlString: '/v1/services/accelerator/top-up-history',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/top-up-history`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `[
+    urlString: '/v1/services/accelerator/history',
+    description: 'Returns your past acceleration requests.',
+    params: [
+      { name: 'X-Mempool-Auth', description: 'Required header. Your API key' },
+      { name: 'status', description: 'Required. <code>all</code>, <code>requested</code>, <code>accelerating</code>, <code>mined</code>, <code>completed</code>, <code>failed</code>' },
+      { name: 'details', description: 'Optional. Pass <code>true</code> to include a detailed <code>history</code> of each request' },
+    ],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/history?status=all&details=true \\
+  -H "X-Mempool-Auth: YOUR_API_KEY"`,
+    response: `[
   {
-    "type": "Bitcoin",
-    "invoiceId": "CCunucVyNw7jUiUz64mmHz",
-    "amount": 10311031,
-    "status": "pending",
-    "date": 1706372653000,
-    "link": "/payment/bitcoin/CCunucVyNw7jUiUz64mmHz"
+    "id": 88,
+    "user_id": 1,
+    "txid": "c5840e89...cee9fde",
+    "status": "completed",
+    "fee_paid": 140019,
+    "added": 1706378704,
+    "last_updated": 1706380231,
+    "max_bid": 14000,
+    "effective_vsize": 135,
+    "effective_fee": 3152,
+    "history": [
+      { "event": "user-requested-acceleration", "timestamp": 1706378704 },
+      { "event": "complete-at-block-827670", "timestamp": 1706380231 }
+    ]
+  }
+]`,
   },
+  {
+    tab: 'pro',
+    cardPosition: 'secondary',
+    cardOrder: 1,
+    cardOptional: false,
+    cardTitle: 'Balance',
+    cardSummary: '',
+    fragment: 'pro-balance',
+    httpRequestMethod: 'GET',
+    urlString: '/v1/services/accelerator/balance',
+    description: 'Returns your currently available balance, locked funds, and total fees paid.',
+    params: [
+      { name: 'X-Mempool-Auth', description: 'Required header. Your API key' },
+    ],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/balance \\
+  -H "X-Mempool-Auth: YOUR_API_KEY"`,
+    response: `{
+  "balance": 99900000,
+  "hold": 101829,
+  "feesPaid": 133721
+}`,
+  },
+  {
+    tab: 'pro',
+    cardPosition: 'secondary',
+    cardOrder: 2,
+    cardOptional: false,
+    cardTitle: 'Top-Up History',
+    cardSummary: '',
+    fragment: 'pro-topup-history',
+    httpRequestMethod: 'GET',
+    urlString: '/v1/services/accelerator/top-up-history',
+    description: 'Returns a list of top-ups you have made as prepayment for the accelerator service.',
+    params: [
+      { name: 'X-Mempool-Auth', description: 'Required header. Your API key' },
+    ],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/top-up-history \\
+  -H "X-Mempool-Auth: YOUR_API_KEY"`,
+    response: `[
   {
     "type": "Bitcoin",
     "invoiceId": "SG1U27R9PdWi3gH3jB9tm9",
@@ -12232,339 +12274,83 @@ export const restApiDocsData = [
     "status": "paid",
     "date": 1706372582000,
     "link": null
-  },
-  ...
-]`,
-        },
-      }
-    }
-  },
-  {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
-    httpRequestMethod: 'GET',
-    fragment: 'accelerator-balance',
-    title: 'GET Available Balance',
-    description: {
-      default: '<p>Returns the user\'s currently available balance, currently locked funds, and total fees paid so far.</p>'
-    },
-    urlString: '/v1/services/accelerator/balance',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/balance`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `{
-  "balance": 99900000,
-  "hold": 101829,
-  "feesPaid": 133721
-}`,
-        },
-      }
-    }
-  },
-  {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
-    httpRequestMethod: 'POST',
-    fragment: 'accelerator-accelerate',
-    title: 'POST Accelerate A Transaction (Pro)',
-    description: {
-      default: '<p>Sends a request to accelerate a transaction.</p>'
-    },
-    urlString: '/v1/services/accelerator/accelerate',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/accelerator/accelerate`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29&userBid=21000000'],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `HTTP/1.1 200 OK`,
-        },
-      }
-    }
-  },
-  {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
-    httpRequestMethod: 'GET',
-    fragment: 'accelerator-history',
-    title: 'GET Acceleration History',
-    description: {
-      default: '<p>Returns the user\'s past acceleration requests.</p><p>Pass one of the following for <code>:status</code> (required): <code>all</code>, <code>requested</code>, <code>accelerating</code>, <code>mined</code>, <code>completed</code>, <code>failed</code>.<br>Pass <code>true</code> in <code>:details</code> to get a detailed <code>history</code> of the acceleration request.</p>'
-    },
-    urlString: '/v1/services/accelerator/history?status=:status&details=:details',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/history?status=all&details=true`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `[
-  {
-    "id": 89,
-    "user_id": 1,
-    "txid": "ae2639469ec000ed1d14e2550cbb01794e1cd288a00cdc7cce18398ba3cc2ffe",
-    "status": "failed"
-    "fee_paid": 0,
-    "added": 1706378712,
-    "last_updated": 1706378712,
-    "confirmations": 4,
-    "base_fee": 0,
-    "vsize_fee": 0,
-    "max_bid": 7000,
-    "effective_vsize": 135,
-    "effective_fee": 3128,
-    "history": [
-      {
-        "event": "user-requested-acceleration",
-        "timestamp": 1706378712
-      },
-      {
-        "event": "accepted_test-api-key",
-        "timestamp": 1706378712
-      },
-      {
-        "event": "failed-at-block-827672",
-        "timestamp": 1706380261
-      }
-    ]
-  },
-  {
-    "id": 88,
-    "user_id": 1,
-    "txid": "c5840e89173331760e959a190b24e2a289121277ed7f8a095fe289b37cee9fde",
-    "status": "completed"
-    "fee_paid": 140019,
-    "added": 1706378704,
-    "last_updated": 1706380231,
-    "confirmations": 6,
-    "base_fee": 40000,
-    "vsize_fee": 100000,
-    "max_bid": 14000,
-    "effective_vsize": 135,
-    "effective_fee": 3152,
-    "history": [
-      {
-        "event": "user-requested-acceleration",
-        "timestamp": 1706378704
-      },
-      {
-        "event": "accepted_test-api-key",
-        "timestamp": 1706378704
-      },
-      {
-        "event": "complete-at-block-827670",
-        "timestamp": 1706380231
-      }
-    ]
-  },
-  {
-    "id": 87,
-    "user_id": 1,
-    "txid": "178b5b9b310f0d667d7ea563a2cdcc17bc8cd15261b58b1653860a724ca83458",
-    "status": "completed"
-    "fee_paid": 90062,
-    "added": 1706378684,
-    "last_updated": 1706380231,
-    "confirmations": 6,
-    "base_fee": 40000,
-    "vsize_fee": 50000,
-    "max_bid": 14000,
-    "effective_vsize": 135,
-    "effective_fee": 3260,
-    "history": [
-      {
-        "event": "user-requested-acceleration",
-        "timestamp": 1706378684
-      },
-      {
-        "event": "accepted_test-api-key",
-        "timestamp": 1706378684
-      },
-      {
-        "event": "complete-at-block-827670",
-        "timestamp": 1706380231
-      }
-    ]
   }
 ]`,
-        },
-      }
-    }
   },
+
+  // ── AUTO TAB ────────────────────────────────────────────────
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
+    tab: 'auto',
+    cardPosition: 'primary',
+    cardOrder: 0,
+    cardOptional: false,
+    cardTitle: 'Set Up Auto-Acceleration',
+    cardSummary: 'Configure trigger conditions for a transaction to be automatically accelerated.',
+    fragment: 'auto-create',
     httpRequestMethod: 'POST',
-    fragment: 'accelerator-cancel',
-    title: 'POST Cancel Acceleration (Pro)',
-    description: {
-      default: '<p>Sends a request to cancel an acceleration in the <code>accelerating</code> status.<br>You can retrieve eligible acceleration <code>id</code> using the history endpoint GET <code>/api/v1/services/accelerator/history?status=accelerating</code>.'
-    },
-    urlString: '/v1/services/accelerator/cancel',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/accelerator/cancel`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['id=42'],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `HTTP/1.1 200 OK`,
-        },
-      }
-    }
-  },
-  {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
-    httpRequestMethod: 'POST',
-    fragment: 'accelerator-auto-accelerate',
-    title: 'POST Auto-Accelerate A Transaction (Pro)',
-    description: {
-      default: '<p>Sends a request to automatically accelerate a transaction based on specified trigger conditions.</p><p>The <code>type</code> parameter must be one of: <code>time_delay</code>, <code>block_height</code>, <code>timestamp</code>, or <code>next_block</code>.<br>The <code>value</code> parameter is required for types other than <code>next_block</code> and depends on the type: hours (floating point, min = 0.5) for <code>time_delay</code>, block height (min = next block height) for <code>block_height</code>, or Unix timestamp (min = now + 60 seconds) for <code>timestamp</code>.</p>'
-    },
     urlString: '/v1/services/accelerator/auto-accelerate',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/accelerator/auto-accelerate`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29&type=time_delay&value=0.5'],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `HTTP/1.1 200 OK`,
-        },
-      }
-    }
+    description: 'Set up auto-acceleration with trigger conditions. The <code>type</code> parameter must be one of: <code>time_delay</code>, <code>block_height</code>, <code>timestamp</code>, or <code>next_block</code>.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+      { name: 'txInput', description: 'The txid of the transaction' },
+      { name: 'type', description: 'Trigger type: <code>time_delay</code>, <code>block_height</code>, <code>timestamp</code>, or <code>next_block</code>' },
+      { name: 'value', description: 'Required for all types except <code>next_block</code>:<br>&bull; <code>time_delay</code> &mdash; hours, floating point (min 0.5)<br>&bull; <code>block_height</code> &mdash; target block height (min = next block)<br>&bull; <code>timestamp</code> &mdash; Unix timestamp (min = now + 60s)' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/accelerator/auto-accelerate \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -H "X-Mempool-Auth: YOUR_API_KEY" \\
+  -d "txInput=ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29" \\
+  -d "type=time_delay" \\
+  -d "value=0.5"`,
+    response: `HTTP/1.1 200 OK`,
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
+    tab: 'auto',
+    cardPosition: 'primary',
+    cardOrder: 1,
+    cardOptional: true,
+    cardTitle: 'Check History',
+    cardSummary: 'View your auto-acceleration requests and their current status.',
+    fragment: 'auto-history',
     httpRequestMethod: 'GET',
-    fragment: 'accelerator-auto-accelerate-history',
-    title: 'GET Auto-Acceleration History',
-    description: {
-      default: '<p>Returns the user\'s auto-acceleration requests history.</p><p>Possible status values: <code>tracking</code>, <code>accelerated</code>, <code>confirmed</code>, <code>canceled</code>.</p>'
-    },
     urlString: '/v1/services/accelerator/auto-accelerate/history',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `/api/v1/services/accelerator/auto-accelerate/history`,
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: [],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `[
+    description: 'Returns your auto-acceleration requests history. Possible status values: <code>tracking</code>, <code>accelerated</code>, <code>confirmed</code>, <code>canceled</code>.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+    ],
+    curlExample: `curl [[hostname]]/api/v1/services/accelerator/auto-accelerate/history \\
+  -H "X-Mempool-Auth: YOUR_API_KEY"`,
+    response: `[
   {
     "id": 15,
-    "txid": "ee13ebb99632377c15c94980357f674d285ac413452050031ea6dcd3e9b2dc29",
+    "txid": "ee13ebb9...b2dc29",
     "status": "accelerated",
     "added": 1706378712,
     "trigger_type": "time_delay",
     "trigger_value": 0.5
-  },
-  {
-    "id": 14,
-    "txid": "c5840e89173331760e959a190b24e2a289121277ed7f8a095fe289b37cee9fde",
-    "status": "confirmed",
-    "added": 1706378704,
-    "trigger_type": "block_height",
-    "trigger_value": 827670
-  },
-  {
-    "id": 13,
-    "txid": "178b5b9b310f0d667d7ea563a2cdcc17bc8cd15261b58b1653860a724ca83458",
-    "status": "tracking",
-    "added": 1706378684,
-    "trigger_type": "next_block",
-    "trigger_value": null
   }
 ]`,
-        },
-      }
-    }
   },
   {
-    options: { officialOnly: true },
-    type: 'endpoint',
-    category: 'accelerator-private',
+    tab: 'auto',
+    cardPosition: 'primary',
+    cardOrder: 2,
+    cardOptional: true,
+    cardTitle: 'Cancel',
+    cardSummary: 'Cancel an auto-acceleration that is in <code>tracking</code> status.',
+    fragment: 'auto-cancel',
     httpRequestMethod: 'POST',
-    fragment: 'accelerator-auto-accelerate-cancel',
-    title: 'POST Cancel Auto-Acceleration (Pro)',
-    description: {
-      default: '<p>Sends a request to cancel an auto-acceleration in the <code>tracking</code> status.<br>You can retrieve eligible auto-acceleration <code>txid</code> using the history endpoint GET <code>/api/v1/services/accelerator/auto-accelerate/history</code>.</p>'
-    },
     urlString: '/v1/services/accelerator/auto-accelerate/cancel',
-    showConditions: [''],
-    showJsExamples: showJsExamplesDefaultFalse,
-    codeExample: {
-      default: {
-        codeTemplate: {
-          curl: `%{1}" "[[hostname]][[baseNetworkUrl]]/api/v1/services/accelerator/auto-accelerate/cancel`, //custom interpolation technique handled in replaceCurlPlaceholder()
-          commonJS: ``,
-          esModule: ``
-        },
-        codeSampleMainnet: {
-          esModule: [],
-          commonJS: [],
-          curl: ['txid=178b5b9b310f0d667d7ea563a2cdcc17bc8cd15261b58b1653860a724ca83458'],
-          headers: 'X-Mempool-Auth: stacksats',
-          response: `HTTP/1.1 200 OK`,
-        },
-      }
-    }
+    description: 'Cancel an auto-acceleration in the <code>tracking</code> status. Retrieve eligible <code>txid</code> using the history endpoint.',
+    params: [
+      { name: 'X-Mempool-Auth', description: accAuthHeaderDesc },
+      { name: 'txid', description: 'The txid of the auto-acceleration to cancel' },
+    ],
+    curlExample: `curl -X POST [[hostname]]/api/v1/services/accelerator/auto-accelerate/cancel \\
+  -H "Content-Type: application/x-www-form-urlencoded" \\
+  -H "X-Mempool-Auth: YOUR_API_KEY" \\
+  -d "txid=178b5b9b310f0d667d7ea563a2cdcc17bc8cd15261b58b1653860a724ca83458"`,
+    response: `HTTP/1.1 200 OK`,
   },
 ];
 
@@ -13304,3 +13090,4 @@ export const electrumApiDocsData = [
 }`
   }
 ];
+

--- a/frontend/src/app/docs/api-docs/api-docs.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs.component.html
@@ -53,7 +53,15 @@
         <div class="doc-item-container" *ngFor="let item of restDocs">
           <div *ngIf="!item.hasOwnProperty('options') || ( item.hasOwnProperty('options') && item.options.hasOwnProperty('officialOnly') && item.options.officialOnly && officialMempoolInstance ) || ( item.hasOwnProperty('options') && item.options.hasOwnProperty('electrsOnly') && item.options.electrsOnly && runningElectrs )">
             <h3 *ngIf="( item.type === 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )">{{ item.title }}</h3>
-            <div *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 )" class="endpoint-container" id="{{ item.fragment }}">
+            <div *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 ) && !item.httpRequestMethod" class="endpoint-container" id="{{ item.fragment }}">
+              <a id="{{ item.fragment + '-tab-header' }}" class="section-header" (click)="anchorLinkClick({event: $event, fragment: item.fragment})">{{ item.title }} <span>{{ item.category }}</span></a>
+              <div class="endpoint-content">
+                <div class="description">
+                  <div [innerHTML]="item.description.default"></div>
+                </div>
+              </div>
+            </div>
+            <div *ngIf="( item.type !== 'category' ) && ( item.showConditions.indexOf(network.val) > -1 ) && item.httpRequestMethod" class="endpoint-container" id="{{ item.fragment }}">
               <a id="{{ item.fragment + '-tab-header' }}" class="section-header" (click)="anchorLinkClick({event: $event, fragment: item.fragment})">{{ item.title }} <span>{{ item.category }}</span></a>
               <div class="endpoint-content">
                 <div class="endpoint">
@@ -226,8 +234,302 @@
       </div>
     </div>
 
+    <div id="acceleratorDocs" *ngIf="whichTab === 'accelerator'">
+
+      <div class="doc-content no-sidebar">
+
+        <p class="doc-welcome-note" i18n="accelerator-api-docs.welcome">Mempool Accelerator&reg; speeds up confirmation of stuck Bitcoin transactions by paying an out-of-band fee to mining pool partners. You can accelerate by clicking the Accelerate button on any transaction page, or programmatically using the API endpoints below. See the <a [routerLink]="['/docs/faq' | relativeUrl]" fragment="what-is-accelerator">FAQ</a> for questions about how the accelerator works and when to use it.</p>
+
+        <!-- Reusable detail panel template -->
+        <ng-template #accDetailPanel let-ep>
+          <h4>{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</h4>
+          <p [innerHTML]="ep.description"></p>
+          <div class="acc-detail-section" *ngIf="ep.params.length">
+            <div class="subtitle">Parameters</div>
+            <table class="acc-param-table">
+              <thead><tr><th>Parameter</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr *ngFor="let param of ep.params">
+                  <td><code>{{ param.name }}</code><ng-container *ngIf="param.badge"> <span class="acc-beta-badge">{{ param.badge }}</span></ng-container></td>
+                  <td [innerHTML]="param.description"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="acc-detail-section">
+            <div class="subtitle">Example Request</div>
+            <pre><code>{{ replaceHostname(ep.curlExample) }}</code></pre>
+          </div>
+          <div class="acc-detail-section">
+            <div class="subtitle">Example Response</div>
+            <pre><code>{{ ep.response }}</code></pre>
+          </div>
+        </ng-template>
+
+        <ul ngbNav #accNav="ngbNav" [animation]="false" [(activeId)]="activeAcceleratorTab" (activeIdChange)="onAccTabChange($event)" class="acc-sub-tabs nav-tabs" role="tablist">
+
+          <!-- PUBLIC API TAB -->
+          <li [ngbNavItem]="0" role="presentation">
+            <a ngbNavLink role="tab">Public API</a>
+            <ng-template ngbNavContent>
+
+              <p class="acc-tab-desc">Accelerate any unconfirmed transaction by paying with Bitcoin Lightning. No account required.</p>
+
+              <div class="acc-flow-cols">
+                <ng-container *ngIf="accEndpoints['pub-estimate'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <span class="acc-flow-tag optional">Optional</span>
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['pub-accelerate'] as ep">
+                  <div class="acc-flow-card main" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['pub-pending'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <span class="acc-flow-tag optional">Optional</span>
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+              </div>
+
+              <ng-container *ngFor="let fragment of ['pub-estimate', 'pub-accelerate', 'pub-pending']">
+                <div class="acc-detail-panel" *ngIf="activeAccDetail === fragment">
+                  <ng-container *ngTemplateOutlet="accDetailPanel; context: { $implicit: accEndpoints[fragment] }"></ng-container>
+                </div>
+              </ng-container>
+
+              <p class="acc-also-note" *ngIf="accSecondary['public']?.length">See also:
+                <ng-container *ngFor="let ep of accSecondary['public']; let last = last">
+                  <a class="acc-toggle-link" (click)="toggleAccDetail(ep.fragment)">{{ ep.cardTitle }}</a><ng-container *ngIf="!last">, </ng-container>
+                </ng-container>
+              </p>
+
+              <ng-container *ngFor="let ep of accSecondary['public']">
+                <div class="acc-detail-panel" *ngIf="activeAccDetail === ep.fragment">
+                  <ng-container *ngTemplateOutlet="accDetailPanel; context: { $implicit: ep }"></ng-container>
+                </div>
+              </ng-container>
+
+            </ng-template>
+          </li>
+
+          <!-- PRO API TAB -->
+          <li [ngbNavItem]="1" role="presentation">
+            <a ngbNavLink role="tab">Pro API</a>
+            <ng-template ngbNavContent>
+
+              <p class="acc-tab-desc">Pre-load account credit for lower costs. You specify a maximum bid and are retrospectively charged only the fee needed.</p>
+
+              <div class="acc-flow-cols">
+                <ng-container *ngIf="accEndpoints['pro-topup'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['pro-accelerate'] as ep">
+                  <div class="acc-flow-card main" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['pro-cancel'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <span class="acc-flow-tag optional">Optional</span>
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+              </div>
+
+              <ng-container *ngFor="let fragment of ['pro-topup', 'pro-accelerate', 'pro-cancel']">
+                <div class="acc-detail-panel" *ngIf="activeAccDetail === fragment">
+                  <ng-container *ngTemplateOutlet="accDetailPanel; context: { $implicit: accEndpoints[fragment] }"></ng-container>
+                </div>
+              </ng-container>
+
+              <p class="acc-also-note" *ngIf="accSecondary['pro']?.length">See also:
+                <ng-container *ngFor="let ep of accSecondary['pro']; let last = last">
+                  <a class="acc-toggle-link" (click)="toggleAccDetail(ep.fragment)">{{ ep.cardTitle }}</a><ng-container *ngIf="!last">, </ng-container>
+                </ng-container>
+              </p>
+
+              <ng-container *ngFor="let ep of accSecondary['pro']">
+                <div class="acc-detail-panel" *ngIf="activeAccDetail === ep.fragment">
+                  <ng-container *ngTemplateOutlet="accDetailPanel; context: { $implicit: ep }"></ng-container>
+                </div>
+              </ng-container>
+
+            </ng-template>
+          </li>
+
+          <!-- AUTO ACCELERATOR TAB -->
+          <li [ngbNavItem]="2" role="presentation">
+            <a ngbNavLink role="tab">Auto Accelerator</a>
+            <ng-template ngbNavContent>
+
+              <p class="acc-tab-desc">Set conditions for transactions to be automatically accelerated when fee rates meet your threshold.</p>
+
+              <div class="acc-flow-cols">
+                <ng-container *ngIf="accEndpoints['auto-create'] as ep">
+                  <div class="acc-flow-card main" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['auto-history'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <span class="acc-flow-tag optional">Optional</span>
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+
+                <span class="acc-flow-arrow">&rarr;</span>
+
+                <ng-container *ngIf="accEndpoints['auto-cancel'] as ep">
+                  <div class="acc-flow-card" [class.active]="activeAccDetail === ep.fragment" (click)="toggleAccDetail(ep.fragment)">
+                    <span class="acc-flow-tag optional">Optional</span>
+                    <h4>{{ ep.cardTitle }}</h4>
+                    <code class="acc-path clickable">{{ ep.httpRequestMethod }} /api{{ ep.urlString }}</code>
+                    <p><span [innerHTML]="ep.cardSummary"></span> <span class="acc-see-details">See details.</span></p>
+                  </div>
+                </ng-container>
+              </div>
+
+              <ng-container *ngFor="let fragment of ['auto-create', 'auto-history', 'auto-cancel']">
+                <div class="acc-detail-panel" *ngIf="activeAccDetail === fragment">
+                  <ng-container *ngTemplateOutlet="accDetailPanel; context: { $implicit: accEndpoints[fragment] }"></ng-container>
+                </div>
+              </ng-container>
+
+            </ng-template>
+          </li>
+
+        </ul>
+
+        <div [ngbNavOutlet]="accNav"></div>
+
+      </div>
+
+    </div>
+
   </div>
 </ng-container>
+
+<ng-template type="what-is-accelerator">
+  <p>Mempool Accelerator&reg; is a service to get your stuck Bitcoin transactions confirmed by paying an out-of-band fee to mining pool partners. No account is required&mdash;view your transaction on mempool.space, click Accelerate, and pay with Lightning, Apple Pay, Cash App Pay, or Google Pay.</p>
+</ng-template>
+
+<ng-template type="how-does-accelerator-work">
+  <p>Mempool sends your acceleration request to our mining pool partners. Partners who choose to accept your acceleration request prioritize your transaction based on your new accelerated fee rate.</p>
+  <p>For example, if you use Mempool Accelerator&reg; to accelerate a 1 sat/vB transaction to a 20 sat/vB target fee rate, mining pool partners will treat the transaction as though it has a 20 sat/vB fee rate.</p>
+</ng-template>
+
+<ng-template type="what-is-accelerator-cost">
+  <p>Acceleration cost includes:</p>
+  <ul>
+    <li>The fee to boost to your selected target fee rate.</li>
+    <li>The Mempool Accelerator&reg; service fee.</li>
+  </ul>
+  <p>View your transaction on mempool.space to see the cost breakdown (see customize and details).</p>
+</ng-template>
+
+<ng-template type="accelerator-modify-request">
+  <p>Once requested, an acceleration cannot currently be modified or canceled by the user.</p>
+</ng-template>
+
+<ng-template type="accelerator-canceled">
+  <p>In order to ensure that Mempool Accelerator&reg; is not used for transaction pinning or other types of abuse we may occasionally cancel an unconfirmed acceleration.</p>
+  <p>For example, if we detect a transaction in conflict with your accelerated transaction the acceleration request will be canceled, and no refund will be given.</p>
+</ng-template>
+
+<ng-template type="accelerator-transparency">
+  <p>All accelerations made using Mempool Accelerator&reg; are made public, an overview of which can be seen on the <a [href]="[ isMempoolSpaceBuild ? '/acceleration' : 'https://mempool.space/acceleration']" [target]="isMempoolSpaceBuild ? '' : 'blank'">Mempool Accelerator&reg; dashboard</a>.</p>
+  <p>Recent accelerations can be seen on the <a [href]="[ isMempoolSpaceBuild ? '/acceleration' : 'https://mempool.space/acceleration']" [target]="isMempoolSpaceBuild ? '' : 'blank'">recent accelerations page</a> or fetched using the <a [routerLink]="['/docs/api/rest' | relativeUrl]" fragment="accelerator-public-history">public API</a>.</p>
+  <p>The additional fees paid to increase the priority of the transaction are displayed on each block page.</p>
+</ng-template>
+
+<ng-template type="accelerator-vs-rbf-cpfp">
+  <p>Miners pick which valid transactions to include in blocks, and generally aim to maximize the transaction fees they earn.</p>
+  <p>There are 3 ways to increase the incentive for a miner to include your transaction:</p>
+
+  <h4>Replace By Fee (RBF)</h4>
+  <p>The sender in an unconfirmed transaction creates a new, higher fee transaction spending some of the same inputs as the transaction being replaced. Often the new transaction will be confirmed instead of the original transaction.</p>
+  <p><b>Limitations of RBF:</b></p>
+  <ul>
+    <li>A new transaction must be signed</li>
+    <li>The sender's wallet must support RBF</li>
+    <li>The txid of the transaction will change</li>
+  </ul>
+
+  <h4>Child Pays for Parent (CPFP)</h4>
+  <p>The recipient in an unconfirmed transaction spends their unconfirmed transaction output, increasing the effective fee of the original transaction. A miner can't confirm the new (child) transaction without also confirming the original (parent) transaction.</p>
+  <p><b>Limitations of CPFP:</b></p>
+  <ul>
+    <li>A new transaction must be signed</li>
+    <li>The sender's wallet must support CPFP</li>
+    <li>The BIP125 unconfirmed ancestor limit may make it impossible to CPFP some transactions</li>
+  </ul>
+
+  <h4>Out of Band Offer</h4>
+  <p>Mempool Accelerator&reg; uses out of band payment rather than a new onchain bitcoin transaction. Unlike RBF and CPFP a new bitcoin transaction does not need to be signed and the prioritization can be paid for using Lightning.</p>
+  <p><b>Limitations of Mempool Accelerator&reg;:</b></p>
+  <ul>
+    <li>A trusted centralized third party is used instead of the trustless peer to peer network</li>
+  </ul>
+</ng-template>
+
+<ng-template type="why-use-accelerator">
+  <p>You should always use RBF or CPFP if you can, and if it makes sense for your use case. If you cannot use RBF, or it doesn't work for your use case, Mempool Accelerator&reg; is available as an option to bump your fee.</p>
+  <p>Mempool Accelerator&reg; is useful in the following scenarios when RBF or CPFP may not be practical:</p>
+  <ul>
+    <li><b>Limited wallet functionality</b> &mdash; Many wallets lack support for RBF or CPFP. Users may be reluctant to switch wallets. Even after switching, a stuck transaction may be purged from most nodes' mempools, making it difficult or impossible for the sender to use RBF or for the receiver to use CPFP.</li>
+    <li><b>Multisig complexities</b> &mdash; Both RBF and CPFP require signing a new transaction, which can be time-consuming or inconvenient for multisig setups. For example, geographically separated multisig wallets may have a signing process that takes several days to complete.</li>
+    <li><b>Lightning Network channel opens</b> &mdash; Channel open transactions that don't have a change output can't have the fee increased using RBF or CPFP. It's also not possible to bump the fee of channels opened to your node using RBF or CPFP.</li>
+    <li><b>Lightning Network channel closes</b> &mdash; Channel close transactions with a fee rate below the network's minimum threshold will not propagate, and therefore can't be accelerated with CPFP. While innovations like anchor outputs + package relay aim to address this issue, many stuck channel closes predate the adoption of these improvements.</li>
+    <li><b>Transaction ID (TXID) immutability requirement</b> &mdash; As a sender, you may need the transaction ID to remain constant, which precludes the use of RBF.</li>
+    <li><b>Excessive unconfirmed descendants</b> &mdash; As a recipient, your transaction may have too many unconfirmed descendant transactions to be eligible for CPFP acceleration.</li>
+    <li><b>Relative timelock restrictions</b> &mdash; As a recipient, your transaction may be subject to a relative timelock, limiting your ability to CPFP it.</li>
+  </ul>
+</ng-template>
+
+<ng-template type="cant-accelerate">
+  <p>A transaction cannot be accelerated using Mempool Accelerator&reg; if it has any of the following properties:</p>
+  <ul>
+    <li><b>Replaceable inputs</b> &mdash; At least one of the transaction's inputs is signed with either the SIGHASH_NONE or SIGHASH_ANYONECANPAY flag, which may allow a third party to replace the transaction.</li>
+    <li><b>Too many sigops</b> &mdash; The number of signature operations multiplied by 20 exceeds the transaction's weight (see <a [routerLink]="['/docs/faq' | relativeUrl]" fragment="what-are-sigops">what are sigops?</a>).</li>
+  </ul>
+</ng-template>
 
 <ng-template type="what-is-a-mempool">
   <p>A mempool (short for "memory pool") is the queue of pending and unconfirmed transactions for a cryptocurrency network node. There is no one global mempool: every node on the network maintains its own mempool, so different nodes may hold different transactions in their mempools.</p>

--- a/frontend/src/app/docs/api-docs/api-docs.component.scss
+++ b/frontend/src/app/docs/api-docs/api-docs.component.scss
@@ -493,6 +493,222 @@ fa-icon {
   font-size: 12px;
 }
 
+/* Accelerator Docs Styles */
+#acceleratorDocs {
+  .acc-sub-tabs {
+    margin: 20px 0 0 0;
+  }
+
+  .acc-tab-desc {
+    margin: 20px 0 16px 0;
+  }
+
+  .acc-partner-box {
+    background-color: var(--bg);
+    border: 1px solid var(--secondary);
+    border-radius: 0.25rem;
+    padding: 14px 18px;
+    margin: 24px 0 0 0;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .acc-beta-badge {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 2px 7px;
+    border-radius: 3px;
+    background-color: rgba(255, 193, 7, 0.15);
+    color: #ffc107;
+    margin-left: 6px;
+    vertical-align: middle;
+
+    &.left-tag {
+      margin-left: 0;
+      flex-shrink: 0;
+    }
+  }
+
+  .acc-flow-cols {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    gap: 0 12px;
+    align-items: stretch;
+    margin: 16px 0;
+
+    @media (max-width: 992px) {
+      grid-template-columns: 1fr;
+    }
+
+  }
+
+  .acc-flow-arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    color: var(--fg);
+    opacity: 0.3;
+
+    @media (max-width: 992px) {
+      transform: rotate(90deg);
+      padding: 4px 0;
+    }
+  }
+
+  .acc-flow-card {
+    background-color: var(--bg);
+    border: 1px solid var(--secondary);
+    border-radius: 0.25rem;
+    padding: 16px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    transition: border-color 0.15s;
+    min-width: 0;
+    overflow: hidden;
+
+    &.active {
+      border-color: var(--info);
+      background-color: rgba(255, 255, 255, 0.03);
+    }
+
+    &:hover {
+      border-color: var(--info);
+    }
+
+    .acc-flow-tag {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      font-size: 0.6rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      padding: 2px 6px;
+      border-radius: 3px;
+
+      &.optional {
+        background-color: rgba(255, 255, 255, 0.08);
+        color: var(--fg);
+        opacity: 0.5;
+      }
+    }
+
+    h4 {
+      margin: 0 0 6px 0;
+      font-size: 1.05rem;
+      color: var(--title-fg);
+    }
+
+    .acc-path {
+      display: block;
+      font-size: 0.72rem;
+      margin-bottom: 10px;
+      word-break: break-all;
+      opacity: 0.5;
+      background-color: transparent;
+      transition: opacity 0.15s ease;
+
+      &.clickable {
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+        text-underline-offset: 3px;
+      }
+    }
+
+    &:hover .acc-path.clickable {
+      opacity: 0.85;
+    }
+
+    .acc-see-details {
+      color: var(--info);
+      cursor: pointer;
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.83rem;
+      opacity: 0.85;
+    }
+
+  }
+
+  .acc-detail-panel {
+    margin: 16px 0;
+    padding-top: 8px;
+
+    > h4 {
+      margin: 0 0 8px 0;
+      font-size: 1rem;
+      color: var(--title-fg);
+      font-family: Consolas, Monaco, monospace;
+      font-weight: bold;
+      overflow-wrap: break-word;
+      word-break: break-all;
+    }
+
+    > p {
+      font-size: 0.85rem;
+      margin-bottom: 16px;
+      opacity: 0.85;
+    }
+  }
+
+  .acc-detail-section {
+    margin-top: 20px;
+
+    .subtitle {
+      font-weight: bold;
+      margin-bottom: 8px;
+    }
+  }
+
+  .acc-param-table {
+    width: 100%;
+    font-size: 0.85rem;
+    margin-bottom: 0;
+    border-collapse: collapse;
+
+    thead {
+      display: none;
+    }
+
+    td {
+      padding: 6px 16px 6px 0;
+      vertical-align: top;
+      border: none;
+
+      &:first-child {
+        white-space: nowrap;
+        opacity: 0.7;
+      }
+    }
+  }
+
+  .acc-also-note {
+    font-size: 0.85rem;
+    opacity: 0.85;
+    margin-top: 12px;
+  }
+
+  .acc-toggle-link {
+    color: var(--info);
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 /* Electrum API Docs Styles */
 #electrs {
   .connection-info {

--- a/frontend/src/app/docs/api-docs/api-docs.component.ts
+++ b/frontend/src/app/docs/api-docs/api-docs.component.ts
@@ -3,7 +3,7 @@ import { Env, StateService } from '@app/services/state.service';
 import { Observable, merge, of, Subject, Subscription } from 'rxjs';
 import { tap, takeUntil } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
-import { faqData, restApiDocsData, wsApiDocsData, electrumApiDocsData } from '@app/docs/api-docs/api-docs-data';
+import { faqData, restApiDocsData, wsApiDocsData, electrumApiDocsData, acceleratorDocsData } from '@app/docs/api-docs/api-docs-data';
 import { FaqTemplateDirective } from '@app/docs/faq-template/faq-template.component';
 
 @Component({
@@ -37,6 +37,10 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
   timeLtrSubscription: Subscription;
   timeLtr: boolean = this.stateService.timeLtr.value;
   isMempoolSpaceBuild = this.stateService.isMempoolSpaceBuild;
+  activeAcceleratorTab = 0;
+  activeAccDetail: string = 'pub-accelerate';
+  accEndpoints: { [fragment: string]: any } = {};
+  accSecondary: { [tab: string]: any[] } = {};
 
   @ViewChildren(FaqTemplateDirective) faqTemplates: QueryList<FaqTemplateDirective>;
   dict = {};
@@ -101,6 +105,16 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
     this.wsDocs = wsApiDocsData;
     this.electrumDocs = electrumApiDocsData;
 
+    for (const ep of acceleratorDocsData) {
+      this.accEndpoints[ep.fragment] = ep;
+      if (ep.cardPosition === 'secondary') {
+        if (!this.accSecondary[ep.tab]) {
+          this.accSecondary[ep.tab] = [];
+        }
+        this.accSecondary[ep.tab].push(ep);
+      }
+    }
+
     this.network$.pipe(takeUntil(this.destroy$)).subscribe((network) => {
       this.active = (network === 'liquid' || network === 'liquidtestnet') ? 2 : 0;
       switch( network ) {
@@ -152,7 +166,7 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
     if (document.getElementById( targetId + '-tab-header' )) {
       tabHeaderHeight = document.getElementById( targetId + '-tab-header' ).scrollHeight;
     }
-    if( ( window.innerWidth <= 992 ) && ( ( this.whichTab === 'rest' ) || ( this.whichTab === 'faq' ) || ( this.whichTab === 'websocket' ) ) && targetId ) {
+    if( ( window.innerWidth <= 992 ) && ( ( this.whichTab === 'rest' ) || ( this.whichTab === 'faq' ) || ( this.whichTab === 'accelerator' ) || ( this.whichTab === 'websocket' ) ) && targetId ) {
       const endpointContainerEl = document.querySelector<HTMLElement>( '#' + targetId );
       const endpointContentEl = document.querySelector<HTMLElement>( '#' + targetId + ' .endpoint-content' );
       const endPointContentElHeight = endpointContentEl.clientHeight;
@@ -169,6 +183,19 @@ export class ApiDocsComponent implements OnInit, AfterViewInit {
         endpointContentEl.classList.add( 'open' );
       }
     }
+  }
+
+  toggleAccDetail(id: string) {
+    this.activeAccDetail = this.activeAccDetail === id ? null : id;
+  }
+
+  onAccTabChange(tabId: number) {
+    const defaults = { 0: 'pub-accelerate', 1: 'pro-accelerate', 2: 'auto-create' };
+    this.activeAccDetail = defaults[tabId] || null;
+  }
+
+  replaceHostname(text: string): string {
+    return text ? text.replace(/\[\[hostname\]\]/g, this.hostname) : '';
   }
 
   wrapUrl(network: string, code: any, websocket: boolean = false) {

--- a/frontend/src/app/docs/docs/docs.component.html
+++ b/frontend/src/app/docs/docs/docs.component.html
@@ -41,6 +41,15 @@
         </ng-template>
       </li>
 
+      <li [ngbNavItem]="4" *ngIf="showAcceleratorApiTab" role="presentation">
+        <a ngbNavLink [routerLink]="['/docs/api/accelerator' | relativeUrl]" role="tab">API - Accelerator</a>
+        <ng-template ngbNavContent>
+
+          <app-api-docs [whichTab]="'accelerator'"></app-api-docs>
+
+        </ng-template>
+      </li>
+
     </ul>
 
     <div id="main-tab-content" [ngbNavOutlet]="nav"></div>

--- a/frontend/src/app/docs/docs/docs.component.ts
+++ b/frontend/src/app/docs/docs/docs.component.ts
@@ -17,6 +17,7 @@ export class DocsComponent implements OnInit {
   env: Env;
   showWebSocketTab = true;
   showFaqTab = true;
+  showAcceleratorApiTab = false;
   showElectrsTab = true;
 
   @HostBinding('attr.dir') dir = 'ltr';
@@ -33,6 +34,7 @@ export class DocsComponent implements OnInit {
     this.websocket.want(['blocks']);
     this.env = this.stateService.env;
     this.showFaqTab = ( this.env.BASE_MODULE === 'mempool' ) ? true : false;
+    this.showAcceleratorApiTab = this.env.OFFICIAL_MEMPOOL_SPACE && this.env.BASE_MODULE === 'mempool';
     this.showElectrsTab = this.stateService.env.OFFICIAL_MEMPOOL_SPACE;
 
     document.querySelector<HTMLElement>( 'html' ).style.scrollBehavior = 'smooth';
@@ -63,6 +65,10 @@ export class DocsComponent implements OnInit {
       } else {
         this.seoService.setDescription($localize`:@@meta.description.docs.websocket-bitcoin:Documentation for the mempool.space WebSocket API service: get real-time info on blocks, mempools, transactions, addresses, and more.`);
       }
+    } else if( url[1].path === 'accelerator' ) {
+      this.activeTab = 4;
+      this.seoService.setTitle($localize`:@@meta.title.docs.accelerator-api:API - Accelerator`);
+      this.seoService.setDescription($localize`:@@meta.description.docs.accelerator-api:Mempool Accelerator\u00AE API documentation for developers and AI agents: public API, partner commissions, Pro API, and Auto Accelerator API.`);
     } else {
       this.activeTab = 3;
       this.seoService.setTitle($localize`:@@meta.title.docs.electrum:Electrum RPC`);


### PR DESCRIPTION
Add a dedicated Accelerator tab to the API docs page with three sub-tabs (Public API, Pro API, Auto Accelerator) showing endpoint flow cards, parameters, curl examples, and example responses.

All endpoint content is data-driven via acceleratorDocsData in api-docs-data.ts. Replace duplicate accelerator entries in the REST API tab with a link to the dedicated Accelerator tab.

<img width="1008" height="723" alt="image" src="https://github.com/user-attachments/assets/68c9c8ea-e03a-4eca-92df-90841f258c90" />

<img width="1008" height="180" alt="image" src="https://github.com/user-attachments/assets/f969c2ea-eda1-4db4-a114-38eda49199c0" />

