### PR TITLE
use esplora liquid assets registry endpoints

### DIFF
--- a/frontend/src/app/components/asset/asset.component.ts
+++ b/frontend/src/app/components/asset/asset.component.ts
@@ -7,7 +7,7 @@ import { WebsocketService } from '@app/services/websocket.service';
 import { StateService } from '@app/services/state.service';
 import { AudioService } from '@app/services/audio.service';
 import { ApiService } from '@app/services/api.service';
-import { of, merge, Subscription, combineLatest } from 'rxjs';
+import { of, merge, Subscription, EMPTY } from 'rxjs';
 import { SeoService } from '@app/services/seo.service';
 import { environment } from '@environments/environment';
 import { AssetsService } from '@app/services/assets.service';
@@ -82,30 +82,26 @@ export class AssetComponent implements OnInit, OnDestroy {
           )
           .pipe(
             switchMap(() => {
-              return combineLatest([this.electrsApiService.getAsset$(this.assetString)
+              return this.electrsApiService.getAsset$(this.assetString)
                 .pipe(
                   catchError((err) => {
                     this.isLoadingAsset = false;
                     this.error = err;
                     this.seoService.logSoft404();
                     console.log(err);
-                    return of(null);
-                  })
-                ), this.assetsService.getAssetsMinimalJson$])
-              .pipe(
-                take(1)
-              );
+                    return EMPTY;
+                  }),
+                  switchMap((asset) => this.assetsService.enrichLiquidAsset$(asset)),
+                  take(1)
+                );
             })
           );
         })
       )
       .pipe(
-        switchMap(([asset, assetsData]) => {
+        switchMap((asset) => {
           this.asset = asset;
-          this.assetContract = assetsData[this.asset.asset_id];
-          if (!this.assetContract) {
-            this.assetContract = [null, '?', 'Unknown', 0];
-          }
+          this.assetContract = [asset.entity?.domain || null, asset.ticker || '?', asset.name || 'Unknown', asset.precision || 0];
           this.seoService.setDescription($localize`:@@meta.description.liquid.asset:Browse an overview of the Liquid asset ${this.assetContract[2]}:INTERPOLATION: (${this.assetContract[1]}:INTERPOLATION:): see issued amount, burned amount, circulating amount, related transactions, and more.`);
           this.blindedIssuance = this.asset.chain_stats.has_blinded_issuances || this.asset.mempool_stats.has_blinded_issuances;
           this.isNativeAsset = asset.asset_id === this.nativeAssetId;

--- a/frontend/src/app/components/assets/asset-group/asset-group.component.ts
+++ b/frontend/src/app/components/assets/asset-group/asset-group.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
-import { combineLatest, Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { ApiService } from '@app/services/api.service';
 import { AssetsService } from '@app/services/assets.service';
@@ -24,22 +24,17 @@ export class AssetGroupComponent implements OnInit {
     this.group$ = this.route.paramMap
       .pipe(
         switchMap((params: ParamMap) => {
-          return combineLatest([
-            this.assetsService.getAssetsJson$,
-            this.apiService.getAssetGroup$(params.get('id')),
-          ]);
+          return this.apiService.getAssetGroup$(params.get('id'));
         }),
-        map(([assets, group]) => {
-          const items = [];
-          // @ts-ignore
-          for (const item of group.assets) {
-            items.push(assets.objects[item]);
-          }
-          return {
-            group: group,
-            assets: items
-          };
-        })
+        switchMap((group) => {
+          return from(Promise.all(group.assets.map((assetId) => this.assetsService.getLiquidAssetData(assetId).catch(() => ({ asset_id: assetId })))))
+            .pipe(
+              map((assets) => ({
+                group: group,
+                assets: assets,
+              }))
+            );
+        }),
       );
   }
 }

--- a/frontend/src/app/components/assets/assets-nav/assets-nav.component.ts
+++ b/frontend/src/app/components/assets/assets-nav/assets-nav.component.ts
@@ -4,12 +4,18 @@ import { Router } from '@angular/router';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
 import { merge, Observable, of, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
-import { AssetExtended } from '@interfaces/electrs.interface';
 import { AssetsService } from '@app/services/assets.service';
 import { SeoService } from '@app/services/seo.service';
 import { StateService } from '@app/services/state.service';
 import { RelativeUrlPipe } from '@app/shared/pipes/relative-url/relative-url.pipe';
 import { environment } from '@environments/environment';
+
+interface AssetSearchResult {
+  asset_id: string;
+  name: string;
+  ticker: string;
+  entity?: { domain: string };
+}
 
 @Component({
   selector: 'app-assets-nav',
@@ -21,10 +27,10 @@ export class AssetsNavComponent implements OnInit {
   @ViewChild('instance', {static: true}) instance: NgbTypeahead;
   nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
   searchForm: UntypedFormGroup;
-  assetsCache: AssetExtended[];
+  assetsCache: AssetSearchResult[];
 
   typeaheadSearchFn: ((text: Observable<string>) => Observable<readonly any[]>);
-  formatterFn = (asset: AssetExtended) => asset.name + ' (' + asset.ticker  + ')';
+  formatterFn = (asset: AssetSearchResult) => asset.name + ' (' + asset.ticker  + ')';
   focus$ = new Subject<string>();
   click$ = new Subject<string>();
 
@@ -62,15 +68,20 @@ export class AssetsNavComponent implements OnInit {
           if (!searchText.length) {
             return of([]);
           }
-          return this.assetsService.getAssetsJson$.pipe(
+          return this.assetsService.getAssetsMinimalJson$.pipe(
             map((assets) => {
               if (searchText.length ) {
-                const filteredAssets = assets.array.filter((asset) => asset.name.toLowerCase().indexOf(searchText.toLowerCase()) > -1
+                const filteredAssets = Object.entries(assets).map(([assetId, assetData]: [string, any[]]) => ({
+                  asset_id: assetId,
+                  entity: assetData[0] ? { domain: assetData[0] } : undefined,
+                  ticker: assetData[1] || '',
+                  name: assetData[2] || '',
+                })).filter((asset) => asset.name.toLowerCase().indexOf(searchText.toLowerCase()) > -1
                   || (asset.ticker || '').toLowerCase().indexOf(searchText.toLowerCase()) > -1
                   || (asset.entity && asset.entity.domain || '').toLowerCase().indexOf(searchText.toLowerCase()) > -1);
                 return filteredAssets.slice(0, this.itemsPerPage);
               } else {
-                return assets.array.slice(0, this.itemsPerPage);
+                return [];
               }
             })
           );

--- a/frontend/src/app/components/assets/assets.component.html
+++ b/frontend/src/app/components/assets/assets.component.html
@@ -18,7 +18,7 @@
 
   <br>
 
-  <ngb-pagination class="pagination-container" [collectionSize]="assets.length" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="ellipses"></ngb-pagination>
+  <ngb-pagination class="pagination-container" [collectionSize]="totalAssets" [rotate]="true" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="pageChange(page)" [maxSize]="paginationMaxSize" [boundaryLinks]="true" [ellipses]="ellipses"></ngb-pagination>
 
   <div class="clearfix"></div>
   <br>

--- a/frontend/src/app/components/assets/assets.component.ts
+++ b/frontend/src/app/components/assets/assets.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { AssetsService } from '@app/services/assets.service';
-import { environment } from '@environments/environment';
 import { UntypedFormGroup } from '@angular/forms';
-import { filter, map, switchMap, take } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
-import { combineLatest, Observable } from 'rxjs';
-import { AssetExtended } from '@interfaces/electrs.interface';
+import { Observable } from 'rxjs';
 import { SeoService } from '@app/services/seo.service';
-import { StateService } from '@app/services/state.service';
+import { AssetRegistryItem } from '@interfaces/electrs.interface';
 
 @Component({
   selector: 'app-assets',
@@ -17,16 +15,14 @@ import { StateService } from '@app/services/state.service';
   standalone: false,
 })
 export class AssetsComponent implements OnInit {
-  nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
   paginationMaxSize = window.matchMedia('(max-width: 670px)').matches ? 4 : 6;
   ellipses = window.matchMedia('(max-width: 670px)').matches ? false : true;
 
-  assets: AssetExtended[];
-  assetsCache: AssetExtended[];
   searchForm: UntypedFormGroup;
-  assets$: Observable<AssetExtended[]>;
+  assets$: Observable<AssetRegistryItem[]>;
 
   page = 1;
+  totalAssets = 0;
   error: any;
 
   itemsPerPage: number;
@@ -38,46 +34,23 @@ export class AssetsComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private seoService: SeoService,
-    private stateService: StateService,
   ) { }
 
   ngOnInit() {
     this.seoService.setTitle($localize`:@@ee8f8008bae6ce3a49840c4e1d39b4af23d4c263:Assets`);
     this.itemsPerPage = Math.max(Math.round(this.contentSpace / this.fiveItemsPxSize) * 5, 10);
 
-    this.assets$ = combineLatest([
-      this.assetsService.getAssetsJson$,
-      this.route.queryParams,
-    ])
+    this.assets$ = this.route.queryParams
       .pipe(
-        take(1),
-        switchMap(([assets, qp]) => {
-          this.assets = assets.array;
-
-          return this.route.queryParams
-            .pipe(
-              filter((queryParams) => {
-                const newPage = parseInt(queryParams.page, 10);
-                if (newPage !== this.page) {
-                  return true;
-                }
-                return false;
-              }),
-              map((queryParams) => {
-                if (queryParams.page) {
-                  const newPage = parseInt(queryParams.page, 10);
-                  this.page = newPage;
-                } else {
-                  this.page = 1;
-                }
-                return '';
-              })
-            );
-        }),
-        map(() => {
+        switchMap((queryParams) => {
+          this.page = queryParams.page ? parseInt(queryParams.page, 10) : 1;
           const start = (this.page - 1) * this.itemsPerPage;
-          return this.assets.slice(start, this.itemsPerPage + start);
-        })
+          return this.assetsService.getLiquidAssetsPage$(start, this.itemsPerPage);
+        }),
+        map((result) => {
+          this.totalAssets = result.total;
+          return result.assets;
+        }),
       );
   }
 

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -59,7 +59,7 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
   refreshOutspends$: ReplaySubject<string[]> = new ReplaySubject();
   refreshChannels$: ReplaySubject<string[]> = new ReplaySubject();
   showDetails$ = new BehaviorSubject<boolean>(false);
-  assetsMinimal: any;
+  assetsMinimal: any = {};
   transactionsLength: number = 0;
   inputRowLimit: number = 12;
   outputRowLimit: number = 12;
@@ -117,12 +117,6 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
         this.updateSignaturesMode();
       }
     });
-
-    if (this.network === 'liquid' || this.network === 'liquidtestnet') {
-      this.assetsService.getAssetsMinimalJson$.subscribe((assets) => {
-        this.assetsMinimal = assets;
-      });
-    }
 
     this.outspendsSubscription = merge(
       this.refreshOutspends$
@@ -238,6 +232,7 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
       }
 
       this.transactionsLength = this.transactions.length;
+      this.loadLiquidAssetData();
 
       if (!this.txPreview) {
         this.cacheService.setTxCache(this.transactions);
@@ -368,6 +363,19 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
         }
       }
     }
+  }
+
+  private loadLiquidAssetData(): void {
+    if (!this.isLiquid) {
+      return;
+    }
+
+    this.assetsService.getLiquidAssetsMinimalData(this.transactions).then((assets) => {
+      this.assetsMinimal = assets;
+      this.ref.markForCheck();
+    }).catch(() => {
+      this.ref.markForCheck();
+    });
   }
 
   updateAddressSimilarities(): void {
@@ -549,6 +557,7 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
           for (const [index, vin] of temp.entries()) {
             newTx.vin[index].isInscription = vin.isInscription;
           }
+          this.loadLiquidAssetData();
           this.ref.markForCheck();
         });
     }

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -78,7 +78,7 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
   zeroValueWidth = 60;
   zeroValueThickness = 20;
   hasLine: boolean;
-  assetsMinimal: any;
+  assetsMinimal: any = {};
   nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
 
   outspendsSubscription: Subscription;
@@ -116,12 +116,6 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.initGraph();
 
-    if (this.network === 'liquid' || this.network === 'liquidtestnet') {
-      this.assetsService.getAssetsMinimalJson$.subscribe((assets) => {
-        this.assetsMinimal = assets;
-      });
-    }
-
     this.outspendsSubscription = merge(
       this.refreshOutspends$
         .pipe(
@@ -156,9 +150,20 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
 
   ngOnChanges(): void {
     this.initGraph();
+    this.loadLiquidAssetData();
     if (!this.cached) {
       this.refreshOutspends$.next(this.tx.txid);
     }
+  }
+
+  private loadLiquidAssetData(): void {
+    if (!this.isLiquid || !this.tx) {
+      return;
+    }
+
+    this.assetsService.getLiquidAssetsMinimalData([this.tx]).then((assets) => {
+      this.assetsMinimal = assets;
+    }).catch(() => {});
   }
 
   initGraph(): void {

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -225,6 +225,14 @@ export interface Entity {
   domain: string;
 }
 
+export interface AssetRegistryItem {
+  asset_id: string;
+  name: string;
+  ticker?: string;
+  domain?: string;
+  entity?: Entity;
+}
+
 interface IssuanceTxin {
   txid: string;
   vin: number;

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -206,6 +206,10 @@ export interface Asset {
   status: Status;
   chain_stats: AssetStats;
   mempool_stats: AssetStats;
+  name?: string;
+  ticker?: string;
+  precision?: number;
+  entity?: Entity;
 }
 
 export interface AssetExtended extends Asset {

--- a/frontend/src/app/services/assets.service.ts
+++ b/frontend/src/app/services/assets.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
-import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
 import { StateService } from '@app/services/state.service';
 import { environment } from '@environments/environment';
-import { Asset, AssetExtended } from '@interfaces/electrs.interface';
+import { ElectrsApiService } from '@app/services/electrs-api.service';
+import { Asset, AssetExtended, AssetRegistryItem } from '@interfaces/electrs.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -15,19 +16,25 @@ export class AssetsService {
   getAssetsJson$: Observable<{ array: AssetExtended[]; objects: any}>;
   getAssetsMinimalJson$: Observable<any>;
   getWorldMapJson$: Observable<any>;
+  registryAvailable = true;
+  private apiBaseUrl = '';
 
   constructor(
     private httpClient: HttpClient,
     private stateService: StateService,
+    private electrsApiService: ElectrsApiService,
   ) {
-    let apiBaseUrl = '';
-    if (!this.stateService.isBrowser) {
-      apiBaseUrl = this.stateService.env.NGINX_PROTOCOL + '://' + this.stateService.env.NGINX_HOSTNAME + ':' + this.stateService.env.NGINX_PORT;
+    this.apiBaseUrl = ''; // use relative URL by default
+    if (!stateService.isBrowser) { // except when inside AU SSR process
+      this.apiBaseUrl = this.stateService.env.NGINX_PROTOCOL + '://' + this.stateService.env.NGINX_HOSTNAME + ':' + this.stateService.env.NGINX_PORT;
     }
+    this.stateService.networkChanged$.subscribe(() => {
+      this.registryAvailable = true;
+    });
 
     this.getAssetsJson$ = this.stateService.networkChanged$
       .pipe(
-        switchMap(() => this.httpClient.get(`${apiBaseUrl}/resources/assets${this.stateService.network === 'liquidtestnet' ? '-testnet' : ''}.json`)),
+        switchMap(() => this.httpClient.get(`${this.apiBaseUrl}/resources/assets${this.stateService.network === 'liquidtestnet' ? '-testnet' : ''}.json`)),
         map((rawAssets) => {
           const assets: AssetExtended[] = Object.values(rawAssets);
 
@@ -56,7 +63,7 @@ export class AssetsService {
       );
     this.getAssetsMinimalJson$ = this.stateService.networkChanged$
     .pipe(
-      switchMap(() => this.httpClient.get(`${apiBaseUrl}/resources/assets${this.stateService.network === 'liquidtestnet' ? '-testnet' : ''}.minimal.json`)),
+      switchMap(() => this.httpClient.get(`${this.apiBaseUrl}/resources/assets${this.stateService.network === 'liquidtestnet' ? '-testnet' : ''}.minimal.json`)),
       map((assetsMinimal) => {
         if (this.stateService.network === 'liquidtestnet') {
           // Hard coding the Liquid Testnet native asset
@@ -67,7 +74,7 @@ export class AssetsService {
       shareReplay(1),
     );
 
-    this.getWorldMapJson$ = this.httpClient.get(apiBaseUrl + '/resources/worldmap.json').pipe(shareReplay());
+    this.getWorldMapJson$ = this.httpClient.get(this.apiBaseUrl + '/resources/worldmap.json').pipe(shareReplay());
   }
 
   public enrichLiquidAsset$(asset: Asset): Observable<Asset> {
@@ -82,5 +89,40 @@ export class AssetsService {
         map((assets) => assets.objects[asset.asset_id] ? { ...asset, ...assets.objects[asset.asset_id] } : asset),
       );
     }
+  }
+
+  public getLiquidAssetsPage$(startIndex: number, limit: number): Observable<{ assets: AssetRegistryItem[]; total: number }> {
+    return (this.registryAvailable ? this.electrsApiService.getLiquidAssetsRegistry$(startIndex, limit).pipe(
+      map((response) => {
+        const assets = response.body || [];
+        const total = parseInt(response.headers.get('X-Total-Results') || `${assets.length}`, 10);
+        if (!total && !assets.length) {
+          this.registryAvailable = false;
+          return null;
+        }
+        return { assets, total };
+      }),
+      catchError((error) => {
+        if (![404, 501].includes(error.status)) {
+          return throwError(() => error);
+        }
+        this.registryAvailable = false;
+        return of(null);
+      }),
+    ) : of(null)).pipe(
+      switchMap((registryPage) => registryPage ? of(registryPage) : this.getAssetsJson$.pipe(
+        map((assets) => ({
+          assets: assets.array.slice(startIndex, startIndex + limit),
+          total: assets.array.length,
+        })),
+      )),
+      map((page) => ({
+        ...page,
+        assets: page.assets.map((asset) => ({
+          ...asset,
+          entity: asset.entity || (asset.domain ? { domain: asset.domain } : undefined),
+        })),
+      })),
+    );
   }
 }

--- a/frontend/src/app/services/assets.service.ts
+++ b/frontend/src/app/services/assets.service.ts
@@ -5,19 +5,21 @@ import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
 import { StateService } from '@app/services/state.service';
 import { environment } from '@environments/environment';
 import { ElectrsApiService } from '@app/services/electrs-api.service';
-import { Asset, AssetExtended, AssetRegistryItem } from '@interfaces/electrs.interface';
+import { Asset, AssetExtended, AssetRegistryItem, Transaction } from '@interfaces/electrs.interface';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AssetsService {
-  nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
-
   getAssetsJson$: Observable<{ array: AssetExtended[]; objects: any}>;
   getAssetsMinimalJson$: Observable<any>;
   getWorldMapJson$: Observable<any>;
   registryAvailable = true;
   private apiBaseUrl = '';
+  private nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
+  private assetsMinimalCache: any = {
+    [this.nativeAssetId]: this.stateService.network === 'liquid' ? [null, 'LBTC', 'Liquid Bitcoin', 8] : [null, 'tLBTC', 'Test Liquid Bitcoin', 8],
+  };
 
   constructor(
     private httpClient: HttpClient,
@@ -30,6 +32,10 @@ export class AssetsService {
     }
     this.stateService.networkChanged$.subscribe(() => {
       this.registryAvailable = true;
+      this.nativeAssetId = this.stateService.network === 'liquidtestnet' ? environment.nativeTestAssetId : environment.nativeAssetId;
+      this.assetsMinimalCache = {
+        [this.nativeAssetId]: this.stateService.network === 'liquid' ? [null, 'LBTC', 'Liquid Bitcoin', 8] : [null, 'tLBTC', 'Test Liquid Bitcoin', 8],
+      };
     });
 
     this.getAssetsJson$ = this.stateService.networkChanged$
@@ -97,6 +103,40 @@ export class AssetsService {
 
     const assets = await firstValueFrom(this.getAssetsJson$);
     return assets.objects[assetId] || {};
+  }
+
+  public async getLiquidAssetMinimalData(assetId: string): Promise<any[]> {
+    if (this.assetsMinimalCache[assetId]) {
+      return this.assetsMinimalCache[assetId];
+    }
+
+    const asset: any = await this.getLiquidAssetData(assetId);
+    if (asset.name || asset.ticker || asset.precision != null) {
+      this.assetsMinimalCache[assetId] = [asset.entity?.domain || asset.domain || null, asset.ticker, asset.name, asset.precision || 0];
+      return this.assetsMinimalCache[assetId];
+    }
+    return null;
+  }
+
+  public async getLiquidAssetsMinimalData(transactions: Transaction[]): Promise<any> {
+    const assetIds = new Set<string>();
+    for (const tx of transactions || []) {
+      for (const vin of tx.vin || []) {
+        if (vin.prevout?.asset && vin.prevout.asset !== this.nativeAssetId) {
+          assetIds.add(vin.prevout.asset);
+        }
+      }
+      for (const vout of tx.vout || []) {
+        if (vout.asset && vout.asset !== this.nativeAssetId) {
+          assetIds.add(vout.asset);
+        }
+      }
+    }
+
+    const missingAssetIds = Array.from(assetIds).filter((assetId) => !this.assetsMinimalCache[assetId]);
+    await Promise.all(missingAssetIds.map((assetId) => this.getLiquidAssetMinimalData(assetId)));
+
+    return this.assetsMinimalCache;
   }
 
   public enrichLiquidAsset$(asset: Asset): Observable<Asset> {

--- a/frontend/src/app/services/assets.service.ts
+++ b/frontend/src/app/services/assets.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of, throwError } from 'rxjs';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
 import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
 import { StateService } from '@app/services/state.service';
 import { environment } from '@environments/environment';
@@ -75,6 +75,28 @@ export class AssetsService {
     );
 
     this.getWorldMapJson$ = this.httpClient.get(this.apiBaseUrl + '/resources/worldmap.json').pipe(shareReplay());
+  }
+
+  public async getLiquidAssetData(assetId: string): Promise<Partial<Asset>> {
+    if (this.stateService.network === 'liquid' && assetId === environment.nativeAssetId) {
+      return { asset_id: assetId, name: 'Liquid Bitcoin', ticker: 'LBTC', precision: 8 };
+    } else if (this.stateService.network === 'liquidtestnet' && assetId === environment.nativeTestAssetId) {
+      return { asset_id: assetId, name: 'Test Liquid Bitcoin', ticker: 'tLBTC', precision: 8 };
+    } else if (this.registryAvailable) {
+      try {
+        const apiAsset = await firstValueFrom(this.electrsApiService.getAsset$(assetId));
+        if (apiAsset.name || apiAsset.ticker || apiAsset.precision != null) {
+          return apiAsset;
+        }
+      } catch (error: any) {
+        if (![404, 501].includes(error?.status)) {
+          throw error;
+        }
+      }
+    }
+
+    const assets = await firstValueFrom(this.getAssetsJson$);
+    return assets.objects[assetId] || {};
   }
 
   public enrichLiquidAsset$(asset: Asset): Observable<Asset> {

--- a/frontend/src/app/services/assets.service.ts
+++ b/frontend/src/app/services/assets.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { StateService } from '@app/services/state.service';
 import { environment } from '@environments/environment';
-import { AssetExtended } from '@interfaces/electrs.interface';
+import { Asset, AssetExtended } from '@interfaces/electrs.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -68,5 +68,19 @@ export class AssetsService {
     );
 
     this.getWorldMapJson$ = this.httpClient.get(apiBaseUrl + '/resources/worldmap.json').pipe(shareReplay());
+  }
+
+  public enrichLiquidAsset$(asset: Asset): Observable<Asset> {
+    if (asset.name || asset.ticker || asset.precision != null) {
+      return of(asset);
+    } else if (this.stateService.network === 'liquid' && asset.asset_id === environment.nativeAssetId) {
+      return of({ ...asset, name: 'Liquid Bitcoin', ticker: 'LBTC', precision: 8 });
+    } else if (this.stateService.network === 'liquidtestnet' && asset.asset_id === environment.nativeTestAssetId) {
+      return of({ ...asset, name: 'Test Liquid Bitcoin', ticker: 'tLBTC', precision: 8 });
+    } else {
+      return this.getAssetsJson$.pipe(
+        map((assets) => assets.objects[asset.asset_id] ? { ...asset, ...assets.objects[asset.asset_id] } : asset),
+      );
+    }
   }
 }

--- a/frontend/src/app/services/electrs-api.service.ts
+++ b/frontend/src/app/services/electrs-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { BehaviorSubject, Observable, catchError, filter, from, of, shareReplay, switchMap, take, tap } from 'rxjs';
-import { Transaction, Address, Outspend, Recent, Asset, ScriptHash, AddressTxSummary, Utxo } from '@interfaces/electrs.interface';
+import { Transaction, Address, Outspend, Recent, Asset, ScriptHash, AddressTxSummary, Utxo, AssetRegistryItem } from '@interfaces/electrs.interface';
 import { StateService } from '@app/services/state.service';
 import { BlockExtended } from '@interfaces/node-api.interface';
 import { calcScriptHash$ } from '@app/bitcoin.utils';
@@ -226,6 +226,16 @@ export class ElectrsApiService {
 
   getAsset$(assetId: string): Observable<Asset> {
     return this.httpClient.get<Asset>(this.apiBaseUrl + this.apiBasePath + '/api/asset/' + assetId);
+  }
+
+  getLiquidAssetsRegistry$(startIndex: number, limit: number): Observable<HttpResponse<AssetRegistryItem[]>> {
+    const params = new HttpParams()
+      .set('start_index', startIndex)
+      .set('limit', limit)
+      .set('sort_field', 'name')
+      .set('sort_dir', 'asc');
+
+    return this.httpClient.get<AssetRegistryItem[]>(this.apiBaseUrl + this.apiBasePath + '/api/assets/registry', { params, observe: 'response' });
   }
 
   getAssetTransactions$(assetId: string): Observable<Transaction[]> {


### PR DESCRIPTION
This PR updates various parts of the Liquid frontend to use asset registry data from the esplora API where available, rather than the bulk `assets*.json` files, on the:
- main asset page
- paginated asset list
- asset group pages
- transaction list component
- bowtie diagram component

and also switches the typeahead search on the assets page to use the lighter `assets.minimal.json` file instead of `assets.json`.

the combined effect should be to make loading and browsing the liquid frontend much faster by avoiding fetching the large `assets.json` file.

note that this requires configuration in the mempool/electrs server to enable the additional registry data.

if the registry data is not available (because it isn't configured, or we aren't using an esplora backend, etc), we fallback gracefully to the `assets*.json` files as before.

completely eliminating the json files requires some new mempool/electrs endpoints, so I'm splitting that into a separate follow up PR.

requires https://github.com/mempool/electrs/pull/152