### PR TITLE
Fix 'see more details here' link in FAQ

### DIFF
--- a/frontend/src/app/docs/api-docs/api-docs.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs.component.html
@@ -330,7 +330,7 @@
 </ng-template>
 
 <ng-template type="why-block-timestamps-dont-always-increase">
-  <p>Block validation rules do not strictly require that a block's timestamp be more recent than the timestamp of the block preceding it. Without a central authority, it's impossible to know what the exact correct time is. Instead, the Bitcoin protocol requires that a block's timestamp meet certain requirements. One of those requirements is that a block's timestamp cannot be older than the median timestamp of the 12 blocks that came before it. See more details <a href="https://en.bitcoin.it/wiki/Block_timestamp" target="_blank">here</a>.</p><p>As a result, timestamps are only accurate to within an hour or so, which sometimes results in blocks with timestamps that appear out of order.</p>
+  <p>Block validation rules do not strictly require that a block's timestamp be more recent than the timestamp of the block preceding it. Without a central authority, it's impossible to know what the exact correct time is. Instead, the Bitcoin protocol requires that a block's timestamp meet certain requirements. One of those requirements is that <a href="https://en.bitcoin.it/wiki/Block_timestamp" target="_blank">a block's timestamp cannot be older than the median timestamp of the 12 blocks that came before it</a>.</p><p>As a result, timestamps are only accurate to within an hour or so, which sometimes results in blocks with timestamps that appear out of order.</p>
 </ng-template>
 
 <ng-template type="why-dont-fee-ranges-match">


### PR DESCRIPTION
<img width="1626" height="607" alt="Screenshot 2026-06-27 at 14 48 31" src="https://github.com/user-attachments/assets/85fbd99f-9cc0-4787-b8a4-be3ebf16fb0a" />

In the future please don't add link text that says "see more details here", instead add the hyperlink around the relevant text of what is being linked