### PR TITLE
[refactor] remove unused referenceId for card on file acceleration

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.ts
@@ -787,7 +787,6 @@ export class AccelerateCheckout implements OnInit, OnDestroy {
             this.tx.txid,
             cardOnFile.card.card_id,
             verificationToken.token,
-            `accelerator-${this.tx.txid.substring(0, 15)}-${Math.round(new Date().getTime() / 1000)}`,
             costUSD,
             verificationToken.userChallenged,
             this.partnerCode

--- a/frontend/src/app/services/services-api.service.ts
+++ b/frontend/src/app/services/services-api.service.ts
@@ -147,8 +147,8 @@ export class ServicesApiServices {
     return this.httpClient.post<any>(`${this.stateService.env.SERVICES_API}/accelerator/accelerate/googlePay`, { txInput: txInput, cardTag: cardTag, token: token, verificationToken: verificationToken, referenceId: referenceId, userApprovedUSD: userApprovedUSD, userChallenged: userChallenged, partnerCode: partnerCode });
   }
 
-  accelerateWithCardOnFile$(txInput: string, token: string, verificationToken: string, referenceId: string, userApprovedUSD: number, userChallenged: boolean, partnerCode: string | undefined) {
-    return this.httpClient.post<any>(`${this.stateService.env.SERVICES_API}/accelerator/accelerate/cardOnFile`, { txInput: txInput, token: token, verificationToken: verificationToken, referenceId: referenceId, userApprovedUSD: userApprovedUSD, userChallenged: userChallenged, partnerCode: partnerCode  });
+  accelerateWithCardOnFile$(txInput: string, cardId: string, verificationToken: string, userApprovedUSD: number, userChallenged: boolean, partnerCode: string | undefined) {
+    return this.httpClient.post<any>(`${this.stateService.env.SERVICES_API}/accelerator/accelerate/cardOnFile`, { txInput: txInput, token: cardId, verificationToken: verificationToken, userApprovedUSD: userApprovedUSD, userChallenged: userChallenged, partnerCode: partnerCode  });
   }
 
   getAccelerations$(): Observable<Acceleration[]> {


### PR DESCRIPTION
I've noticed this small issue while working on https://github.com/mempool/mempool.space/pull/2303

As you can see, referenceId is not used by the route https://github.com/mempool/mempool.space/blob/fdfb25131e1b8228ac438ec53c5a250a37967496/backend/src/features/accelerator/accelerator.routes.ts#L603-L668