### PR TITLE
fix fee and reward graphs on networks without price indexing

### DIFF
--- a/backend/src/api/common.ts
+++ b/backend/src/api/common.ts
@@ -902,6 +902,15 @@ export class Common {
     );
   }
 
+  // must match the conditions under which the indexer runs the 'blocksPrices' task,
+  // otherwise queries will join against a blocks_prices table that is never populated
+  static blockPricesIndexingEnabled(): boolean {
+    return (
+      !['testnet', 'signet', 'testnet4', 'regtest'].includes(config.MEMPOOL.NETWORK) &&
+      config.FIAT_PRICE.ENABLED === true
+    );
+  }
+
   static setDateMidnight(date: Date): void {
     date.setUTCHours(0);
     date.setUTCMinutes(0);

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -137,7 +137,7 @@ class Indexer {
 
     switch (task) {
       case 'blocksPrices': {
-        if (!['testnet', 'signet', 'testnet4', 'regtest'].includes(config.MEMPOOL.NETWORK) && config.FIAT_PRICE.ENABLED) {
+        if (Common.blockPricesIndexingEnabled()) {
           let latestPriceId;
           try {
             latestPriceId = await PricesRepository.$getLatestPriceId();

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -773,14 +773,16 @@ class BlocksRepository {
    */
   public async $getHistoricalBlockFees(div: number, interval: string | null, timespan?: {from: number, to: number}): Promise<any> {
     try {
+      const withPrices = Common.blockPricesIndexingEnabled();
+
       let query = `SELECT
         CAST(AVG(blocks.height) as INT) as avgHeight,
         CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(fees) as INT) as avgFees,
-        prices.USD
-        FROM blocks
+        CAST(AVG(fees) as INT) as avgFees${withPrices ? `,
+        prices.USD` : ''}
+        FROM blocks${withPrices ? `
         JOIN blocks_prices on blocks_prices.height = blocks.height
-        JOIN prices on prices.id = blocks_prices.price_id
+        JOIN prices on prices.id = blocks_prices.price_id` : ''}
         WHERE stale = 0
       `;
 
@@ -806,14 +808,16 @@ class BlocksRepository {
    */
   public async $getHistoricalBlockRewards(div: number, interval: string | null): Promise<any> {
     try {
+      const withPrices = Common.blockPricesIndexingEnabled();
+
       let query = `SELECT
         CAST(AVG(blocks.height) as INT) as avgHeight,
         CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(reward) as INT) as avgRewards,
-        prices.USD
-        FROM blocks
+        CAST(AVG(reward) as INT) as avgRewards${withPrices ? `,
+        prices.USD` : ''}
+        FROM blocks${withPrices ? `
         JOIN blocks_prices on blocks_prices.height = blocks.height
-        JOIN prices on prices.id = blocks_prices.price_id
+        JOIN prices on prices.id = blocks_prices.price_id` : ''}
         WHERE stale = 0
       `;
 

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
@@ -110,6 +110,7 @@ export class BlockFeesGraphComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
+    const showFiat = !this.stateService.isAnyTestnet();
     const feesBtcLabel = $localize`:@@graphs.blockFees.feesBtc:Fees BTC`;
     const feesFiatLabel = $localize`:@@graphs.blockFees.feesFiat:Fees ${this.currency}:currency:`;
 
@@ -186,7 +187,7 @@ export class BlockFeesGraphComponent implements OnInit {
           hideOverlap: true,
         }
       },
-      legend: data.blockFees.length === 0 ? undefined : {
+      legend: (data.blockFees.length === 0 || !showFiat) ? undefined : {
         top: 'top',
         data: [
           {
@@ -224,7 +225,7 @@ export class BlockFeesGraphComponent implements OnInit {
             }
           },
         },
-        {
+        ...(showFiat ? [{
           type: 'value',
           position: 'right',
           axisLabel: {
@@ -236,7 +237,7 @@ export class BlockFeesGraphComponent implements OnInit {
           splitLine: {
             show: false,
           },
-        },
+        }] : []),
       ],
       series: data.blockFees.length === 0 ? undefined : [
         {
@@ -253,7 +254,7 @@ export class BlockFeesGraphComponent implements OnInit {
             opacity: 1,
           }
         },
-        {
+        ...(showFiat ? [{
           legendHoverLink: false,
           zlevel: 1,
           yAxisIndex: 1,
@@ -266,7 +267,7 @@ export class BlockFeesGraphComponent implements OnInit {
             width: 2,
             opacity: 1,
           }
-        },
+        }] : []),
       ],
       dataZoom: data.blockFees.length === 0 ? undefined : [{
         type: 'inside',

--- a/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
+++ b/frontend/src/app/components/block-fees-graph/block-fees-graph.component.ts
@@ -110,7 +110,7 @@ export class BlockFeesGraphComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
-    const showFiat = !this.stateService.isAnyTestnet();
+    const showFiat = !this.stateService.isAnyTestnet() && data.blockFeesFiat.length > 0;
     const feesBtcLabel = $localize`:@@graphs.blockFees.feesBtc:Fees BTC`;
     const feesFiatLabel = $localize`:@@graphs.blockFees.feesFiat:Fees ${this.currency}:currency:`;
 

--- a/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.ts
+++ b/frontend/src/app/components/block-fees-subsidy-graph/block-fees-subsidy-graph.component.ts
@@ -146,6 +146,12 @@ export class BlockFeesSubsidyGraphComponent implements OnInit {
   }
 
   prepareChartOptions() {
+    // instances without price indexing return no fiat data, so the fiat mode has nothing to show
+    const showFiat = this.data.blockFeesFiat.length > 0;
+    if (!showFiat && this.displayMode === 'fiat') {
+      this.displayMode = 'normal';
+    }
+
     let title: object;
     if (this.data.blockFees.length === 0) {
       title = {
@@ -258,7 +264,7 @@ export class BlockFeesSubsidyGraphComponent implements OnInit {
             },
             icon: 'roundRect',
           },
-          {
+          ...(showFiat ? [{
             name: this.subsidyUsdLabel,
             inactiveColor: 'var(--grey)',
             textStyle: {
@@ -273,7 +279,7 @@ export class BlockFeesSubsidyGraphComponent implements OnInit {
               color: 'var(--fg)',
             },
             icon: 'roundRect',
-          },
+          }] : []),
           {
             name: this.subsidyPercentLabel,
             inactiveColor: 'var(--grey)',
@@ -292,8 +298,10 @@ export class BlockFeesSubsidyGraphComponent implements OnInit {
           },
         ],
         selected: {
-          [this.subsidyUsdLabel]: this.displayMode === 'fiat' && this.legend.subsidy,
-          [this.feesUsdLabel]: this.displayMode === 'fiat' && this.legend.fees,
+          ...(showFiat ? {
+            [this.subsidyUsdLabel]: this.displayMode === 'fiat' && this.legend.subsidy,
+            [this.feesUsdLabel]: this.displayMode === 'fiat' && this.legend.fees,
+          } : {}),
           [this.subsidyLabel]: this.displayMode === 'normal' && this.legend.subsidy,
           [this.feesLabel]: this.displayMode === 'normal' && this.legend.fees,
           [this.subsidyPercentLabel]: this.displayMode === 'percentage' && this.legend.subsidy,

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
@@ -107,7 +107,7 @@ export class BlockRewardsGraphComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
-    const showFiat = !this.stateService.isAnyTestnet();
+    const showFiat = !this.stateService.isAnyTestnet() && data.blockRewardsFiat.length > 0;
     let title: object;
     if (data.blockRewards.length === 0) {
       title = {

--- a/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
+++ b/frontend/src/app/components/block-rewards-graph/block-rewards-graph.component.ts
@@ -107,6 +107,7 @@ export class BlockRewardsGraphComponent implements OnInit {
   }
 
   prepareChartOptions(data) {
+    const showFiat = !this.stateService.isAnyTestnet();
     let title: object;
     if (data.blockRewards.length === 0) {
       title = {
@@ -182,7 +183,7 @@ export class BlockRewardsGraphComponent implements OnInit {
           hideOverlap: true,
         }
       },
-      legend: data.blockRewards.length === 0 ? undefined : {
+      legend: (data.blockRewards.length === 0 || !showFiat) ? undefined : {
         top: 'top',
         data: [
           {
@@ -226,7 +227,7 @@ export class BlockRewardsGraphComponent implements OnInit {
             }
           },
         },
-        {
+        ...(showFiat ? [{
           min: (value) => {
             return Math.round(value.min * (1.0 - scaleFactor) * 10) / 10;
           },
@@ -244,7 +245,7 @@ export class BlockRewardsGraphComponent implements OnInit {
           splitLine: {
             show: false,
           },
-        },
+        }] : []),
       ],
       series: data.blockRewards.length === 0 ? undefined : [
         {
@@ -257,7 +258,7 @@ export class BlockRewardsGraphComponent implements OnInit {
           smooth: 0.25,
           symbol: 'none',
         },
-        {
+        ...(showFiat ? [{
           legendHoverLink: false,
           zlevel: 1,
           yAxisIndex: 1,
@@ -273,7 +274,7 @@ export class BlockRewardsGraphComponent implements OnInit {
           areaStyle: {
             opacity: 0.05,
           }
-        },
+        }] : []),
       ],
       dataZoom: data.blockRewards.length === 0 ? undefined : [{
         type: 'inside',

--- a/frontend/src/app/components/graphs/graphs.component.html
+++ b/frontend/src/app/components/graphs/graphs.component.html
@@ -19,7 +19,7 @@
         i18n="mining.block-fee-rates">Block Fee Rates</a>
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-fees' | relativeUrl]"
         i18n="mining.block-fees">Block Fees</a>
-      <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-fees-subsidy' | relativeUrl]"
+      <a *ngIf="isMainnet" class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-fees-subsidy' | relativeUrl]"
         i18n="mining.block-fees-subsidy-subsidy">Block Fees Vs Subsidy</a>
       <a class="dropdown-item" routerLinkActive="active" [routerLink]="['/graphs/mining/block-rewards' | relativeUrl]"
         i18n="mining.block-rewards">Block Rewards</a>

--- a/frontend/src/app/graphs/graphs.routing.module.ts
+++ b/frontend/src/app/graphs/graphs.routing.module.ts
@@ -142,7 +142,7 @@ const routes: Routes = [
           },
           {
             path: 'mining/block-fees-subsidy',
-            data: { networks: ['bitcoin'] },
+            data: { networks: ['bitcoin'], networkSpecific: true, onlySubnet: [''] },
             component: BlockFeesSubsidyGraphComponent,
           },
           {


### PR DESCRIPTION
Fixes #6668

## What this changes

**Backend, make the price joins conditional.** New helper `Common.blockPricesIndexingEnabled()`
mirrors exactly the condition under which the indexer runs the `blocksPrices` task. When it
returns false, `$getHistoricalBlockFees` and `$getHistoricalBlockRewards` omit the price column
and both joins. The query generated on mainnet is unchanged, so there is no behaviour change and
no risk of a regression there. The indexer now reuses the helper instead of its own copy of the
network list, so the query and the indexer cannot drift apart.

**Frontend, Block Fees and Block Rewards are BTC-only on test networks.** The fiat series, the
right axis and the legend are hidden when `stateService.isAnyTestnet()` is true, following the
same pattern already used in `address-graph.component.ts`.

**Frontend, Block Fees vs Subsidy is mainnet-only.** The route gets
`networkSpecific: true, onlySubnet: ['']`, which covers direct URL access, and the menu entry is
hidden outside mainnet. Same mechanism the acceleration pages already use.

This also fixes self-hosted mainnet instances running with `FIAT_PRICE.ENABLED = false`, which
have the same empty `blocks_prices` table and the same broken charts today.

## How it was verified

Tested against a real synced testnet4 node with 5035 blocks indexed and `blocks_prices` and
`prices` both empty, which is the exact condition that triggers the bug.

| endpoint | before | after |
| --- | --- | --- |
| `mining/blocks/fees/1m` | `[]` | 1487 rows |
| `mining/blocks/rewards/1m` | `[]` | 1487 rows |
| `mining/blocks/fee-rates/1m` | 1487 rows | 1487 rows, unchanged |

No `USD` field is returned on test networks, so the frontend filters produce empty fiat series
without any extra handling. In the browser on testnet4, both charts render the BTC line with no
fiat axis or legend, the Block Fees vs Subsidy URL redirects to the network root, and its menu
entry is gone. Mainnet behaviour is unchanged. Typecheck and ESLint are clean on every file
touched, and the existing backend test suite passes.

## Why not a LEFT JOIN

A LEFT JOIN would also fix the issue, but it would let rows with a null price reach mainnet for
the first time. In Block Fees vs Subsidy the fiat arrays are filtered and then drawn against a
category axis, so they are aligned by index. A gap in the middle of the data would shift the
whole fiat curve and display wrong values. The conditional query avoids that entirely by leaving
the mainnet query untouched.