### PR TITLE
Feat: log scales

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.html
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.html
@@ -7,33 +7,43 @@
       <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
         <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
       </button>
-    </div>  
+    </div>
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="daysAvailable">
       <div class="btn-group btn-group-toggle" name="radioBasic">
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 3" [class.active]="radioGroupForm.get('dateSpan').value === '1w'">
-          <input type="radio" [value]="'1w'" fragment="1w" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1W
+          <input type="radio" [value]="'1w'" [fragment]="getFragment({time: '1w'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1W
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 7" [class.active]="radioGroupForm.get('dateSpan').value === '1m'">
-          <input type="radio" [value]="'1m'" fragment="1m" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1M
+          <input type="radio" [value]="'1m'" [fragment]="getFragment({time: '1m'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 30" [class.active]="radioGroupForm.get('dateSpan').value === '3m'">
-          <input type="radio" [value]="'3m'" fragment="3m" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 3M
+          <input type="radio" [value]="'3m'" [fragment]="getFragment({time: '3m'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 3M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 90" [class.active]="radioGroupForm.get('dateSpan').value === '6m'">
-          <input type="radio" [value]="'6m'" fragment="6m" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 6M
+          <input type="radio" [value]="'6m'" [fragment]="getFragment({time: '6m'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 6M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 180" [class.active]="radioGroupForm.get('dateSpan').value === '1y'">
-          <input type="radio" [value]="'1y'" fragment="1y" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1Y
+          <input type="radio" [value]="'1y'" [fragment]="getFragment({time: '1y'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 1Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 360" [class.active]="radioGroupForm.get('dateSpan').value === '2y'">
-          <input type="radio" [value]="'2y'" fragment="2y" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 2Y
+          <input type="radio" [value]="'2y'" [fragment]="getFragment({time: '2y'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 2Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="daysAvailable >= 720" [class.active]="radioGroupForm.get('dateSpan').value === '3y'">
-          <input type="radio" [value]="'3y'" fragment="3y" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 3Y
+          <input type="radio" [value]="'3y'" [fragment]="getFragment({time: '3y'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> 3Y
         </label>
         <label class="btn btn-primary btn-sm" [class.active]="radioGroupForm.get('dateSpan').value === 'all'">
-          <input type="radio" [value]="'all'" fragment="all" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> ALL
+          <input type="radio" [value]="'all'" [fragment]="getFragment({time: 'all'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="dateSpan"> ALL
+        </label>
+      </div>
+    </form>
+    <form [formGroup]="scaleForm" class="formRadioGroup mr-0 mr-md-2">
+      <div class="btn-group btn-group-toggle" name="radioScale">
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'linear'">
+          <input type="radio" [value]="'linear'" [fragment]="getFragment({scale: 'linear'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.linear-scale">Linear</span>
+        </label>
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'log'">
+          <input type="radio" [value]="'log'" [fragment]="getFragment({scale: 'log'})" [routerLink]="['/graphs/acceleration/fees' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.log-scale">Log</span>
         </label>
       </div>
     </form>

--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
@@ -36,8 +36,11 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
   @Input() period: '24h' | '1w' | '1m' | '1y' | 'all' = '1y';
   @Input() accelerations$: Observable<Acceleration[]>;
 
+  logScale = false;
+
   miningWindowPreference: string;
   radioGroupForm: UntypedFormGroup;
