### PR TITLE
Revert "[ssr] accept 301 and 302 as valid for nginx cache"

### DIFF
--- a/production/nginx/server-common.conf
+++ b/production/nginx/server-common.conf
@@ -217,7 +217,7 @@ location @mempool-space-ssr {
 	proxy_cache_background_update on;
 	proxy_cache_use_stale updating;
 	proxy_cache unfurler;
-	proxy_cache_valid 200 301 302 5m; # will re-render page if older than this
+	proxy_cache_valid 200 5m; # will re-render page if older than this
 	proxy_redirect off;
 
 	expires 5m;


### PR DESCRIPTION
Reverts mempool/mempool#6612

We're reverting because if the subdomain does not exist, nginx serves the cached redirect of a previous user which is completely wrong