### PR TITLE
cluster mempool previews & improvements

### DIFF
--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.html
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.html
@@ -19,26 +19,50 @@
           [attr.fill]="edge.childColor"
           [attr.fill-opacity]="edge.childInactive ? 0.45 : 1" />
       </marker>
-      <marker id="edge-arrow-highlight"
+      <marker [attr.id]="idPrefix + '-edge-arrow-ancestor'"
         markerUnits="userSpaceOnUse"
         markerWidth="8" markerHeight="8"
         refX="5" refY="4"
         orient="auto">
-        <path d="M 0,0.5 L 7.5,4 L 0,7.5 Z" fill="white" />
+        <path class="edge-arrow-ancestor-path" d="M 0,0.5 L 7.5,4 L 0,7.5 Z" />
+      </marker>
+      <marker [attr.id]="idPrefix + '-edge-arrow-descendant'"
+        markerUnits="userSpaceOnUse"
+        markerWidth="8" markerHeight="8"
+        refX="5" refY="4"
+        orient="auto">
+        <path class="edge-arrow-descendant-path" d="M 0,0.5 L 7.5,4 L 0,7.5 Z" />
+      </marker>
+      <marker [attr.id]="idPrefix + '-edge-arrow-direct'"
+        markerUnits="userSpaceOnUse"
+        markerWidth="8" markerHeight="8"
+        refX="5" refY="4"
+        orient="auto">
+        <path class="edge-arrow-direct-path" d="M 0,0.5 L 7.5,4 L 0,7.5 Z" />
       </marker>
     </defs>
 
     <ng-container *ngIf="!preview">
       <path *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
         class="chunk-border"
-        [class.inactive]="outline.chunkIndex !== activeChunkIndex"
-        [attr.d]="outline.path" />
+        [class.inactive]="outline.chunkIndex !== effectiveActiveChunk"
+        [attr.d]="outline.path"
+        [ngbTooltip]="chunkLabelTooltip"
+        container="body"
+        placement="top"
+        (mouseenter)="onChunkEnter(outline.chunkIndex)"
+        (mouseleave)="onChunkLeave()" />
 
       <text *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
         class="chunk-label"
-        [class.inactive]="outline.chunkIndex !== activeChunkIndex"
+        [class.inactive]="outline.chunkIndex !== effectiveActiveChunk"
         [attr.x]="outline.labelX" [attr.y]="outline.labelY"
-        text-anchor="middle">
+        text-anchor="middle"
+        [ngbTooltip]="chunkLabelTooltip"
+        container="body"
+        placement="top"
+        (mouseenter)="onChunkEnter(outline.chunkIndex)"
+        (mouseleave)="onChunkLeave()">
         {{ outline.feerate | feeRounding }} sat/vB
       </text>
     </ng-container>
@@ -50,13 +74,17 @@
           fill="none"
           stroke="transparent"
           stroke-width="12"
-          (mouseenter)="onEdgeEnter(i)"
+          (mouseenter)="onEdgeEnter(i, $event)"
+          (mousemove)="onEdgeMove($event)"
           (mouseleave)="onEdgeLeave()" />
         <path class="edge-line"
           [class.highlighted]="edge.highlighted"
+          [class.ancestor]="edge.highlightKind === 'ancestor'"
+          [class.descendant]="edge.highlightKind === 'descendant'"
+          [class.direct]="edge.highlightKind === 'direct'"
           [attr.d]="edge.path"
-          [attr.stroke]="preview ? 'white' : (edge.highlighted ? 'white' : 'url(#' + edge.gradientId + ')')"
-          [attr.marker-end]="preview ? null : (edge.highlighted ? 'url(#edge-arrow-highlight)' : 'url(#' + edge.markerId + ')')"
+          [attr.stroke]="preview ? 'white' : (edge.highlighted ? null : 'url(#' + edge.gradientId + ')')"
+          [attr.marker-end]="preview ? null : (edge.highlightKind === 'ancestor' ? 'url(#' + idPrefix + '-edge-arrow-ancestor)' : edge.highlightKind === 'descendant' ? 'url(#' + idPrefix + '-edge-arrow-descendant)' : edge.highlightKind === 'direct' ? 'url(#' + idPrefix + '-edge-arrow-direct)' : 'url(#' + edge.markerId + ')')"
           fill="none" />
       </g>
     </ng-container>
@@ -72,7 +100,8 @@
         <rect class="node-rect"
           [class.current]="node.isCurrent"
           [class.hovered]="node.hovered"
-          [class.related]="node.related"
+          [class.ancestor]="node.relation === 'ancestor'"
+          [class.descendant]="node.relation === 'descendant'"
           [attr.x]="node.rectX" [attr.y]="node.rectY"
           [attr.width]="node.width" [attr.height]="node.height"
           [attr.rx]="node.rx"
@@ -85,15 +114,43 @@
       </g>
     </ng-container>
   </svg>
+</div>
 
-  <div #tooltip
-    class="cluster-tooltip"
-    *ngIf="hoverNode"
-    [style.left.px]="tooltipPosition.x"
-    [style.top.px]="tooltipPosition.y">
-    <p>{{ hoverNode.tx.txid | shortenString }}</p>
-    <p>{{ hoverNode.tx.fee | number }} sat</p>
-    <p [innerHTML]="hoverNode.tx.weight / 4 | vbytes: 2"></p>
-    <p>{{ hoverNode.feerate | feeRounding }} sat/vB</p>
+<ng-template #chunkLabelTooltip><span i18n="cluster.mempool-chunk|Mempool chunk tooltip">mempool chunk</span></ng-template>
+
+<div #tooltip
+  class="cluster-tooltip"
+  *ngIf="hoverNode || hoverEdge"
+  [style.left.px]="tooltipPosition.x"
+  [style.top.px]="tooltipPosition.y">
+  <ng-container *ngIf="hoverNode">
+    <div class="tx-id-row">
+      <span>{{ hoverNode.tx.txid | shortenString }}</span>
+      <span class="this-tx-badge" *ngIf="hoverNode.isCurrent" i18n="cluster.this-transaction|this transaction">this transaction</span>
+    </div>
+    <div class="tooltip-body">
+      <table class="stats">
+        <tr>
+          <th i18n="transaction.fee|Transaction fee">Fee</th>
+          <td>{{ hoverNode.tx.fee | number }} <span class="unit" i18n="shared.sats">sats</span></td>
+        </tr>
+        <tr>
+          <th i18n="transaction.vsize|Virtual size">Size</th>
+          <td><span [innerHTML]="hoverNode.tx.weight / 4 | vbytes: 2"></span></td>
+        </tr>
+        <tr>
+          <th i18n="transaction.fee-rate|Transaction fee rate">Fee rate</th>
+          <td>{{ hoverNode.feerate | feeRounding }} <span class="unit">sat/vB</span></td>
+        </tr>
+      </table>
+      <div class="legend">
+        <div><span class="swatch ancestor"></span><span i18n="cluster.parents|parents">parents</span></div>
+        <div><span class="swatch descendant"></span><span i18n="cluster.children|children">children</span></div>
+      </div>
+    </div>
+  </ng-container>
+  <div class="legend edge-legend" *ngIf="!hoverNode && hoverEdge">
+    <div><span class="swatch ancestor"></span><span i18n="cluster.parent|parent">parent</span></div>
+    <div><span class="swatch descendant"></span><span i18n="cluster.child|child">child</span></div>
   </div>
 </div>

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.html
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.html
@@ -1,5 +1,5 @@
-<div class="graph-container" #graphContainer>
-  <svg [attr.width]="svgWidth" [attr.height]="svgHeight" xmlns="http://www.w3.org/2000/svg">
+<div class="graph-container" [class.preview]="preview" #graphContainer>
+  <svg [attr.width]="svgWidth" [attr.height]="svgHeight" [attr.viewBox]="svgViewBox" xmlns="http://www.w3.org/2000/svg">
     <defs>
       <linearGradient *ngFor="let edge of edges; trackBy: trackByEdgeId"
         [attr.id]="edge.gradientId"
@@ -28,56 +28,62 @@
       </marker>
     </defs>
 
-    <path *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
-      class="chunk-border"
-      [class.inactive]="outline.chunkIndex !== activeChunkIndex"
-      [attr.d]="outline.path" />
+    <ng-container *ngIf="!preview">
+      <path *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
+        class="chunk-border"
+        [class.inactive]="outline.chunkIndex !== activeChunkIndex"
+        [attr.d]="outline.path" />
 
-    <text *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
-      class="chunk-label"
-      [class.inactive]="outline.chunkIndex !== activeChunkIndex"
-      [attr.x]="outline.labelX" [attr.y]="outline.labelY"
-      text-anchor="middle">
-      {{ outline.feerate | feeRounding }} sat/vB
-    </text>
-
-    <g *ngFor="let edge of edges; let i = index; trackBy: trackByEdgeId">
-      <path class="edge-hitarea"
-        [attr.d]="edge.path"
-        fill="none"
-        stroke="transparent"
-        stroke-width="12"
-        (mouseenter)="onEdgeEnter(i)"
-        (mouseleave)="onEdgeLeave()" />
-      <path class="edge-line"
-        [class.highlighted]="edge.highlighted"
-        [attr.d]="edge.path"
-        [attr.stroke]="edge.highlighted ? 'white' : 'url(#' + edge.gradientId + ')'"
-        [attr.marker-end]="edge.highlighted ? 'url(#edge-arrow-highlight)' : 'url(#' + edge.markerId + ')'"
-        fill="none" />
-    </g>
-
-    <g *ngFor="let node of nodes; trackBy: trackByNodeIndex"
-      class="node-group"
-      [class.inactive-fill]="node.inactive"
-      (mouseenter)="onNodeEnter(node, $event)"
-      (mousemove)="onNodeMove($event)"
-      (mouseleave)="onNodeLeave()"
-      (click)="onNodeClick(node)">
-      <rect class="node-rect"
-        [class.current]="node.isCurrent"
-        [class.hovered]="node.hovered"
-        [class.related]="node.related"
-        [attr.x]="node.rectX" [attr.y]="node.rectY"
-        [attr.width]="nodeW" [attr.height]="nodeH"
-        [attr.rx]="nodeRx"
-        [attr.fill]="node.color" />
-      <text class="node-label"
-        [attr.x]="node.x" [attr.y]="node.y"
-        text-anchor="middle" dominant-baseline="central">
-        {{ node.feerate | feeRounding }}
+      <text *ngFor="let outline of chunkOutlines; trackBy: trackByChunkIndex"
+        class="chunk-label"
+        [class.inactive]="outline.chunkIndex !== activeChunkIndex"
+        [attr.x]="outline.labelX" [attr.y]="outline.labelY"
+        text-anchor="middle">
+        {{ outline.feerate | feeRounding }} sat/vB
       </text>
-    </g>
+    </ng-container>
+
+    <ng-container *ngFor="let edge of edges; let i = index; trackBy: trackByEdgeId">
+      <g *ngIf="edge.visible">
+        <path class="edge-hitarea"
+          [attr.d]="edge.path"
+          fill="none"
+          stroke="transparent"
+          stroke-width="12"
+          (mouseenter)="onEdgeEnter(i)"
+          (mouseleave)="onEdgeLeave()" />
+        <path class="edge-line"
+          [class.highlighted]="edge.highlighted"
+          [attr.d]="edge.path"
+          [attr.stroke]="preview ? 'white' : (edge.highlighted ? 'white' : 'url(#' + edge.gradientId + ')')"
+          [attr.marker-end]="preview ? null : (edge.highlighted ? 'url(#edge-arrow-highlight)' : 'url(#' + edge.markerId + ')')"
+          fill="none" />
+      </g>
+    </ng-container>
+
+    <ng-container *ngFor="let node of nodes; trackBy: trackByNodeIndex">
+      <g *ngIf="node.visible"
+        class="node-group"
+        [class.inactive-fill]="node.inactive"
+        (mouseenter)="onNodeEnter(node, $event)"
+        (mousemove)="onNodeMove($event)"
+        (mouseleave)="onNodeLeave()"
+        (click)="onNodeClick(node)">
+        <rect class="node-rect"
+          [class.current]="node.isCurrent"
+          [class.hovered]="node.hovered"
+          [class.related]="node.related"
+          [attr.x]="node.rectX" [attr.y]="node.rectY"
+          [attr.width]="node.width" [attr.height]="node.height"
+          [attr.rx]="node.rx"
+          [attr.fill]="node.color" />
+        <text *ngIf="!preview" class="node-label"
+          [attr.x]="node.x" [attr.y]="node.y"
+          text-anchor="middle" dominant-baseline="central">
+          {{ node.feerate | feeRounding }}
+        </text>
+      </g>
+    </ng-container>
   </svg>
 
   <div #tooltip

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
@@ -15,6 +15,10 @@
     overflow: hidden;
     pointer-events: none;
     border-radius: 4px;
