### PR TITLE
[echart] fix regression from v6

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-fees-graph/acceleration-fees-graph.component.ts
@@ -220,6 +220,7 @@ export class AccelerationFeesGraphComponent implements OnInit, OnChanges, OnDest
         },
       },
       legend: {
+        top: 'top',
         data: [
           {
             name: this.totalBidBoostLabel,

--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -211,6 +211,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
       },
       graphic: graphicElements.length > 0 ? graphicElements : undefined,
       legend: (this.showLegend && !this.stateService.isAnyTestnet()) ? {
+        top: 'top',
         data: [
           {
             name: $localize`:@@7e69426bd97a606d8ae6026762858e6e7c86a1fd:Balance`,
@@ -451,6 +452,7 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
       },
       graphic: graphicElements.length > 0 ? graphicElements : undefined,
       legend: {
+        top: 'top',
         selected: this.selected,
       },
       dataZoom: this.allowZoom ? [{

--- a/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
+++ b/frontend/src/app/components/block-fee-rates-graph/block-fee-rates-graph.component.ts
@@ -281,6 +281,7 @@ export class BlockFeeRatesGraphComponent implements OnInit {
         },
       },
       legend: (this.widget || data.series.length === 0) ? undefined : {
+        top: 'top',
         padding: [10, 75],
         data: data.legends,
         selected:  JSON.parse(this.storageService.getValue('fee_rates_legend') || 'null') ?? {

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
@@ -187,6 +187,7 @@ export class BlockFeesGraphComponent implements OnInit {
         }
       },
       legend: data.blockFees.length === 0 ? undefined : {
+        top: 'top',
         data: [
           {
             name: feesBtcLabel,

--- a/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.ts
+++ b/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.ts
@@ -240,6 +240,7 @@ export class BlockFeesSubsidyGraphComponent implements OnInit {
         }
       ],
       legend: this.data.blockFees.length === 0 ? undefined : {
+        top: 'top',
         data: [
           {
             name: this.subsidyLabel,

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
@@ -183,6 +183,7 @@ export class BlockRewardsGraphComponent implements OnInit {
         }
       },
       legend: data.blockRewards.length === 0 ? undefined : {
+        top: 'top',
         data: [
           {
             name: 'Rewards BTC',

--- a/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.ts
+++ b/frontend/src/app/components/block-sizes-weights-graph/block-sizes-weights-graph.component.ts
@@ -182,7 +182,7 @@ export class BlockSizesWeightsGraphComponent implements OnInit {
         }
       },
       legend: data.sizes.length === 0 ? undefined : {
-        padding: 10,
+        top: 'top',
         data: [
           {
             name: $localize`:@@7faaaa08f56427999f3be41df1093ce4089bbd75:Size`,

--- a/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
+++ b/frontend/src/app/components/hashrate-chart/hashrate-chart.component.ts
@@ -287,6 +287,7 @@ export class HashrateChartComponent implements OnInit {
         }
       },
       legend: (this.widget || data.hashrates.length === 0) ? undefined : {
+        top: 'top',
         data: [
           {
             name: $localize`:@@79a9dc5b1caca3cbeb1733a19515edacc5fc7920:Hashrate`,

--- a/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
+++ b/frontend/src/app/components/hashrates-chart-pools/hashrate-chart-pools.component.ts
@@ -250,6 +250,7 @@ export class HashrateChartPoolsComponent implements OnInit {
         }
       },
       legend: (this.isMobile() || data.series.length === 0) ? undefined : {
+        top: 'top',
         data: data.legends
       },
       yAxis: data.series.length === 0 ? undefined : {

--- a/frontend/src/app/components/pool/pool.component.ts
+++ b/frontend/src/app/components/pool/pool.component.ts
@@ -240,6 +240,7 @@ export class PoolComponent implements OnInit, OnDestroy {
         }
       },
       legend: {
+        top: 'top',
         data: [
           {
             name: $localize`:@@79a9dc5b1caca3cbeb1733a19515edacc5fc7920:Hashrate`,

--- a/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.ts
+++ b/frontend/src/app/components/treasuries/treasuries-graph/treasuries-graph.component.ts
@@ -402,6 +402,7 @@ export class TreasuriesGraphComponent implements OnInit, OnChanges, OnDestroy {
 
     this.chartOptions = {
       legend: {
+        top: 'top',
         selected: this.selectedWallets,
       }
     };

--- a/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.ts
+++ b/frontend/src/app/lightning/statistics-chart/lightning-statistics-chart.component.ts
@@ -200,7 +200,7 @@ export class LightningStatisticsChartComponent implements OnInit, OnChanges {
         }
       },
       legend: this.widget || data.channel_count.length === 0 ? undefined : {
-        padding: 10,
+        top: 'top',
         data: [
           {
             name: $localize`:@@807cf11e6ac1cde912496f764c176bdfdd6b7e19:Channels`,


### PR DESCRIPTION
Fix regression introduced by https://github.com/mempool/mempool.space/pull/2486
All legends are by default at the bottom of charts so we have to manually put them back up.

Right now only hybrid build has the regression because https://github.com/mempool/mempool/pull/6606 has not yet been merged into the FOSS repo.