### PR TITLE
Fix page jump on mobile when scrolling to footer

### DIFF
--- a/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
+++ b/frontend/src/app/components/acceleration/accelerations-list/accelerations-list.component.scss
@@ -97,6 +97,10 @@ tr, td, th {
 }
 
 .widget {
+  .acceleration-list {
+    overflow-anchor: none;
+  }
+
   .txid {
     width: 30%;
     overflow: hidden;

--- a/frontend/src/app/components/custom-dashboard/custom-dashboard.component.scss
+++ b/frontend/src/app/components/custom-dashboard/custom-dashboard.component.scss
@@ -135,6 +135,7 @@
 }
 
 .latest-transactions {
+  overflow-anchor: none;
   width: 100%;
   text-align: left;
   table-layout:fixed;
@@ -223,6 +224,7 @@
 }
 
 .lastest-replacements-table {
+  overflow-anchor: none;
   width: 100%;
   text-align: left;
   table-layout:fixed;

--- a/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.scss
+++ b/frontend/src/app/components/liquid-reserves-audit/federation-addresses-list/federation-addresses-list.component.scss
@@ -10,6 +10,10 @@
   }
 }
 
+.widget table {
+  overflow-anchor: none;
+}
+
 tr, td, th {
   border: 0px;
   padding-top: 0.65rem;

--- a/frontend/src/app/components/liquid-reserves-audit/recent-pegs-list/recent-pegs-list.component.scss
+++ b/frontend/src/app/components/liquid-reserves-audit/recent-pegs-list/recent-pegs-list.component.scss
@@ -4,6 +4,10 @@
   margin-top: 13px;
 }
 
+.widget table {
+  overflow-anchor: none;
+}
+
 tr, td, th {
   border: 0px;
   padding-top: 0.65rem;

--- a/frontend/src/app/components/recent-transactions-list/recent-transactions-list.component.scss
+++ b/frontend/src/app/components/recent-transactions-list/recent-transactions-list.component.scss
@@ -93,6 +93,8 @@
 }
 
 .widget .latest-transactions {
+  overflow-anchor: none;
+
   .table-cell-satoshis {
     @media (min-width: 768px) {
       display: none;

--- a/frontend/src/app/dashboard/dashboard.component.scss
+++ b/frontend/src/app/dashboard/dashboard.component.scss
@@ -180,6 +180,7 @@
 }
 
 .lastest-replacements-table {
+  overflow-anchor: none;
   width: 100%;
   text-align: left;
   table-layout:fixed;


### PR DESCRIPTION
Fixes a page jump happening in a few places in the app, easily reproducible by scrolling to the footer on the main dashboard. See how the browser is anchoring to a moving row of the Recent Transactions widget, causing the jumps:

https://github.com/user-attachments/assets/fb0f5fcd-ca12-4aeb-a5dc-9e83b683d154

This PR adds `overflow-anchor: none;` property to affected widgets to exclude the moving rows from anchor selection.

`overflow-anchor` seems to be [not yet supported on webkit](https://webkit.org/css-status/#?search=overflow-anchor), but when testing on Safari iOS the issue is fixed.