### PR TITLE
fix failing liquid asset e2e tests

### DIFF
--- a/frontend/cypress/e2e/liquid/liquid.spec.ts
+++ b/frontend/cypress/e2e/liquid/liquid.spec.ts
@@ -113,7 +113,7 @@ describe('Liquid', () => {
       it('allows searching assets', () => {
         cy.visit(`${basePath}/assets`);
         cy.waitForSkeletonGone();
-        cy.get('.container-xl input').click().type('Liquid Bitcoin').then(() => {
+        cy.get('.container-xl input').click().type('Tether USD').then(() => {
           cy.get('ngb-typeahead-window', { timeout: 30000 }).should('have.length', 1);
         });
       });

--- a/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
+++ b/frontend/cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
@@ -79,7 +79,7 @@ describe('Liquid Testnet', () => {
       it('allows searching assets', () => {
         cy.visit(`${basePath}/assets`);
         cy.waitForSkeletonGone();
-        cy.get('.container-xl input').click().type('Liquid Bitcoin').then(() => {
+        cy.get('.container-xl input').click().type('Tether USD').then(() => {
           cy.get('ngb-typeahead-window').should('have.length', 1);
         });
       });


### PR DESCRIPTION
Liquid assets search now uses the `/api/assets/registry/search?q=` API, rather than loading a static `assets.json` file.

the search API doesn't currently include the "native" LBTC and tLBTC assets, but the Cypress e2e tests still used "Liquid Bitcoin" as the test string for the assets search feature, so those tests were broken.

this PR switches those tests to search for a non-native asset we know exists on both Liquid and Liquid Testnet, which makes the tests pass again.

separately we might want to also fix the mempool/electrs registry search API endpoints to include native assets.