### PR TITLE
Improve accelerator checkout fee bars

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
@@ -149,7 +149,10 @@
   flex-direction: row;
   align-items: stretch;
   margin-top: 1em;
-  min-height: 350px;
+
+  @media (min-width: 768px) {
+    min-height: 350px;
+  }
 }
 
 .payment-area {

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
@@ -149,6 +149,7 @@
   flex-direction: row;
   align-items: stretch;
   margin-top: 1em;
+  min-height: 350px;
 }
 
 .payment-area {

--- a/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.scss
@@ -1,5 +1,6 @@
 .fee-graph {
   height: 100%;
+  min-height: 300px;
   min-width: 120px;
   width: 120px;
   margin-left: 4em;
@@ -16,7 +17,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      min-height: 30px;
+      min-height: 0;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -33,9 +34,11 @@
       }
 
       .fee {
-        font-size: 0.9em;
+        font-size: 0.75em;
         opacity: 0;
         pointer-events: none;
+        position: absolute;
+        top: 20px;
       }
 
       .spacer {
@@ -44,6 +47,7 @@
         flex-grow: 1;
         pointer-events: none;
       }
+
 
       .line {
         position: absolute;
@@ -77,13 +81,10 @@
         .fill {
           background: var(--green);
         }
-        .line {
-          .fee-rate {
-            top: 0;
-          }
+        .line .fee-rate {
+          top: 0;
         }
         .fee {
-          position: absolute;
           opacity: 1;
           z-index: 11;
         }
@@ -94,7 +95,6 @@
           background: var(--tertiary);
         }
         .fee {
-          position: absolute;
           opacity: 1;
           z-index: 11;
         }

--- a/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-fee-graph.component.ts
@@ -70,11 +70,11 @@ export class AccelerateFeeGraphComponent implements OnInit, AfterViewInit, OnCha
     const numBars = hasNextBlockRate ? 4 : 3;
     const maxRate = Math.max(...this.maxRateOptions.map(option => option.rate));
     const baseRate = this.estimate.txSummary.effectiveFee / this.estimate.txSummary.effectiveVsize;
-    let baseHeight = Math.max(this.height - (numBars * 30), this.height * (baseRate / maxRate));
+    let baseHeight = Math.max(this.height - (numBars * 50), this.height * (baseRate / maxRate));
     const bars: GraphBar[] = [];
     let lastHeight = 0;
     if (hasNextBlockRate) {
-      lastHeight = Math.max(lastHeight + 30, (this.height * ((this.estimate.targetFeeRate - baseRate) / maxRate)));
+      lastHeight = Math.max(lastHeight + 50, (this.height * ((this.estimate.targetFeeRate - baseRate) / maxRate)));
       bars.push({
         rate: this.estimate.targetFeeRate,
         height: lastHeight,
@@ -84,7 +84,7 @@ export class AccelerateFeeGraphComponent implements OnInit, AfterViewInit, OnCha
       });
     }
     this.maxRateOptions.forEach((option, index) => {
-      lastHeight = Math.max(lastHeight + 30, (this.height * ((option.rate - baseRate) / maxRate)));
+      lastHeight = Math.max(lastHeight + 50, (this.height * ((option.rate - baseRate) / maxRate)));
       bars.push({
         rate: option.rate,
         height: lastHeight,
@@ -98,6 +98,14 @@ export class AccelerateFeeGraphComponent implements OnInit, AfterViewInit, OnCha
 
     bars.reverse();
 
+    const minBaseHeight = 50;
+    if (this.height - lastHeight < minBaseHeight) {
+      const scale = (this.height - minBaseHeight) / lastHeight;
+      lastHeight = this.height - minBaseHeight;
+      for (const bar of bars) {
+        bar.height = Math.round(bar.height * scale);
+      }
+    }
     baseHeight = this.height - lastHeight;
 
     for (const bar of bars) {


### PR DESCRIPTION
When customizing accelerator fee rates, the second band was most of the times squished and overlapping with the others.

Hovering also caused the sats value to overlap with the dotted lines.

Changed the font size a bit and tried improve the vertical alignment and size of the bands.

Before:

<img width="263" height="572" alt="Screenshot 2026-04-06 at 5 35 02 PM" src="https://github.com/user-attachments/assets/eed14cab-5b0f-4767-87a4-b900554723b7" />

After:

<img width="260" height="563" alt="Screenshot 2026-04-06 at 5 35 06 PM" src="https://github.com/user-attachments/assets/e4762a98-b8f0-4b8e-ab41-15f8bbe1b4a5" />

--

Before:

<img width="274" height="544" alt="Screenshot 2026-04-06 at 5 36 08 PM" src="https://github.com/user-attachments/assets/86953839-ffb6-4101-a5de-da69ebad6b42" />

After:

<img width="258" height="568" alt="Screenshot 2026-04-06 at 5 36 15 PM" src="https://github.com/user-attachments/assets/440bb7c3-3eb2-492e-97e8-84c23b7b7c12" />

--

Before:

<img width="238" height="528" alt="Screenshot 2026-04-06 at 5 38 42 PM" src="https://github.com/user-attachments/assets/43dc2a55-6d73-4dda-bc8c-ae31cc56505a" />

After:

<img width="244" height="546" alt="Screenshot 2026-04-06 at 5 38 47 PM" src="https://github.com/user-attachments/assets/e8e8b6f6-31bc-440f-a9c9-25893449abca" />
