### PR TITLE
Fix extra dependabot cooldown properties

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,9 +56,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 3
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     ignore:
       - dependency-name: "*"
         update-types:
@@ -70,9 +67,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 3
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     ignore:
       - dependency-name: "*"
         update-types:
@@ -84,9 +78,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 3
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
Dependabot started complaining about these extra fields:

```
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/3/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/3/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/3/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/4/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/4/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/4/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
