### PR TITLE
[feat] BIP-54 tag for blocks

### DIFF
--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -52,6 +52,7 @@ class Blocks {
   private quarterEpochBlockTime: number | null = null;
   private newBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: TransactionExtended[]) => void)[] = [];
   private classifyingBlocks: boolean = false;
+  private updatingBlocksMissingBip54Tag: boolean = false;
   private oldestCoreLogTimestamp: number | undefined | null = undefined;
 
   private mainLoopTimeout: number = 120000;
@@ -386,6 +387,8 @@ class Blocks {
           extras.firstSeen = getBlockFirstSeenFromLogs(block.id, block.timestamp, oldestLog);
         }
       }
+
+      extras.coinbaseBip54 = Common.isBip54Coinbase(block, transactions[0]);
     }
 
     blk.extras = <BlockExtension>extras;
@@ -1081,6 +1084,65 @@ class Blocks {
     }
 
     this.classifyingBlocks = false;
+  }
+
+  /** @asyncSafe */
+  public async $updateBlocksMissingBip54Tag(): Promise<void> {
+    if (this.updatingBlocksMissingBip54Tag) {
+      return;
+    }
+
+    this.updatingBlocksMissingBip54Tag = true;
+
+    if (!Common.indexingEnabled() || Common.isLiquid()) {
+      return;
+    }
+
+    const blocksMissingCoinbaseBip54 = await BlocksRepository.$getBlocksMissingBip54Tag();
+
+    if (!blocksMissingCoinbaseBip54.length) {
+      this.updatingBlocksMissingBip54Tag = false;
+      return;
+   }
+
+    let timer = Date.now();
+    let updatedThisRun = 0;
+    let updatedInTotal = 0;
+    let numToUpdate = blocksMissingCoinbaseBip54.length;
+
+    logger.debug(`Updating blocks missing bip54 tag from #${blocksMissingCoinbaseBip54[0].height} to #${blocksMissingCoinbaseBip54[blocksMissingCoinbaseBip54.length - 1].height}`, logger.tags.mining);
+    for (const block of blocksMissingCoinbaseBip54) {
+      try {
+        const coinbaseTx = await bitcoinApi.$getCoinbaseTx(block.id);
+
+        const coinbaseBip54 = Common.isBip54Coinbase(block, coinbaseTx);
+        if (coinbaseBip54 === null) {
+          numToUpdate--;
+          continue;
+        }
+
+        await BlocksRepository.$updateCoinbaseBip54(coinbaseBip54, block.id);
+        updatedInTotal++;
+        updatedThisRun++;
+
+      } catch (e) {
+        logger.warn(`Failed to update bip54 tag field in block #${block.height}. Reason: ` + (e instanceof Error ? e.message : e), logger.tags.mining);
+      }
+
+      const elapsedSeconds = (Date.now() - timer) / 1000;
+      if (elapsedSeconds > 5) {
+        const perSecond = updatedThisRun / elapsedSeconds;
+        const progress = (updatedInTotal / numToUpdate) * 100;
+        logger.debug(`Updated bip54 tag of #${block.height}: ${updatedInTotal} / ${numToUpdate}  (${progress.toFixed(2)}%) | ~${perSecond.toFixed(1)} blocks/s`, logger.tags.mining);
+        timer = Date.now();
+        updatedThisRun = 0;
+      }
+
+      await Common.sleep$(250); //Don't DoS the DB
+    }
+    logger.debug(`Update of blocks missing bip54 tag completed`, logger.tags.mining);
+
+    this.updatingBlocksMissingBip54Tag = false;
   }
 
   /**

--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -1156,6 +1156,20 @@ export class Common {
     });
   }
 
+  static isBip54Coinbase (block: IEsploraApi.Block | {id: string, height: number, timestamp: number}, coinbaseTx: IEsploraApi.Transaction): boolean | null {
+    if (typeof block.height !== 'number' || typeof block.timestamp !== 'number') {
+      return null;
+    }
+
+    const timeFirstMainnetBip54Coinbase = 1771507776;
+    if (block.timestamp < timeFirstMainnetBip54Coinbase) {
+      return null;
+    }
+
+    const seq = coinbaseTx.vin[0].sequence;
+    return (block.height > 0 && coinbaseTx.locktime === block.height - 1 && typeof seq === 'number' && seq !== 0xffffffff);
+  }
+
   private static validateTransactionHex(txhex: string): string {
     // Do not mutate txhex
 

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 112;
+  private static currentVersion = 113;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1259,6 +1259,11 @@ class DatabaseMigration {
     if (databaseSchemaVersion < 112) {
       await this.$executeQuery(this.getCreateFlagsValuesTableQuery(), await this.$checkIfTableExists('flag_values'));
       await this.updateToSchemaVersion(112);
+    }
+
+    if (databaseSchemaVersion < 113) {
+      await this.$executeQuery('ALTER TABLE `blocks` ADD coinbase_bip_54 TINYINT(1) NULL DEFAULT NULL');
+      await this.updateToSchemaVersion(113);
     }
   }
 

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -230,6 +230,7 @@ class Indexer {
       void blocks.$generateFlagValuesDatabase();
       // do not wait for classify blocks to finish
       void blocks.$classifyBlocks();
+      void blocks.$updateBlocksMissingBip54Tag();
       runSuccessful = true;
     } catch (e) {
       nextRunDelay = retryDelay;

--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -319,6 +319,7 @@ export interface BlockExtension {
   coinbaseAddresses: string[] | null;
   coinbaseSignature: string | null;
   coinbaseSignatureAscii: string | null;
+  coinbaseBip54: boolean | null;
   virtualSize: number;
   avgTxSize: number;
   totalInputs: number;

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -61,6 +61,7 @@ interface DatabaseBlock {
   totalInputAmt: number;
   firstSeen: string; // UNIX_TIMESTAMP() returns a string when applied to datetime(6)
   stale: boolean;
+  coinbaseBip54: boolean | null;
 }
 
 const BLOCK_DB_FIELDS = `
@@ -92,6 +93,7 @@ const BLOCK_DB_FIELDS = `
   blocks.coinbase_addresses AS coinbaseAddresses,
   blocks.coinbase_signature AS coinbaseSignature,
   blocks.coinbase_signature_ascii AS coinbaseSignatureAscii,
+  blocks.coinbase_bip_54 AS coinbaseBip54,
   blocks.avg_tx_size AS avgTxSize,
   blocks.total_inputs AS totalInputs,
   blocks.total_outputs AS totalOutputs,
@@ -132,7 +134,7 @@ class BlocksRepository {
         total_inputs,       total_outputs,            total_input_amt,   total_output_amt,
         fee_percentiles,    segwit_total_txs,         segwit_total_size, segwit_total_weight,
         median_fee_amt,     coinbase_signature_ascii, definition_hash,   index_version,
-        stale,              first_seen
+        stale,              first_seen,               coinbase_bip_54
       ) VALUE (
         ?, ?, FROM_UNIXTIME(?), ?,
         ?, ?, ?, ?,
@@ -144,7 +146,7 @@ class BlocksRepository {
         ?, ?, ?, ?,
         ?, ?, ?, ?,
         ?, ?, ?, ?,
-        ?, FROM_UNIXTIME(?)
+        ?, FROM_UNIXTIME(?), ?
       )`;
 
       const poolDbId = await PoolsRepository.$getPoolByUniqueId(block.extras.pool.id);
@@ -194,7 +196,8 @@ class BlocksRepository {
         poolsUpdater.currentSha,
         BlocksRepository.version,
         (block.stale ? 1 : 0),
-        block.extras.firstSeen === null ? 1 : block.extras.firstSeen // Sentinel value 1 indicates that we could not find first seen time
+        block.extras.firstSeen === null ? 1 : block.extras.firstSeen, // Sentinel value 1 indicates that we could not find first seen time
+        block.extras.coinbaseBip54 ?? null
       ];
 
       await DB.query(query, params);
@@ -1294,6 +1297,7 @@ class BlocksRepository {
     extras.utxoSetSize = dbBlk.utxoSetSize;
     extras.totalInputAmt = dbBlk.totalInputAmt;
     extras.virtualSize = dbBlk.weight / 4.0;
+    extras.coinbaseBip54 = dbBlk.coinbaseBip54;
 
     extras.firstSeen = null;
     if (config.CORE_RPC.DEBUG_LOG_PATH) {
@@ -1425,6 +1429,43 @@ class BlocksRepository {
       throw e;
     }
     return blocksMigrated;
+  }
+
+  /** @asyncSafe */
+  public async $getBlocksMissingBip54Tag(): Promise<{id: string, height: number, timestamp: number}[]> {
+    const timeFirstMainnetBip54Coinbase = 1771507776;
+    const query = `SELECT 
+    hash as id, 
+    height,
+    UNIX_TIMESTAMP(blocks.blockTimestamp) AS timestamp
+    FROM blocks
+    where coinbase_bip_54 IS NULL AND
+    stale = 0 AND
+    height > 0 AND
+    blockTimestamp >= FROM_UNIXTIME(${timeFirstMainnetBip54Coinbase})
+    ORDER BY height DESC`;
+
+    try {
+      const [blocks]: any[] = await DB.query(query);
+
+      return blocks;
+    } catch (e) {
+      logger.err(`Cannot get blocks with missing bip54 flag. Reason: ` + (e instanceof Error ? e.message : e));
+    }
+
+    return [];
+  }
+
+  public async $updateCoinbaseBip54(result: boolean, hash: string): Promise<void> {
+    const query = `UPDATE blocks SET coinbase_bip_54 = ? WHERE hash = ?`;
+    const params = [result, hash];
+
+    try {
+      await DB.query(query, params);
+    } catch (e) {
+      logger.err(`Couldn't update coinbaseBip54 field for block ${hash}. Reason: ` + (e instanceof Error ? e.message : e));
+      throw e;
+    }
   }
 }
 

