### PR TITLE
Send stratum jobs only when requested on stratum page

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -446,7 +446,7 @@ class WebsocketHandler {
             delete client['track-mempool'];
           }
 
-          if (parsedMessage && parsedMessage['track-stratum'] != null) {
+          if (parsedMessage && parsedMessage['track-stratum'] !== undefined) {
             if (parsedMessage['track-stratum'] === 'all' || typeof parsedMessage['track-stratum'] === 'number') {
               const sub = parsedMessage['track-stratum'];
               client['track-stratum'] = sub;

--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -450,7 +450,7 @@ class WebsocketHandler {
             if (parsedMessage['track-stratum'] === 'all' || typeof parsedMessage['track-stratum'] === 'number') {
               const sub = parsedMessage['track-stratum'];
               client['track-stratum'] = sub;
-              response['stratumJobs'] = this.socketData['stratumJobs'];
+              response['stratumJobs'] = JSON.stringify(stratumApi.getJobs());
             } else {
               client['track-stratum'] = false;
             }
@@ -1369,8 +1369,6 @@ class WebsocketHandler {
   }
 
   public handleNewStratumJob(job: StratumJob): void {
-    this.updateSocketDataFields({ 'stratumJobs': stratumApi.getJobs() });
-
     for (const server of this.webSocketServers) {
       server.clients.forEach((client) => {
         if (client.readyState !== WebSocket.OPEN) {

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, Input, LOCALE_ID, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, Input, LOCALE_ID, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { echarts, EChartsOption } from '@app/graphs/echarts';
 import { BehaviorSubject, Observable, Subscription, combineLatest, of } from 'rxjs';
@@ -26,7 +26,7 @@ interface AccelerationTotal {
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PoolComponent implements OnInit {
+export class PoolComponent implements OnInit, OnDestroy {
   @Input() right: number | string = 45;
   @Input() left: number | string = 75;
 
@@ -365,5 +365,6 @@ export class PoolComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.slugSubscription.unsubscribe();
+    this.websocketService.stopTrackStratum();
   }
 }


### PR DESCRIPTION
`StratumJobs` is currently added to every init response, this PR fixes that to only send these on `track-stratum` subscriptions.