### PR TITLE
Fix effective fee row on mobile

### DIFF
--- a/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
+++ b/frontend/src/app/components/transaction/transaction-details/transaction-details.component.scss
@@ -172,8 +172,16 @@
     gap: 0.5rem;
     flex-wrap: wrap;
 
+    @media (max-width: 849.98px) {
+      justify-content: flex-end;
+    }
+
     .effective-fee-container {
       flex: 0 0 auto;
+
+      @media (max-width: 425px) {
+        align-items: flex-end;
+      }
     }
   }
 }


### PR DESCRIPTION
Effective fee row value is not correctly right aligned on mobile when transaction is part of a cluter:

| Before  | After |
| ------------- | ------------- |
| <img width="330" alt="Screenshot 2026-07-03 at 12 11 18" src="https://github.com/user-attachments/assets/a1fe6e1b-32f7-4330-b6e3-12162ae86e76" /> | <img width="330" alt="Screenshot 2026-07-03 at 12 11 14" src="https://github.com/user-attachments/assets/47eb233a-a9c1-4559-b2e7-0a4f8e5078d3" /> |

