### PR TITLE
PERF: Bitcoind-only instances

### DIFF
--- a/backend/src/rpc-api/jsonrpc.ts
+++ b/backend/src/rpc-api/jsonrpc.ts
@@ -7,6 +7,8 @@ const JsonRPC = function (opts) {
   this.opts = opts || {};
   // @ts-ignore
   this.http = this.opts.ssl ? https : http;
+  // @ts-ignore
+  this.agent = new this.http.Agent({ keepAlive: true, maxSockets: 16 }); // We match the max sockets to bitcoin core's default max threads on v31
 };
 
 JsonRPC.prototype.call = function (method, params) {
@@ -46,7 +48,7 @@ JsonRPC.prototype.call = function (method, params) {
         'Host': this.opts.host || 'localhost',
         'Content-Length': requestJSON.length
       },
-      agent: false,
+      agent: this.agent,
       rejectUnauthorized: this.opts.ssl && this.opts.sslStrict !== false
     };
 
@@ -67,110 +69,121 @@ JsonRPC.prototype.call = function (method, params) {
       requestOptions.auth = this.opts.user + ':' + this.opts.pass;
     }
 
-    // Now we'll make a request to the server
-    let cbCalled = false;
-    const request = this.http.request(requestOptions);
+    const attempt = (canRetry: boolean) => {
+      // Now we'll make a request to the server
+      let cbCalled = false;
+      const request = this.http.request(canRetry ? requestOptions : {...requestOptions, agent: false});
 
-    // start request timeout timer
-    const reqTimeout = setTimeout(function () {
-      if (cbCalled) {return;}
-      cbCalled = true;
-      request.abort();
-      const err = new Error('ETIMEDOUT');
-      // @ts-ignore
-      err.code = 'ETIMEDOUT';
-      reject(err);
-    }, this.opts.timeout || 30000);
-
-    // set additional timeout on socket in case of remote freeze after sending headers
-    request.setTimeout(this.opts.timeout || 30000, function () {
-      if (cbCalled) {return;}
-      cbCalled = true;
-      request.abort();
-      const err = new Error('ESOCKETTIMEDOUT');
-      // @ts-ignore
-      err.code = 'ESOCKETTIMEDOUT';
-      reject(err);
-    });
-
-    request.on('error', function (err) {
-      if (cbCalled) {return;}
-      cbCalled = true;
-      clearTimeout(reqTimeout);
-      reject(err);
-    });
-
-    request.on('response', (response) => {
-      clearTimeout(reqTimeout);
-
-      // We need to buffer the response chunks in a nonblocking way.
-      let buffer = '';
-      response.on('data', function (chunk) {
-        buffer = buffer + chunk;
-      });
-      // When all the responses are finished, we decode the JSON and
-      // depending on whether it's got a result or an error, we call
-      // emitSuccess or emitError on the promise.
-      response.on('end', () => {
-        let err;
-
+      // start request timeout timer
+      const reqTimeout = setTimeout(function () {
         if (cbCalled) {return;}
         cbCalled = true;
+        request.abort();
+        const err = new Error('ETIMEDOUT');
+        // @ts-ignore
+        err.code = 'ETIMEDOUT';
+        reject(err);
+      }, this.opts.timeout || 30000);
 
-        try {
-          var decoded = JSON.parse(buffer);
-        } catch (e) {
-          // if we authenticated using a cookie and it failed, read the cookie file again
-          if (
-            response.statusCode === 401 /* Unauthorized */ &&
-            this.opts.cookie
-          ) {
-            this.cachedCookie = undefined;
-          }
+      // set additional timeout on socket in case of remote freeze after sending headers
+      request.setTimeout(this.opts.timeout || 30000, function () {
+        if (cbCalled) {return;}
+        cbCalled = true;
+        request.abort();
+        const err = new Error('ESOCKETTIMEDOUT');
+        // @ts-ignore
+        err.code = 'ESOCKETTIMEDOUT';
+        reject(err);
+      });
 
-          if (response.statusCode !== 200) {
-            err = new Error('Invalid params, response status code: ' + response.statusCode);
-            err.code = -32602;
-            reject(err);
-          } else {
-            err = new Error('Problem parsing JSON response from server');
-            err.code = -32603;
-            reject(err);
-          }
+      request.on('error', (err) => {
+        if (cbCalled) {return;}
+        cbCalled = true;
+        clearTimeout(reqTimeout);
+        // bitcoind may close an idle keep-alive socket at the same moment we reuse it;
+        // retry once on a fresh connection, only for that specific race
+        if (canRetry && err.code === 'ECONNRESET' && request.reusedSocket) {
+          attempt(false);
           return;
         }
+        reject(err);
+      });
 
-        if (!Array.isArray(decoded)) {
-          decoded = [decoded];
-        }
+      request.on('response', (response) => {
+        clearTimeout(reqTimeout);
 
-        // iterate over each response, normally there will be just one
-        // unless a batch rpc call response is being processed
-        decoded.forEach(function (decodedResponse, i) {
-          if (decodedResponse.hasOwnProperty('error') && decodedResponse.error != null) {
-            if (reject) {
-              err = new Error(decodedResponse.error.message || '');
-              if (decodedResponse.error.code) {
-                err.code = decodedResponse.error.code;
-              }
+        // We need to buffer the response chunks in a nonblocking way.
+        const chunks: Buffer[] = [];
+        response.on('data', function (chunk) {
+          chunks.push(chunk);
+        });
+        // When all the responses are finished, we decode the JSON and
+        // depending on whether it's got a result or an error, we call
+        // emitSuccess or emitError on the promise.
+        response.on('end', () => {
+          let err;
+
+          if (cbCalled) {return;}
+          cbCalled = true;
+
+          try {
+            const buffer = Buffer.concat(chunks).toString('utf8');
+            var decoded = JSON.parse(buffer);
+          } catch (e) {
+            // if we authenticated using a cookie and it failed, read the cookie file again
+            if (
+              response.statusCode === 401 /* Unauthorized */ &&
+              this.opts.cookie
+            ) {
+              this.cachedCookie = undefined;
+            }
+
+            if (response.statusCode !== 200) {
+              err = new Error('Invalid params, response status code: ' + response.statusCode);
+              err.code = -32602;
+              reject(err);
+            } else {
+              err = new Error('Problem parsing JSON response from server');
+              err.code = -32603;
               reject(err);
             }
-          } else if (decodedResponse.hasOwnProperty('result')) {
-            // @ts-ignore
-            resolve(decodedResponse.result, response.headers);
-          } else {
-            if (reject) {
-              err = new Error(decodedResponse.error.message || '');
-              if (decodedResponse.error.code) {
-                err.code = decodedResponse.error.code;
-              }
-              reject(err);
-            }
+            return;
           }
+
+          if (!Array.isArray(decoded)) {
+            decoded = [decoded];
+          }
+
+          // iterate over each response, normally there will be just one
+          // unless a batch rpc call response is being processed
+          decoded.forEach(function (decodedResponse, i) {
+            if (decodedResponse.hasOwnProperty('error') && decodedResponse.error != null) {
+              if (reject) {
+                err = new Error(decodedResponse.error.message || '');
+                if (decodedResponse.error.code) {
+                  err.code = decodedResponse.error.code;
+                }
+                reject(err);
+              }
+            } else if (decodedResponse.hasOwnProperty('result')) {
+              // @ts-ignore
+              resolve(decodedResponse.result, response.headers);
+            } else {
+              if (reject) {
+                err = new Error(decodedResponse.error.message || '');
+                if (decodedResponse.error.code) {
+                  err.code = decodedResponse.error.code;
+                }
+                reject(err);
+              }
+            }
+          });
         });
       });
-    });
-    request.end(requestJSON);
+      request.end(requestJSON);
+    };
+
+    attempt(true);
   });
 };
 

--- a/backend/src/rpc-api/jsonrpc.ts
+++ b/backend/src/rpc-api/jsonrpc.ts
@@ -2,6 +2,15 @@ const http = require('http');
 const https = require('https');
 import { readFileSync } from 'fs';
 
+const RETRY_SAFE_RPCS = new Set([
+  'getbestblockhash',       'getblock',           'getblockchaininfo',    'getblockcount',
+  'getblockhash',           'getblockheader',     'getblockstats',        'getchaintips',
+  'getdifficulty',          'getindexinfo',       'getmempoolancestors',  'getmempoolentry',
+  'getmempoolinfo',         'getnetworkhashps',   'getnetworkinfo',       'getrawmempool',
+  'getrawtransaction',      'gettxout',           'gettxoutsetinfo',
+  'decoderawtransaction',   'testmempoolaccept',  'validateaddress',
+]);
+
 const JsonRPC = function (opts) {
   // @ts-ignore
   this.opts = opts || {};
@@ -69,6 +78,8 @@ JsonRPC.prototype.call = function (method, params) {
       requestOptions.auth = this.opts.user + ':' + this.opts.pass;
     }
 
+    const retrySafe = (Array.isArray(method) ? method.map((m) => m.method) : [method]).every((m) => RETRY_SAFE_RPCS.has(String(m).toLowerCase()));
+
     const attempt = (canRetry: boolean) => {
       // Now we'll make a request to the server
       let cbCalled = false;
@@ -102,7 +113,7 @@ JsonRPC.prototype.call = function (method, params) {
         clearTimeout(reqTimeout);
         // bitcoind may close an idle keep-alive socket at the same moment we reuse it;
         // retry once on a fresh connection, only for that specific race
-        if (canRetry && err.code === 'ECONNRESET' && request.reusedSocket) {
+        if (canRetry && retrySafe && err.code === 'ECONNRESET' && request.reusedSocket) {
           attempt(false);
           return;
         }
@@ -166,8 +177,7 @@ JsonRPC.prototype.call = function (method, params) {
                 reject(err);
               }
             } else if (decodedResponse.hasOwnProperty('result')) {
-              // @ts-ignore
-              resolve(decodedResponse.result, response.headers);
+              resolve(decodedResponse.result);
             } else {
               if (reject) {
                 err = new Error(decodedResponse.error.message || '');


### PR DESCRIPTION
## The problem
A bottleneck was identified mainly for bitcoind-only instances, due to the overhead of a new TCP connection per each call to bitcoind because `jsonrpc.ts` sets `agent: false` At the default poll rate of 2s it is ~130K connections/day just for base update loop (`getmempoolinfo` + `getrawmempool` + `getblockcount`) + 2 calls per new tx in mempool (`getrawtransaction` + `getmempoolentry`) + the per block calls in `blocks.$updateBlocks()`. 

In a 5 mins profiling, the most CPU consuming function filtered by self time was `connect` as of  c31b0e816d8593e83aa1f48d5fd1653ca783e29f.

The setup was:
1. Bitcoin core v31.0 signet (localhost RPC).
2. MEMPOOL.BACKEND: `None`
3. MEMPOOL.POLL_RATE_MS: `2000`

Result:
<img width="600" height="auto" alt="Screenshot 2026-07-14 at 12 59 19 AM" src="https://github.com/user-attachments/assets/8eef643f-988a-48c4-af04-cf2667c54aa0" />

Total time of functions calling RPC:
<img width="600" height="auto" alt="Screenshot 2026-07-14 at 1 23 46 AM" src="https://github.com/user-attachments/assets/b98b2a90-64b7-4b69-b933-68052d449012" />

## Changes
1. Replace `agent: false` with a shared instance of `http.agent({keepAlive: true, maxSockets: 16})` so calls reuse a warm socket. `maxSockets: 16` matches [bitcoin core's current default max threads](https://github.com/bitcoin/bitcoin/blob/11ae426552239f1e5bf351b354783f869989c88b/src/httpserver.h#L32-L35).
2. Retry a request once on a fresh connection when it fails with `ECONNRESET` on a reused socket, to cover the edge case bitcoind closes a TCP connection at the exact moment a call is done.
3. Push response chunks in a Buffer[] and decode once, instead redeclaring and concatenation.

After this changes the profiling results were:

<img width="600" height="auto" alt="Screenshot 2026-07-14 at 1 35 36 AM" src="https://github.com/user-attachments/assets/34ee6647-f4e8-42e4-aa90-54d3889cab16" />

<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/c6ce0253-6e55-48c7-9006-350f23bbe5ae" />

## Note

These changes have not been tested in mainnet