### PR TITLE
fix: remove indexing block's badge from unnecesary graphs

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.html
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.html
@@ -1,4 +1,3 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
 
 <div [class.full-container]="!widget">
   <div *ngIf="!widget" class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/address-graph/address-graph.component.html
+++ b/frontend/src/app/components/address-graph/address-graph.component.html
@@ -1,4 +1,3 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
 
 <div [class.full-container]="!widget">
   <ng-container *ngIf="!error">

--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
+<app-indexing-progress *ngIf="!widget" [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div [class.full-container]="!widget">
   <div *ngIf="!widget" class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress></app-indexing-progress>
+<app-indexing-progress [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.html
+++ b/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress></app-indexing-progress>
+<app-indexing-progress [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/block-health-graph/block-health-graph.component.html
+++ b/frontend/src/app/components/block-health-graph/block-health-graph.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress></app-indexing-progress>
+<app-indexing-progress [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div class="full-container">
   <div class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.html
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress></app-indexing-progress>
+<app-indexing-progress [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div class="full-container">
 

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.html
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.html
@@ -1,3 +1,5 @@
+<app-indexing-progress [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
+
 <div class="full-container">
 
   <div class="card-header mb-0 mb-md-4">

--- a/frontend/src/app/components/blocks-list/blocks-list.component.html
+++ b/frontend/src/app/components/blocks-list/blocks-list.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
+<app-indexing-progress *ngIf="!widget" [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div class="container-xl" style="min-height: 335px" [ngClass]="{'widget': widget, 'full-height': !widget, 'legacy': !isMempoolModule}">
   <div *ngIf="!widget" class="float-start" style="display: flex; width: 100%; align-items: center;">

--- a/frontend/src/app/components/indexing-progress/indexing-progress.component.html
+++ b/frontend/src/app/components/indexing-progress/indexing-progress.component.html
@@ -1,3 +1,3 @@
-<app-loading-indicator [name]="'block-indexing'" i18n-label label="Indexing blocks"></app-loading-indicator>
-<app-loading-indicator [name]="'daily-hashrate-indexing'" i18n-label label="Indexing network hashrate"></app-loading-indicator>
-<app-loading-indicator [name]="'weekly-hashrate-indexing'" i18n-label label="Indexing pools hashrate"></app-loading-indicator>
+<app-loading-indicator *ngIf="showBlocks" [name]="'block-indexing'" i18n-label label="Indexing blocks"></app-loading-indicator>
+<app-loading-indicator *ngIf="showNetworkHashrate" [name]="'daily-hashrate-indexing'" i18n-label label="Indexing network hashrate"></app-loading-indicator>
+<app-loading-indicator *ngIf="showPoolsHashrate" [name]="'weekly-hashrate-indexing'" i18n-label label="Indexing pools hashrate"></app-loading-indicator>

--- a/frontend/src/app/components/indexing-progress/indexing-progress.component.scss
+++ b/frontend/src/app/components/indexing-progress/indexing-progress.component.scss
@@ -1,16 +1,23 @@
-.sticky-loading {
-  position: absolute;
+:host {
+  position: fixed;
   right: 10px;
   z-index: 1000;
   font-size: 14px;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+
   @media (width >= 992px) {
     left: 32px;
     top: 55px;
   }
+
   @media (576px <= width < 992px ) {
     left: 18px;
     top: 55px;
   }
+
   @media (width <= 575px) {
     left: 18px;
     top: 100px;

--- a/frontend/src/app/components/indexing-progress/indexing-progress.component.ts
+++ b/frontend/src/app/components/indexing-progress/indexing-progress.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-indexing-progress',
@@ -7,6 +7,10 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
   standalone: false,
 })
 export class IndexingProgressComponent implements OnInit {
+  @Input() showBlocks: boolean = true;
+  @Input() showNetworkHashrate: boolean = true;
+  @Input() showPoolsHashrate: boolean = true;
+
   constructor(
   ) {}
 

--- a/frontend/src/app/components/indexing-progress/indexing-progress.component.ts
+++ b/frontend/src/app/components/indexing-progress/indexing-progress.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core
 @Component({
   selector: 'app-indexing-progress',
   templateUrl: './indexing-progress.component.html',
+  styleUrl: 'indexing-progress.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })

--- a/frontend/src/app/components/loading-indicator/loading-indicator.component.html
+++ b/frontend/src/app/components/loading-indicator/loading-indicator.component.html
@@ -1,3 +1,3 @@
-<div *ngIf="this.indexingProgress$ | async as progress" class="sticky-loading">
+<div *ngIf="this.indexingProgress$ | async as progress">
   <span *ngIf="progress >= 0" class="me-auto badge rounded-pill bg-warning">{{ this.label }} ({{ progress }}%)</span>
 </div>

--- a/frontend/src/app/components/loading-indicator/loading-indicator.component.ts
+++ b/frontend/src/app/components/loading-indicator/loading-indicator.component.ts
@@ -7,7 +7,6 @@ import { WebsocketService } from '@app/services/websocket.service';
 @Component({
   selector: 'app-loading-indicator',
   templateUrl: './loading-indicator.component.html',
-  styleUrls: ['./loading-indicator.component.scss'],
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/components/pool-ranking/pool-ranking.component.html
+++ b/frontend/src/app/components/pool-ranking/pool-ranking.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
+<app-indexing-progress *ngIf="!widget" [showNetworkHashrate]="false" [showPoolsHashrate]="false"></app-indexing-progress>
 
 <div [class]="widget === false ? 'full-container' : ''">
 

--- a/frontend/src/app/components/pool/pool.component.html
+++ b/frontend/src/app/components/pool/pool.component.html
@@ -1,4 +1,4 @@
-<app-indexing-progress></app-indexing-progress>
+<app-indexing-progress [showNetworkHashrate]="false"></app-indexing-progress>
 
 <div class="container-xl" *ngIf="!error; else errorTemplate">
 

--- a/frontend/src/app/components/price-chart/price-chart.component.html
+++ b/frontend/src/app/components/price-chart/price-chart.component.html
@@ -1,4 +1,3 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
 
 <div [class]="widget === false ? 'full-container' : ''">
 

--- a/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.html
+++ b/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.html
@@ -1,4 +1,3 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
 
 <div [class.full-container]="!widget">
   <ng-container *ngIf="!error">

--- a/frontend/src/app/components/utxo-graph/utxo-graph.component.html
+++ b/frontend/src/app/components/utxo-graph/utxo-graph.component.html
@@ -1,4 +1,3 @@
-<app-indexing-progress *ngIf="!widget"></app-indexing-progress>
 
 <div [class.full-container]="!widget">
   <ng-container *ngIf="!error">


### PR DESCRIPTION
closes #6556 

This PR removes the `app-indexing-indicator` from the components it is unnecessary, and hides specific loading indicators depending on the component dependency of the progress, following the next table.

| Component | Blocks | Pools hashrate (weekly) | Hashrate (daily) |
|---|---|---|---|
| `block-fee-rates-graph` | ✅ | ❌ | ❌ |
| `block-fees-graph` | ✅ | ❌ | ❌ |
| `block-fees-subsidy-graph` | ✅ | ❌ | ❌ |
| `block-health-graph` | ✅ | ❌ | ❌ |
| `block-rewards-graph` | ✅ | ❌ | ❌ |
| `block-sizes-weights-graph` | ✅ | ❌ | ❌ |
| `blocks-list` | ✅ | ❌ | ❌ |
| `pool-ranking` | ✅ | ❌ | ❌ |
| `pool` | ✅ | ✅ | ❌ |

This is the list of components I ripped off the indexing-indicator completely as they don't depend on any of the three loading indicators:

- `acceleration-fees-graph`
- `address-graph`
- `price-chart`
- `treasuries-graph`
- `utxo-graph`