### PR TITLE
fix correct 1-year block capacity calculation

### DIFF
--- a/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
+++ b/frontend/src/app/components/acceleration/acceleration-stats/acceleration-stats.component.ts
@@ -69,7 +69,7 @@ export class AccelerationStatsComponent implements OnInit, OnChanges {
         this.blocksInPeriod = 30.5 * 144;
         break;
       case '1y':
-        this.blocksInPeriod = 30.5 * 144 * 365;
+        this.blocksInPeriod = 144 * 365;
         break;
       case 'all':
         this.blocksInPeriod = Infinity;


### PR DESCRIPTION
## What changed

Fixed the estimated block count used to calculate the `Total vSize` percentage for the `1y` acceleration stats period.

The previous calculation used an extra `30.5` multiplier, effectively treating one year as 30.5 years of blocks and causing the value to round down to `0.00%`.

closes #6711