### PR TITLE
Fix: /fee-estimates BDK-Esplora protocol compliance

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -143,8 +143,19 @@ class BitcoinRoutes {
     }
     const result = feeApi.getPreciseRecommendedFee();
 
+    // Note: Manually tested against rust-esplora-client 0.12.3
+    // to make sure the status code and extra header didn't blow everything up.
+    // 3xx redirects with a Location header were silently followed and caused the client to
+    // blow up, 4xx and 5xx caused errors in the client as well, so only 2xx was acceptable for this endpoint.
+
+    // HTTP 203 Non-Authoritative Information is used to indicate
+    // that the response is not the original from the server, but a transformed version of it.
+    res.statusCode = 203;
+    res.setHeader(
+      'x-warning-from-mempool',
+      `This endpoint is deprecated and will be removed in a future release. Please use /api/v1/fees/precise instead.`,
+    );
     res.json({
-      'warning': 'This endpoint is deprecated and will be removed in a future release. Please use /api/v1/fees/precise instead.',
       '1': result.fastestFee,
       '2': result.fastestFee,
       '3': result.halfHourFee,


### PR DESCRIPTION
Manually tested against rust-esplora-client 0.12.3 to make sure the status code and extra header didn't blow everything up. 3xx redirects with a Location header were silently followed and caused the client to blow up, 4xx and 5xx caused errors in the client as well, so only 2xx was acceptable for this endpoint. 203 works fine and adding the extra header did nothing to the client library.

Looking at the implementation (which is the only thing close to a spec) there is no guarantee that all the keys are present. (It flat_maps over the responses for each target and returns None if error or -1 is returned before collecting into HashMap)

Due to this fact I considered removing all the intermediary keys and only including 1, 3, 6 and two other numbers that feel like economy/minimum...

but I have a sinking feeling that some application is relying on all the base targets being present, due to the API interface of BDK's fee estimate being weakly typed.

We don't want someone's app that says `if fee_target == FeeTarget::Slow { fee_estimates.get(17).unwrap() } ...` to blow up.