### PR TITLE
Always include firstSeen field in block extras object

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -373,6 +373,7 @@ class Blocks {
         }
       }
 
+      extras.firstSeen = null;
       if (config.CORE_RPC.DEBUG_LOG_PATH) {
         const oldestLog = this.getOldestCoreLogTimestamp();
         if (oldestLog) {
@@ -955,12 +956,12 @@ class Blocks {
     logger.debug(`Found first seen times of ${foundCount} / ${results.length} blocks in Core logs, saving to database...`);
     await BlocksRepository.$saveFirstSeenTimes(results);
 
+    const blocksByHash = new Map<string, BlockExtended>(this.blocks.map<[string, BlockExtended]>(block => [block.id, block]));
+
     for (const { hash, firstSeen } of results) {
-      if (firstSeen !== null) {
-        const cachedBlock = this.blocks.find(blk => blk.id === hash);
-        if (cachedBlock) {
-          cachedBlock.extras.firstSeen = firstSeen;
-        }
+      const cachedBlock = blocksByHash.get(hash);
+      if (cachedBlock?.extras) {
+        cachedBlock.extras.firstSeen = firstSeen;
       }
     }
 


### PR DESCRIPTION
The `firstSeen` field of `api/v1/block/:hash` is inconsistent for blocks with missing first seen time: 

- `firstSeen: null` is included in blocks loaded from database
- omitted in blocks loaded from memory

This PR should always set `firstSeen: null` in the response (modulo a few pre-fix cached blocks).