### PR TITLE
add: Inifinite scrolling to blocks/stale page

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -61,6 +61,7 @@ class BitcoinRoutes {
       .get(config.MEMPOOL.API_URL_PREFIX + 'blocks-bulk/:from/:to', this.getBlocksByBulk.bind(this))
       .get(config.MEMPOOL.API_URL_PREFIX + 'chain-tips', this.getChainTips.bind(this))
       .get(config.MEMPOOL.API_URL_PREFIX + 'stale-tips', this.getStaleTips.bind(this))
+      .get(config.MEMPOOL.API_URL_PREFIX + 'stale-tips/:height', this.getStaleTips.bind(this))
       .post(config.MEMPOOL.API_URL_PREFIX + 'prevouts', this.$getPrevouts)
       .post(config.MEMPOOL.API_URL_PREFIX + 'cpfp', this.getCpfpLocalTxs)
       // Temporarily add txs/package endpoint for all backends until esplora supports it
@@ -628,14 +629,18 @@ class BitcoinRoutes {
   private async getStaleTips(req: Request, res: Response) {
     try {
       if (['mainnet', 'testnet', 'signet', 'testnet4', 'regtest'].includes(config.MEMPOOL.NETWORK)) { // Bitcoin
-        res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
-        const tips = await chainTips.getStaleTips();
-        if (tips.length > 0) {
-          res.json(tips);
-        } else {
-          handleError(req, res, 503, `Temporarily unavailable`);
-          return;
+        let fromHeight: number | undefined;
+        if (req.params.height !== undefined) {
+          fromHeight = parseInt(req.params.height, 10);
+          if (isNaN(fromHeight) || fromHeight < 0) {
+            handleError(req, res, 400, `Parameter 'height' must be a block height (integer)`);
+            return;
+          }
         }
+
+        res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
+        const tips = await chainTips.$getStaleTipsPage(fromHeight, 10);
+        res.json(tips);
       } else { // Liquid
         handleError(req, res, 404, `This API is only available for Bitcoin networks`);
         return;

--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -639,7 +639,7 @@ class BitcoinRoutes {
         }
 
         res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
-        const tips = await chainTips.$getStaleTipsPage(fromHeight, 10);
+        const tips = await chainTips.$getStaleTipsPage(fromHeight, 25);
         res.json(tips);
       } else { // Liquid
         handleError(req, res, 404, `This API is only available for Bitcoin networks`);

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -71,7 +71,7 @@ class ChainTips {
                 orphan = {
                   height: block.height,
                   hash: block.id,
-                  branchlen: chain.branchlen - 1,
+                  branchlen: chain.branchlen,
                   status: chain.status,
                   prevhash: block.previousblockhash,
                 };
@@ -244,7 +244,7 @@ class ChainTips {
       tips.push({
         height: staleTip.height,
         hash: staleTip.hash,
-        branchlen: staleTip.branchlen - 1,
+        branchlen: staleTip.branchlen,
         status: staleTip.status,
         stale,
         canonical,

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -13,7 +13,7 @@ export interface ChainTip {
   height: number;
   hash: string;
   branchlen: number;
-  status?: 'invalid' | 'active' | 'valid-fork' | 'valid-headers' | 'headers-only';
+  status: 'invalid' | 'active' | 'valid-fork' | 'valid-headers' | 'headers-only';
 };
 
 export interface StaleTip extends ChainTip {
@@ -218,12 +218,9 @@ class ChainTips {
   /** @asyncUnsafe */
   public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
     const cacheTips = this.getStaleTips();
-    if (!Common.indexingEnabled()) {
-      const page = fromHeight === undefined ? cacheTips : cacheTips.filter(tip => tip.height < fromHeight);
-      return page.slice(0, limit);
-    }
 
-    const staleTips = await BlocksRepository.$getStaleTips(fromHeight, limit);
+    const allStaleTips = this.chainTips.filter(chainTip => chainTip.status === 'valid-fork' || chainTip.status === 'valid-headers').sort((a, b) => b.height - a.height);
+    const staleTipsPage = fromHeight === undefined ? allStaleTips.slice(0, limit) : allStaleTips.filter(tip => tip.height < fromHeight).slice(0, limit);
 
     const cacheTipsMap = new Map<string, StaleTip>();
     for (const cacheTip of cacheTips) {
@@ -231,31 +228,25 @@ class ChainTips {
     }
 
     const tips: StaleTip[] = [];
-    for (const staleTip of staleTips) {
-
-      const cachedTip = cacheTipsMap.get(staleTip.id);
+    for (const staleTip of staleTipsPage) {
+      const cachedTip = cacheTipsMap.get(staleTip.hash);
       if (cachedTip) {
         tips.push(cachedTip);
         continue;
       }
 
       const canonical = await BlocksRepository.$getBlockByHeight(staleTip.height);
-      if (!canonical) {
+      const stale = await BlocksRepository.$getBlockByHash(staleTip.hash);
+      if (!canonical || !stale) {
         continue;
-      }
-
-      let prevBlock = await BlocksRepository.$getBlockByHash(staleTip.previousblockhash);
-      let branchlen = 0;
-      while(prevBlock?.stale) {
-        prevBlock = await BlocksRepository.$getBlockByHash(prevBlock.previousblockhash);
-        branchlen++;
       }
 
       tips.push({
         height: staleTip.height,
-        hash: staleTip.id,
-        branchlen,
-        stale: staleTip,
+        hash: staleTip.hash,
+        branchlen: staleTip.branchlen - 1,
+        status: staleTip.status,
+        stale,
         canonical,
       });
     }

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -2,6 +2,7 @@ import config from '../config';
 import logger from '../logger';
 import { BlockExtended } from '../mempool.interfaces';
 import BlocksSummariesRepository from '../repositories/BlocksSummariesRepository';
+import BlocksRepository from '../repositories/BlocksRepository';
 import bitcoinApi, { bitcoinCoreApi } from './bitcoin/bitcoin-api-factory';
 import bitcoinClient from './bitcoin/bitcoin-client';
 import { IEsploraApi } from './bitcoin/esplora-api.interface';
@@ -12,7 +13,7 @@ export interface ChainTip {
   height: number;
   hash: string;
   branchlen: number;
-  status: 'invalid' | 'active' | 'valid-fork' | 'valid-headers' | 'headers-only';
+  status?: 'invalid' | 'active' | 'valid-fork' | 'valid-headers' | 'headers-only';
 };
 
 export interface StaleTip extends ChainTip {
@@ -210,6 +211,60 @@ class ChainTips {
 
   public getStaleTips(): StaleTip[] {
     return Object.values(this.staleTips).sort((a, b) => b.height - a.height);
+  }
+
+  /** @asyncSafe */
+  public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
+    const cacheTips = this.getStaleTips();
+    if (!Common.indexingEnabled()) {
+      const page = fromHeight === undefined ? cacheTips : cacheTips.filter(tip => tip.height < fromHeight);
+      return page.slice(0, limit);
+    }
+
+    const staleBlocks = await BlocksRepository.$getStaleBlocks(fromHeight, limit);
+
+    // map the previous block hashes of each stale block so we can reconstrunct branch lengths
+    const staleByPrevhash: { [prevhash: string]: BlockExtended } = {};
+    for (const block of staleBlocks) {
+      if (block.previousblockhash) {
+        staleByPrevhash[block.previousblockhash] = block;
+      }
+    }
+
+    const cacheTipsMap = new Map<string, StaleTip>();
+    for (const cacheTip of cacheTips) {
+      cacheTipsMap.set(cacheTip.hash, cacheTip);
+    }
+
+    const tips: StaleTip[] = [];
+    for (const staleBlock of staleBlocks) {
+
+      const cachedTip = cacheTipsMap.get(staleBlock.id);
+      if (cachedTip) {
+        tips.push(cachedTip);
+        continue;
+      }
+
+      const canonical = await BlocksRepository.$getBlockByHeight(staleBlock.height);
+      if (!canonical) {
+        continue;
+      }
+      // walk up the stale branch to find its tip, depth = branchTipHeight - staleHeight
+      let branchTip = staleBlock;
+      while (staleByPrevhash[branchTip.id]) {
+        branchTip = staleByPrevhash[branchTip.id];
+      }
+
+      tips.push({
+        height: staleBlock.height,
+        hash: staleBlock.id,
+        branchlen: branchTip.height - staleBlock.height,
+        stale: staleBlock,
+        canonical,
+      });
+    }
+
+    return tips;
   }
 
   clearOrphanCacheAboveHeight(height: number): void {

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -24,6 +24,7 @@ export interface StaleTip extends ChainTip {
 export interface OrphanedBlock {
   height: number;
   hash: string;
+  branchlen: number;
   status: 'valid-fork' | 'valid-headers' | 'headers-only';
   prevhash: string;
 }
@@ -70,6 +71,7 @@ class ChainTips {
                 orphan = {
                   height: block.height,
                   hash: block.id,
+                  branchlen: chain.branchlen - 1,
                   status: chain.status,
                   prevhash: block.previousblockhash,
                 };
@@ -173,7 +175,7 @@ class ChainTips {
           this.staleTips[staleBlock.height] = {
             height: staleBlock.height,
             hash: staleBlock.id,
-            branchlen: tip.height - staleBlock.height,
+            branchlen: tip.branchlen,
             status: tip.status,
             stale: staleBlock,
             canonical: canonicalBlock,
@@ -213,7 +215,7 @@ class ChainTips {
     return Object.values(this.staleTips).sort((a, b) => b.height - a.height);
   }
 
-  /** @asyncSafe */
+  /** @asyncUnsafe */
   public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
     const cacheTips = this.getStaleTips();
     if (!Common.indexingEnabled()) {
@@ -221,15 +223,7 @@ class ChainTips {
       return page.slice(0, limit);
     }
 
-    const staleBlocks = await BlocksRepository.$getStaleBlocks(fromHeight, limit);
-
-    // map the previous block hashes of each stale block so we can reconstruct branch lengths
-    const staleByPrevhash: { [prevhash: string]: BlockExtended } = {};
-    for (const block of staleBlocks) {
-      if (block.previousblockhash) {
-        staleByPrevhash[block.previousblockhash] = block;
-      }
-    }
+    const staleTips = await BlocksRepository.$getStaleTips(fromHeight, limit);
 
     const cacheTipsMap = new Map<string, StaleTip>();
     for (const cacheTip of cacheTips) {
@@ -237,29 +231,31 @@ class ChainTips {
     }
 
     const tips: StaleTip[] = [];
-    for (const staleBlock of staleBlocks) {
+    for (const staleTip of staleTips) {
 
-      const cachedTip = cacheTipsMap.get(staleBlock.id);
+      const cachedTip = cacheTipsMap.get(staleTip.id);
       if (cachedTip) {
         tips.push(cachedTip);
         continue;
       }
 
-      const canonical = await BlocksRepository.$getBlockByHeight(staleBlock.height);
+      const canonical = await BlocksRepository.$getBlockByHeight(staleTip.height);
       if (!canonical) {
         continue;
       }
-      // walk up the stale branch to find its tip, depth = branchTipHeight - staleHeight
-      let branchTip = staleBlock;
-      while (staleByPrevhash[branchTip.id]) {
-        branchTip = staleByPrevhash[branchTip.id];
+
+      let prevBlock = await BlocksRepository.$getBlockByHash(staleTip.previousblockhash);
+      let branchlen = 0;
+      while(prevBlock?.stale) {
+        prevBlock = await BlocksRepository.$getBlockByHash(prevBlock.previousblockhash);
+        branchlen++;
       }
 
       tips.push({
-        height: staleBlock.height,
-        hash: staleBlock.id,
-        branchlen: branchTip.height - staleBlock.height,
-        stale: staleBlock,
+        height: staleTip.height,
+        hash: staleTip.id,
+        branchlen,
+        stale: staleTip,
         canonical,
       });
     }

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -31,20 +31,22 @@ export interface OrphanedBlock {
 
 class ChainTips {
   private chainTips: ChainTip[] = [];
-  private staleTips: Record<number, StaleTip> = {};
+  private validChainTips: ChainTip[] = []; // 'valid-fork' and 'valid-headers' only, in descending height order
+  private staleBlocks: Record<string, BlockExtended> = {};
   private orphanedBlocks: { [hash: string]: OrphanedBlock } = {};
   private blockCache: { [hash: string]: OrphanedBlock } = {};
   private orphansByHeight: { [height: number]: OrphanedBlock[] } = {};
   private indexingOrphanedBlocks = false;
   private indexingQueue: { blockhash?: string, block?: IEsploraApi.Block, tip: OrphanedBlock }[] = [];
 
-  private staleTipsCacheSize = 50;
+  private staleBlocksCacheSize = 50;
   private maxIndexingQueueSize = 100;
 
   /** @asyncSafe */
   public async updateOrphanedBlocks(): Promise<void> {
     try {
       this.chainTips = await bitcoinClient.getChainTips();
+      this.validChainTips = this.chainTips.filter(tip => tip.status === 'valid-fork' || tip.status === 'valid-headers').sort((a, b) => b.height - a.height);
 
       const activeTipHeight = this.chainTips.find(tip => tip.status === 'active')?.height || (await bitcoinApi.$getBlockHeightTip());
       let minIndexHeight = 0;
@@ -122,13 +124,7 @@ class ChainTips {
         this.orphansByHeight[orphan.height].push(orphan);
       }
 
-      const heightsToKeep = new Set(this.chainTips.filter(tip => tip.status !== 'active').map(tip => tip.height));
-      const heightsToRemove: number[] = Object.keys(this.staleTips).map(Number).filter(height => !heightsToKeep.has(height));
-      for (const height of heightsToRemove) {
-        delete this.staleTips[height];
-      }
-
-      this.trimStaleTipsCache();
+      this.trimStaleBlocksCache();
 
       // index new orphaned blocks in the background
       void this.$indexOrphanedBlocks();
@@ -160,7 +156,7 @@ class ChainTips {
         }
         let staleBlock: BlockExtended | undefined;
         const alreadyIndexed = await BlocksSummariesRepository.$isSummaryIndexed(block.id);
-        const needToCache = Object.keys(this.staleTips).length < this.staleTipsCacheSize || block.height > Object.keys(this.staleTips).map(Number).sort((a, b) => b - a)[this.staleTipsCacheSize - 1];
+        const needToCache = this.shouldCacheStaleBlock(block.id, block.height);
         if (!alreadyIndexed) {
           staleBlock = await blocks.$indexBlock(block.id, block, true);
           await blocks.$indexBlockSummary(block.id, block.height, true);
@@ -171,16 +167,9 @@ class ChainTips {
         }
 
         if (staleBlock && needToCache) {
-          const canonicalBlock = await blocks.$indexBlockByHeight(staleBlock.height);
-          this.staleTips[staleBlock.height] = {
-            height: staleBlock.height,
-            hash: staleBlock.id,
-            branchlen: tip.branchlen,
-            status: tip.status,
-            stale: staleBlock,
-            canonical: canonicalBlock,
-          };
-          this.trimStaleTipsCache();
+          // ensure the canonical block is correctly indexed
+          await blocks.$indexBlockByHeight(staleBlock.height);
+          this.cacheStaleBlock(staleBlock);
         }
       } catch (e) {
         logger.err(`Failed to index orphaned block ${block?.id} at height ${block?.height}. Reason: ${e instanceof Error ? e.message : e}`);
@@ -189,12 +178,42 @@ class ChainTips {
     this.indexingOrphanedBlocks = false;
   }
 
-  private trimStaleTipsCache(): void {
-    const staleTipHeights = Object.keys(this.staleTips).map(Number).sort((a, b) => b - a);
-    if (staleTipHeights.length > this.staleTipsCacheSize) {
-      const heightsToDiscard = staleTipHeights.slice(this.staleTipsCacheSize);
-      for (const height of heightsToDiscard) {
-        delete this.staleTips[height];
+  private shouldCacheStaleBlock(hash: string, height: number): boolean {
+    // already cached
+    if (this.staleBlocks[hash]) {
+      return false;
+    }
+
+    // cache is not full
+    const cachedBlocks = Object.values(this.staleBlocks);
+    if (cachedBlocks.length < this.staleBlocksCacheSize) {
+      return true;
+    }
+
+    // otherwise cache if this block is newer than the oldest in the cache
+    const oldestCachedHeight = cachedBlocks.reduce((min, block) => Math.min(min, block.height), Infinity);
+    return height >= oldestCachedHeight;
+  }
+
+  private cacheStaleBlock(block: BlockExtended): void {
+    this.staleBlocks[block.id] = block;
+    this.trimStaleBlocksCache();
+  }
+
+  // evict the oldest stale blocks until the cache is within the size limit
+  private trimStaleBlocksCache(): void {
+    // sort by height
+    const cachedBlocks = Object.values(this.staleBlocks).sort((a, b) => {
+      if (b.height !== a.height) {
+        return b.height - a.height;
+      }
+      // tie-break by hash
+      return a.id.localeCompare(b.id);
+    });
+    // delete everything beyond the size limit
+    if (cachedBlocks.length > this.staleBlocksCacheSize) {
+      for (const block of cachedBlocks.slice(this.staleBlocksCacheSize)) {
+        delete this.staleBlocks[block.id];
       }
     }
   }
@@ -211,41 +230,27 @@ class ChainTips {
     return this.chainTips;
   }
 
-  public getStaleTips(): StaleTip[] {
-    return Object.values(this.staleTips).sort((a, b) => b.height - a.height);
-  }
-
-  /** @asyncUnsafe */
+  /** @asyncSafe */
   public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
-    const cacheTips = this.getStaleTips();
+    const start = fromHeight === undefined ? 0 : this.validChainTips.findIndex(tip => tip.height < fromHeight);
+    const staleTipsPage = start === -1 ? [] : this.validChainTips.slice(start, start + limit);
 
-    const allStaleTips = this.chainTips.filter(chainTip => chainTip.status === 'valid-fork' || chainTip.status === 'valid-headers').sort((a, b) => b.height - a.height);
-    const staleTipsPage = fromHeight === undefined ? allStaleTips.slice(0, limit) : allStaleTips.filter(tip => tip.height < fromHeight).slice(0, limit);
-
-    const cacheTipsMap = new Map<string, StaleTip>();
-    for (const cacheTip of cacheTips) {
-      cacheTipsMap.set(cacheTip.hash, cacheTip);
-    }
-
+    // hydrate tips with block data
     const tips: StaleTip[] = [];
     for (const staleTip of staleTipsPage) {
-      const cachedTip = cacheTipsMap.get(staleTip.hash);
-      if (cachedTip) {
-        tips.push(cachedTip);
-        continue;
+      // fetch blocks from caches if available, or DB otherwise
+      const canonical = blocks.getBlocks().find(block => block.height === staleTip.height) || await BlocksRepository.$getBlockByHeight(staleTip.height);
+      let stale: BlockExtended | null | undefined = this.staleBlocks[staleTip.hash];
+      if (!stale) {
+        stale = await BlocksRepository.$getBlockByHash(staleTip.hash);
       }
-
-      const canonical = await BlocksRepository.$getBlockByHeight(staleTip.height);
-      const stale = await BlocksRepository.$getBlockByHash(staleTip.hash);
+      // skip tips with missing block data
       if (!canonical || !stale) {
         continue;
       }
 
       tips.push({
-        height: staleTip.height,
-        hash: staleTip.hash,
-        branchlen: staleTip.branchlen,
-        status: staleTip.status,
+        ...staleTip,
         stale,
         canonical,
       });

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -230,14 +230,31 @@ class ChainTips {
     return this.chainTips;
   }
 
-  /** @asyncSafe */
-  public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
+  /**
+   * get paginated stale chain tips
+   * @param fromHeight - start height (exclusive)
+   * @param count - requested page size (target, but not strictly enforced)
+   *
+   * @asyncSafe
+   */
+  public async $getStaleTipsPage(fromHeight: number | undefined, count: number): Promise<StaleTip[]> {
     const start = fromHeight === undefined ? 0 : this.validChainTips.findIndex(tip => tip.height < fromHeight);
-    const staleTipsPage = start === -1 ? [] : this.validChainTips.slice(start, start + limit);
+    // no tips beyond the requested height, we can return early
+    if (start === -1) {
+      return [];
+    }
 
-    // hydrate tips with block data
+    // fill the response array with hydrated tip data
     const tips: StaleTip[] = [];
-    for (const staleTip of staleTipsPage) {
+    let lastHeight;
+    for (let index = start; index < this.validChainTips.length; index++) {
+      const staleTip = this.validChainTips[index];
+      // stretch the page to include any remaining blocks at the last included height to avoid pagination gaps with a height-based cursor
+      if (tips.length >= count) {
+        if (staleTip.height !== lastHeight) {
+          break;
+        }
+      }
       // fetch blocks from caches if available, or DB otherwise
       const canonical = blocks.getBlocks().find(block => block.height === staleTip.height) || await BlocksRepository.$getBlockByHeight(staleTip.height);
       let stale: BlockExtended | null | undefined = this.staleBlocks[staleTip.hash];
@@ -254,6 +271,7 @@ class ChainTips {
         stale,
         canonical,
       });
+      lastHeight = staleTip.height;
     }
 
     return tips;

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -223,7 +223,7 @@ class ChainTips {
 
     const staleBlocks = await BlocksRepository.$getStaleBlocks(fromHeight, limit);
 
-    // map the previous block hashes of each stale block so we can reconstrunct branch lengths
+    // map the previous block hashes of each stale block so we can reconstruct branch lengths
     const staleByPrevhash: { [prevhash: string]: BlockExtended } = {};
     for (const block of staleBlocks) {
       if (block.previousblockhash) {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -600,47 +600,6 @@ class BlocksRepository {
   }
 
   /**
-   * Get a page of stale blocks, ordered by descending height, paginated by height.
-   * When fromHeight is defined, only stale blocks strictly below it are returned.
-   * @asyncSafe
-   */
-  public async $getStaleTips(fromHeight: number | undefined, limit: number): Promise<BlockExtended[]> {
-    try {
-      const params: (number)[] = [];
-      let heightFilter = '';
-      if (fromHeight !== undefined) {
-        heightFilter = ' AND blocks.height < ?';
-        params.push(fromHeight);
-      }
-      params.push(limit);
-
-      const [rows]: any[] = await DB.query(`
-        SELECT ${BLOCK_DB_FIELDS}
-        FROM blocks
-        JOIN pools ON blocks.pool_id = pools.id
-        WHERE blocks.stale = 1${heightFilter}
-        AND NOT EXISTS (
-          SELECT 1 FROM blocks AS child
-          WHERE child.previous_block_hash = blocks.hash
-          AND child.stale = 1
-        )
-        ORDER BY blocks.height DESC
-        LIMIT ?`,
-        params
-      );
-
-      const staleTips: BlockExtended[] = [];
-      for (const row of rows) {
-        staleTips.push(await this.formatDbBlockIntoExtendedBlock(row as DatabaseBlock));
-      }
-      return staleTips;
-    } catch (e) {
-      logger.err(`Cannot get stale tips. Reason: ` + (e instanceof Error ? e.message : e));
-      throw e;
-    }
-  }
-
-  /**
    * Return blocks difficulty
    * @asyncSafe
    */

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -604,7 +604,7 @@ class BlocksRepository {
    * When fromHeight is defined, only stale blocks strictly below it are returned.
    * @asyncSafe
    */
-  public async $getStaleBlocks(fromHeight: number | undefined, limit: number): Promise<BlockExtended[]> {
+  public async $getStaleTips(fromHeight: number | undefined, limit: number): Promise<BlockExtended[]> {
     try {
       const params: (number)[] = [];
       let heightFilter = '';
@@ -619,18 +619,23 @@ class BlocksRepository {
         FROM blocks
         JOIN pools ON blocks.pool_id = pools.id
         WHERE blocks.stale = 1${heightFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM blocks AS child
+          WHERE child.previous_block_hash = blocks.hash
+          AND child.stale = 1
+        )
         ORDER BY blocks.height DESC
         LIMIT ?`,
         params
       );
 
-      const staleBlocks: BlockExtended[] = [];
+      const staleTips: BlockExtended[] = [];
       for (const row of rows) {
-        staleBlocks.push(await this.formatDbBlockIntoExtendedBlock(row as DatabaseBlock));
+        staleTips.push(await this.formatDbBlockIntoExtendedBlock(row as DatabaseBlock));
       }
-      return staleBlocks;
+      return staleTips;
     } catch (e) {
-      logger.err(`Cannot get stale blocks. Reason: ` + (e instanceof Error ? e.message : e));
+      logger.err(`Cannot get stale tips. Reason: ` + (e instanceof Error ? e.message : e));
       throw e;
     }
   }
@@ -1292,6 +1297,7 @@ class BlocksRepository {
     blk.previousblockhash = dbBlk.previousblockhash;
     blk.mediantime = dbBlk.mediantime;
     blk.indexVersion = dbBlk.index_version;
+    blk.stale = dbBlk.stale;
     // BlockExtension
     extras.totalFees = dbBlk.totalFees;
     extras.medianFee = dbBlk.medianFee;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -600,6 +600,42 @@ class BlocksRepository {
   }
 
   /**
+   * Get a page of stale blocks, ordered by descending height, paginated by height.
+   * When fromHeight is defined, only stale blocks strictly below it are returned.
+   * @asyncSafe
+   */
+  public async $getStaleBlocks(fromHeight: number | undefined, limit: number): Promise<BlockExtended[]> {
+    try {
+      const params: (number)[] = [];
+      let heightFilter = '';
+      if (fromHeight !== undefined) {
+        heightFilter = ' AND blocks.height < ?';
+        params.push(fromHeight);
+      }
+      params.push(limit);
+
+      const [rows]: any[] = await DB.query(`
+        SELECT ${BLOCK_DB_FIELDS}
+        FROM blocks
+        JOIN pools ON blocks.pool_id = pools.id
+        WHERE blocks.stale = 1${heightFilter}
+        ORDER BY blocks.height DESC
+        LIMIT ?`,
+        params
+      );
+
+      const staleBlocks: BlockExtended[] = [];
+      for (const row of rows) {
+        staleBlocks.push(await this.formatDbBlockIntoExtendedBlock(row as DatabaseBlock));
+      }
+      return staleBlocks;
+    } catch (e) {
+      logger.err(`Cannot get stale blocks. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
    * Return blocks difficulty
    * @asyncSafe
    */

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -577,6 +577,7 @@ class BlocksRepository {
 
   /**
    * Get one block by hash
+   * @asyncSafe
    */
   public async $getBlockByHash(hash: string): Promise<BlockExtended | null> {
     try {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -576,6 +576,31 @@ class BlocksRepository {
   }
 
   /**
+   * Get the canonical block hash at a given height
+   * @asyncSafe
+   */
+  public async $getCanonicalBlockHashByHeight(height: number): Promise<string | null> {
+    try {
+      const [rows]: any[] = await DB.query(`
+        SELECT hash
+        FROM blocks
+        WHERE height = ? AND stale = 0
+        LIMIT 1`,
+        [height]
+      );
+
+      if (rows.length <= 0) {
+        return null;
+      }
+
+      return rows[0].hash;
+    } catch (e) {
+      logger.err(`Cannot get canonical block hash at height ${height}. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
    * Get one block by hash
    * @asyncSafe
    */
@@ -1258,6 +1283,9 @@ class BlocksRepository {
     blk.mediantime = dbBlk.mediantime;
     blk.indexVersion = dbBlk.index_version;
     blk.stale = dbBlk.stale;
+    if (dbBlk.stale) {
+      blk.canonical = await this.$getCanonicalBlockHashByHeight(dbBlk.height) || undefined;
+    }
     // BlockExtension
     extras.totalFees = dbBlk.totalFees;
     extras.medianFee = dbBlk.medianFee;

--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -116,13 +116,18 @@
         </div>
       </div>
 
-      <div class="no-chain-tips" *ngIf="!chainTips?.length && !isLoading">
+      <div class="no-chain-tips" *ngIf="!chainTips?.length && !isLoading && !error">
         <p i18n="chain-tips.no-stale-blocks-yet">This node hasn't seen any stale blocks yet!</p>
       </div>
     </ng-container>
 
     <div *ngIf="isLoadingMore" class="text-center loading-more">
       <div class="spinner-border" role="status"></div>
+    </div>
+
+    <div *ngIf="error && !isLoading && !isLoadingMore" class="alert alert-danger text-center loading-more" role="alert">
+      <span i18n="chain-tips.load-error">Failed to load more stale chain tips.</span>
+      <button type="button" class="btn btn-sm btn-danger ms-2" (click)="retryLoadMore()" i18n="chain-tips.retry">Retry</button>
     </div>
   </div>
   

--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -4,7 +4,7 @@
 
   <div class="clearfix"></div>
 
-  <div class="chain-tips" [ngStyle]="{ 'min-height': '295px', 'opacity': isLoading ? '0.75' : '1' }">
+  <div class="chain-tips" infiniteScroll [alwaysCallback]="true" [infiniteScrollDistance]="2" [infiniteScrollThrottle]="50" (scrolled)="loadMore()" [ngStyle]="{ 'min-height': '295px', 'opacity': isLoading ? '0.75' : '1' }">
     <ng-container *ngIf="chainTips$ | async as chainTips">
       <div *ngFor="let chainTip of chainTips" class="chain-tip">
         <p class="info">
@@ -116,10 +116,14 @@
         </div>
       </div>
 
-      <div class="no-chain-tips" *ngIf="!chainTips?.length">
+      <div class="no-chain-tips" *ngIf="!chainTips?.length && !isLoading">
         <p i18n="chain-tips.no-stale-blocks-yet">This node hasn't seen any stale blocks yet!</p>
       </div>
     </ng-container>
+
+    <div *ngIf="isLoadingMore" class="text-center loading-more">
+      <div class="spinner-border" role="status"></div>
+    </div>
   </div>
   
 </div>

--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -17,7 +17,7 @@
               <span *ngSwitchCase="'invalid'" class="badge bg-info" i18n="chain-tips.invalid">Invalid</span>
               <span *ngSwitchDefault>{{ chainTip.status }}</span>
             </span>
-            <span class="badge bg-secondary depth-badge" i18n="chain-tips.depth">Depth {{ chainTip.branchlen + 1 }}</span>
+            <span class="badge bg-secondary depth-badge" i18n="chain-tips.depth">Depth {{ chainTip.branchlen }}</span>
           </span>
         </p>
         <div class="stale-tip-wrapper">

--- a/frontend/src/app/components/stale-list/stale-list.component.ts
+++ b/frontend/src/app/components/stale-list/stale-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { catchError, distinctUntilChanged, map, share, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of, timer } from 'rxjs';
+import { catchError, map, retry, share, switchMap, tap } from 'rxjs/operators';
 import { StaleTip, BlockExtended } from '@interfaces/node-api.interface';
 import { ApiService } from '@app/services/api.service';
 import { StateService } from '@app/services/state.service';
@@ -21,7 +21,7 @@ export class StaleList implements OnInit {
   isLoading = true;
   isLoadingMore = false;
   fullyLoaded = false;
-  error: any;
+  error: unknown = null;
 
   gradientColors = {
     '': ['var(--mainnet-alt)', 'var(--primary)'],
@@ -41,17 +41,27 @@ export class StaleList implements OnInit {
 
   ngOnInit(): void {
     this.chainTips$ = this.loadMoreSubject.pipe(
-      distinctUntilChanged(),
-      switchMap(() => this.apiService.getStaleTips$(this.chainTips[this.chainTips.length - 1]?.height).pipe(
+      switchMap((height) => this.apiService.getStaleTips$(height).pipe(
         map((chainTips) => chainTips.filter((chainTip) => chainTip.status !== 'active') as StaleTip[]),
+        retry({
+          count: 2,
+          delay: (err) => {
+            this.error = err;
+            return timer(1000);
+          },
+        }),
         catchError((err) => {
           this.error = err;
           this.isLoading = false;
           this.isLoadingMore = false;
-          return of([]);
+          return of(null);
         }),
       )),
       tap((newChainTips) => {
+        if (newChainTips === null) {
+          return;
+        }
+        this.error = null;
         if (!newChainTips.length) {
           this.fullyLoaded = true;
         } else {
@@ -79,11 +89,22 @@ export class StaleList implements OnInit {
   }
 
   loadMore(): void {
-    if (this.isLoadingMore || this.fullyLoaded) {
+    if (this.isLoading || this.isLoadingMore || this.fullyLoaded || this.error) {
       return;
     }
     this.isLoadingMore = true;
-    this.loadMoreSubject.next(this.chainTips[this.chainTips.length - 1]?.height);
+    const height = this.chainTips[this.chainTips.length - 1]?.height;
+    this.loadMoreSubject.next(height);
+  }
+
+  retryLoadMore(): void {
+    if (this.isLoading || this.isLoadingMore || this.fullyLoaded) {
+      return;
+    }
+    this.error = null;
+    this.isLoadingMore = true;
+    const height = this.chainTips[this.chainTips.length - 1]?.height;
+    this.loadMoreSubject.next(height);
   }
 
   getBlockGradient(block: BlockExtended): string {

--- a/frontend/src/app/components/stale-list/stale-list.component.ts
+++ b/frontend/src/app/components/stale-list/stale-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, distinctUntilChanged, map, share, switchMap, tap } from 'rxjs/operators';
 import { StaleTip, BlockExtended } from '@interfaces/node-api.interface';
 import { ApiService } from '@app/services/api.service';
 import { StateService } from '@app/services/state.service';
@@ -16,9 +16,12 @@ import { seoDescriptionNetwork } from '@app/shared/common.utils';
 })
 export class StaleList implements OnInit {
   chainTips$: Observable<StaleTip[]>;
-  nextChainTipSubject = new BehaviorSubject(null);
-  urlFragmentSubscription: Subscription;
+  loadMoreSubject = new BehaviorSubject<number | undefined>(undefined);
+  chainTips: StaleTip[] = [];
   isLoading = true;
+  isLoadingMore = false;
+  fullyLoaded = false;
+  error: any;
 
   gradientColors = {
     '': ['var(--mainnet-alt)', 'var(--primary)'],
@@ -37,30 +40,50 @@ export class StaleList implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.chainTips$ = this.apiService.getStaleTips$().pipe(
-      map((chainTips) => {
-        const filtered = chainTips.filter((chainTip) => chainTip.status !== 'active') as StaleTip[];
-
-        filtered.forEach((chainTip) => {
-          if (chainTip.stale?.extras) {
-            chainTip.stale.extras.minFee = this.getMinBlockFee(chainTip.stale);
-            chainTip.stale.extras.maxFee = this.getMaxBlockFee(chainTip.stale);
-          }
-          if (chainTip.canonical?.extras) {
-            chainTip.canonical.extras.minFee = this.getMinBlockFee(chainTip.canonical);
-            chainTip.canonical.extras.maxFee = this.getMaxBlockFee(chainTip.canonical);
-          }
-        });
-
-        return filtered;
-      }),
-      tap(() => {
+    this.chainTips$ = this.loadMoreSubject.pipe(
+      distinctUntilChanged(),
+      switchMap(() => this.apiService.getStaleTips$(this.chainTips[this.chainTips.length - 1]?.height).pipe(
+        map((chainTips) => chainTips.filter((chainTip) => chainTip.status !== 'active') as StaleTip[]),
+        catchError((err) => {
+          this.error = err;
+          this.isLoading = false;
+          this.isLoadingMore = false;
+          return of([]);
+        }),
+      )),
+      tap((newChainTips) => {
+        if (!newChainTips.length) {
+          this.fullyLoaded = true;
+        } else {
+          newChainTips.forEach((chainTip) => {
+            if (chainTip.stale?.extras) {
+              chainTip.stale.extras.minFee = this.getMinBlockFee(chainTip.stale);
+              chainTip.stale.extras.maxFee = this.getMaxBlockFee(chainTip.stale);
+            }
+            if (chainTip.canonical?.extras) {
+              chainTip.canonical.extras.minFee = this.getMinBlockFee(chainTip.canonical);
+              chainTip.canonical.extras.maxFee = this.getMaxBlockFee(chainTip.canonical);
+            }
+          });
+          this.chainTips = this.chainTips.concat(newChainTips);
+        }
         this.isLoading = false;
-      })
+        this.isLoadingMore = false;
+      }),
+      map(() => this.chainTips),
+      share(),
     );
 
     this.seoService.setTitle($localize`:@@page.stale-chain-tips:Stale Chain Tips`);
     this.seoService.setDescription($localize`:@@meta.description.stale-chain-tips:See the most recent stale chain tips on the Bitcoin${seoDescriptionNetwork(this.stateService.network)} network.`);
+  }
+
+  loadMore(): void {
+    if (this.isLoadingMore || this.fullyLoaded) {
+      return;
+    }
+    this.isLoadingMore = true;
+    this.loadMoreSubject.next(this.chainTips[this.chainTips.length - 1]?.height);
   }
 
   getBlockGradient(block: BlockExtended): string {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -172,8 +172,8 @@ export class ApiService {
     return this.httpClient.get<ChainTip[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/chain-tips');
   }
 
-  getStaleTips$(): Observable<StaleTip[]> {
-    return this.httpClient.get<StaleTip[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/stale-tips');
+  getStaleTips$(height?: number): Observable<StaleTip[]> {
+    return this.httpClient.get<StaleTip[]>(this.apiBaseUrl + this.apiBasePath + '/api/v1/stale-tips' + (height !== undefined ? `/${height}` : ``));
   }
 
   liquidPegs$(): Observable<CurrentPegs> {


### PR DESCRIPTION
Closes #6555

### Summary

This PR implements a lazy loader infinite scroll in the blocks/stale page, it previously rendered a list of the latest 50 items in memory with no chance to see older stale blocks. This PR adds height based pagination served from the database history where stale = 1, falling back to cache when indexing is disabled and prioritizing current cache stale blocks.

### Backend

- Added new query for stale blocks in BlocksRepository.$getStaleBlocks.
- Added ChaintTips.$getStaleTipsPage(fromHeight, limit) to assemble the ChainTips from BlockExtended type.
- $getStateTipsPage returns cachedTips if indexing is disabled and if the stale block from the database matches a cachedBlock hash.
- Route added `stale-tips/:height`

### Frontend

- Added height parameter to ApiService.getStaleTips$.
- Stalelist component refactored for infinite scrolling with loading spinner at the bottom.

### Considerations
- DB-only stale blocks have no status, returning an undefined status to the frontend, so maybe is a good idea to either include the statuses in the database or make a default badge for these cases.
- Branchlen (Depth) of DB stale blocks is inferred using previousblockhash.
- Tested with a regtest node.

https://github.com/user-attachments/assets/ba186f2d-d5d0-4cea-acef-6a4418022a11