### PR TITLE
Fix syntax error on provenance check script

### DIFF
--- a/.github/workflows/dependabot-provenance-check.yml
+++ b/.github/workflows/dependabot-provenance-check.yml
@@ -44,7 +44,7 @@ jobs:
             DEP=$(echo "$DEP" | xargs)
 
             NEW_VERSION=$(echo "$UPDATED_DEPS_JSON" | jq -r --arg name "$DEP" '
-              .[] | select(.dependency-name == $name) | .new-version
+              .[] | select(.["dependency-name"] == $name) | .["new-version"]
             ' | head -n 1)
 
             if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then


### PR DESCRIPTION
Fixes the syntax error on the workflow:

```
Run IFS=',' read -ra DEPS <<< "path-to-regexp"
jq: error: version/0 is not defined at <top-level>, line 2:
    .[] | select(.dependency-name == $name) | .new-version                                                   
jq: 1 compile error
Error: Could not determine updated version for dependency path-to-regexp from Dependabot metadata
```