### PR TITLE
Fix apple-mobile-web-app-capable deprecation warning

### DIFF
--- a/frontend/src/index.liquid.html
+++ b/frontend/src/index.liquid.html
@@ -29,6 +29,7 @@
   <link id="canonical" rel="canonical" href="https://liquid.network">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/liquid/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.bitb.html
+++ b/frontend/src/index.mempool.bitb.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://bitwise.mempool.space">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.html
+++ b/frontend/src/index.mempool.html
@@ -40,6 +40,7 @@
   <link rel="shortcut icon" href="/resources/favicons/favicon.ico">
   <link id="canonical" rel="canonical" href="https://mempool.space">
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.meta.html
+++ b/frontend/src/index.mempool.meta.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://metaplanet.mempool.space">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.onbtc.html
+++ b/frontend/src/index.mempool.onbtc.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://bitcoin.gob.sv">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.river.html
+++ b/frontend/src/index.mempool.river.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://river.mempool.space">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.strategy.html
+++ b/frontend/src/index.mempool.strategy.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://strategy.mempool.space">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">

--- a/frontend/src/index.mempool.xxi.html
+++ b/frontend/src/index.mempool.xxi.html
@@ -30,6 +30,7 @@
   <link id="canonical" rel="canonical" href="https://xxi.mempool.space">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="msapplication-config" content="/resources/favicons/browserconfig.xml">


### PR DESCRIPTION
Fixing the following warning:

`<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">`