### PR TITLE
Use unique run ids for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
             cypress/e2e/signet/*.spec.ts
           group: Tests on Chrome (${{ matrix.module }})
           browser: "chrome"
-          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}"
+          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}"
         env:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -407,7 +407,7 @@ jobs:
             cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
           group: Tests on Chrome (${{ matrix.module }})
           browser: "chrome"
-          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}"
+          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}"
         env:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -431,7 +431,7 @@ jobs:
             cypress/e2e/testnet4/*.spec.ts
           group: Tests on Chrome (${{ matrix.module }})
           browser: "chrome"
-          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}"
+          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ matrix.module }}-${{ github.run_id }}-${{ github.run_attempt }}"
         env:
           CYPRESS_REROUTE_TESTNET: true
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Should fix clashing run ids:

```
The run you are attempting to access is already complete and will not accept new groups.

The existing run is: https://cloud.cypress.io/projects/***/runs

When a run finishes all of its groups, it waits for a configurable set of time before finally completing. You must add more groups during that time period.

The --tag flag you passed was: pull_request
The --group flag you passed was: Tests on Chrome (testnet4)
The --parallel flag you passed was: true
The --ciBuildId flag you passed was: 70d1874cfdc577263d2947e8a173c95774168710-CI Pipeline for the Backend and Frontend-pull_request
```