### PR TITLE
fix: viewing link in x app

### DIFF
--- a/frontend/src/app/components/tracker/tracker.component.scss
+++ b/frontend/src/app/components/tracker/tracker.component.scss
@@ -20,6 +20,14 @@
   & > * {
     flex-shrink: 0;
   }
+
+  // X’s iOS in-app browser overlays bottom controls without reporting a safe-area inset.
+  // Its incorrect svh value reveals the obscured strip via svh - dvh so correct browsers collapse it to zero.
+  &::after {
+    content: '';
+    flex-shrink: 0;
+    height: max(0px, 100svh - 100dvh);
+  }
 }
 
 .heading {


### PR DESCRIPTION
I investigated this issue on-device and found that the problem is specific to X's in-app browser on iOS.

X overlays its own browser controls on top of the bottom of the webview, but reports no bottom safe-area inset. More importantly, it reports `100svh` as the same height as `100lvh`, so the small viewport is effectively incorrect. In my tests, `100svh` was 737px while `100dvh` and `visualViewport.height` correctly reported 691px.

Simply switching the tracker from `svh` to `dvh` does not fully solve the issue. When the transaction view overflows and becomes scrollable, X still uses the incorrect `svh`-sized scroll viewport, causing the bottom of the document to remain hidden behind the browser chrome.

The fix uses the difference between the two viewport units as a dynamic bottom spacer:

```scss
.mobile-container {
  &::after {
    content: '';
    flex-shrink: 0;
    height: max(0px, 100svh - 100dvh);
  }
}
```

On X/iOS this resolves to the exact height of the obscured area and updates when the tweet action sheet expands. In browsers where `svh` is implemented correctly, the value resolves to `0px`, so the layout remains unchanged.

Verified on-device with confirmed and unconfirmed transactions in X on iOS, including with the tweet sheet expanded, as well as Safari and Chrome on iOS and X on Android.

Known limitation: this specifically detects browsers that misreport `svh`. An in-app browser that overlays controls while still reporting a correct small viewport would not be covered by this approach.

Closes #6685 