### PR TITLE
Fix: Grab cursor blockchain wrapper

### DIFF
--- a/frontend/src/app/components/blockchain/blockchain.component.scss
+++ b/frontend/src/app/components/blockchain/blockchain.component.scss
@@ -114,11 +114,3 @@
     direction: rtl;
   }
 }
-.blockchain-wrapper {
-  cursor: grab;
-}
-
-.blockchain-wrapper:active {
-  cursor: grabbing;
-}
-

--- a/frontend/src/app/components/start/start.component.scss
+++ b/frontend/src/app/components/start/start.component.scss
@@ -55,6 +55,14 @@
   &.time-rtl .reset-scroll {
     left: 10px;
   }
+
+  &:hover {
+    cursor: grab;
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 .warning-label {


### PR DESCRIPTION
As described in the issue, grab cursor on hover disappeared on 4th latest block.

Fixes #6352 