### PR TITLE
Fix Liquid URL from block height search

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -226,7 +226,7 @@ export class BlockComponent implements OnInit, OnDestroy {
                 switchMap((hash) => {
                   this.blockHash = hash;
                   this.location.replaceState(
-                    this.router.createUrlTree([(this.network ? '/' + this.network : '') + '/block/', hash]).toString()
+                    this.router.createUrlTree([this.relativeUrlPipe.transform('/block/'), hash]).toString()
                   );
                   this.seoService.updateCanonical(this.location.path());
                   return this.apiService.getBlock$(hash).pipe(


### PR DESCRIPTION
When searching for a block by height on Liquid, the address bar URL is wrongly rewritten to `https://liquid.network/liquid/block/<hash>` because the block component rewrite the URL with the raw network prefix `'/' + this.network` instead of using `RelativeUrlPipe`.