+  scaleForm: UntypedFormGroup;
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
@@ -71,6 +74,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
   ) {
     this.radioGroupForm = this.formBuilder.group({ dateSpan: '1w' });
     this.radioGroupForm.controls.dateSpan.setValue('1w');
+    this.scaleForm = this.formBuilder.group({scaleFunction: 'linear'});
   }
 
   ngOnInit(): void {
@@ -84,8 +88,33 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
     this.radioGroupForm.controls.dateSpan.setValue(this.miningWindowPreference);
 
     this.fragmentSubscription = this.route.fragment.subscribe((fragment) => {
-      if (['1w', '1m', '1y', 'all'].indexOf(fragment) > -1) {
-        this.radioGroupForm.controls.dateSpan.setValue(fragment, { emitEvent: false });
+      if (!fragment) {
+        return;
+      }
+
+      let timeVal = null;
+      let scaleVal = null;
+
+      if (fragment.includes('=')) {
+        const params = new URLSearchParams(fragment);
+        timeVal = params.get('time');
+        scaleVal = params.get('scale');
+      } else {
+        if (['1w', '1m', '1y', 'all'].includes(fragment)) {
+          timeVal = fragment;
+        }
+        if (['linear', 'log'].includes(fragment)) {
+          scaleVal = fragment;
+        }
+      }
+
+      if (timeVal && ['1w', '1m', '1y', 'all'].includes(timeVal)) {
+        this.radioGroupForm.controls.dateSpan.setValue(timeVal, { emitEvent: false });
+      }
+
+      if (scaleVal && ['linear', 'log'].includes(scaleVal)) {
+        this.scaleForm.controls.scaleFunction.setValue(scaleVal, { emitEvent: false });
+        this.onScaleChange();
       }
     });
     this.aggregatedHistory$ = combineLatest([
@@ -186,10 +215,10 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
 
           for (const tick of ticks) {
             if (tick.seriesName === this.totalBidBoostLabel) {
-              if (tick.data[1] > 10_000_000) {
-                tooltip += `${tick.marker} ${this.totalBidBoostLabel}: ${formatNumber(tick.data[1] / 100_000_000, this.locale, '1.0-8')} BTC<br>`;
+              if (tick.data[3] > 10_000_000) {
+                tooltip += `${tick.marker} ${this.totalBidBoostLabel}: ${formatNumber(tick.data[3] / 100_000_000, this.locale, '1.0-8')} BTC<br>`;
               } else {
-                tooltip += `${tick.marker} ${this.totalBidBoostLabel}: ${formatNumber(tick.data[1], this.locale, '1.0-0')} sats<br>`;
+                tooltip += `${tick.marker} ${this.totalBidBoostLabel}: ${formatNumber(tick.data[3], this.locale, '1.0-0')} sats<br>`;
               }
             } else if (tick && tick.seriesName === this.acceleratedLabel) {
               tooltip += `${tick.marker} ${this.acceleratedLabel}: ${formatNumber(tick.data[1], this.locale, '1.0-0')}<br>`;
@@ -248,7 +277,8 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
       },
       yAxis: data.length === 0 ? undefined : [
         {
-          type: 'value',
+          type: this.logScale ? 'log' : 'value',
+          min: this.logScale ? 0.1 : undefined,
           name: this.totalBidBoostLabel,
           position: 'right',
           nameTextStyle: {
@@ -269,7 +299,8 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
           splitLine: null
         },
         {
-          type: 'value',
+          type: this.logScale ? 'log' : 'value',
+          min: this.logScale ? 1 : undefined,
           name: this.acceleratedLabel,
           position: 'left',
           axisLabel: {
@@ -293,7 +324,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
         {
           name: this.totalBidBoostLabel,
           data: data.map(h =>  {
-            return [h.timestamp * 1000, h.sumBidBoost, h.avgHeight];
+            return [h.timestamp * 1000, this.logScale ? Math.max(h.sumBidBoost, 0.1) : h.sumBidBoost, h.avgHeight, h.sumBidBoost];
           }),
           type: 'line',
           symbol: 'none',
@@ -309,7 +340,8 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
             return [h.timestamp * 1000, h.count, h.avgHeight];
           }),
           type: 'bar',
-          barWidth: '90%',
+          barWidth: this.logScale ? undefined : '90%',
+          barMinHeight: this.logScale ? 4 : undefined,
         },
       ],
       dataZoom: (this.widget || data.length === 0 )? undefined : [{
@@ -370,5 +402,43 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
     this.aggregatedHistorySubscription?.unsubscribe();
     this.fragmentSubscription?.unsubscribe();
     this.statsSubscription?.unsubscribe();
+  }
+
+  getFragment(setParams: Record<string, string> = {}): string {
+    const params = new URLSearchParams(this.route.snapshot.fragment || '');
+    params.set('time', setParams.time || this.radioGroupForm.controls.dateSpan.value);
+    params.set('scale', setParams.scale || this.scaleForm.controls.scaleFunction.value);
+    return params.toString();
+  }
+
+  onScaleChange() {
+    this.logScale = this.scaleForm.get('scaleFunction')?.value === 'log';
+
+    if (!this.chartInstance || !this.chartOptions.yAxis || !this.chartOptions.series) {
+      return;
+    }
+    const yAxes = this.chartOptions.yAxis as any[];
+    const series = this.chartOptions.series as any[];
+
+    yAxes[0].type = this.logScale ? 'log' : 'value';
+    yAxes[0].min = this.logScale ? 0.1 : undefined;
+
+    yAxes[1].type = this.logScale ? 'log' : 'value';
+    yAxes[1].min = this.logScale ? 1 : undefined;
+
+    series[0].data.map(h =>  {
+      if (this.logScale && h[1] === 0) {
+        h[1] = 0.1;
+      } else if (!this.logScale && h[1] === 0.1 && h[3] === 0) {
+        h[1] = 0;
+      }
+      return h;
+    });
+    series[1].barWidth = this.logScale ? undefined : '90%';
+    series[1].barMinHeight = this.logScale ? 4 : undefined;
+    this.chartInstance.setOption({
+      yAxis: yAxes,
+      series: series
+    });
   }
 }

--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
@@ -12,34 +12,44 @@
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" name="radioBasic">
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 144" [class.active]="radioGroupForm.get('dateSpan').value === '24h'">
-          <input type="radio" [value]="'24h'" fragment="24h" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 24h
+          <input type="radio" [value]="'24h'" [fragment]="getFragment({time: '24h'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 24h
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 432" [class.active]="radioGroupForm.get('dateSpan').value === '3d'">
-          <input type="radio" [value]="'3d'" fragment="3d" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3D
+          <input type="radio" [value]="'3d'" [fragment]="getFragment({time: '3d'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3D
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 1008" [class.active]="radioGroupForm.get('dateSpan').value === '1w'">
-          <input type="radio" [value]="'1w'" fragment="1w" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1W
+          <input type="radio" [value]="'1w'" [fragment]="getFragment({time: '1w'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1W
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 4320" [class.active]="radioGroupForm.get('dateSpan').value === '1m'">
-          <input type="radio" [value]="'1m'" fragment="1m" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1M
+          <input type="radio" [value]="'1m'" [fragment]="getFragment({time: '1m'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 12960" [class.active]="radioGroupForm.get('dateSpan').value === '3m'">
-          <input type="radio" [value]="'3m'" fragment="3m" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3M
+          <input type="radio" [value]="'3m'" [fragment]="getFragment({time: '3m'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 25920" [class.active]="radioGroupForm.get('dateSpan').value === '6m'">
-          <input type="radio" [value]="'6m'" fragment="6m" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 6M
+          <input type="radio" [value]="'6m'" [fragment]="getFragment({time: '6m'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 6M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 52560" [class.active]="radioGroupForm.get('dateSpan').value === '1y'">
-          <input type="radio" [value]="'1y'" fragment="1y" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1Y
+          <input type="radio" [value]="'1y'" [fragment]="getFragment({time: '1y'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 1Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 105120" [class.active]="radioGroupForm.get('dateSpan').value === '2y'">
-          <input type="radio" [value]="'2y'" fragment="2y" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 2Y
+          <input type="radio" [value]="'2y'" [fragment]="getFragment({time: '2y'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 2Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 157680" [class.active]="radioGroupForm.get('dateSpan').value === '3y'">
-          <input type="radio" [value]="'3y'" fragment="3y" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3Y
+          <input type="radio" [value]="'3y'" [fragment]="getFragment({time: '3y'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> 3Y
         </label>
         <label class="btn btn-primary btn-sm" [class.active]="radioGroupForm.get('dateSpan').value === 'all'">
-          <input type="radio" [value]="'all'" fragment="all" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> ALL
+          <input type="radio" [value]="'all'" [fragment]="getFragment({time: 'all'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="dateSpan"> ALL
+        </label>
+      </div>
+    </form>
+    <form [formGroup]="scaleForm" class="formRadioGroup mr-0 mr-md-2">
+      <div class="btn-group btn-group-toggle" name="radioScale">
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'linear'">
+          <input type="radio" [value]="'linear'" [fragment]="getFragment({scale: 'linear'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.linear-scale">Linear</span>
+        </label>
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'log'">
+          <input type="radio" [value]="'log'" [fragment]="getFragment({scale: 'log'})" [routerLink]="['/graphs/mining/block-fee-rates' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.log-scale">Log</span>
         </label>
       </div>
     </form>

--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
@@ -33,9 +33,11 @@ export class BlockFeeRatesGraphComponent implements OnInit {
   @Input() widget = false;
   @Input() right: number | string = 45;
   @Input() left: number | string = 75;
+  logScale = false;
 
   miningWindowPreference: string;
   radioGroupForm: UntypedFormGroup;
+  scaleForm: UntypedFormGroup;
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
@@ -64,6 +66,7 @@ export class BlockFeeRatesGraphComponent implements OnInit {
   ) {
     this.radioGroupForm = this.formBuilder.group({ dateSpan: '1y' });
     this.radioGroupForm.controls.dateSpan.setValue('1y');
+    this.scaleForm = this.formBuilder.group({scaleFunction: 'linear'});
   }
 
   ngOnInit(): void {
@@ -81,8 +84,33 @@ export class BlockFeeRatesGraphComponent implements OnInit {
       this.route
         .fragment
         .subscribe((fragment) => {
-          if (['24h', '3d', '1w', '1m', '3m', '6m', '1y', '2y', '3y', 'all'].indexOf(fragment) > -1) {
-            this.radioGroupForm.controls.dateSpan.setValue(fragment, { emitEvent: false });
+          if (!fragment) {
+            return;
+          }
+
+          let timeVal = null;
+          let scaleVal = null;
+
+          if (fragment.includes('=')) {
+            const params = new URLSearchParams(fragment);
+            timeVal = params.get('time');
+            scaleVal = params.get('scale');
+          } else {
+            if (['24h', '3d', '1w', '1m', '3m', '6m', '1y', '2y', '3y', 'all'].includes(fragment)) {
+              timeVal = fragment;
+            }
+            if (['linear', 'log'].includes(fragment)) {
+              scaleVal = fragment;
+            }
+          }
+
+          if (timeVal && ['24h', '3d', '1w', '1m', '3m', '6m', '1y', '2y', '3y', 'all'].includes(timeVal)) {
+            this.radioGroupForm.controls.dateSpan.setValue(timeVal, { emitEvent: false });
+          }
+
+          if (scaleVal && ['linear', 'log'].includes(scaleVal)) {
+            this.scaleForm.controls.scaleFunction.setValue(scaleVal, { emitEvent: false });
+            this.onScaleChange();
           }
         });
     }
@@ -123,32 +151,35 @@ export class BlockFeeRatesGraphComponent implements OnInit {
                   '90th': [],
                   'Max': []
                 };
+                const clamp = (val: number): number =>  this.logScale ? this.getLogValue(val) : val;
                 for (const rate of response.body) {
                   const timestamp = rate.timestamp * 1000;
                   if (this.widget) {
-                    seriesData['Median'].push([timestamp, rate.avgFee_50, rate.avgHeight]);
+                    seriesData['Median'].push([timestamp, rate.avgFee_50, rate.avgHeight, rate.avgFee_50]);
                   } else {
-                    seriesData['Min'].push([timestamp, rate.avgFee_0, rate.avgHeight]);
-                    seriesData['10th'].push([timestamp, rate.avgFee_10, rate.avgHeight]);
-                    seriesData['25th'].push([timestamp, rate.avgFee_25, rate.avgHeight]);
-                    seriesData['Median'].push([timestamp, rate.avgFee_50, rate.avgHeight]);
-                    seriesData['75th'].push([timestamp, rate.avgFee_75, rate.avgHeight]);
-                    seriesData['90th'].push([timestamp, rate.avgFee_90, rate.avgHeight]);
-                    seriesData['Max'].push([timestamp, rate.avgFee_100, rate.avgHeight]);
+                    seriesData['Min'].push([timestamp, clamp(rate.avgFee_0), rate.avgHeight, rate.avgFee_0]);
+                    seriesData['10th'].push([timestamp, clamp(rate.avgFee_10), rate.avgHeight, rate.avgFee_10]);
+                    seriesData['25th'].push([timestamp, clamp(rate.avgFee_25), rate.avgHeight, rate.avgFee_25]);
+                    seriesData['Median'].push([timestamp, clamp(rate.avgFee_50), rate.avgHeight, rate.avgFee_50]);
+                    seriesData['75th'].push([timestamp, clamp(rate.avgFee_75), rate.avgHeight, rate.avgFee_75]);
+                    seriesData['90th'].push([timestamp, clamp(rate.avgFee_90), rate.avgHeight, rate.avgFee_90]);
+                    seriesData['Max'].push([timestamp, clamp(rate.avgFee_100), rate.avgHeight, rate.avgFee_100]);
                   }
                 }
 
                 // Prepare chart
                 const series = [];
                 const legends = [];
+                let zIndex = 10;
                 for (const percentile in seriesData) {
                   series.push({
-                    zlevel: 0,
-                    stack: 'Total',
+                    z: this.logScale ? zIndex-- : 0,
+                    stack: this.logScale ? undefined : 'Total',
                     name: percentile,
                     data: seriesData[percentile],
                     type: 'bar',
                     barWidth: '100%',
+                    barGap: '-100%',
                     large: true,
                   });
 
@@ -170,7 +201,7 @@ export class BlockFeeRatesGraphComponent implements OnInit {
                   for (let i = maResolution - 1; i < seriesData['Median'].length; ++i) {
                     let avg = 0;
                     for (let y = maResolution - 1; y >= 0; --y) {
-                      avg += seriesData['Median'][i - y][1];
+                      avg += seriesData['Median'][i - y][3];
                     }
                     avg /= maResolution;
                     medianMa.push([seriesData['Median'][i][0], avg, seriesData['Median'][i][2]]);
@@ -228,7 +259,8 @@ export class BlockFeeRatesGraphComponent implements OnInit {
         show: !this.isMobile(),
         trigger: 'axis',
         axisPointer: {
-          type: 'line'
+          type: 'line',
+          z: 50
         },
         backgroundColor: 'rgba(17, 19, 31, 1)',
         borderRadius: 4,
@@ -246,9 +278,9 @@ export class BlockFeeRatesGraphComponent implements OnInit {
 
           for (const rate of data.reverse()) {
             if (weightMode) {
-              tooltip += `${rate.marker} ${rate.seriesName}: ${(rate.data[1] / 4).toFixed(2)} sats/WU<br>`;
+              tooltip += `${rate.marker} ${rate.seriesName}: ${(rate.data[3] / 4).toFixed(2)} sats/WU<br>`;
             } else {
-              tooltip += `${rate.marker} ${rate.seriesName}: ${rate.data[1].toFixed(2)} sats/vByte<br>`;
+              tooltip += `${rate.marker} ${rate.seriesName}: ${rate.data[3].toFixed(2)} sats/vByte<br>`;
             }
           }
 
@@ -299,11 +331,13 @@ export class BlockFeeRatesGraphComponent implements OnInit {
         axisLabel: {
           color: 'rgb(110, 112, 121)',
           formatter: (val) => {
+            let realVal = this.logScale ? Math.pow(10, val) : val;
+
             if (weightMode) {
-              val /= 4;
+              realVal /= 4;
             }
-            const selectedPowerOfTen: any = selectPowerOfTen(val);
-            const newVal = Math.round(val / selectedPowerOfTen.divider);
+            const selectedPowerOfTen: any = selectPowerOfTen(realVal);
+            const newVal = Math.round(realVal / selectedPowerOfTen.divider);
             return `${newVal}${selectedPowerOfTen.unit} s/${weightMode ? 'WU': 'vB'}`;
           },
         },
@@ -315,7 +349,9 @@ export class BlockFeeRatesGraphComponent implements OnInit {
           }
         },
         type: 'value',
-        max: (val) => this.timespan === 'all' ? Math.min(val.max, 5000) : undefined,
+        min: 0,
+        minInterval: this.logScale ? 1 : undefined,
+        max: (val) => (!this.logScale && this.timespan === 'all') ? Math.min(val.max, 5000) : undefined,
       },
       series: data.series,
       dataZoom: this.widget ? null : [{
@@ -387,5 +423,48 @@ export class BlockFeeRatesGraphComponent implements OnInit {
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';
     this.chartInstance.setOption(this.chartOptions);
+  }
+
+  getFragment(setParams: Record<string, string> = {}): string {
+    const params = new URLSearchParams(this.route.snapshot.fragment || '');
+    params.set('time', setParams.time || this.radioGroupForm.controls.dateSpan.value);
+    params.set('scale', setParams.scale || this.scaleForm.controls.scaleFunction.value);
+    return params.toString();
+  }
+
+  onScaleChange() {
+    this.logScale = this.scaleForm.get('scaleFunction')?.value === 'log';
+    let zIndex = 10;
+
+    if (!this.chartInstance || !this.chartOptions.yAxis || !this.chartOptions.series) {
+      return;
+    }
+
+    const yAxis = this.chartOptions.yAxis as any;
+    yAxis.max = (!this.logScale && this.timespan === 'all') ? (val) => Math.min(val.max, 5000) : undefined;
+    yAxis.minInterval = this.logScale ? 1 : undefined;
+
+    (this.chartOptions.series as any[]).forEach(seriesItem => {
+      if (seriesItem.type === 'bar') {
+        seriesItem.stack = this.logScale ? undefined : 'Total';
+        seriesItem.z = this.logScale ? zIndex-- : 0;
+      }
+      seriesItem.data.forEach(point => {
+        if (this.logScale) {
+          point[1] = this.logScale ? this.getLogValue(point[3]) : point[3];
+        } else {
+          point[1] = point[3];
+        }
+      });
+    });
+
+    this.chartInstance.setOption({
+      yAxis: yAxis,
+      series: this.chartOptions.series
+    });
+  }
+
+  private getLogValue(val: number): number {
+    return val < 1 ? 0 : Math.max(0.02, Math.log10(val));
   }
 }

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
@@ -7,30 +7,40 @@
       <button class="btn p-0 pl-2" style="margin: 0 0 4px 0px" (click)="onSaveChart()">
         <fa-icon [icon]="['fas', 'download']" [fixedWidth]="true"></fa-icon>
       </button>
-    </div>  
+    </div>
 
     <form [formGroup]="radioGroupForm" class="formRadioGroup" *ngIf="(statsObservable$ | async) as stats">
       <div class="btn-group btn-group-toggle" name="radioBasic">
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 4320" [class.active]="radioGroupForm.get('dateSpan').value === '1m'">
-          <input type="radio" [value]="'1m'" fragment="1m" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 1M
+          <input type="radio" [value]="'1m'" [fragment]="getFragment({time: '1m'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 1M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 12960" [class.active]="radioGroupForm.get('dateSpan').value === '3m'">
-          <input type="radio" [value]="'3m'" fragment="3m" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 3M
+          <input type="radio" [value]="'3m'" [fragment]="getFragment({time: '3m'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 3M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 25920" [class.active]="radioGroupForm.get('dateSpan').value === '6m'">
-          <input type="radio" [value]="'6m'" fragment="6m" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 6M
+          <input type="radio" [value]="'6m'" [fragment]="getFragment({time: '6m'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 6M
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 52560" [class.active]="radioGroupForm.get('dateSpan').value === '1y'">
-          <input type="radio" [value]="'1y'" fragment="1y" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 1Y
+          <input type="radio" [value]="'1y'" [fragment]="getFragment({time: '1y'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 1Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 105120" [class.active]="radioGroupForm.get('dateSpan').value === '2y'">
-          <input type="radio" [value]="'2y'" fragment="2y" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 2Y
+          <input type="radio" [value]="'2y'" [fragment]="getFragment({time: '2y'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 2Y
         </label>
         <label class="btn btn-primary btn-sm" *ngIf="stats.blockCount >= 157680" [class.active]="radioGroupForm.get('dateSpan').value === '3y'">
-          <input type="radio" [value]="'3y'" fragment="3y" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 3Y
+          <input type="radio" [value]="'3y'" [fragment]="getFragment({time: '3y'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> 3Y
         </label>
         <label class="btn btn-primary btn-sm" [class.active]="radioGroupForm.get('dateSpan').value === 'all'">
-          <input type="radio" [value]="'all'" fragment="all" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> ALL
+          <input type="radio" [value]="'all'" [fragment]="getFragment({time: 'all'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="dateSpan"> ALL
+        </label>
+      </div>
+    </form>
+    <form [formGroup]="scaleForm" class="formRadioGroup mr-0 mr-md-2">
+      <div class="btn-group btn-group-toggle" name="radioScale">
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'linear'">
+          <input type="radio" [value]="'linear'" [fragment]="getFragment({scale: 'linear'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.linear-scale">Linear</span>
+        </label>
+        <label class="btn btn-primary btn-sm" [class.active]="scaleForm.get('scaleFunction').value === 'log'">
+          <input type="radio" [value]="'log'" [fragment]="getFragment({scale: 'log'})" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]" formControlName="scaleFunction"> <span i18n="charts.log-scale">Log</span>
         </label>
       </div>
     </form>

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
@@ -9,7 +9,7 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { download, formatterXAxis } from '@app/shared/graphs.utils';
 import { StorageService } from '@app/services/storage.service';
 import { MiningService } from '@app/services/mining.service';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FiatShortenerPipe } from '@app/shared/pipes/fiat-shortener.pipe';
 import { FiatCurrencyPipe } from '@app/shared/pipes/fiat-currency.pipe';
 import { StateService } from '@app/services/state.service';
@@ -33,8 +33,11 @@ export class BlockFeesGraphComponent implements OnInit {
   @Input() right: number | string = 45;
   @Input() left: number | string = 75;
 
+  logScale = false;
+
   miningWindowPreference: string;
   radioGroupForm: UntypedFormGroup;
+  scaleForm: UntypedFormGroup;
 
   chartOptions: EChartsOption = {};
   chartInitOptions = {
@@ -58,11 +61,13 @@ export class BlockFeesGraphComponent implements OnInit {
     private miningService: MiningService,
     public stateService: StateService,
     private route: ActivatedRoute,
+    private router: Router,
     private fiatShortenerPipe: FiatShortenerPipe,
     private fiatCurrencyPipe: FiatCurrencyPipe,
   ) {
     this.radioGroupForm = this.formBuilder.group({ dateSpan: '1y' });
     this.radioGroupForm.controls.dateSpan.setValue('1y');
+    this.scaleForm = this.formBuilder.group({scaleFunction: 'linear'});
     this.currency = 'USD';
   }
 
@@ -76,8 +81,33 @@ export class BlockFeesGraphComponent implements OnInit {
     this.route
       .fragment
       .subscribe((fragment) => {
-        if (['1m', '3m', '6m', '1y', '2y', '3y', 'all'].indexOf(fragment) > -1) {
-          this.radioGroupForm.controls.dateSpan.setValue(fragment, { emitEvent: false });
+        if (!fragment) {
+          return;
+        }
+
+        let timeVal = null;
+        let scaleVal = null;
+
+        if (fragment.includes('=')) {
+          const params = new URLSearchParams(fragment);
+          timeVal = params.get('time');
+          scaleVal = params.get('scale');
+        } else {
+          if (['1m', '3m', '6m', '1y', '2y', '3y', 'all'].includes(fragment)) {
+            timeVal = fragment;
+          }
+          if (['linear', 'log'].includes(fragment)) {
+            scaleVal = fragment;
+          }
+        }
+
+        if (timeVal && ['1m', '3m', '6m', '1y', '2y', '3y', 'all'].includes(timeVal)) {
+          this.radioGroupForm.controls.dateSpan.setValue(timeVal, { emitEvent: false });
+        }
+
+        if (scaleVal && ['linear', 'log'].includes(scaleVal)) {
+          this.scaleForm.controls.scaleFunction.setValue(scaleVal, { emitEvent: false });
+          this.onScaleChange();
         }
       });
 
@@ -89,12 +119,14 @@ export class BlockFeesGraphComponent implements OnInit {
           this.storageService.setValue('miningWindowPreference', timespan);
           this.timespan = timespan;
           this.isLoading = true;
+
           return this.apiService.getHistoricalBlockFees$(timespan)
             .pipe(
               tap((response) => {
+                const clampSats = (val: number) => this.logScale ? Math.max(val, 1) : val;
                 this.prepareChartOptions({
-                  blockFees: response.body.map(val => [val.timestamp * 1000, val.avgFees / 100000000, val.avgHeight]),
-                  blockFeesFiat: response.body.filter(val => val[this.currency] > 0).map(val => [val.timestamp * 1000, val.avgFees / 100000000 * val[this.currency], val.avgHeight]),
+                  blockFees: response.body.map(val => [val.timestamp * 1000, clampSats(val.avgFees) / 100000000, val.avgHeight, val.avgFees / 100000000]),
+                  blockFeesFiat: response.body.filter(val => val[this.currency] > 0).map(val => [val.timestamp * 1000, clampSats(val.avgFees) / 100000000 * val[this.currency], val.avgHeight, val.avgFees / 100000000 * val[this.currency]]),
                 });
                 this.isLoading = false;
               }),
@@ -168,9 +200,9 @@ export class BlockFeesGraphComponent implements OnInit {
 
           for (const tick of data) {
             if (tick.seriesIndex === 0) {
-              tooltip += `${tick.marker} ${feesBtcLabel}: ${formatNumber(tick.data[1], this.locale, '1.3-3')} BTC<br>`;
+              tooltip += `${tick.marker} ${feesBtcLabel}: ${formatNumber(tick.data[3], this.locale, '1.3-3')} BTC<br>`;
             } else if (tick.seriesIndex === 1) {
-              tooltip += `${tick.marker} ${feesFiatLabel}: ${this.fiatCurrencyPipe.transform(tick.data[1], null, this.currency) }<br>`;
+              tooltip += `${tick.marker} ${feesFiatLabel}: ${this.fiatCurrencyPipe.transform(tick.data[3], null, this.currency) }<br>`;
             }
           }
 
@@ -208,7 +240,8 @@ export class BlockFeesGraphComponent implements OnInit {
       },
       yAxis: data.blockFees.length === 0 ? undefined : [
         {
-          type: 'value',
+          type: this.logScale ? 'log' : 'value',
+          min: this.logScale ? 0.001 : undefined,
           axisLabel: {
             color: 'rgb(110, 112, 121)',
             formatter: (val) => {
@@ -224,7 +257,8 @@ export class BlockFeesGraphComponent implements OnInit {
           },
         },
         {
-          type: 'value',
+          type: this.logScale ? 'log' : 'value',
+          min: this.logScale ? 0.01 : undefined,
           position: 'right',
           axisLabel: {
             color: 'rgb(110, 112, 121)',
@@ -319,5 +353,43 @@ export class BlockFeesGraphComponent implements OnInit {
     this.chartOptions.grid.bottom = prevBottom;
     this.chartOptions.backgroundColor = 'none';
     this.chartInstance.setOption(this.chartOptions);
+  }
+
+  getFragment(setParams: Record<string, string> = {}): string {
+    const params = new URLSearchParams(this.route.snapshot.fragment || '');
+    params.set('time', setParams.time || this.radioGroupForm.controls.dateSpan.value);
+    params.set('scale', setParams.scale || this.scaleForm.controls.scaleFunction.value);
+    return params.toString();
+  }
+
+  onScaleChange() {
+    this.logScale = this.scaleForm.get('scaleFunction')?.value === 'log';
+
+    if (!this.chartInstance || !this.chartOptions.yAxis) {
+      return;
+    }
+
+    const yAxes = this.chartOptions.yAxis as any[];
+
+    yAxes[0].type = this.logScale ? 'log' : 'value';
+    yAxes[0].min = this.logScale ? 0.001 : undefined;
+
+    yAxes[1].type = this.logScale ? 'log' : 'value';
+    yAxes[1].min = this.logScale ? 0.01 : undefined;
+
+    (this.chartOptions.series as any[]).forEach((seriesItem, index) => {
+      seriesItem.data.forEach(point => {
+        if (index === 0) {
+          point[1] = this.logScale ? Math.max(point[3], 0.001) : point[3];
+        } else if (index === 1) {
+          point[1] = this.logScale ? Math.max(point[3], 0.01) : point[3];
+        }
+      });
+    });
+
+    this.chartInstance.setOption({
+      yAxis: yAxes,
+      series: this.chartOptions.series
+    });
   }
 }


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->

### Summary
This PR implements a new feature as shown in issue #5360 , allowing the user to see a switch to a log scale in the Y Axis of the following graphs:

1. [Block fee rates](https://mempool.space/graphs/mining/block-fee-rates)
2. [Block fees](https://mempool.space/graphs/mining/block-fees)
3. [Acceleration fees](https://mempool.space/graphs/acceleration/fees)

### Changes
1. Implemented a `toggleScale` method in the three graph components.
2. Added clamping functions to prevent echart errors when log(0), which usually occurs in early dates of Bitcoin fees.
3. Added toggle checkbox in the three graphs to easily switch from normal steps-graph to log scale.
4. When log is true changed from `bar` to `line` in block fee rates as eChart does not support stacked bars in a log scale, and unstacked bars cover each other by overlapping.

### Screenshots
<img width="1290" height="524" alt="image" src="https://github.com/user-attachments/assets/14c3bd23-b8d6-4c93-a6f3-85f3f0efecfb" />
<img width="1299" height="529" alt="image" src="https://github.com/user-attachments/assets/0f511150-a542-4786-a78d-feb5970bb285" />
<img width="1290" height="523" alt="image" src="https://github.com/user-attachments/assets/071937ac-12bc-49c8-84da-56b4f0db122c" />

Closes #5360 
