### PR TITLE
fix: winning block link overflows in stale block view

### DIFF
--- a/frontend/src/app/components/block/block.component.scss
+++ b/frontend/src/app/components/block/block.component.scss
@@ -13,6 +13,10 @@
   .alert-mempool {
     flex-direction: row;
     flex-wrap: wrap;
+
+    app-truncate {
+      min-width: 0;
+    }
   }
 
   .container-button {


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="852" height="916" alt="image" src="https://github.com/user-attachments/assets/4438eb1f-15a5-4b3e-b500-7a2a4da48be3" />|<img width="716" height="1016" alt="image" src="https://github.com/user-attachments/assets/21f4765f-e54e-4f77-9551-c5bd46aace94" />|

fixes #6667 