--- a/frontend/src/app/components/block/block.component.html
+++ b/frontend/src/app/components/block/block.component.html
@@ -212,6 +212,16 @@
         </span>
         </td>
       </tr>
+      @if (network !== 'liquid' && network !== 'liquidtestnet' && block.extras.coinbaseBip54) {
+        <tr>
+          <td i18n="transaction.features|Transaction features">Features</td>
+          <td>
+            <span class="badge bg-success" i18n="block.bip54" i18n-ngbTooltip="bip54-tooltip" ngbTooltip="Coinbase is forward-compatible with BIP-54 (nLockTime = height − 1, nSequence ≠ 0xffffffff)." placement="bottom">
+              BIP-54 coinbase
+            </span>
+          </td>
+        </tr>
+      }
     </ng-container>
     <ng-template #loadingRest>
       <tr>

--- a/frontend/src/app/interfaces/node-api.interface.ts
+++ b/frontend/src/app/interfaces/node-api.interface.ts
@@ -215,6 +215,7 @@ export interface BlockExtension {
   feeRange?: number[];
   reward?: number;
   coinbaseRaw?: string;
+  coinbaseBip54?: boolean | null;
   matchRate?: number;
   expectedFees?: number;
   expectedWeight?: number;


### PR DESCRIPTION
closes #6474 

### Add BIP-54 coinbase badge

Flags blocks whose coinbase is forward-compatible with BIP-54 (nLockTime === height - 1 and nSequence !== 0xffffffff) and shows a "BIP-54 coinbase" badge in the block view.

- new blocks.coinbase_bip_54 column (migration v112)
- computed at block-save time and exposed as block.extras.coinbaseBip54
- indexer task $updateBlocksMissingCoinbaseBip54 backfills existing rows
- only evaluated for blocks after the first forward compatible coinbase tx on mainnet at [height 937404](https://mempool.space/tx/21da7e1707d7edff00627c4316a7d89d26bf94acc59a0320ab72c86f7b84a7fb).

Tested on signet and testnet3.

<img width="1071" height="671" alt="image" src="https://github.com/user-attachments/assets/eab90b5a-8d51-485a-8b35-22f761f06961" />

