### PR TITLE
Add Federation reserves ratio to monitoring page

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
+++ b/backend/src/api/bitcoin/bitcoin-api-abstract-factory.ts
@@ -57,4 +57,19 @@ export interface HealthCheckHost {
   unreachable: boolean;
   checked: boolean;
   lastChecked: number;
+  hashes?: {
+    frontend?: string;
+    hybrid?: string;
+    backend?: string;
+    electrs?: string;
+    ssr?: string;
+    core?: string;
+    os?: string;
+    lastUpdated?: number;
+  };
+  liquidAudit?: {
+    pegRatio: number;
+    bitcoinLastBlockUpdate: number;
+    liquidLastBlockUpdate: number;
+  };
 }

--- a/frontend/src/app/components/server-health/server-health.component.html
+++ b/frontend/src/app/components/server-health/server-health.component.html
@@ -19,6 +19,7 @@
             <th class="rtt only-small">RTT</th>
             <th class="rtt only-large">RTT</th>
             <th class="height">Height</th>
+            <th *ngIf="isLiquid" class="peg">Peg</th>
             <th class="hybrid hash">Hybrid</th>
             <th class="frontend hash">Front</th>
             <th class="backend hash">Back</th>
@@ -35,6 +36,7 @@
             <td class="rtt only-small">{{ (host.rtt / 1000) | number : '1.1-1' }} {{ host.rtt == null ? '' : 's'}} {{ !host.checked ? '⏳' : (host.unreachable ? '🔥' : '✅') }}</td>
             <td class="rtt only-large">{{ host.rtt | number : '1.0-0' }} {{ host.rtt == null ? '' : 'ms'}} {{ !host.checked ? '⏳' : (host.unreachable ? '🔥' : '✅') }}</td>
             <td class="height">{{ host.latestHeight }} {{ !host.checked ? '⏳' : (host.outOfSync ? '🚫' : (host.latestHeight && host.latestHeight < maxHeight ? '🟧' : '✅')) }}</td>
+            <td class="peg" *ngIf="isLiquid">{{ formatPegRatio(host.liquidAudit?.pegRatio) }}</td>
             <ng-container *ngFor="let type of ['hybrid', 'frontend', 'backend', 'electrs', 'ssr', 'core', 'os']">
               <td class="{{type}}" [class.hash]="type !== 'core' && type !== 'os'" [class.version]="type === 'core' || type === 'os'" [style.background-color]="colors[host.host][type]">
                 @if (type !== 'core' && type !== 'os' && host.hashes?.[type]) {

--- a/frontend/src/app/components/server-health/server-health.component.scss
+++ b/frontend/src/app/components/server-health/server-health.component.scss
@@ -35,6 +35,10 @@
       &.rtt, &.height {
         text-align: right;
       }
+      &.peg {
+        text-align: right;
+        white-space: nowrap;
+      }
       &.only-small {
         display: table-cell;
       }

--- a/frontend/src/app/components/server-health/server-health.component.ts
+++ b/frontend/src/app/components/server-health/server-health.component.ts
@@ -18,6 +18,7 @@ export class ServerHealthComponent implements OnInit {
   interval: number;
   now: number = Date.now();
   colors: Record<string, Record<string, string>> = {};
+  isLiquid = false;
 
   repoMap = {
     frontend: 'mempool',
@@ -93,6 +94,8 @@ export class ServerHealthComponent implements OnInit {
       this.now = Date.now();
       this.cd.markForCheck();
     }, 1000);
+
+    this.isLiquid = this.stateService.network === 'liquid';
   }
 
   trackByFn(index: number, host: HealthCheckHost): string {
@@ -170,5 +173,14 @@ export class ServerHealthComponent implements OnInit {
 
     const hue = (index / (sortedVersions.length - 1)) * 120;
     return `hsl(${hue}, 70%, 35%)`;
+  }
+
+  public formatPegRatio(pegRatio: number | null | undefined): string {
+    if (pegRatio == null) {
+      return '?';
+    }
+
+    const ratio = Math.floor(pegRatio);
+    return `${ratio}%${ratio >= 100 ? ' ✅' : ' 🔥'}`;
   }
 }

--- a/frontend/src/app/interfaces/websocket.interface.ts
+++ b/frontend/src/app/interfaces/websocket.interface.ts
@@ -156,6 +156,11 @@ export interface HealthCheckHost {
     core?: string;
     os?: string;
   };
+  liquidAudit?: {
+    pegRatio: number;
+    bitcoinLastBlockUpdate: number;
+    liquidLastBlockUpdate: number;
+  };
 }
 
 export interface StratumJob {


### PR DESCRIPTION
This PR adds Liquid federation audit metrics to the monitoring service.

For now only the peg ratio is shown on the frontend monitoring page because the Liquid / bitcoin last block audit wouldn’t fit, but they are exposed on the websocket.

<img width="765" height="876" alt="Screenshot 2026-02-27 at 12 50 50" src="https://github.com/user-attachments/assets/b8436a12-cae1-4f95-b30e-425a309a97a7" />
