### PR TITLE
make adding transactions to cluster mempool idempotent

### DIFF
--- a/backend/src/__tests__/cluster-mempool/cluster-mempool.test.ts
+++ b/backend/src/__tests__/cluster-mempool/cluster-mempool.test.ts
@@ -95,6 +95,23 @@ describe('ClusterMempool', () => {
       expect(cm.getTxCount()).toBe(2);
     });
 
+    it('should skip duplicate tx additions', () => {
+      const mempool = buildMempool([]);
+      const cm = new ClusterMempool(mempool);
+      const tx = makeTx(txid('a1'), 100, 100);
+      mempool[tx.txid] = tx;
+
+      cm.applyMempoolChange({
+        added: [tx, tx],
+        removed: [],
+        accelerations: {},
+      });
+
+      expect(cm.getClusterCount()).toBe(1);
+      expect(cm.getTxCount()).toBe(1);
+      expect(cm.getBlocks(1)[0].txids).toEqual([tx.txid]);
+    });
+
     it('should handle removing a tx', () => {
       const parentId = txid('a1');
       const childId = txid('a2');

--- a/backend/src/cluster-mempool/cluster-mempool.ts
+++ b/backend/src/cluster-mempool/cluster-mempool.ts
@@ -431,6 +431,12 @@ export class ClusterMempool {
     for (const tx of added) {
       const txid = tx.txid;
 
+      // sanity check for duplicate transactions
+      if (this.getClusterForTx(txid) !== null) {
+        logger.warn(`ClusterMempool.processAdditions: ${txid} was already added, skipping`);
+        continue;
+      }
+
       for (const vin of tx.vin) {
         if (!vin.is_coinbase) {
           this.spentBy.set(`${vin.txid}:${vin.vout}`, txid);


### PR DESCRIPTION
I noticed in some obscure failure modes it's possible for the backend to add the same transaction to the cluster mempool more than once.

this PR adds an explicit check for duplicates before accepting new transactions into the mempool cluster data structures, and logs a warning when that check fails to make it easier to debug these kinds of issues in future.