### PR TITLE
fix balance chart monotonic time hack

### DIFF
--- a/frontend/src/app/components/address-graph/address-graph.component.ts
+++ b/frontend/src/app/components/address-graph/address-graph.component.ts
@@ -492,15 +492,15 @@ export class AddressGraphComponent implements OnChanges, OnDestroy {
     // Add a point at today's date to make the graph end at the current time
     extendedSummary.unshift({ time: Date.now() / 1000, value: 0 });
 
-    let maxTime = Date.now() / 1000;
-
+    const timeStep = 0.001;
     const oneHour = 60 * 60;
     // Fill gaps longer than interval
     for (let i = 0; i < extendedSummary.length - 1; i++) {
-      if (extendedSummary[i].time > maxTime) {
-        extendedSummary[i].time = maxTime - 30;
+      if (extendedSummary[i].height !== undefined && extendedSummary[i + 1].height === extendedSummary[i].height) {
+        extendedSummary[i + 1].time = extendedSummary[i].time;
+      } else if (extendedSummary[i + 1].time >= extendedSummary[i].time) {
+        extendedSummary[i + 1].time = extendedSummary[i].time - timeStep;
       }
-      maxTime = extendedSummary[i].time;
       const hours = Math.floor((extendedSummary[i].time - extendedSummary[i + 1].time) / oneHour);
       if (hours > 1) {
         for (let j = 1; j < hours; j++) {


### PR DESCRIPTION
fixes enforcement of monotonic timestamps for history events in the balance chart to better handle addresses with very many transactions over a short period.

when an address has transactions in blocks with out-of-order timestamps, we have to manually adjust the event timestamps to avoid "time travelling" graphs and incorrect instantaneous balances.

a previous attempt to implement this applied excessive offsets to each history event separately, which caused the corrections to accumulate and skew the graph when there are very many affected data points.

this PR fixes those issues.

before:
<img width="1130" height="502" alt="Screenshot 2026-07-14 at 2 29 48 AM" src="https://github.com/user-attachments/assets/b8699da0-fba5-44c3-b1b9-0e09f342b56d" />

after:
<img width="1130" height="502" alt="Screenshot 2026-07-14 at 2 29 17 AM" src="https://github.com/user-attachments/assets/53740b91-b1a9-4319-85a5-6120b6c2470f" />

