### PR TITLE
add: skeleton in #acceleratingRow

### DIFF
--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -46,7 +46,7 @@
 <ng-template #detailsRight>
   <ng-container *ngTemplateOutlet="feeRow"></ng-container>
   <ng-container *ngTemplateOutlet="feeRateRow"></ng-container>
-  @if (!isLoadingTx && !tx?.status?.confirmed && isAcceleration && ((cpfpInfo && hasEffectiveFeeRate) || accelerationInfo)) {
+  @if (!isLoadingTx && !tx?.status?.confirmed && isAcceleration) {
     <ng-container *ngTemplateOutlet="acceleratingRow"></ng-container>
   } @else {
     <ng-container *ngTemplateOutlet="effectiveRateRow"></ng-container>
@@ -275,12 +275,26 @@
 </ng-template>
 
 <ng-template #acceleratingRow>
-  <tr>
-    <td rowspan="2" colspan="2" style="padding: 0;">
-      <app-active-acceleration-box [acceleratedBy]="tx.acceleratedBy" [effectiveFeeRate]="tx.effectiveFeePerVsize" [accelerationInfo]="accelerationInfo" [miningStats]="miningStats" [hasCpfp]="hasCpfp" (toggleCpfp)="toggleCpfp()" [chartPositionLeft]="isMobile"></app-active-acceleration-box>
-    </td>
-  </tr>
-  <tr></tr>
+  @if (accelerationInfo) {
+    <tr>
+      <td rowspan="2" colspan="2" style="padding: 0;">
+        <app-active-acceleration-box [acceleratedBy]="tx.acceleratedBy" [effectiveFeeRate]="tx.effectiveFeePerVsize" [accelerationInfo]="accelerationInfo" [miningStats]="miningStats" [hasCpfp]="hasCpfp" (toggleCpfp)="toggleCpfp()" [chartPositionLeft]="isMobile"></app-active-acceleration-box>
+      </td>
+    </tr>
+    <tr></tr>
+  } @else {
+    <tr>
+      <td rowspan="2" colspan="2"  style="padding: 0;">
+        <table style="width: 100%;">
+          <tbody>
+            <tr><td><span class="skeleton-loader"></span></td></tr>
+            <tr><td><span class="skeleton-loader"></span></td></tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr></tr>
+  }
 </ng-template>
 
 <ng-template #minerRow>


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
### Summary
This PR fixes #5435, by adding an skeleton loader inside `#acceleratingRow` template when `accelerationInfo` is null.

### Changes
1. Changed the if statement inside #detailsRigt to pass even if the `accelerationInfo` is still null.
2. Moved the `accelerationInfo` check inside the `#acceleratingRow` template to show skeleton when is null.
3. Added the skeleton in `else` case.

### Considerations
In order to test my changes I faked the following `accelerationInfo` (Not included in this PR):
<img width="494" height="376" alt="image" src="https://github.com/user-attachments/assets/b8e20c68-a712-4f76-8338-5dc257087842" />

### Video

Desktop

https://github.com/user-attachments/assets/b55f3682-e54b-4d95-9de6-f0abcc0a7485

Mobile

https://github.com/user-attachments/assets/3c07257d-8a1a-4ef2-a3c7-00c835e1cdf9
