### PR TITLE
feat: add network enabled guard to routing for testnet, testnet4, and signet paths

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -9,11 +9,11 @@ import { StatusViewComponent } from '@components/status-view/status-view.compone
 import { AddressGroupComponent } from '@components/address-group/address-group.component';
 import { TrackerGuard } from '@app/route-guards';
 
-const browserWindow = window || {};
+const browserWindow = window as typeof window & { __env?: any };
 // @ts-ignore
 const browserWindowEnv = browserWindow.__env || {};
 
-let routes: Routes = [
+const testnetRoutes: Routes = browserWindowEnv.TESTNET_ENABLED ? [
   {
     path: 'testnet',
     children: [
@@ -52,6 +52,9 @@ let routes: Routes = [
       },
     ]
   },
+] : [];
+
+const testnet4Routes: Routes = browserWindowEnv.TESTNET4_ENABLED ? [
   {
     path: 'testnet4',
     children: [
@@ -90,6 +93,9 @@ let routes: Routes = [
       },
     ]
   },
+] : [];
+
+const signetRoutes: Routes = browserWindowEnv.SIGNET_ENABLED ? [
   {
     path: 'signet',
     children: [
@@ -133,6 +139,9 @@ let routes: Routes = [
       },
     ]
   },
+] : [];
+
+const regtestRoutes: Routes = browserWindowEnv.REGTEST_ENABLED ? [
   {
     path: 'regtest',
     children: [
@@ -176,6 +185,13 @@ let routes: Routes = [
       },
     ]
   },
+] : [];
+
+let routes: Routes = [
+  ...testnetRoutes,
+  ...testnet4Routes,
+  ...signetRoutes,
+  ...regtestRoutes,
   {
     path: '',
     pathMatch: 'full',
@@ -262,46 +278,50 @@ let routes: Routes = [
   },
 ];
 
+const liquidTestnetRoutes: Routes = browserWindowEnv.LIQUID_TESTNET_ENABLED ? [
+  {
+    path: 'testnet',
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        loadChildren: () => import('@app/liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+        data: { preload: true },
+      },
+      {
+        path: '',
+        loadChildren: () => import ('@app/liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule),
+        data: { preload: true },
+      },
+      {
+        path: 'widget/wallet',
+        children: [],
+        component: AddressGroupComponent,
+        data: {
+          networkSpecific: true,
+        }
+      },
+      {
+        path: 'status',
+        data: { networks: ['bitcoin', 'liquid'] },
+        component: StatusViewComponent
+      },
+      {
+        path: '',
+        loadChildren: () => import('@app/liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
+        data: { preload: true },
+      },
+      {
+        path: '**',
+        redirectTo: '/signet'
+      },
+    ]
+  },
+] : [];
+
 if (browserWindowEnv && browserWindowEnv.BASE_MODULE === 'liquid') {
   routes = [
-    {
-      path: 'testnet',
-      children: [
-        {
-          path: '',
-          pathMatch: 'full',
-          loadChildren: () => import('@app/liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
-          data: { preload: true },
-        },
-        {
-          path: '',
-          loadChildren: () => import ('@app/liquid/liquid-master-page.module').then(m => m.LiquidMasterPageModule),
-          data: { preload: true },
-        },
-        {
-          path: 'widget/wallet',
-          children: [],
-          component: AddressGroupComponent,
-          data: {
-            networkSpecific: true,
-          }
-        },
-        {
-          path: 'status',
-          data: { networks: ['bitcoin', 'liquid'] },
-          component: StatusViewComponent
-        },
-        {
-          path: '',
-          loadChildren: () => import('@app/liquid/liquid-graphs.module').then(m => m.LiquidGraphsModule),
-          data: { preload: true },
-        },
-        {
-          path: '**',
-          redirectTo: '/signet'
-        },
-      ]
-    },
+    ...liquidTestnetRoutes,
     {
       path: '',
       pathMatch: 'full',


### PR DESCRIPTION
Description
	•	Adds NetworkEnabledGuard and applies it as canMatch to the testnet, testnet4, and signet route roots.
	•	When a network is disabled via window.__env flags (TESTNET_ENABLED, TESTNET4_ENABLED, SIGNET_ENABLED), navigation to that network route is prevented and redirected to /.
	•	Keeps existing routing behavior unchanged for enabled networks.
	•	Closes #5496

How I tested
	•	Ran locally with TESTNET_ENABLED=false → Navigating to /testnet redirects to / (expected behavior)
	•	Ran locally with TESTNET_ENABLED=true → /testnet loads normally
Repeated the same validation for:
	•	TESTNET4_ENABLED
	•	SIGNET_ENABLED
