### PR TITLE
Update provenance check json keys

### DIFF
--- a/.github/workflows/dependabot-provenance-check.yml
+++ b/.github/workflows/dependabot-provenance-check.yml
@@ -44,7 +44,7 @@ jobs:
             DEP=$(echo "$DEP" | xargs)
 
             NEW_VERSION=$(echo "$UPDATED_DEPS_JSON" | jq -r --arg name "$DEP" '
-              .[] | select(.["dependency-name"] == $name) | .["new-version"]
+              .[] | select(.dependencyName == $name) | .newVersion
             ' | head -n 1)
 
             if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then


### PR DESCRIPTION
Update the keys so the provenance check workflow can pull the updated dependency version again