### PR TITLE
stale tips refactor suggestions

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -639,7 +639,7 @@ class BitcoinRoutes {
         }
 
         res.setHeader('Expires', new Date(Date.now() + 1000 * 60).toUTCString());
-        const tips = await chainTips.$getStaleTipsPage(fromHeight, 10);
+        const tips = await chainTips.$getStaleTipsPage(fromHeight, 25);
         res.json(tips);
       } else { // Liquid
         handleError(req, res, 404, `This API is only available for Bitcoin networks`);

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -71,7 +71,7 @@ class ChainTips {
                 orphan = {
                   height: block.height,
                   hash: block.id,
-                  branchlen: chain.branchlen - 1,
+                  branchlen: chain.branchlen,
                   status: chain.status,
                   prevhash: block.previousblockhash,
                 };
@@ -244,7 +244,7 @@ class ChainTips {
       tips.push({
         height: staleTip.height,
         hash: staleTip.hash,
-        branchlen: staleTip.branchlen - 1,
+        branchlen: staleTip.branchlen,
         status: staleTip.status,
         stale,
         canonical,

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -31,20 +31,22 @@ export interface OrphanedBlock {
 
 class ChainTips {
   private chainTips: ChainTip[] = [];
-  private staleTips: Record<number, StaleTip> = {};
+  private validChainTips: ChainTip[] = []; // 'valid-fork' and 'valid-headers' only, in descending height order
+  private staleBlocks: Record<string, BlockExtended> = {};
   private orphanedBlocks: { [hash: string]: OrphanedBlock } = {};
   private blockCache: { [hash: string]: OrphanedBlock } = {};
   private orphansByHeight: { [height: number]: OrphanedBlock[] } = {};
   private indexingOrphanedBlocks = false;
   private indexingQueue: { blockhash?: string, block?: IEsploraApi.Block, tip: OrphanedBlock }[] = [];
 
-  private staleTipsCacheSize = 50;
+  private staleBlocksCacheSize = 50;
   private maxIndexingQueueSize = 100;
 
   /** @asyncSafe */
   public async updateOrphanedBlocks(): Promise<void> {
     try {
       this.chainTips = await bitcoinClient.getChainTips();
+      this.validChainTips = this.chainTips.filter(tip => tip.status === 'valid-fork' || tip.status === 'valid-headers').sort((a, b) => b.height - a.height);
 
       const activeTipHeight = this.chainTips.find(tip => tip.status === 'active')?.height || (await bitcoinApi.$getBlockHeightTip());
       let minIndexHeight = 0;
@@ -122,13 +124,7 @@ class ChainTips {
         this.orphansByHeight[orphan.height].push(orphan);
       }
 
-      const heightsToKeep = new Set(this.chainTips.filter(tip => tip.status !== 'active').map(tip => tip.height));
-      const heightsToRemove: number[] = Object.keys(this.staleTips).map(Number).filter(height => !heightsToKeep.has(height));
-      for (const height of heightsToRemove) {
-        delete this.staleTips[height];
-      }
-
-      this.trimStaleTipsCache();
+      this.trimStaleBlocksCache();
 
       // index new orphaned blocks in the background
       void this.$indexOrphanedBlocks();
@@ -160,7 +156,7 @@ class ChainTips {
         }
         let staleBlock: BlockExtended | undefined;
         const alreadyIndexed = await BlocksSummariesRepository.$isSummaryIndexed(block.id);
-        const needToCache = Object.keys(this.staleTips).length < this.staleTipsCacheSize || block.height > Object.keys(this.staleTips).map(Number).sort((a, b) => b - a)[this.staleTipsCacheSize - 1];
+        const needToCache = this.shouldCacheStaleBlock(block.id, block.height);
         if (!alreadyIndexed) {
           staleBlock = await blocks.$indexBlock(block.id, block, true);
           await blocks.$indexBlockSummary(block.id, block.height, true);
@@ -171,16 +167,9 @@ class ChainTips {
         }
 
         if (staleBlock && needToCache) {
-          const canonicalBlock = await blocks.$indexBlockByHeight(staleBlock.height);
-          this.staleTips[staleBlock.height] = {
-            height: staleBlock.height,
-            hash: staleBlock.id,
-            branchlen: tip.branchlen,
-            status: tip.status,
-            stale: staleBlock,
-            canonical: canonicalBlock,
-          };
-          this.trimStaleTipsCache();
+          // ensure the canonical block is correctly indexed
+          await blocks.$indexBlockByHeight(staleBlock.height);
+          this.cacheStaleBlock(staleBlock);
         }
       } catch (e) {
         logger.err(`Failed to index orphaned block ${block?.id} at height ${block?.height}. Reason: ${e instanceof Error ? e.message : e}`);
@@ -189,12 +178,42 @@ class ChainTips {
     this.indexingOrphanedBlocks = false;
   }
 
-  private trimStaleTipsCache(): void {
-    const staleTipHeights = Object.keys(this.staleTips).map(Number).sort((a, b) => b - a);
-    if (staleTipHeights.length > this.staleTipsCacheSize) {
-      const heightsToDiscard = staleTipHeights.slice(this.staleTipsCacheSize);
-      for (const height of heightsToDiscard) {
-        delete this.staleTips[height];
+  private shouldCacheStaleBlock(hash: string, height: number): boolean {
+    // already cached
+    if (this.staleBlocks[hash]) {
+      return false;
+    }
+
+    // cache is not full
+    const cachedBlocks = Object.values(this.staleBlocks);
+    if (cachedBlocks.length < this.staleBlocksCacheSize) {
+      return true;
+    }
+
+    // otherwise cache if this block is newer than the oldest in the cache
+    const oldestCachedHeight = cachedBlocks.reduce((min, block) => Math.min(min, block.height), Infinity);
+    return height >= oldestCachedHeight;
+  }
+
+  private cacheStaleBlock(block: BlockExtended): void {
+    this.staleBlocks[block.id] = block;
+    this.trimStaleBlocksCache();
+  }
+
+  // evict the oldest stale blocks until the cache is within the size limit
+  private trimStaleBlocksCache(): void {
+    // sort by height
+    const cachedBlocks = Object.values(this.staleBlocks).sort((a, b) => {
+      if (b.height !== a.height) {
+        return b.height - a.height;
+      }
+      // tie-break by hash
+      return a.id.localeCompare(b.id);
+    });
+    // delete everything beyond the size limit
+    if (cachedBlocks.length > this.staleBlocksCacheSize) {
+      for (const block of cachedBlocks.slice(this.staleBlocksCacheSize)) {
+        delete this.staleBlocks[block.id];
       }
     }
   }
@@ -211,41 +230,27 @@ class ChainTips {
     return this.chainTips;
   }
 
-  public getStaleTips(): StaleTip[] {
-    return Object.values(this.staleTips).sort((a, b) => b.height - a.height);
-  }
-
-  /** @asyncUnsafe */
+  /** @asyncSafe */
   public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
-    const cacheTips = this.getStaleTips();
+    const start = fromHeight === undefined ? 0 : this.validChainTips.findIndex(tip => tip.height < fromHeight);
+    const staleTipsPage = start === -1 ? [] : this.validChainTips.slice(start, start + limit);
 
-    const allStaleTips = this.chainTips.filter(chainTip => chainTip.status === 'valid-fork' || chainTip.status === 'valid-headers').sort((a, b) => b.height - a.height);
-    const staleTipsPage = fromHeight === undefined ? allStaleTips.slice(0, limit) : allStaleTips.filter(tip => tip.height < fromHeight).slice(0, limit);
-
-    const cacheTipsMap = new Map<string, StaleTip>();
-    for (const cacheTip of cacheTips) {
-      cacheTipsMap.set(cacheTip.hash, cacheTip);
-    }
-
+    // hydrate tips with block data
     const tips: StaleTip[] = [];
     for (const staleTip of staleTipsPage) {
-      const cachedTip = cacheTipsMap.get(staleTip.hash);
-      if (cachedTip) {
-        tips.push(cachedTip);
-        continue;
+      // fetch blocks from caches if available, or DB otherwise
+      const canonical = blocks.getBlocks().find(block => block.height === staleTip.height) || await BlocksRepository.$getBlockByHeight(staleTip.height);
+      let stale: BlockExtended | null | undefined = this.staleBlocks[staleTip.hash];
+      if (!stale) {
+        stale = await BlocksRepository.$getBlockByHash(staleTip.hash);
       }
-
-      const canonical = await BlocksRepository.$getBlockByHeight(staleTip.height);
-      const stale = await BlocksRepository.$getBlockByHash(staleTip.hash);
+      // skip tips with missing block data
       if (!canonical || !stale) {
         continue;
       }
 
       tips.push({
-        height: staleTip.height,
-        hash: staleTip.hash,
-        branchlen: staleTip.branchlen,
-        status: staleTip.status,
+        ...staleTip,
         stale,
         canonical,
       });

--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -230,14 +230,31 @@ class ChainTips {
     return this.chainTips;
   }
 
-  /** @asyncSafe */
-  public async $getStaleTipsPage(fromHeight: number | undefined, limit: number): Promise<StaleTip[]> {
+  /**
+   * get paginated stale chain tips
+   * @param fromHeight - start height (exclusive)
+   * @param count - requested page size (target, but not strictly enforced)
+   *
+   * @asyncSafe
+   */
+  public async $getStaleTipsPage(fromHeight: number | undefined, count: number): Promise<StaleTip[]> {
     const start = fromHeight === undefined ? 0 : this.validChainTips.findIndex(tip => tip.height < fromHeight);
-    const staleTipsPage = start === -1 ? [] : this.validChainTips.slice(start, start + limit);
+    // no tips beyond the requested height, we can return early
+    if (start === -1) {
+      return [];
+    }
 
-    // hydrate tips with block data
+    // fill the response array with hydrated tip data
     const tips: StaleTip[] = [];
-    for (const staleTip of staleTipsPage) {
+    let lastHeight;
+    for (let index = start; index < this.validChainTips.length; index++) {
+      const staleTip = this.validChainTips[index];
+      // stretch the page to include any remaining blocks at the last included height to avoid pagination gaps with a height-based cursor
+      if (tips.length >= count) {
+        if (staleTip.height !== lastHeight) {
+          break;
+        }
+      }
       // fetch blocks from caches if available, or DB otherwise
       const canonical = blocks.getBlocks().find(block => block.height === staleTip.height) || await BlocksRepository.$getBlockByHeight(staleTip.height);
       let stale: BlockExtended | null | undefined = this.staleBlocks[staleTip.hash];
@@ -254,6 +271,7 @@ class ChainTips {
         stale,
         canonical,
       });
+      lastHeight = staleTip.height;
     }
 
     return tips;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -577,6 +577,7 @@ class BlocksRepository {
 
   /**
    * Get one block by hash
+   * @asyncSafe
    */
   public async $getBlockByHash(hash: string): Promise<BlockExtended | null> {
     try {

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -576,6 +576,31 @@ class BlocksRepository {
   }
 
   /**
+   * Get the canonical block hash at a given height
+   * @asyncSafe
+   */
+  public async $getCanonicalBlockHashByHeight(height: number): Promise<string | null> {
+    try {
+      const [rows]: any[] = await DB.query(`
+        SELECT hash
+        FROM blocks
+        WHERE height = ? AND stale = 0
+        LIMIT 1`,
+        [height]
+      );
+
+      if (rows.length <= 0) {
+        return null;
+      }
+
+      return rows[0].hash;
+    } catch (e) {
+      logger.err(`Cannot get canonical block hash at height ${height}. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
+  }
+
+  /**
    * Get one block by hash
    * @asyncSafe
    */
@@ -1258,6 +1283,9 @@ class BlocksRepository {
     blk.mediantime = dbBlk.mediantime;
     blk.indexVersion = dbBlk.index_version;
     blk.stale = dbBlk.stale;
+    if (dbBlk.stale) {
+      blk.canonical = await this.$getCanonicalBlockHashByHeight(dbBlk.height) || undefined;
+    }
     // BlockExtension
     extras.totalFees = dbBlk.totalFees;
     extras.medianFee = dbBlk.medianFee;

--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -116,13 +116,18 @@
         </div>
       </div>
 
-      <div class="no-chain-tips" *ngIf="!chainTips?.length && !isLoading">
+      <div class="no-chain-tips" *ngIf="!chainTips?.length && !isLoading && !error">
         <p i18n="chain-tips.no-stale-blocks-yet">This node hasn't seen any stale blocks yet!</p>
       </div>
     </ng-container>
 
     <div *ngIf="isLoadingMore" class="text-center loading-more">
       <div class="spinner-border" role="status"></div>
+    </div>
+
+    <div *ngIf="error && !isLoading && !isLoadingMore" class="alert alert-danger text-center loading-more" role="alert">
+      <span i18n="chain-tips.load-error">Failed to load more stale chain tips.</span>
+      <button type="button" class="btn btn-sm btn-danger ms-2" (click)="retryLoadMore()" i18n="chain-tips.retry">Retry</button>
     </div>
   </div>
   

--- a/frontend/src/app/components/stale-list/stale-list.component.html
+++ b/frontend/src/app/components/stale-list/stale-list.component.html
@@ -17,7 +17,7 @@
               <span *ngSwitchCase="'invalid'" class="badge bg-info" i18n="chain-tips.invalid">Invalid</span>
               <span *ngSwitchDefault>{{ chainTip.status }}</span>
             </span>
-            <span class="badge bg-secondary depth-badge" i18n="chain-tips.depth">Depth {{ chainTip.branchlen + 1 }}</span>
+            <span class="badge bg-secondary depth-badge" i18n="chain-tips.depth">Depth {{ chainTip.branchlen }}</span>
           </span>
         </p>
         <div class="stale-tip-wrapper">

--- a/frontend/src/app/components/stale-list/stale-list.component.ts
+++ b/frontend/src/app/components/stale-list/stale-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { catchError, distinctUntilChanged, map, share, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of, timer } from 'rxjs';
+import { catchError, map, retry, share, switchMap, tap } from 'rxjs/operators';
 import { StaleTip, BlockExtended } from '@interfaces/node-api.interface';
 import { ApiService } from '@app/services/api.service';
 import { StateService } from '@app/services/state.service';
@@ -21,7 +21,7 @@ export class StaleList implements OnInit {
   isLoading = true;
   isLoadingMore = false;
   fullyLoaded = false;
-  error: any;
+  error: unknown = null;
 
   gradientColors = {
     '': ['var(--mainnet-alt)', 'var(--primary)'],
@@ -41,17 +41,27 @@ export class StaleList implements OnInit {
 
   ngOnInit(): void {
     this.chainTips$ = this.loadMoreSubject.pipe(
-      distinctUntilChanged(),
-      switchMap(() => this.apiService.getStaleTips$(this.chainTips[this.chainTips.length - 1]?.height).pipe(
+      switchMap((height) => this.apiService.getStaleTips$(height).pipe(
         map((chainTips) => chainTips.filter((chainTip) => chainTip.status !== 'active') as StaleTip[]),
+        retry({
+          count: 2,
+          delay: (err) => {
+            this.error = err;
+            return timer(1000);
+          },
+        }),
         catchError((err) => {
           this.error = err;
           this.isLoading = false;
           this.isLoadingMore = false;
-          return of([]);
+          return of(null);
         }),
       )),
       tap((newChainTips) => {
+        if (newChainTips === null) {
+          return;
+        }
+        this.error = null;
         if (!newChainTips.length) {
           this.fullyLoaded = true;
         } else {
@@ -79,11 +89,22 @@ export class StaleList implements OnInit {
   }
 
   loadMore(): void {
-    if (this.isLoadingMore || this.fullyLoaded) {
+    if (this.isLoading || this.isLoadingMore || this.fullyLoaded || this.error) {
       return;
     }
     this.isLoadingMore = true;
-    this.loadMoreSubject.next(this.chainTips[this.chainTips.length - 1]?.height);
+    const height = this.chainTips[this.chainTips.length - 1]?.height;
+    this.loadMoreSubject.next(height);
+  }
+
+  retryLoadMore(): void {
+    if (this.isLoading || this.isLoadingMore || this.fullyLoaded) {
+      return;
+    }
+    this.error = null;
+    this.isLoadingMore = true;
+    const height = this.chainTips[this.chainTips.length - 1]?.height;
+    this.loadMoreSubject.next(height);
   }
 
   getBlockGradient(block: BlockExtended): string {


### PR DESCRIPTION
a few suggested fixes and changes for #6561:

---

(1) removes the `branchlen` decrement on the backend and increment on the frontend, since these cancel out anyway.

---

(2) adds error handling and retry logic in the frontend, so that pagination scrolling doesn't cut off on a non-200 response:
- distinguish errors from empty array responses (which signal the end of available results).
- retry a few times on failure, throttled to 1 retry per second.
- keep the loading spinner up while retrying.
- show an error message with a manual retry button after repeated errors.

---

(3) refactors `chain-tips.ts` to cache recent stale blocks by hash (`staleBlocks`) instead of recent stale tips by height (`staleTips`), which allows a bit of a simplification of the pagination cache logic.

as part of that simplification, also fixes an issue where tips could be skipped during pagination when multiple tips at the same height straddled a page boundary.

instead, we now "stretch" the page to include any remaining tips at the same height as the last one to be included. this wouldn't be appropriate for normal pagination, since it makes the number of items per page unpredictable, but I think it's a reasonable solution for an API intended to support an infinite scrolling interface.

possible alternative solutions:
- use a composite cursor instead of a purely height-based one.
- request and/or return pages with overlapping height ranges, and deduplicate on the client side.

---

(4) increases the target page size from 10 to 25 to reduce pagination overhead.

---

(5) fixes the `/block/:hash` page, which was broken for stale blocks due to a missing `canonical` field in stale blocks returned by the `/api/v1/block/:hash` endpoint.