### PR TITLE
fix scheduleSingleTask

### DIFF
--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -143,7 +143,8 @@ class Indexer {
             latestPriceId = await PricesRepository.$getLatestPriceId();
           } catch (e) {
             logger.debug('failed to fetch latest price id from db: ' + (e instanceof Error ? e.message : e));
-          }          if (priceUpdater.historyInserted === false || latestPriceId === null) {
+          }
+          if (priceUpdater.historyInserted === false || latestPriceId === null) {
             logger.debug(`Blocks prices indexer is waiting for the price updater to complete`, logger.tags.mining);
             this.scheduleSingleTask(task, 10000);
           } else {

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -113,12 +113,11 @@ class Indexer {
       }
     }
     this.tasksScheduled[task] = setTimeout(async () => {
+      delete this.tasksScheduled[task];
       try {
         await this.runSingleTask(task);
       } catch (e) {
         logger.err(`Unexpected error in scheduled task ${task}: ` + (e instanceof Error ? e.message : e));
-      } finally {
-        clearTimeout(this.tasksScheduled[task]);
       }
     }, timeout);
   }


### PR DESCRIPTION
fixes a bug in `scheduleSingleTask`, which could cause subsequent scheduled runs of the same task to skipped.

currently only affects the `blocksPrices` task, and only in rare cases, but might explain a previously reported issue where "Cannot save block price for ${blockExtended.height} because the price updater hasnt completed yet. Trying again in 10 seconds." was logged, but the retry never actually happened.