+    background-color: var(--cluster-preview-background, var(--stat-box-bg));
+    box-shadow: var(--cluster-preview-shadow, none);
+    cursor: var(--cluster-preview-cursor, default);
+    transition: box-shadow 150ms ease, background-color 150ms ease;
 
     svg {
       display: block;

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
@@ -23,10 +23,10 @@
     overflow: hidden;
     pointer-events: none;
     border-radius: 4px;
-    background-color: var(--cluster-preview-background, var(--stat-box-bg));
+    background-color: transparent;
     box-shadow: var(--cluster-preview-shadow, none);
     cursor: var(--cluster-preview-cursor, default);
-    transition: box-shadow 150ms ease, background-color 150ms ease;
+    transition: box-shadow 150ms ease;
 
     svg {
       display: block;

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
@@ -9,6 +9,35 @@
   svg {
     display: inline-block;
   }
+
+  &.preview {
+    padding: 0;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: 4px;
+
+    svg {
+      display: block;
+      width: 100%;
+      -webkit-mask:
+        linear-gradient(to right, transparent 0, #000 6%, #000 94%, transparent 100%),
+        linear-gradient(to bottom, transparent 0, #000 12%, #000 88%, transparent 100%);
+      -webkit-mask-composite: source-in;
+      mask:
+        linear-gradient(to right, transparent 0, #000 6%, #000 94%, transparent 100%),
+        linear-gradient(to bottom, transparent 0, #000 12%, #000 88%, transparent 100%);
+      mask-composite: intersect;
+    }
+
+    .node-rect {
+      stroke-width: 2;
+    }
+
+    .edge-line {
+      stroke-width: 0.5;
+      opacity: 0.55;
+    }
+  }
 }
 
 .chunk-border {

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.scss
@@ -1,3 +1,11 @@
+:host {
+  position: relative;
+  display: block;
+  --cluster-ancestor-color: var(--info);
+  --cluster-descendant-color: var(--primary);
+  --cluster-direct-color: white;
+}
+
 .graph-container {
   position: relative;
   width: 100%;
@@ -73,6 +81,30 @@
   stroke-width: 2;
   transition: stroke 150ms;
   pointer-events: none;
+
+  &.ancestor {
+    stroke: var(--cluster-ancestor-color);
+  }
+
+  &.descendant {
+    stroke: var(--cluster-descendant-color);
+  }
+
+  &.direct {
+    stroke: var(--cluster-direct-color);
+  }
+}
+
+.edge-arrow-ancestor-path {
+  fill: var(--cluster-ancestor-color);
+}
+
+.edge-arrow-descendant-path {
+  fill: var(--cluster-descendant-color);
+}
+
+.edge-arrow-direct-path {
+  fill: var(--cluster-direct-color);
 }
 
 .node-group {
@@ -89,15 +121,19 @@
   transition: stroke 150ms;
 
   &.current {
-    stroke: var(--mainnet-alt);
+    stroke: var(--cluster-direct-color);
   }
 
-  &.related {
-    stroke: rgba(255, 255, 255, 0.6);
+  &.ancestor {
+    stroke: var(--cluster-ancestor-color);
+  }
+
+  &.descendant {
+    stroke: var(--cluster-descendant-color);
   }
 
   &.hovered {
-    stroke: white;
+    stroke: var(--cluster-direct-color);
   }
 }
 
@@ -114,13 +150,78 @@
   border-radius: 4px;
   box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.5);
   color: var(--tooltip-grey);
-  padding: 10px 15px;
+  padding: 8px 12px;
   text-align: left;
   pointer-events: none;
-  max-width: 350px;
+  max-width: 360px;
+  white-space: nowrap;
 
-  p {
-    margin: 0;
-    white-space: nowrap;
+  .tx-id-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .this-tx-badge {
+    font-size: 0.75em;
+    background: rgba(255, 255, 255, 0.12);
+    color: white;
+    border-radius: 3px;
+    padding: 1px 6px;
+  }
+
+  .tooltip-body {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  table.stats {
+    border-collapse: collapse;
+
+    th, td {
+      padding: 1px 0;
+      font-weight: normal;
+      vertical-align: baseline;
+    }
+
+    th {
+      text-align: left;
+      padding-right: 10px;
+      opacity: 0.7;
+    }
+
+    .unit {
+      opacity: 0.7;
+      font-size: 0.85em;
+    }
+  }
+
+  .legend {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.85em;
+    padding-left: 10px;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+
+    > div {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+  }
+
+  .swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+
+    &.ancestor { background: var(--cluster-ancestor-color); }
+    &.descendant { background: var(--cluster-descendant-color); }
   }
 }

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
@@ -1,14 +1,15 @@
-import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy, ElementRef, ViewChild, ChangeDetectorRef, HostListener } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy, ElementRef, ViewChild, ChangeDetectorRef, HostListener, AfterViewInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { CpfpClusterTx, CpfpClusterChunk } from '@app/interfaces/node-api.interface';
 import { ThemeService } from '@app/services/theme.service';
 import { StateService } from '@app/services/state.service';
 import { feeLevels } from '@app/app.constants';
 import { computeGridLayout, GridLayout } from './cluster-layout';
-import { renderLayout, RenderedNode, RenderedEdge, RenderedChunkOutline, NODE_W, NODE_H } from './cluster-renderer';
+import { renderLayout, RenderedNode, RenderedEdge, RenderedChunkOutline } from './cluster-renderer';
 
-const NODE_RX = 6;
 const RESIZE_DEBOUNCE_MS = 100;
+
+let nextClusterDiagramInstance = 0;
 
 @Component({
   selector: 'app-cluster-diagram',
@@ -17,9 +18,10 @@ const RESIZE_DEBOUNCE_MS = 100;
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ClusterDiagramComponent implements OnChanges {
+export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDestroy {
   @Input() cluster: { txs: CpfpClusterTx[]; chunks: CpfpClusterChunk[]; chunkIndex: number };
   @Input() txid: string;
+  @Input() preview = false;
 
   @ViewChild('graphContainer', { static: true }) graphContainer: ElementRef;
   @ViewChild('tooltip') tooltipElement: ElementRef;
@@ -32,16 +34,17 @@ export class ClusterDiagramComponent implements OnChanges {
   chunkOutlines: RenderedChunkOutline[] = [];
   svgWidth = 0;
   svgHeight = 0;
+  svgViewBox: string | null = null;
   activeChunkIndex = 0;
 
   hoverNode: RenderedNode | null = null;
   tooltipPosition = { x: 0, y: 0 };
 
-  readonly nodeW = NODE_W;
-  readonly nodeH = NODE_H;
-  readonly nodeRx = NODE_RX;
+  readonly idPrefix = `cluster-${++nextClusterDiagramInstance}`;
 
   private resizeTimer: ReturnType<typeof setTimeout> | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private lastObservedWidth = 0;
 
   constructor(
     private router: Router,
@@ -52,8 +55,7 @@ export class ClusterDiagramComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (!this.cluster?.txs?.length) { return; }
-    this.activeChunkIndex = this.cluster.chunkIndex;
-    const clusterChanged = changes['cluster'];
+    const clusterChanged = changes['cluster'] || changes['preview'];
     if (clusterChanged) {
       this.computeLayout();
     }
@@ -61,8 +63,28 @@ export class ClusterDiagramComponent implements OnChanges {
   }
 
   private computeLayout(): void {
-    this.txs = this.cluster.txs;
-    this.chunks = this.cluster.chunks;
+    if (this.preview && this.cluster.chunks.length > 0) {
+      const activeChunk = this.cluster.chunks[this.cluster.chunkIndex];
+      const memberSet = new Set(activeChunk.txs);
+      const remap = new Map<number, number>();
+      activeChunk.txs.forEach((origIdx, newIdx) => remap.set(origIdx, newIdx));
+
+      this.txs = activeChunk.txs.map(origIdx => ({
+        ...this.cluster.txs[origIdx],
+        parents: this.cluster.txs[origIdx].parents
+          .filter(p => memberSet.has(p))
+          .map(p => remap.get(p) as number),
+      }));
+      this.chunks = [{
+        txs: this.txs.map((_, i) => i),
+        feerate: activeChunk.feerate,
+      }];
+      this.activeChunkIndex = 0;
+    } else {
+      this.txs = this.cluster.txs;
+      this.chunks = this.cluster.chunks;
+      this.activeChunkIndex = this.cluster.chunkIndex;
+    }
     this.gridLayout = computeGridLayout(this.txs, this.chunks);
   }
 
@@ -88,6 +110,8 @@ export class ClusterDiagramComponent implements OnChanges {
       txids: this.txs.map(tx => tx.txid),
       chunkFeerates: this.chunks.map(c => c.feerate),
       getColor,
+      preview: this.preview,
+      idPrefix: this.idPrefix,
     });
 
     this.nodes = result.nodes;
@@ -95,9 +119,11 @@ export class ClusterDiagramComponent implements OnChanges {
     this.chunkOutlines = result.chunkOutlines;
     this.svgWidth = result.svgWidth;
     this.svgHeight = result.svgHeight;
+    this.svgViewBox = result.viewBox;
   }
 
   onNodeEnter(node: RenderedNode, event: MouseEvent): void {
+    if (this.preview) { return; }
     this.hoverNode = node;
     this.clearHighlights();
     node.hovered = true;
@@ -115,17 +141,20 @@ export class ClusterDiagramComponent implements OnChanges {
   }
 
   onNodeMove(event: MouseEvent): void {
+    if (this.preview) { return; }
     this.updateTooltipPosition(event);
     this.cd.markForCheck();
   }
 
   onNodeLeave(): void {
+    if (this.preview) { return; }
     this.hoverNode = null;
     this.clearHighlights();
     this.cd.markForCheck();
   }
 
   onEdgeEnter(edgeIndex: number): void {
+    if (this.preview) { return; }
     this.clearHighlights();
     const edge = this.edges[edgeIndex];
     edge.highlighted = true;
@@ -135,11 +164,13 @@ export class ClusterDiagramComponent implements OnChanges {
   }
 
   onEdgeLeave(): void {
+    if (this.preview) { return; }
     this.clearHighlights();
     this.cd.markForCheck();
   }
 
   onNodeClick(node: RenderedNode): void {
+    if (this.preview) { return; }
     const network = this.stateService.network;
     const prefix = network && network !== 'mainnet' ? `/${network}` : '';
     this.router.navigate([prefix + '/tx/', node.tx.txid]);
@@ -200,6 +231,31 @@ export class ClusterDiagramComponent implements OnChanges {
 
   @HostListener('window:resize')
   onResize(): void {
+    this.scheduleRerender();
+  }
+
+  ngAfterViewInit(): void {
+    if (typeof ResizeObserver !== 'undefined' && this.graphContainer?.nativeElement) {
+      this.resizeObserver = new ResizeObserver(entries => {
+        const width = entries[0]?.contentRect.width ?? 0;
+        if (Math.abs(width - this.lastObservedWidth) < 1) { return; }
+        this.lastObservedWidth = width;
+        this.scheduleRerender();
+      });
+      this.resizeObserver.observe(this.graphContainer.nativeElement);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    if (this.resizeTimer !== null) {
+      clearTimeout(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+  }
+
+  private scheduleRerender(): void {
     if (this.resizeTimer !== null) {
       clearTimeout(this.resizeTimer);
     }

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
@@ -38,6 +38,8 @@ export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDest
   activeChunkIndex = 0;
 
   hoverNode: RenderedNode | null = null;
+  hoverEdge: RenderedEdge | null = null;
+  hoverChunkIndex: number | null = null;
   tooltipPosition = { x: 0, y: 0 };
 
   readonly idPrefix = `cluster-${++nextClusterDiagramInstance}`;
@@ -129,11 +131,13 @@ export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDest
     node.hovered = true;
     for (const edge of this.edges) {
       if (edge.parentIndex === node.index) {
-        this.nodes[edge.childIndex].related = true;
+        this.nodes[edge.childIndex].relation = 'descendant';
         edge.highlighted = true;
+        edge.highlightKind = 'descendant';
       } else if (edge.childIndex === node.index) {
-        this.nodes[edge.parentIndex].related = true;
+        this.nodes[edge.parentIndex].relation = 'ancestor';
         edge.highlighted = true;
+        edge.highlightKind = 'ancestor';
       }
     }
     this.updateTooltipPosition(event);
@@ -153,20 +157,59 @@ export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDest
     this.cd.markForCheck();
   }
 
-  onEdgeEnter(edgeIndex: number): void {
+  onEdgeEnter(edgeIndex: number, event: MouseEvent): void {
     if (this.preview) { return; }
     this.clearHighlights();
     const edge = this.edges[edgeIndex];
     edge.highlighted = true;
-    this.nodes[edge.parentIndex].related = true;
-    this.nodes[edge.childIndex].related = true;
+    edge.highlightKind = 'direct';
+    this.nodes[edge.parentIndex].relation = 'ancestor';
+    this.nodes[edge.childIndex].relation = 'descendant';
+    this.hoverEdge = edge;
+    this.updateTooltipPosition(event);
+    this.cd.markForCheck();
+  }
+
+  onEdgeMove(event: MouseEvent): void {
+    if (this.preview) { return; }
+    this.updateTooltipPosition(event);
     this.cd.markForCheck();
   }
 
   onEdgeLeave(): void {
     if (this.preview) { return; }
+    this.hoverEdge = null;
     this.clearHighlights();
     this.cd.markForCheck();
+  }
+
+  onChunkEnter(chunkIndex: number): void {
+    if (this.preview) { return; }
+    this.hoverChunkIndex = chunkIndex;
+    this.applyEffectiveChunk();
+    this.cd.markForCheck();
+  }
+
+  onChunkLeave(): void {
+    if (this.preview) { return; }
+    this.hoverChunkIndex = null;
+    this.applyEffectiveChunk();
+    this.cd.markForCheck();
+  }
+
+  get effectiveActiveChunk(): number {
+    return this.hoverChunkIndex ?? this.activeChunkIndex;
+  }
+
+  private applyEffectiveChunk(): void {
+    const effective = this.effectiveActiveChunk;
+    for (const node of this.nodes) {
+      node.inactive = node.chunkIndex !== effective;
+    }
+    for (const edge of this.edges) {
+      edge.parentInactive = this.nodes[edge.parentIndex].chunkIndex !== effective;
+      edge.childInactive = this.nodes[edge.childIndex].chunkIndex !== effective;
+    }
   }
 
   onNodeClick(node: RenderedNode): void {
@@ -179,40 +222,31 @@ export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDest
   private clearHighlights(): void {
     for (const node of this.nodes) {
       node.hovered = false;
-      node.related = false;
+      node.relation = null;
     }
     for (const edge of this.edges) {
       edge.highlighted = false;
+      edge.highlightKind = null;
     }
   }
 
   private updateTooltipPosition(event: MouseEvent): void {
     if (!this.graphContainer) { return; }
+    if (!this.hoverNode && !this.hoverEdge) { return; }
     const container = this.graphContainer.nativeElement;
     const rect = container.getBoundingClientRect();
-    let x = event.clientX - rect.left + container.scrollLeft + 15;
-    let y = event.clientY - rect.top + container.scrollTop + 15;
-
+    const pointerX = event.clientX - rect.left;
+    const pad = 0;
+    let tipW = 0;
     if (this.tooltipElement) {
-      const tipRect = this.tooltipElement.nativeElement.getBoundingClientRect();
-      const visibleLeft = container.scrollLeft;
-      const visibleRight = visibleLeft + rect.width;
-      const visibleTop = container.scrollTop;
-      const visibleBottom = visibleTop + rect.height;
-
-      if (x + tipRect.width > visibleRight) {
-        x = Math.max(visibleLeft, visibleRight - tipRect.width - 10);
-      }
-      if (x < visibleLeft) {
-        x = visibleLeft;
-      }
-      if (y + tipRect.height > visibleBottom) {
-        y = y - tipRect.height - 30;
-      }
-      if (y < visibleTop) {
-        y = visibleTop;
-      }
+      tipW = this.tooltipElement.nativeElement.getBoundingClientRect().width;
     }
+
+    const visibleW = rect.width;
+
+    const onLeftHalf = pointerX < visibleW / 2;
+    const x = onLeftHalf ? visibleW - tipW - pad : pad;
+    const y = pad;
 
     this.tooltipPosition = { x, y };
   }

--- a/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-diagram.component.ts
@@ -237,12 +237,14 @@ export class ClusterDiagramComponent implements OnChanges, AfterViewInit, OnDest
     const rect = container.getBoundingClientRect();
     const pointerX = event.clientX - rect.left;
     const pad = 0;
-    let tipW = 0;
-    if (this.tooltipElement) {
-      tipW = this.tooltipElement.nativeElement.getBoundingClientRect().width;
-    }
-
     const visibleW = rect.width;
+    let tipW = Math.min(360, visibleW);
+    if (this.tooltipElement) {
+      const measuredW = this.tooltipElement.nativeElement.getBoundingClientRect().width;
+      if (measuredW > 0) {
+        tipW = Math.min(measuredW, visibleW);
+      }
+    }
 
     const onLeftHalf = pointerX < visibleW / 2;
     const x = onLeftHalf ? visibleW - tipW - pad : pad;

--- a/frontend/src/app/components/cluster-diagram/cluster-layout.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-layout.ts
@@ -140,6 +140,18 @@ function assignRows(
 ): Int32Array {
   const rows = new Int32Array(n);
   const placed = new Uint8Array(n);
+  const nodeCol = new Int32Array(n);
+  for (let c = 0; c < colNodes.length; c++) {
+    for (const i of colNodes[c]) { nodeCol[i] = c; }
+  }
+
+  const nearestDescendantCol = new Int32Array(n);
+  nearestDescendantCol.fill(maxCol + 1);
+  for (let i = n - 1; i >= 0; i--) {
+    for (const ch of children[i]) {
+      nearestDescendantCol[i] = Math.min(nearestDescendantCol[i], nodeCol[ch], nearestDescendantCol[ch]);
+    }
+  }
 
   for (let c = maxCol; c >= 0; c--) {
     const layer = colNodes[c];
@@ -160,14 +172,24 @@ function assignRows(
       return (totalRows - 1) / 2;
     });
 
-    const sorted = layer.map((nodeIdx, arrIdx) => ({ nodeIdx, arrIdx, target: targets[arrIdx], chunk: txChunk[nodeIdx] }));
+    const sorted = layer.map((nodeIdx, arrIdx) => ({
+      nodeIdx, arrIdx, target: targets[arrIdx], chunk: txChunk[nodeIdx], nearestDescendantCol: nearestDescendantCol[nodeIdx],
+    }));
     sorted.sort((a, b) => {
       const dt = a.target - b.target;
       if (Math.abs(dt) > 0.001) { return dt; }
-      return a.chunk - b.chunk;
+      if (a.chunk !== b.chunk) { return a.chunk - b.chunk; }
+      if (a.nearestDescendantCol !== b.nearestDescendantCol) {
+        return a.nearestDescendantCol - b.nearestDescendantCol;
+      }
+      return a.nodeIdx - b.nodeIdx;
     });
 
-    const slots = pickSlots(sorted.map(s => s.target), totalRows);
+    const slots = pickSlots(
+      sorted.map(s => s.target),
+      totalRows,
+      hasDescendantColumnTie(sorted.map(s => s.nodeIdx), sorted.map(s => s.target), nearestDescendantCol, maxCol),
+    );
     for (let k = 0; k < sorted.length; k++) {
       rows[sorted[k].nodeIdx] = slots[k];
       placed[sorted[k].nodeIdx] = 1;
@@ -178,7 +200,7 @@ function assignRows(
     const forward = pass % 2 === 0;
     for (let c = forward ? 0 : maxCol; forward ? c <= maxCol : c >= 0; forward ? c++ : c--) {
       const layer = colNodes[c];
-      if (layer.length <= 1) { continue; }
+      if (layer.length === 0) { continue; }
 
       const targets = layer.map(i => {
         const neighbors = forward ? txs[i].parents : children[i];
@@ -189,11 +211,22 @@ function assignRows(
       });
 
       const indexed = layer.map((_, idx) => idx);
-      indexed.sort((a, b) => targets[a] - targets[b]);
+      indexed.sort((a, b) => {
+        const dt = targets[a] - targets[b];
+        if (Math.abs(dt) > 0.001) { return dt; }
+        if (nearestDescendantCol[layer[a]] !== nearestDescendantCol[layer[b]]) {
+          return nearestDescendantCol[layer[a]] - nearestDescendantCol[layer[b]];
+        }
+        return layer[a] - layer[b];
+      });
 
-      const currentSlots = layer.map(i => rows[i]).sort((a, b) => a - b);
+      const slots = pickSlots(
+        indexed.map(i => targets[i]),
+        totalRows,
+        hasDescendantColumnTie(indexed.map(i => layer[i]), indexed.map(i => targets[i]), nearestDescendantCol, maxCol),
+      );
       for (let k = 0; k < indexed.length; k++) {
-        rows[layer[indexed[k]]] = currentSlots[k];
+        rows[layer[indexed[k]]] = slots[k];
       }
     }
   }
@@ -203,9 +236,30 @@ function assignRows(
   return rows;
 }
 
-function pickSlots(targets: number[], totalRows: number): number[] {
+function hasDescendantColumnTie(
+  nodes: number[],
+  targets: number[],
+  nearestDescendantCol: Int32Array,
+  maxCol: number,
+): boolean {
+  for (let i = 0; i < nodes.length; i++) {
+    if (nearestDescendantCol[nodes[i]] > maxCol) { continue; }
+    for (let j = 0; j < nodes.length; j++) {
+      if (
+        i !== j
+        && nearestDescendantCol[nodes[i]] !== nearestDescendantCol[nodes[j]]
+        && Math.abs(targets[i] - targets[j]) < 0.001
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function pickSlots(targets: number[], totalRows: number, packFullLayer = false): number[] {
   const count = targets.length;
-  if (count >= totalRows) {
+  if (count >= totalRows && !packFullLayer) {
     return targets.map((_, i) => i);
   }
 
@@ -278,23 +332,48 @@ function computeWaypoints(
     return waypoints;
   }
 
+  const lo = -1;
+  const hi = maxRow + 1;
   for (let c = pNode.col + 1; c < cNode.col; c++) {
     const frac = (c - pNode.col) / (cNode.col - pNode.col);
     const idealRow = pNode.row + frac * (cNode.row - pNode.row);
-    let bestRow = Math.max(0, Math.min(maxRow, Math.round(idealRow)));
+    const targetRow = Math.max(lo, Math.min(hi, Math.round(idealRow)));
 
-    if (nodeAt.has(cellKey(c, bestRow))) {
-      for (let dr = 1; dr <= maxRow; dr++) {
-        if (bestRow + dr <= maxRow && !nodeAt.has(cellKey(c, bestRow + dr))) { bestRow = bestRow + dr; break; }
-        if (bestRow - dr >= 0 && !nodeAt.has(cellKey(c, bestRow - dr))) { bestRow = bestRow - dr; break; }
-      }
-    }
-
-    waypoints.push({ col: c, row: bestRow });
+    waypoints.push({
+      col: c,
+      row: selectOpenWaypointRow(c, targetRow, idealRow, nodeAt, lo, hi),
+    });
   }
 
   waypoints.push({ col: cNode.col, row: cNode.row });
   return waypoints;
+}
+
+function selectOpenWaypointRow(
+  col: number,
+  targetRow: number,
+  idealRow: number,
+  nodeAt: Map<string, number>,
+  lo: number,
+  hi: number,
+): number {
+  if (!nodeAt.has(cellKey(col, targetRow))) {
+    return targetRow;
+  }
+
+  const preferDown = idealRow > targetRow;
+  for (let dr = 1; dr <= hi - lo; dr++) {
+    const first = preferDown ? targetRow + dr : targetRow - dr;
+    const second = preferDown ? targetRow - dr : targetRow + dr;
+    if (first >= lo && first <= hi && !nodeAt.has(cellKey(col, first))) {
+      return first;
+    }
+    if (second >= lo && second <= hi && !nodeAt.has(cellKey(col, second))) {
+      return second;
+    }
+  }
+
+  return targetRow;
 }
 
 interface VSeg {
@@ -775,7 +854,11 @@ function assignHorizontalLanes(edges: GridEdge[], rowLaneCounts: number[]): void
       edgeSegments.sort((a, b) => a.col - b.col);
       let start = 0;
       for (let i = 1; i <= edgeSegments.length; i++) {
-        if (i === edgeSegments.length || edgeSegments[i].col !== edgeSegments[i - 1].col + 1) {
+        const prev = edgeSegments[i - 1];
+        const curr = edgeSegments[i];
+        const contiguous = curr && curr.col === prev.col + 1
+          && !(prev.type === 'approach' && curr.type === 'approach');
+        if (i === edgeSegments.length || !contiguous) {
           const spanSegs = edgeSegments.slice(start, i);
           const colOrders = new Map<number, number>();
           for (const s of spanSegs) { if (s.type !== 'approach') { colOrders.set(s.col, s.order); } }
@@ -907,7 +990,32 @@ function assignLanes(
   for (let i = 0; i < n; i++) {
     lane[i] = Math.floor((minLane[i] + totalLanes - 1 - distToSink[i]) / 2);
   }
+  separateOverlappingLanes(lines, lane, compare);
   return lane;
+}
+
+function separateOverlappingLanes(
+  lines: { minPos: number; maxPos: number }[],
+  lane: number[],
+  compare: (i: number, j: number) => number,
+): void {
+  for (let pass = 0; pass < lines.length * lines.length; pass++) {
+    let changed = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      for (let j = i + 1; j < lines.length; j++) {
+        const lo = Math.max(lines[i].minPos, lines[j].minPos);
+        const hi = Math.min(lines[i].maxPos, lines[j].maxPos);
+        if (lo >= hi || lane[i] !== lane[j]) { continue; }
+
+        const cmp = compare(i, j);
+        lane[cmp > 0 ? i : j]++;
+        changed = true;
+      }
+    }
+
+    if (!changed) { return; }
+  }
 }
 
 
@@ -1049,19 +1157,17 @@ function computeAlternativeWaypoints(
 ): { col: number; row: number }[] {
   const waypoints: { col: number; row: number }[] = [{ col: pNode.col, row: pNode.row }];
 
+  const lo = -1;
+  const hi = maxRow + 1;
   for (let c = pNode.col + 1; c < cNode.col; c++) {
     const frac = (c - pNode.col) / (cNode.col - pNode.col);
     const idealRow = pNode.row + frac * (cNode.row - pNode.row);
-    let targetRow = Math.max(0, Math.min(maxRow, Math.round(idealRow) + offset));
+    const targetRow = Math.max(lo, Math.min(hi, Math.round(idealRow) + offset));
 
-    if (nodeAt.has(cellKey(c, targetRow))) {
-      for (let dr = 1; dr <= maxRow; dr++) {
-        if (targetRow + dr <= maxRow && !nodeAt.has(cellKey(c, targetRow + dr))) { targetRow = targetRow + dr; break; }
-        if (targetRow - dr >= 0 && !nodeAt.has(cellKey(c, targetRow - dr))) { targetRow = targetRow - dr; break; }
-      }
-    }
-
-    waypoints.push({ col: c, row: targetRow });
+    waypoints.push({
+      col: c,
+      row: selectOpenWaypointRow(c, targetRow, idealRow, nodeAt, lo, hi),
+    });
   }
 
   waypoints.push({ col: cNode.col, row: cNode.row });

--- a/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
@@ -7,6 +7,9 @@ export interface RenderedNode {
   y: number;
   rectX: number;
   rectY: number;
+  width: number;
+  height: number;
+  rx: number;
   color: string;
   chunkIndex: number;
   feerate: number;
@@ -14,6 +17,7 @@ export interface RenderedNode {
   isCurrent: boolean;
   hovered: boolean;
   related: boolean;
+  visible: boolean;
 }
 
 export interface RenderedEdge {
@@ -31,6 +35,7 @@ export interface RenderedEdge {
   x2: number;
   y2: number;
   highlighted: boolean;
+  visible: boolean;
 }
 
 export interface RenderedChunkOutline {
@@ -50,6 +55,8 @@ export interface RenderParams {
   txids: string[];
   chunkFeerates: number[];
   getColor: (feerate: number) => string;
+  preview?: boolean;
+  idPrefix: string;
 }
 
 interface RenderResult {
@@ -58,6 +65,19 @@ interface RenderResult {
   chunkOutlines: RenderedChunkOutline[];
   svgWidth: number;
   svgHeight: number;
+  viewBox: string | null;
+}
+
+interface RenderDimensions {
+  nodeW: number;
+  nodeH: number;
+  cellPadY: number;
+  minCellW: number;
+  maxCellW: number;
+  marginX: number;
+  marginY: number;
+  laneSpacing: number;
+  nodeRx: number;
 }
 
 interface GridGeometry {
@@ -68,38 +88,57 @@ interface GridGeometry {
   cellW: number;
   totalCols: number;
   totalRows: number;
+  dim: RenderDimensions;
 }
 
-export const NODE_W = 64;
-export const NODE_H = 30;
-const MIN_CELL_W = 80;
-const MAX_CELL_W = 120;
-const CELL_PAD_Y = 16;
-const MARGIN_X = 20;
-const MARGIN_Y = 30;
-const LANE_SPACING = 6;
-const MIN_GUTTER_W = 3 * LANE_SPACING;
-const MIN_GUTTER_H = 3 * LANE_SPACING;
+const DEFAULT_DIMENSIONS: RenderDimensions = {
+  nodeW: 64,
+  nodeH: 30,
+  cellPadY: 16,
+  minCellW: 80,
+  maxCellW: 120,
+  marginX: 20,
+  marginY: 30,
+  laneSpacing: 6,
+  nodeRx: 6,
+};
+
+const PREVIEW_DIMENSIONS: RenderDimensions = {
+  nodeW: 10,
+  nodeH: 10,
+  cellPadY: 2,
+  minCellW: 18,
+  maxCellW: 80,
+  marginX: 3,
+  marginY: 3,
+  laneSpacing: 2,
+  nodeRx: 2,
+};
+
+const PREVIEW_VIEWPORT_HEIGHT = 48;
 const OUTLINE_PAD = 6;
 
 export function renderLayout(layout: GridLayout, params: RenderParams): RenderResult {
   if (layout.nodes.length === 0) {
-    return { nodes: [], edges: [], chunkOutlines: [], svgWidth: 0, svgHeight: 0 };
+    return { nodes: [], edges: [], chunkOutlines: [], svgWidth: 0, svgHeight: 0, viewBox: null };
   }
 
-  const cellH = NODE_H + CELL_PAD_Y;
+  const dim = params.preview ? PREVIEW_DIMENSIONS : DEFAULT_DIMENSIONS;
+  const minGutterW = 3 * dim.laneSpacing;
+  const minGutterH = 3 * dim.laneSpacing;
+  const cellH = dim.nodeH + dim.cellPadY;
 
   const rowHeights: number[] = [];
   for (let r = 0; r < layout.rows; r++) {
     const laneCount = (layout.rowLaneCounts && layout.rowLaneCounts[r]) || 0;
     if (r % 2 === 0) {
-      rowHeights.push(Math.max(cellH, (laneCount + 1) * LANE_SPACING));
+      rowHeights.push(Math.max(cellH, (laneCount + 1) * dim.laneSpacing));
     } else {
-      rowHeights.push(Math.max(MIN_GUTTER_H, (laneCount + 1) * LANE_SPACING));
+      rowHeights.push(Math.max(minGutterH, (laneCount + 1) * dim.laneSpacing));
     }
   }
 
-  const rowTopY: number[] = [MARGIN_Y];
+  const rowTopY: number[] = [dim.marginY];
   for (let r = 1; r < layout.rows; r++) {
     rowTopY.push(rowTopY[r - 1] + rowHeights[r - 1]);
   }
@@ -107,16 +146,24 @@ export function renderLayout(layout: GridLayout, params: RenderParams): RenderRe
   const gutterWidths: number[] = [];
   for (let c = 0; c < layout.cols - 1; c++) {
     const laneCount = (layout.colLaneCounts && layout.colLaneCounts[c]) || 0;
-    gutterWidths.push(Math.max(MIN_GUTTER_W, (laneCount + 1) * LANE_SPACING));
+    gutterWidths.push(Math.max(minGutterW, (laneCount + 1) * dim.laneSpacing));
   }
   const totalGutterW = gutterWidths.reduce((a, b) => a + b, 0);
 
-  const fixedWidth = MARGIN_X * 2 + totalGutterW;
-  const cellW = layout.cols > 0
-    ? Math.max(MIN_CELL_W, Math.min(MAX_CELL_W, (params.containerWidth - fixedWidth) / layout.cols))
-    : MIN_CELL_W;
+  const fixedWidth = dim.marginX * 2 + totalGutterW;
+  let cellW: number;
+  if (params.preview) {
+    const activeCols = activeChunkColCount(layout, params.activeChunkIndex);
+    const denom = Math.max(1, activeCols);
+    cellW = Math.max(dim.minCellW, Math.min(dim.maxCellW,
+      (params.containerWidth - dim.marginX * 2) / denom));
+  } else if (layout.cols > 0) {
+    cellW = Math.max(dim.minCellW, Math.min(dim.maxCellW, (params.containerWidth - fixedWidth) / layout.cols));
+  } else {
+    cellW = dim.minCellW;
+  }
 
-  const colLeftX: number[] = [MARGIN_X];
+  const colLeftX: number[] = [dim.marginX];
   for (let c = 1; c < layout.cols; c++) {
     colLeftX.push(colLeftX[c - 1] + cellW + gutterWidths[c - 1]);
   }
@@ -124,16 +171,66 @@ export function renderLayout(layout: GridLayout, params: RenderParams): RenderRe
   const geo: GridGeometry = {
     colLeftX, rowTopY, rowHeights, gutterWidths, cellW,
     totalCols: layout.cols, totalRows: layout.rows,
+    dim,
   };
 
   const nodes = renderNodes(layout.nodes, params, geo);
-  const edges = renderEdges(layout.edges, nodes, geo);
-  const chunkOutlines = renderChunkOutlines(layout.chunks, params, geo);
+  const edges = renderEdges(layout.edges, nodes, geo, params.idPrefix);
+  const chunkOutlines = params.preview ? [] : renderChunkOutlines(layout.chunks, params, geo);
 
-  const svgWidth = MARGIN_X * 2 + layout.cols * cellW + totalGutterW;
-  const svgHeight = rowTopY[layout.rows - 1] + rowHeights[layout.rows - 1] + MARGIN_Y;
+  const fullWidth = dim.marginX * 2 + layout.cols * cellW + totalGutterW;
+  const fullHeight = rowTopY[layout.rows - 1] + rowHeights[layout.rows - 1] + dim.marginY;
 
-  return { nodes, edges, chunkOutlines, svgWidth, svgHeight };
+  if (params.preview) {
+    const selected = nodes.find(n => n.isCurrent && n.visible) ?? nodes.find(n => n.visible);
+    if (!selected) {
+      return { nodes, edges, chunkOutlines, svgWidth: fullWidth, svgHeight: fullHeight, viewBox: null };
+    }
+
+    const vbHeight = PREVIEW_VIEWPORT_HEIGHT;
+    const vbWidth = Math.max(dim.minCellW * 3, params.containerWidth || dim.minCellW * 8);
+
+    let activeMinX = Infinity, activeMaxX = -Infinity;
+    let activeMinY = Infinity, activeMaxY = -Infinity;
+    for (const n of nodes) {
+      if (n.visible) {
+        activeMinX = Math.min(activeMinX, n.rectX);
+        activeMaxX = Math.max(activeMaxX, n.rectX + n.width);
+        activeMinY = Math.min(activeMinY, n.rectY);
+        activeMaxY = Math.max(activeMaxY, n.rectY + n.height);
+      }
+    }
+    const pad = dim.marginX;
+    const chunkFits = isFinite(activeMinX) && (activeMaxX - activeMinX) + 2 * pad <= vbWidth;
+    const vbX = chunkFits
+      ? (activeMinX + activeMaxX) / 2 - vbWidth / 2
+      : selected.x - vbWidth / 2;
+    const chunkFitsVertically = isFinite(activeMinY) && (activeMaxY - activeMinY) + 2 * dim.marginY <= vbHeight;
+    const vbY = chunkFitsVertically
+      ? (activeMinY + activeMaxY) / 2 - vbHeight / 2
+      : selected.y - vbHeight / 2;
+
+    return {
+      nodes, edges, chunkOutlines,
+      svgWidth: vbWidth,
+      svgHeight: vbHeight,
+      viewBox: `${vbX} ${vbY} ${vbWidth} ${vbHeight}`,
+    };
+  }
+
+  return { nodes, edges, chunkOutlines, svgWidth: fullWidth, svgHeight: fullHeight, viewBox: null };
+}
+
+function activeChunkColCount(layout: GridLayout, activeChunkIndex: number): number {
+  let minCol = Infinity, maxCol = -Infinity;
+  for (const n of layout.nodes) {
+    if (n.chunkIndex === activeChunkIndex) {
+      if (n.col < minCol) { minCol = n.col; }
+      if (n.col > maxCol) { maxCol = n.col; }
+    }
+  }
+  if (!isFinite(minCol)) { return layout.cols; }
+  return maxCol - minCol + 1;
 }
 
 function geoCellX(geo: GridGeometry, col: number): number {
@@ -141,7 +238,7 @@ function geoCellX(geo: GridGeometry, col: number): number {
 }
 
 function geoCellY(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return MARGIN_Y; }
+  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
   return geo.rowTopY[row] + geo.rowHeights[row] / 2;
 }
 
@@ -154,7 +251,7 @@ function geoCellLeft(geo: GridGeometry, col: number): number {
 }
 
 function geoCellTop(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return MARGIN_Y; }
+  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
   return geo.rowTopY[row];
 }
 
@@ -163,7 +260,7 @@ function geoCellRight(geo: GridGeometry, col: number): number {
 }
 
 function geoCellBottom(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return MARGIN_Y; }
+  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
   return geo.rowTopY[row] + geo.rowHeights[row];
 }
 
@@ -186,6 +283,7 @@ function renderNodes(gridNodes: GridNode[], params: RenderParams, geo: GridGeome
     const feerate = params.txFees[gn.index] / (params.txWeights[gn.index] / 4);
     const color = params.getColor(feerate);
     const inactive = gn.chunkIndex !== params.activeChunkIndex;
+    const visible = !params.preview || !inactive;
 
     return {
       index: gn.index,
@@ -195,8 +293,11 @@ function renderNodes(gridNodes: GridNode[], params: RenderParams, geo: GridGeome
         weight: params.txWeights[gn.index],
       },
       x, y,
-      rectX: x - NODE_W / 2,
-      rectY: y - NODE_H / 2,
+      rectX: x - geo.dim.nodeW / 2,
+      rectY: y - geo.dim.nodeH / 2,
+      width: geo.dim.nodeW,
+      height: geo.dim.nodeH,
+      rx: geo.dim.nodeRx,
       color,
       chunkIndex: gn.chunkIndex,
       feerate,
@@ -204,6 +305,7 @@ function renderNodes(gridNodes: GridNode[], params: RenderParams, geo: GridGeome
       isCurrent: params.txids[gn.index] === params.currentTxid,
       hovered: false,
       related: false,
+      visible,
     };
   });
 }
@@ -216,8 +318,9 @@ interface FanInfo {
 function computeFanInfos(
   gridEdges: GridEdge[],
   side: 'exit' | 'entry',
+  dim: RenderDimensions,
 ): (FanInfo | undefined)[] {
-  const nodeHalfH = NODE_H / 2;
+  const nodeHalfH = dim.nodeH / 2;
   const nodeKey = side === 'exit' ? 'parent' : 'child';
 
   const groups = new Map<number, number[]>();
@@ -241,7 +344,7 @@ function computeFanInfos(
     for (const ei of edgeIndices) {
       const slot = side === 'exit' ? gridEdges[ei].exitSlot : gridEdges[ei].entrySlot;
       const count = side === 'exit' ? gridEdges[ei].exitCount : gridEdges[ei].entryCount;
-      if (Math.abs(slotToOffset(slot, count)) > nodeHalfH) {
+      if (Math.abs(slotToOffset(slot, count, dim)) > nodeHalfH) {
         anyNeedsFan = true;
         break;
       }
@@ -250,14 +353,14 @@ function computeFanInfos(
     if (!anyNeedsFan) { continue; }
 
     const nodeCount = edgeIndices.length;
-    const edgeSpacing = (NODE_H - 2) / Math.max(1, nodeCount - 1);
+    const edgeSpacing = (dim.nodeH - 2) / Math.max(1, nodeCount - 1);
 
     let maxDy = 0;
     const nodeEdgeOffsets: number[] = [];
     for (let k = 0; k < edgeIndices.length; k++) {
       const slot = side === 'exit' ? gridEdges[edgeIndices[k]].exitSlot : gridEdges[edgeIndices[k]].entrySlot;
       const count = side === 'exit' ? gridEdges[edgeIndices[k]].exitCount : gridEdges[edgeIndices[k]].entryCount;
-      const laneOffset = slotToOffset(slot, count);
+      const laneOffset = slotToOffset(slot, count, dim);
       const nodeEdgeOffset = (k - (nodeCount - 1) / 2) * edgeSpacing;
       nodeEdgeOffsets.push(nodeEdgeOffset);
       maxDy = Math.max(maxDy, Math.abs(laneOffset - nodeEdgeOffset));
@@ -275,9 +378,10 @@ function computeFanInfos(
 
 function renderEdges(
   gridEdges: GridEdge[], renderedNodes: RenderedNode[], geo: GridGeometry,
+  idPrefix: string,
 ): RenderedEdge[] {
-  const exitFanInfos = computeFanInfos(gridEdges, 'exit');
-  const entryFanInfos = computeFanInfos(gridEdges, 'entry');
+  const exitFanInfos = computeFanInfos(gridEdges, 'exit', geo.dim);
+  const entryFanInfos = computeFanInfos(gridEdges, 'entry', geo.dim);
 
   return gridEdges.map((ge, idx) => {
     const pNode = renderedNodes[ge.parent];
@@ -293,8 +397,8 @@ function renderEdges(
       parentIndex: ge.parent,
       childIndex: ge.child,
       path,
-      gradientId: `edge-grad-${idx}`,
-      markerId: `edge-arrow-${idx}`,
+      gradientId: `${idPrefix}-edge-grad-${idx}`,
+      markerId: `${idPrefix}-edge-arrow-${idx}`,
       parentColor: pNode.color,
       childColor: cNode.color,
       parentInactive: pNode.inactive,
@@ -302,6 +406,7 @@ function renderEdges(
       x1: first.x, y1: first.y,
       x2: last.x, y2: last.y,
       highlighted: false,
+      visible: pNode.visible && cNode.visible,
     };
   });
 }
@@ -319,11 +424,11 @@ function waypointsToPixels(
   const wp = edge.waypoints;
   if (wp.length < 2) { return []; }
 
-  const exitOffset = slotToOffset(edge.exitSlot, edge.exitCount);
-  const entryOffset = slotToOffset(edge.entrySlot, edge.entryCount);
+  const exitOffset = slotToOffset(edge.exitSlot, edge.exitCount, geo.dim);
+  const entryOffset = slotToOffset(edge.entrySlot, edge.entryCount, geo.dim);
   const points: PathPoint[] = [];
 
-  const startNodeX = geoCellX(geo, wp[0].col) + NODE_W / 2;
+  const startNodeX = geoCellX(geo, wp[0].col) + geo.dim.nodeW / 2;
   const cy0 = geoCellY(geo, wp[0].row);
 
   if (exitFan) {
@@ -336,7 +441,7 @@ function waypointsToPixels(
   let curY = cy0 + exitOffset;
   for (let i = 0; i < wp.length - 1; i++) {
     const vInfo = edge.verticalSlots[i];
-    const gx = geoGutterCenterX(geo, wp[i].col) + slotToOffset(vInfo.slot, vInfo.count);
+    const gx = geoGutterCenterX(geo, wp[i].col) + slotToOffset(vInfo.slot, vInfo.count, geo.dim);
     const isLast = i === wp.length - 2;
 
     let nextY: number;
@@ -344,7 +449,7 @@ function waypointsToPixels(
       nextY = geoCellY(geo, wp[i + 1].row) + entryOffset;
     } else {
       const hInfo = edge.horizontalSlots[i];
-      nextY = geoCellY(geo, wp[i + 1].row) + slotToOffset(hInfo.slot, hInfo.count);
+      nextY = geoCellY(geo, wp[i + 1].row) + slotToOffset(hInfo.slot, hInfo.count, geo.dim);
     }
 
     if (points[points.length - 1].x !== gx) {
@@ -358,12 +463,12 @@ function waypointsToPixels(
 
     if (!isLast) {
       const nextVInfo = edge.verticalSlots[i + 1];
-      const nextGx = geoGutterCenterX(geo, wp[i + 1].col) + slotToOffset(nextVInfo.slot, nextVInfo.count);
+      const nextGx = geoGutterCenterX(geo, wp[i + 1].col) + slotToOffset(nextVInfo.slot, nextVInfo.count, geo.dim);
       points.push({ x: nextGx, y: curY });
     }
   }
 
-  const endNodeX = geoCellX(geo, wp[wp.length - 1].col) - NODE_W / 2;
+  const endNodeX = geoCellX(geo, wp[wp.length - 1].col) - geo.dim.nodeW / 2;
   const cyLast = geoCellY(geo, wp[wp.length - 1].row);
 
   if (entryFan) {
@@ -376,9 +481,9 @@ function waypointsToPixels(
   return points;
 }
 
-function slotToOffset(slot: number, count: number): number {
+function slotToOffset(slot: number, count: number, dim: RenderDimensions): number {
   if (count <= 1) { return 0; }
-  return (slot - (count - 1) / 2) * LANE_SPACING;
+  return (slot - (count - 1) / 2) * dim.laneSpacing;
 }
 
 function buildEdgePath(points: PathPoint[]): string {

--- a/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
@@ -91,6 +91,8 @@ interface GridGeometry {
   cellW: number;
   totalCols: number;
   totalRows: number;
+  virtualTopY: number;
+  virtualBottomY: number;
   dim: RenderDimensions;
 }
 
@@ -141,10 +143,26 @@ export function renderLayout(layout: GridLayout, params: RenderParams): RenderRe
     }
   }
 
-  const rowTopY: number[] = [dim.marginY];
+  let needsVirtualTop = false;
+  let needsVirtualBottom = false;
+  for (const e of layout.edges) {
+    for (const wp of e.waypoints) {
+      if (wp.row < 0) { needsVirtualTop = true; }
+      if (wp.row >= layout.rows) { needsVirtualBottom = true; }
+    }
+  }
+  const virtualGap = dim.laneSpacing * 3;
+  const topPad = needsVirtualTop ? virtualGap : 0;
+  const bottomPad = needsVirtualBottom ? virtualGap : 0;
+
+  const rowTopY: number[] = [dim.marginY + topPad];
   for (let r = 1; r < layout.rows; r++) {
     rowTopY.push(rowTopY[r - 1] + rowHeights[r - 1]);
   }
+  const virtualTopY = needsVirtualTop ? dim.marginY + topPad / 2 : dim.marginY;
+  const virtualBottomY = layout.rows > 0
+    ? rowTopY[layout.rows - 1] + rowHeights[layout.rows - 1] + bottomPad / 2
+    : dim.marginY;
 
   const gutterWidths: number[] = [];
   for (let c = 0; c < layout.cols - 1; c++) {
@@ -174,6 +192,7 @@ export function renderLayout(layout: GridLayout, params: RenderParams): RenderRe
   const geo: GridGeometry = {
     colLeftX, rowTopY, rowHeights, gutterWidths, cellW,
     totalCols: layout.cols, totalRows: layout.rows,
+    virtualTopY, virtualBottomY,
     dim,
   };
 
@@ -182,7 +201,7 @@ export function renderLayout(layout: GridLayout, params: RenderParams): RenderRe
   const chunkOutlines = params.preview ? [] : renderChunkOutlines(layout.chunks, params, geo);
 
   const fullWidth = dim.marginX * 2 + layout.cols * cellW + totalGutterW;
-  const fullHeight = rowTopY[layout.rows - 1] + rowHeights[layout.rows - 1] + dim.marginY;
+  const fullHeight = rowTopY[layout.rows - 1] + rowHeights[layout.rows - 1] + bottomPad + dim.marginY;
 
   if (params.preview) {
     const selected = nodes.find(n => n.isCurrent && n.visible) ?? nodes.find(n => n.visible);
@@ -241,7 +260,8 @@ function geoCellX(geo: GridGeometry, col: number): number {
 }
 
 function geoCellY(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
+  if (row < 0) { return geo.virtualTopY; }
+  if (row >= geo.totalRows) { return geo.virtualBottomY; }
   return geo.rowTopY[row] + geo.rowHeights[row] / 2;
 }
 
@@ -254,7 +274,8 @@ function geoCellLeft(geo: GridGeometry, col: number): number {
 }
 
 function geoCellTop(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
+  if (row < 0) { return geo.virtualTopY; }
+  if (row >= geo.totalRows) { return geo.virtualBottomY; }
   return geo.rowTopY[row];
 }
 
@@ -263,19 +284,24 @@ function geoCellRight(geo: GridGeometry, col: number): number {
 }
 
 function geoCellBottom(geo: GridGeometry, row: number): number {
-  if (row < 0 || row >= geo.totalRows) { return geo.dim.marginY; }
+  if (row < 0) { return geo.virtualTopY; }
+  if (row >= geo.totalRows) { return geo.virtualBottomY; }
   return geo.rowTopY[row] + geo.rowHeights[row];
 }
 
-function borderX(geo: GridGeometry, b: number): number {
+function borderX(geo: GridGeometry, b: number, side: 'left' | 'right' | null = null): number {
   if (b <= 0) { return geoCellLeft(geo, 0) - OUTLINE_PAD; }
   if (b >= geo.totalCols) { return geoCellRight(geo, geo.totalCols - 1) + OUTLINE_PAD; }
+  if (side === 'left') { return geoCellLeft(geo, b) - geo.dim.laneSpacing / 2; }
+  if (side === 'right') { return geoCellRight(geo, b - 1) + geo.dim.laneSpacing / 2; }
   return (geoCellRight(geo, b - 1) + geoCellLeft(geo, b)) / 2;
 }
 
-function borderY(geo: GridGeometry, b: number): number {
+function borderY(geo: GridGeometry, b: number, side: 'top' | 'bottom' | null = null): number {
   if (b <= 0) { return geoCellTop(geo, 0) - OUTLINE_PAD; }
   if (b >= geo.totalRows) { return geoCellBottom(geo, geo.totalRows - 1) + OUTLINE_PAD; }
+  if (side === 'top') { return geoCellTop(geo, b) + geo.dim.laneSpacing / 2; }
+  if (side === 'bottom') { return geoCellBottom(geo, b - 1) - geo.dim.laneSpacing / 2; }
   return (geoCellBottom(geo, b - 1) + geoCellTop(geo, b)) / 2;
 }
 
@@ -554,7 +580,7 @@ function renderChunkOutlines(
       const ty = borderY(geo, r);
       if (ty < labelY || (ty === labelY && cx < labelX)) {
         labelX = cx;
-        labelY = ty - 4;
+        labelY = ty - 8;
       }
     }
 
@@ -578,10 +604,16 @@ function collectBoundarySegments(chunk: ChunkRegion, geo: GridGeometry): Segment
 
   for (const cell of chunk.cells) {
     const c = cellCol(cell), r = cellRow(cell);
-    const left = borderX(geo, c);
-    const right = borderX(geo, c + 1);
-    const top = borderY(geo, r);
-    const bottom = borderY(geo, r + 1);
+    const left = cornerX(chunk, geo, c, r);
+    const right = cornerX(chunk, geo, c + 1, r);
+    const bottomLeft = cornerX(chunk, geo, c, r + 1);
+    const bottomRight = cornerX(chunk, geo, c + 1, r + 1);
+    const top = borderY(geo, r, 'top');
+    const bottom = borderY(geo, r + 1, 'bottom');
+    const leftTop = cornerY(chunk, geo, c, r);
+    const leftBottom = cornerY(chunk, geo, c, r + 1);
+    const rightTop = cornerY(chunk, geo, c + 1, r);
+    const rightBottom = cornerY(chunk, geo, c + 1, r + 1);
 
     const hasAbove = chunk.cells.has(cellKey(c, r - 1));
     const hasBelow = chunk.cells.has(cellKey(c, r + 1));
@@ -589,12 +621,52 @@ function collectBoundarySegments(chunk: ChunkRegion, geo: GridGeometry): Segment
     const hasRight = chunk.cells.has(cellKey(c + 1, r));
 
     if (!hasAbove) { segments.push({ x1: left, y1: top, x2: right, y2: top }); }
-    if (!hasBelow) { segments.push({ x1: right, y1: bottom, x2: left, y2: bottom }); }
-    if (!hasLeft) { segments.push({ x1: left, y1: bottom, x2: left, y2: top }); }
-    if (!hasRight) { segments.push({ x1: right, y1: top, x2: right, y2: bottom }); }
+    if (!hasBelow) { segments.push({ x1: bottomRight, y1: bottom, x2: bottomLeft, y2: bottom }); }
+    if (!hasLeft) {
+      const x = borderX(geo, c, 'left');
+      segments.push({ x1: x, y1: leftBottom, x2: x, y2: leftTop });
+    }
+    if (!hasRight) {
+      const x = borderX(geo, c + 1, 'right');
+      segments.push({ x1: x, y1: rightTop, x2: x, y2: rightBottom });
+    }
   }
 
   return segments;
+}
+
+function cornerX(chunk: ChunkRegion, geo: GridGeometry, col: number, row: number): number {
+  const side = verticalBoundarySide(
+    chunk.cells.has(cellKey(col - 1, row)),
+    chunk.cells.has(cellKey(col, row)),
+  ) || verticalBoundarySide(
+    chunk.cells.has(cellKey(col - 1, row - 1)),
+    chunk.cells.has(cellKey(col, row - 1)),
+  );
+  return borderX(geo, col, side);
+}
+
+function verticalBoundarySide(leftOccupied: boolean, rightOccupied: boolean): 'left' | 'right' | null {
+  if (!leftOccupied && rightOccupied) { return 'left'; }
+  if (leftOccupied && !rightOccupied) { return 'right'; }
+  return null;
+}
+
+function cornerY(chunk: ChunkRegion, geo: GridGeometry, col: number, row: number): number {
+  const side = horizontalBoundarySide(
+    chunk.cells.has(cellKey(col, row - 1)),
+    chunk.cells.has(cellKey(col, row)),
+  ) || horizontalBoundarySide(
+    chunk.cells.has(cellKey(col - 1, row - 1)),
+    chunk.cells.has(cellKey(col - 1, row)),
+  );
+  return borderY(geo, row, side);
+}
+
+function horizontalBoundarySide(aboveOccupied: boolean, belowOccupied: boolean): 'top' | 'bottom' | null {
+  if (!aboveOccupied && belowOccupied) { return 'top'; }
+  if (aboveOccupied && !belowOccupied) { return 'bottom'; }
+  return null;
 }
 
 function endpointKey(x: number, y: number): string {

--- a/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
+++ b/frontend/src/app/components/cluster-diagram/cluster-renderer.ts
@@ -1,5 +1,7 @@
 import { GridLayout, GridNode, GridEdge, ChunkRegion, cellKey, cellCol, cellRow } from './cluster-layout';
 
+export type RelatedKind = null | 'ancestor' | 'descendant' | 'direct';
+
 export interface RenderedNode {
   index: number;
   tx: { txid: string; fee: number; weight: number };
@@ -16,7 +18,7 @@ export interface RenderedNode {
   inactive: boolean;
   isCurrent: boolean;
   hovered: boolean;
-  related: boolean;
+  relation: RelatedKind;
   visible: boolean;
 }
 
@@ -35,6 +37,7 @@ export interface RenderedEdge {
   x2: number;
   y2: number;
   highlighted: boolean;
+  highlightKind: RelatedKind;
   visible: boolean;
 }
 
@@ -304,7 +307,7 @@ function renderNodes(gridNodes: GridNode[], params: RenderParams, geo: GridGeome
       inactive,
       isCurrent: params.txids[gn.index] === params.currentTxid,
       hovered: false,
-      related: false,
+      relation: null,
       visible,
     };
   });
@@ -406,6 +409,7 @@ function renderEdges(
       x1: first.x, y1: first.y,
       x2: last.x, y2: last.y,
       highlighted: false,
+      highlightKind: null,
       visible: pNode.visible && cNode.visible,
     };
   });

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -252,24 +252,26 @@
           <td i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>
         }
         <td>
-          <div class="effective-fee-container">
-            @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize || tx.acceleration)) {
-              <app-fee-rate [class.oobFees]="isAcceleration" [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
-            } @else {
-              <app-fee-rate [class.oobFees]="isAcceleration" [fee]="tx.effectiveFeePerVsize"></app-fee-rate>
-            }
+          <div class="effective-fee-row">
+            <div class="effective-fee-container">
+              @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize || tx.acceleration)) {
+                <app-fee-rate [class.oobFees]="isAcceleration" [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
+              } @else {
+                <app-fee-rate [class.oobFees]="isAcceleration" [fee]="tx.effectiveFeePerVsize"></app-fee-rate>
+              }
 
-            @if (tx?.status?.confirmed && !tx.acceleration && !accelerationInfo && tx.fee && tx.effectiveFeePerVsize) {
-              <app-tx-fee-rating class="ms-2 me-2 effective-fee-rating" [tx]="tx"></app-tx-fee-rating>
+              @if (tx?.status?.confirmed && !tx.acceleration && !accelerationInfo && tx.fee && tx.effectiveFeePerVsize) {
+                <app-tx-fee-rating class="ms-2 me-2 effective-fee-rating" [tx]="tx"></app-tx-fee-rating>
+              }
+            </div>
+            @if (cpfpInfo?.cluster && tx?.txid) {
+              <div class="cluster-preview-inline">
+                <app-cluster-diagram [cluster]="cpfpInfo.cluster" [txid]="tx.txid" [preview]="true"></app-cluster-diagram>
+              </div>
+            } @else if (hasCpfp) {
+              <button type="button" class="btn btn-outline-info btn-sm btn-small-height" (click)="toggleCpfp()">CPFP</button>
             }
           </div>
-          @if (hasCpfp) {
-            @if (cpfpInfo?.cluster) {
-              <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-end" (click)="toggleCpfp()" i18n="transaction.cluster|Cluster">Cluster</button>
-            } @else {
-              <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-end" (click)="toggleCpfp()">CPFP</button>
-            }
-          }
         </td>
       </tr>
     }

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -265,9 +265,22 @@
               }
             </div>
             @if (cpfpInfo?.cluster && tx?.txid) {
-              <div class="cluster-preview-inline">
-                <app-cluster-diagram [cluster]="cpfpInfo.cluster" [txid]="tx.txid" [preview]="true"></app-cluster-diagram>
+              <div class="cluster-preview-inline" role="button" tabindex="0"
+                [ngbTooltip]="clusterPreviewTooltip"
+                placement="bottom"
+                tooltipClass="cluster-preview-ngb-tooltip"
+                container="body"
+                (click)="toggleCpfp()"
+                (keydown.enter)="toggleCpfp()"
+                (keydown.space)="toggleCpfp(); $event.preventDefault()">
+                <app-cluster-diagram class="cluster-preview-diagram" [cluster]="cpfpInfo.cluster" [txid]="tx.txid" [preview]="true"></app-cluster-diagram>
+                <fa-icon class="cluster-preview-expand" [icon]="['fas', cpfpMode ? 'compress' : 'expand']" [fixedWidth]="true"></fa-icon>
               </div>
+              <ng-template #clusterPreviewTooltip>
+                <p i18n="cluster.preview.chunk-line">This transaction belongs to a chunk of {{ clusterPreviewStats.chunkSize }} transaction{{ clusterPreviewStats.chunkSize === 1 ? '' : 's' }}, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
+                <p *ngIf="clusterPreviewStats.otherChunks > 0" i18n="cluster.preview.cluster-line">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunk{{ clusterPreviewStats.otherChunks === 1 ? '' : 's' }}.</p>
+                <p class="hint" i18n="cluster.preview.click-hint">Click for more details.</p>
+              </ng-template>
             } @else if (hasCpfp) {
               <button type="button" class="btn btn-outline-info btn-sm btn-small-height" (click)="toggleCpfp()">CPFP</button>
             }

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -270,7 +270,7 @@
           <td i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>
         }
         <td>
-          <div class="effective-fee-row" [class.has-cluster-preview]="cpfpInfo?.cluster && tx?.txid">
+          <div class="effective-fee-row" [class.has-cluster-preview]="cpfpInfo?.cluster && tx?.txid && !isAcceleration">
             <div class="effective-fee-container">
               @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize || tx.acceleration)) {
                 <app-fee-rate [class.oobFees]="isAcceleration" [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
@@ -282,7 +282,7 @@
                 <app-tx-fee-rating class="ms-2 me-2 effective-fee-rating" [tx]="tx"></app-tx-fee-rating>
               }
             </div>
-            @if (cpfpInfo?.cluster && tx?.txid) {
+            @if (cpfpInfo?.cluster && tx?.txid && !isAcceleration) {
               <ng-container *ngTemplateOutlet="clusterPreviewButton; context: { cluster: cpfpInfo.cluster, txid: tx.txid }"></ng-container>
             } @else if (hasCpfp) {
               <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-end" (click)="toggleCpfp()">CPFP</button>
@@ -290,7 +290,7 @@
           </div>
         </td>
       </tr>
-      @if (cpfpInfo?.cluster && tx?.txid) {
+      @if (cpfpInfo?.cluster && tx?.txid && !isAcceleration) {
         <tr class="cluster-preview-table-row">
           <td colspan="2">
             <ng-container *ngTemplateOutlet="clusterPreviewButton; context: { cluster: cpfpInfo.cluster, txid: tx.txid }"></ng-container>

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -268,7 +268,6 @@
           } @else if (clusterPreviewStats.otherChunks > 1) {
             <p i18n="cluster.preview.cluster-line-many">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunks.</p>
           }
-          <p class="hint" i18n="cluster.preview.click-hint">Click for more details.</p>
         </ng-template>
       </ng-template>
       <tr>

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -245,6 +245,24 @@
 <ng-template #effectiveRateRow>
   @if (!isLoadingTx) {
     @if ((cpfpInfo && hasEffectiveFeeRate) || (accelerationInfo && isAcceleration)) {
+      <ng-template #clusterPreviewButton let-cluster="cluster" let-txid="txid">
+        <div class="cluster-preview-inline" role="button" tabindex="0"
+          [ngbTooltip]="clusterPreviewTooltip"
+          placement="bottom"
+          tooltipClass="cluster-preview-ngb-tooltip"
+          container="body"
+          (click)="toggleCpfp()"
+          (keydown.enter)="toggleCpfp()"
+          (keydown.space)="toggleCpfp(); $event.preventDefault()">
+          <app-cluster-diagram class="cluster-preview-diagram" [cluster]="cluster" [txid]="txid" [preview]="true"></app-cluster-diagram>
+          <fa-icon class="cluster-preview-expand" [icon]="['fas', cpfpMode ? 'compress' : 'expand']" [fixedWidth]="true"></fa-icon>
+        </div>
+        <ng-template #clusterPreviewTooltip>
+          <p i18n="cluster.preview.chunk-line">This transaction belongs to a chunk of {{ clusterPreviewStats.chunkSize }} transaction{{ clusterPreviewStats.chunkSize === 1 ? '' : 's' }}, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
+          <p *ngIf="clusterPreviewStats.otherChunks > 0" i18n="cluster.preview.cluster-line">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunk{{ clusterPreviewStats.otherChunks === 1 ? '' : 's' }}.</p>
+          <p class="hint" i18n="cluster.preview.click-hint">Click for more details.</p>
+        </ng-template>
+      </ng-template>
       <tr>
         @if (isAcceleration) {
           <td i18n="transaction.accelerated-fee-rate|Accelerated transaction fee rate">Accelerated fee rate</td>
@@ -252,7 +270,7 @@
           <td i18n="transaction.effective-fee-rate|Effective transaction fee rate">Effective fee rate</td>
         }
         <td>
-          <div class="effective-fee-row">
+          <div class="effective-fee-row" [class.has-cluster-preview]="cpfpInfo?.cluster && tx?.txid">
             <div class="effective-fee-container">
               @if (accelerationInfo?.acceleratedFeeRate && (!tx.effectiveFeePerVsize || accelerationInfo.acceleratedFeeRate >= tx.effectiveFeePerVsize || tx.acceleration)) {
                 <app-fee-rate [class.oobFees]="isAcceleration" [fee]="accelerationInfo.acceleratedFeeRate"></app-fee-rate>
@@ -265,28 +283,20 @@
               }
             </div>
             @if (cpfpInfo?.cluster && tx?.txid) {
-              <div class="cluster-preview-inline" role="button" tabindex="0"
-                [ngbTooltip]="clusterPreviewTooltip"
-                placement="bottom"
-                tooltipClass="cluster-preview-ngb-tooltip"
-                container="body"
-                (click)="toggleCpfp()"
-                (keydown.enter)="toggleCpfp()"
-                (keydown.space)="toggleCpfp(); $event.preventDefault()">
-                <app-cluster-diagram class="cluster-preview-diagram" [cluster]="cpfpInfo.cluster" [txid]="tx.txid" [preview]="true"></app-cluster-diagram>
-                <fa-icon class="cluster-preview-expand" [icon]="['fas', cpfpMode ? 'compress' : 'expand']" [fixedWidth]="true"></fa-icon>
-              </div>
-              <ng-template #clusterPreviewTooltip>
-                <p i18n="cluster.preview.chunk-line">This transaction belongs to a chunk of {{ clusterPreviewStats.chunkSize }} transaction{{ clusterPreviewStats.chunkSize === 1 ? '' : 's' }}, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
-                <p *ngIf="clusterPreviewStats.otherChunks > 0" i18n="cluster.preview.cluster-line">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunk{{ clusterPreviewStats.otherChunks === 1 ? '' : 's' }}.</p>
-                <p class="hint" i18n="cluster.preview.click-hint">Click for more details.</p>
-              </ng-template>
+              <ng-container *ngTemplateOutlet="clusterPreviewButton; context: { cluster: cpfpInfo.cluster, txid: tx.txid }"></ng-container>
             } @else if (hasCpfp) {
-              <button type="button" class="btn btn-outline-info btn-sm btn-small-height" (click)="toggleCpfp()">CPFP</button>
+              <button type="button" class="btn btn-outline-info btn-sm btn-small-height float-end" (click)="toggleCpfp()">CPFP</button>
             }
           </div>
         </td>
       </tr>
+      @if (cpfpInfo?.cluster && tx?.txid) {
+        <tr class="cluster-preview-table-row">
+          <td colspan="2">
+            <ng-container *ngTemplateOutlet="clusterPreviewButton; context: { cluster: cpfpInfo.cluster, txid: tx.txid }"></ng-container>
+          </td>
+        </tr>
+      }
     }
   } @else {
     <ng-container *ngTemplateOutlet="skeletonDetailsRow"></ng-container>

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.html
@@ -258,8 +258,16 @@
           <fa-icon class="cluster-preview-expand" [icon]="['fas', cpfpMode ? 'compress' : 'expand']" [fixedWidth]="true"></fa-icon>
         </div>
         <ng-template #clusterPreviewTooltip>
-          <p i18n="cluster.preview.chunk-line">This transaction belongs to a chunk of {{ clusterPreviewStats.chunkSize }} transaction{{ clusterPreviewStats.chunkSize === 1 ? '' : 's' }}, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
-          <p *ngIf="clusterPreviewStats.otherChunks > 0" i18n="cluster.preview.cluster-line">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunk{{ clusterPreviewStats.otherChunks === 1 ? '' : 's' }}.</p>
+          @if (clusterPreviewStats.chunkSize === 1) {
+            <p i18n="cluster.preview.chunk-line-one">This transaction belongs to a chunk of 1 transaction, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
+          } @else {
+            <p i18n="cluster.preview.chunk-line-many">This transaction belongs to a chunk of {{ clusterPreviewStats.chunkSize }} transactions, with combined effective fee rate <strong>{{ clusterPreviewStats.chunkFeerate | feeRounding }} sat/vB</strong>.</p>
+          }
+          @if (clusterPreviewStats.otherChunks === 1) {
+            <p i18n="cluster.preview.cluster-line-one">In a mempool cluster containing 1 other chunk.</p>
+          } @else if (clusterPreviewStats.otherChunks > 1) {
+            <p i18n="cluster.preview.cluster-line-many">In a mempool cluster containing {{ clusterPreviewStats.otherChunks }} other chunks.</p>
+          }
           <p class="hint" i18n="cluster.preview.click-hint">Click for more details.</p>
         </ng-template>
       </ng-template>

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
@@ -185,9 +185,55 @@
   align-items: center;
   overflow: visible;
   margin: -0.75rem -0.75rem -0.75rem 0;
+  cursor: pointer;
 
-  app-cluster-diagram {
+  .cluster-preview-diagram {
     display: block;
     width: 100%;
+    --cluster-preview-cursor: pointer;
+  }
+
+  .cluster-preview-expand {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    color: var(--info);
+    font-size: 0.85em;
+    opacity: 0;
+    transition: opacity 150ms ease;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  &:focus-visible { outline: none; }
+
+  &:hover .cluster-preview-expand,
+  &:focus-visible .cluster-preview-expand {
+    opacity: 1;
+  }
+
+  &:hover .cluster-preview-diagram,
+  &:focus-visible .cluster-preview-diagram {
+    --cluster-preview-background: color-mix(in srgb, var(--info) 8%, var(--stat-box-bg));
+    --cluster-preview-shadow: 0 0 0 1px var(--info), 0 0 8px color-mix(in srgb, var(--info) 35%, transparent);
+  }
+}
+
+::ng-deep .cluster-preview-ngb-tooltip .tooltip-inner {
+  text-align: left;
+  max-width: 320px;
+  padding: 10px 12px;
+
+  p {
+    margin: 0 0 6px;
+    line-height: 1.35;
+
+    &:last-child { margin-bottom: 0; }
+
+    &.hint {
+      margin-top: 8px;
+      opacity: 0.8;
+      font-style: italic;
+    }
   }
 }

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
@@ -166,25 +166,27 @@
 }
 
 .effective-fee-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  &.has-cluster-preview {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 
-  .effective-fee-container {
-    flex: 0 0 auto;
+    .effective-fee-container {
+      flex: 0 0 auto;
+    }
   }
 }
 
 .cluster-preview-inline {
   position: relative;
-  flex: 1 1 80px;
-  min-width: 80px;
-  max-width: 100%;
+  flex: 1 1 120px;
+  min-width: 120px;
+  max-width: 300px;
   display: flex;
   align-items: center;
   overflow: visible;
-  margin: -0.75rem -0.75rem -0.75rem 0;
+  margin: -0.75rem -0.75rem -0.75rem auto;
   cursor: pointer;
 
   .cluster-preview-diagram {
@@ -214,8 +216,39 @@
 
   &:hover .cluster-preview-diagram,
   &:focus-visible .cluster-preview-diagram {
-    --cluster-preview-background: color-mix(in srgb, var(--info) 8%, var(--stat-box-bg));
     --cluster-preview-shadow: 0 0 0 1px var(--info), 0 0 8px color-mix(in srgb, var(--info) 35%, transparent);
+  }
+}
+
+.cluster-preview-table-row {
+  display: none;
+}
+
+@media (max-width: 849.98px) and (min-width: 500px) {
+  .cluster-preview-inline {
+    order: -1;
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 499.98px) {
+  .effective-fee-row.has-cluster-preview .cluster-preview-inline {
+    display: none;
+  }
+
+  .cluster-preview-table-row {
+    display: table-row;
+
+    td {
+      padding-top: 0;
+    }
+
+    .cluster-preview-inline {
+      width: 100%;
+      flex-basis: 100%;
+      max-width: 100%;
+      margin: -0.25rem 0 -0.75rem;
+    }
   }
 }
 

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
@@ -164,3 +164,30 @@
   opacity: 0.5;
   pointer-events: none;
 }
+
+.effective-fee-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  .effective-fee-container {
+    flex: 0 0 auto;
+  }
+}
+
+.cluster-preview-inline {
+  position: relative;
+  flex: 1 1 80px;
+  min-width: 80px;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  overflow: visible;
+  margin: -0.75rem -0.75rem -0.75rem 0;
+
+  app-cluster-diagram {
+    display: block;
+    width: 100%;
+  }
+}

--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.ts
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.ts
@@ -40,6 +40,7 @@ export class TransactionDetailsComponent implements OnInit {
   @Input() isCached: boolean;
   @Input() ETA$: Observable<ETA>;
   @Input() unbroadcasted: boolean;
+  @Input() cpfpMode: boolean = false;
 
   @Output() accelerateClicked = new EventEmitter<boolean>();
   @Output() toggleCpfp$ = new EventEmitter<void>();
@@ -54,5 +55,15 @@ export class TransactionDetailsComponent implements OnInit {
 
   toggleCpfp(): void {
     this.toggleCpfp$.emit();
+  }
+
+  get clusterPreviewStats(): { chunkSize: number; chunkFeerate: number; otherChunks: number } {
+    const cluster = this.cpfpInfo?.cluster;
+    const chunk = cluster?.chunks[cluster.chunkIndex];
+    return {
+      chunkSize: chunk?.txs.length ?? 0,
+      chunkFeerate: chunk?.feerate ?? 0,
+      otherChunks: Math.max(0, (cluster?.chunks.length ?? 0) - 1),
+    };
   }
 }

--- a/frontend/src/app/components/transaction/transaction-raw.component.ts
+++ b/frontend/src/app/components/transaction/transaction-raw.component.ts
@@ -68,7 +68,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
   fetchCpfp: boolean;
   cpfpInfo: CpfpInfo | null;
   hasCpfp: boolean = false;
-  cpfpMode: 'advanced' | 'simple' | null = null;
+  cpfpMode: boolean = false;
   mempoolBlocksSubscription: Subscription;
 
   constructor(
@@ -90,10 +90,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
     this.seoService.setTitle($localize`:@@d7f92e6fe26fba6fff568cbdae5db4a5c8c6a55c:Preview Transaction`);
     this.seoService.setDescription($localize`:@@meta.description.preview-tx:Preview a transaction to the Bitcoin${seoDescriptionNetwork(this.stateService.network)} network using the transaction's raw hex data.`);
     this.websocketService.want(['blocks', 'mempool-blocks']);
-    const cpfpParam = this.route.snapshot.queryParams['cpfp'];
-    if (cpfpParam === 'advanced' || cpfpParam === 'simple') {
-      this.cpfpMode = cpfpParam;
-    }
+    this.cpfpMode = this.route.snapshot.queryParams['cpfp'] === 'true';
     this.pushTxForm = this.formBuilder.group({
       txRaw: ['', Validators.required],
     });
@@ -394,15 +391,10 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
   }
 
   toggleCpfp() {
-    const newMode = this.cpfpMode ? null : (this.cpfpInfo?.cluster ? 'advanced' : 'simple');
-    this.updateCpfpMode(newMode);
-  }
-
-  private updateCpfpMode(mode: 'advanced' | 'simple' | null) {
-    this.cpfpMode = mode;
+    this.cpfpMode = !this.cpfpMode;
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: { cpfp: mode },
+      queryParams: { cpfp: this.cpfpMode ? 'true' : null },
       queryParamsHandling: 'merge',
       preserveFragment: true,
       replaceUrl: true,

--- a/frontend/src/app/components/transaction/transaction-raw.component.ts
+++ b/frontend/src/app/components/transaction/transaction-raw.component.ts
@@ -90,7 +90,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
     this.seoService.setTitle($localize`:@@d7f92e6fe26fba6fff568cbdae5db4a5c8c6a55c:Preview Transaction`);
     this.seoService.setDescription($localize`:@@meta.description.preview-tx:Preview a transaction to the Bitcoin${seoDescriptionNetwork(this.stateService.network)} network using the transaction's raw hex data.`);
     this.websocketService.want(['blocks', 'mempool-blocks']);
-    this.cpfpMode = this.route.snapshot.queryParams['cpfp'] === 'true';
+    this.cpfpMode = this.isCpfpParamEnabled(this.route.snapshot.queryParams['cpfp']);
     this.pushTxForm = this.formBuilder.group({
       txRaw: ['', Validators.required],
     });
@@ -335,7 +335,7 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
     this.isLoadingCpfpInfo = false;
     this.isLoadingBroadcast = false;
     this.adjustedVsize = null;
-    this.cpfpMode = null;
+    this.cpfpMode = false;
     this.hasCpfp = false;
     this.fetchCpfp = false;
     this.cpfpInfo = null;
@@ -378,6 +378,10 @@ export class TransactionRawComponent implements OnInit, OnDestroy {
     } else {
       setTimeout(() => { this.setGraphSize(); }, 1);
     }
+  }
+
+  private isCpfpParamEnabled(cpfpParam: string | undefined): boolean {
+    return cpfpParam === 'true' || cpfpParam === 'advanced' || cpfpParam === 'simple';
   }
 
   setupGraph() {

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -85,12 +85,12 @@
       <span id="cluster" #cluster class="anchor"></span>
       <br>
       <div class="title float-start">
-        <h2 *ngIf="cpfpInfo?.cluster" i18n="transaction.cluster|Cluster">Cluster</h2>
-        <h2 *ngIf="!cpfpInfo?.cluster" i18n="transaction.related-transactions|CPFP List">Related Transactions</h2>
+        <h2 *ngIf="cpfpInfo?.cluster && !isAcceleration" i18n="transaction.cluster|Cluster">Cluster</h2>
+        <h2 *ngIf="!cpfpInfo?.cluster || isAcceleration" i18n="transaction.related-transactions|CPFP List">Related Transactions</h2>
       </div>
       <button type="button" class="btn btn-outline-info btn-sm float-end" (click)="toggleCpfp()" i18n="hide">Hide</button>
       <div class="clearfix"></div>
-      <ng-container *ngIf="cpfpInfo?.cluster; else legacyCpfp">
+      <ng-container *ngIf="cpfpInfo?.cluster && !isAcceleration; else legacyCpfp">
         <div class="box">
           <app-cluster-diagram
             [cluster]="cpfpInfo.cluster" [txid]="tx.txid">

--- a/frontend/src/app/components/transaction/transaction.component.html
+++ b/frontend/src/app/components/transaction/transaction.component.html
@@ -68,6 +68,7 @@
       [hasEffectiveFeeRate]="hasEffectiveFeeRate"
       [cpfpInfo]="cpfpInfo"
       [hasCpfp]="hasCpfp"
+      [cpfpMode]="cpfpMode"
       [accelerationInfo]="accelerationInfo"
       [replaced]="replaced"
       [isCached]="isCached"
@@ -81,13 +82,14 @@
 
     <!-- CPFP Details -->
     <ng-container *ngIf="cpfpMode && hasCpfp">
+      <span id="cluster" #cluster class="anchor"></span>
       <br>
-      <div class="subtitle-block">
-        <div class="title">
-          <h2 *ngIf="cpfpInfo?.cluster" i18n="transaction.cluster|Cluster">Cluster</h2>
-          <h2 *ngIf="!cpfpInfo?.cluster" i18n="transaction.related-transactions|CPFP List">Related Transactions</h2>
-        </div>
+      <div class="title float-start">
+        <h2 *ngIf="cpfpInfo?.cluster" i18n="transaction.cluster|Cluster">Cluster</h2>
+        <h2 *ngIf="!cpfpInfo?.cluster" i18n="transaction.related-transactions|CPFP List">Related Transactions</h2>
       </div>
+      <button type="button" class="btn btn-outline-info btn-sm float-end" (click)="toggleCpfp()" i18n="hide">Hide</button>
+      <div class="clearfix"></div>
       <ng-container *ngIf="cpfpInfo?.cluster; else legacyCpfp">
         <div class="box">
           <app-cluster-diagram

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -1133,7 +1133,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
         relativeTo: this.route,
         queryParams: { cpfp: this.cpfpMode ? 'true' : null },
         queryParamsHandling: 'merge',
-        fragment: this.cpfpMode ? 'cluster' : undefined,
+        fragment: this.getCpfpFragment(),
         replaceUrl: true,
       });
     } else {
@@ -1149,6 +1149,20 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private isCpfpParamEnabled(cpfpParam: string | undefined): boolean {
     return cpfpParam === 'true' || cpfpParam === 'advanced' || cpfpParam === 'simple';
+  }
+
+  private getCpfpFragment(): string | null {
+    const currentParams = new URLSearchParams(this.fragmentParams?.toString() || this.route.snapshot.fragment || '');
+    const fragmentParams = new URLSearchParams();
+    if (this.cpfpMode) {
+      fragmentParams.set('cluster', '');
+    }
+    for (const [key, value] of currentParams.entries()) {
+      if (key !== 'cluster') {
+        fragmentParams.set(key, value);
+      }
+    }
+    return fragmentParams.toString() || null;
   }
 
   toggleGraph() {

--- a/frontend/src/app/components/transaction/transaction.component.ts
+++ b/frontend/src/app/components/transaction/transaction.component.ts
@@ -119,7 +119,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   isAcceleration: boolean = false;
   accelerationCanceled: boolean = false;
   filters: Filter[] = [];
-  cpfpMode: 'advanced' | 'simple' | null = null;
+  cpfpMode: boolean = false;
   miningStats: MiningStats;
   fetchCpfp$ = new Subject<string>();
   transactionTimes$ = new Subject<string>();
@@ -197,6 +197,13 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+  @ViewChild('cluster')
+  set clusterAnchor(element: ElementRef | null | undefined) {
+    if (element) {
+      setTimeout(() => { this.applyFragment(); }, 0);
+    }
+  }
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -221,10 +228,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit() {
     this.enterpriseService.page();
     this.isDetailsOpen = this.route.snapshot.queryParams['showDetails'] === 'true';
-    const cpfpParam = this.route.snapshot.queryParams['cpfp'];
-    if (cpfpParam === 'advanced' || cpfpParam === 'simple') {
-      this.cpfpMode = cpfpParam;
-    }
+    this.cpfpMode = this.isCpfpParamEnabled(this.route.snapshot.queryParams['cpfp']);
 
     const urlParams = new URLSearchParams(window.location.search);
     this.forceAccelerationSummary = !!urlParams.get('cash_request_id');
@@ -1104,8 +1108,7 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
     this.auditStatus = null;
     this.accelerationPositions = null;
     this.isDetailsOpen = this.route.snapshot.queryParams['showDetails'] === 'true';
-    const cpfpParam = this.route.snapshot.queryParams['cpfp'];
-    this.cpfpMode = (cpfpParam === 'advanced' || cpfpParam === 'simple') ? cpfpParam : null;
+    this.cpfpMode = this.isCpfpParamEnabled(this.route.snapshot.queryParams['cpfp']);
     document.body.scrollTo(0, 0);
     this.isAcceleration = false;
     this.isAccelerated$.next(this.isAcceleration);
@@ -1124,19 +1127,28 @@ export class TransactionComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   toggleCpfp() {
-    const newMode = this.cpfpMode ? null : (this.cpfpInfo?.cluster ? 'advanced' : 'simple');
-    this.updateCpfpMode(newMode);
+    this.cpfpMode = !this.cpfpMode;
+    if (this.cpfpInfo?.cluster) {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { cpfp: this.cpfpMode ? 'true' : null },
+        queryParamsHandling: 'merge',
+        fragment: this.cpfpMode ? 'cluster' : undefined,
+        replaceUrl: true,
+      });
+    } else {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { cpfp: this.cpfpMode ? 'simple' : null },
+        queryParamsHandling: 'merge',
+        preserveFragment: true,
+        replaceUrl: true,
+      });
+    }
   }
 
-  private updateCpfpMode(mode: 'advanced' | 'simple' | null) {
-    this.cpfpMode = mode;
-    this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { cpfp: mode },
-      queryParamsHandling: 'merge',
-      preserveFragment: true,
-      replaceUrl: true,
-    });
+  private isCpfpParamEnabled(cpfpParam: string | undefined): boolean {
+    return cpfpParam === 'true' || cpfpParam === 'advanced' || cpfpParam === 'simple';
   }
 
   toggleGraph() {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -9,7 +9,7 @@ import { faFilter, faAngleDown, faAngleUp, faAngleRight, faAngleLeft, faBolt, fa
   faCircleCheck, faUserCircle, faCheck, faRocket, faScaleBalanced, faHourglassStart, faHourglassHalf, faHourglassEnd, faWandMagicSparkles, faTimeline,
   faCircleXmark, faCalendarCheck, faMoneyBillTrendUp, faRobot, faShareNodes, faCreditCard, faMicroscope, faExclamationTriangle, faLockOpen, faPaperclip, faAddressCard,
   faMedal, faBug, faFilePdf, faPiggyBank, faLayerGroup, faHeart, faCashRegister, faCodeFork, faCode, 
-  faCalendar, faPause, faPlay} from '@fortawesome/free-solid-svg-icons';
+  faCalendar, faPause, faPlay, faExpand, faCompress} from '@fortawesome/free-solid-svg-icons';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { MenuComponent } from '@components/menu/menu.component';
 import { PreviewTitleComponent } from '@components/master-page-preview/preview-title.component';
@@ -498,5 +498,7 @@ export class SharedModule {
     library.addIcons(faCode);
     library.addIcons(faPause);
     library.addIcons(faPlay);
+    library.addIcons(faExpand);
+    library.addIcons(faCompress);
   }
 }


### PR DESCRIPTION
This PR revamps the new cluster mempool visualization by:
- adding a new inline preview of the diagram in the effective fee rate row (when available).
- improving the interactivity of the full size diagram with better tooltips and highlighting.
- improving the cluster diagram layout algorithms so that they are easier to read and look better more often.

The inline preview uses the same cluster visualization component, but massively simplified to work at very small sizes, limited to only the immediate "chunk" to which this transaction belongs (instead of the whole mempool cluster), and zoomed in on the current transaction if necessary.

https://github.com/user-attachments/assets/19cff0a2-c255-4459-a31b-7d3325f38202

---

The inline preview replaces the "Cluster" toggle button for opening the full size diagram, and shows an informative tooltip on hover.

https://github.com/user-attachments/assets/c91dd0ed-e2a4-49d8-92d6-70c8c6fd3cb3

---

clicking the inline preview opens the full size interactive diagram and scrolls the page down to see it.

<img width="1132" height="790" alt="Screenshot 2026-05-04 at 11 14 37 AM" src="https://github.com/user-attachments/assets/0ee0b7fb-9791-42d0-b506-ec09279d2fb4" />

---

the general idea is that the preview shows at a glance the rough shape of the transaction's cluster mempool "chunk" (the set of related transactions which produce the "effective" fee rate in cluster mempool).

that gives you an immediate insight into what kind of CPFP relationship the transaction might have (is it boosting a ton of low fee parents? is it _being_ boosted by many high fee children? is it part of a long chain of 1-parent-1-child transactions? etc etc).

here are some examples from various mock mempool clusters:

<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 16 27 AM" src="https://github.com/user-attachments/assets/223604f5-3007-4ab1-b30d-eec86ac311b0" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 16 15 AM" src="https://github.com/user-attachments/assets/4aba7133-afc7-4ce4-a285-e6ff76baf919" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 16 05 AM" src="https://github.com/user-attachments/assets/3694e2a9-da9a-4a85-a789-090aa9856e14" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 15 53 AM" src="https://github.com/user-attachments/assets/4fb40b0b-e023-4d06-8c2f-440403db9537" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 15 37 AM" src="https://github.com/user-attachments/assets/6f40c71e-6a94-4a77-a7d7-5fe002583035" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 17 16 AM" src="https://github.com/user-attachments/assets/d49e6ef2-dd03-46a4-bf40-ba2eee27bec5" />
<img width="538" height="67" alt="Screenshot 2026-05-04 at 11 16 55 AM" src="https://github.com/user-attachments/assets/f7a1345c-998c-414d-b731-48f36588884b" />
<img width="538" height="111" alt="Screenshot 2026-05-04 at 11 47 14 AM" src="https://github.com/user-attachments/assets/e957b809-9cde-49ce-9816-2773fff76204" />
<img width="465" height="52" alt="Screenshot 2026-05-04 at 11 49 20 AM" src="https://github.com/user-attachments/assets/3db8e1b5-01b3-4208-8e80-df445a84bdd6" />

---

_**note - this doesn't support accelerated transactions yet**_

for now accelerated txs default to the legacy CPFP UX, and I'll add support in a follow up PR.