### PR TITLE
fix: False positive coinjoin (#6464)

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -749,7 +749,15 @@ export class Common {
     // fast but bad heuristic to detect possible coinjoins
     // (at least 5 inputs and 5 outputs, less than half of which are unique amounts, with no address reuse)
     const addressReuse = Object.keys(reusedOutputAddresses).reduce((acc, key) => Math.max(acc, (reusedInputAddresses[key] || 0) + (reusedOutputAddresses[key] || 0)), 0) > 1;
-    if (!addressReuse && tx.vin.length >= 5 && tx.vout.length >= 5 && (Object.keys(inValues).length + Object.keys(outValues).length) <= (tx.vin.length + tx.vout.length) / 2 ) {
+    const tokenRelated = (flags & (TransactionFlags.inscription | TransactionFlags.op_return)) !== 0n;
+    if (!addressReuse &&
+        tx.vin.length >= 5 &&
+        tx.vout.length >= 5 &&
+        (Object.keys(inValues).length + Object.keys(outValues).length) <= (tx.vin.length + tx.vout.length) / 2 &&
+        !tokenRelated &&
+        tx.vin.length / tx.vout.length < 5 &&
+        tx.vin.length / tx.vout.length > 0.2
+      ) {
       flags |= TransactionFlags.coinjoin;
     }
     // more than 5:1 input:output ratio

--- a/frontend/src/app/shared/transaction.utils.ts
+++ b/frontend/src/app/shared/transaction.utils.ts
@@ -935,7 +935,15 @@ export function getTransactionFlags(tx: Transaction, cpfpInfo?: CpfpInfo, replac
   // fast but bad heuristic to detect possible coinjoins
   // (at least 5 inputs and 5 outputs, less than half of which are unique amounts, with no address reuse)
   const addressReuse = Object.keys(reusedOutputAddresses).reduce((acc, key) => Math.max(acc, (reusedInputAddresses[key] || 0) + (reusedOutputAddresses[key] || 0)), 0) > 1;
-  if (!addressReuse && tx.vin.length >= 5 && tx.vout.length >= 5 && (Object.keys(inValues).length + Object.keys(outValues).length) <= (tx.vin.length + tx.vout.length) / 2 ) {
+  const tokenRelated = (flags & (TransactionFlags.inscription | TransactionFlags.op_return)) !== 0n;
+  if (!addressReuse &&
+      tx.vin.length >= 5 &&
+      tx.vout.length >= 5 &&
+      (Object.keys(inValues).length + Object.keys(outValues).length) <= (tx.vin.length + tx.vout.length) / 2 &&
+      !tokenRelated &&
+      tx.vin.length / tx.vout.length < 5 &&
+      tx.vin.length / tx.vout.length > 0.2
+      ) {
     flags |= TransactionFlags.coinjoin;
   }
   // more than 5:1 input:output ratio


### PR DESCRIPTION
fixes #6464

In the case of the following txs:
https://mempool.space/tx/d956c419e95adafcc39584a41a232bcecd2428051dde04132cdb469731cf60ce
https://mempool.space/tx/03159c7534e3b82d6452c6174fc4cffce25019e34b00777c902d679639c27ea3
https://mempool.space/tx/d339704a51e85280a293b28e0a391f08ed888fc07c2f0a545014fe65f7470b69

They are flagged as coinjoin, but we can easily recognize they are not, as there's not as many outputs with the same amount.

So I added a condition that checks if a fifth of the inValues count at least 5 inputs with the same amount. The same for the outputs, but individually.

I was able to test inside the tx page only, not in block overview graph, as I'm still not able to run the backend.

Feedback is appreciated!