### PR TITLE
Stats accelerator dashboard

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -45,6 +45,7 @@ export class AccelerationStatsComponent implements OnInit, OnChanges {
       websocketRefresh$,
       this.stateService.chainTip$.pipe(distinctUntilChanged())
     ).pipe(
+      debounceTime(0),
       switchMap(() =>
         this.servicesApiService
           .getAccelerationStats$({ timeframe: this.timespan })

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
-import { BehaviorSubject, EMPTY, Observable, merge, catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, EMPTY, Observable, merge, catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap, throttleTime } from 'rxjs';
 import { ServicesApiServices } from '@app/services/services-api.service';
 import { StateService } from '@app/services/state.service';
 
@@ -37,7 +37,7 @@ export class AccelerationStatsComponent implements OnInit, OnChanges {
         (delta) =>
           !delta.reset && (!!delta.added.length || !!delta.removed.length)
       ),
-      debounceTime(2000)
+      throttleTime(2000)
     );
 
     this.accelerationStats$ = merge(

--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, EMPTY, Observable, merge, catchError, debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs';
 import { ServicesApiServices } from '@app/services/services-api.service';
+import { StateService } from '@app/services/state.service';
 
 export type AccelerationStats = {
   totalRequested: number;
@@ -21,21 +22,44 @@ export class AccelerationStatsComponent implements OnInit, OnChanges {
   @Input() timespan: '24h' | '1m' | '1y' | 'all' = '1y';
   accelerationStats$: Observable<AccelerationStats>;
   blocksInPeriod: number = 7 * 144;
+  private timespan$ = new BehaviorSubject<'24h' | '1m' | '1y' | 'all'>(
+    this.timespan
+  );
 
   constructor(
-    private servicesApiService: ServicesApiServices
-  ) { }
+    private servicesApiService: ServicesApiServices,
+    private stateService: StateService
+  ) {}
 
   ngOnInit(): void {
-    this.updateStats();
+    const websocketRefresh$ = this.stateService.accelerations$.pipe(
+      filter(
+        (delta) =>
+          !delta.reset && (!!delta.added.length || !!delta.removed.length)
+      ),
+      debounceTime(2000)
+    );
+
+    this.accelerationStats$ = merge(
+      this.timespan$.pipe(tap(() => this.updateBlocksInPeriod())),
+      websocketRefresh$,
+      this.stateService.chainTip$.pipe(distinctUntilChanged())
+    ).pipe(
+      switchMap(() =>
+        this.servicesApiService
+          .getAccelerationStats$({ timeframe: this.timespan })
+          .pipe(
+            catchError(() => EMPTY)
+          )
+      )
+    );
   }
 
   ngOnChanges(): void {
-    this.updateStats();
+    this.timespan$.next(this.timespan);
   }
 
-  updateStats(): void {
-    this.accelerationStats$ = this.servicesApiService.getAccelerationStats$({ timeframe: this.timespan });
+  private updateBlocksInPeriod(): void {
     switch (this.timespan) {
       case '24h':
         this.blocksInPeriod = 144;


### PR DESCRIPTION
Close #6601 

“acceleration-stats” was the only component of the dashboard that wasn't reactive,  so I brought this one in line it keeps the HTTP endpoint as the source of truth but now refetches on timespan change, on websocket acceleration deltas (debounced), and on each new block. Verified live against production data the stats now update on both new accelerations and new blocks without a refresh.
