### PR TITLE
Use txospenderindex to link spend transactions on non esplora backend

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.interface.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.interface.ts
@@ -206,6 +206,13 @@ export namespace IBitcoinApi {
     'utxo_increase': number;
     'utxo_size_inc': number;
   }
+
+  export interface TxSpendingPrevout {
+    txid: string;
+    vout: number;
+    spendingtxid?: string; // the transaction id of the transaction spending this output (omitted if unspent)
+    blockhash?: string; // the hash of the block containing the spending transaction (omitted if unspent or the spending tx is not confirmed)
+  }
 }
 
 export interface TestMempoolAcceptResult {

--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -7,6 +7,7 @@ import mempool from '../mempool';
 import { TransactionExtended } from '../../mempool.interfaces';
 import transactionUtils from '../transaction-utils';
 import { Common } from '../common';
+import indexer from '../../indexer';
 
 class BitcoinApi implements AbstractBitcoinApi {
   private rawMempoolCache: IBitcoinApi.RawMempool | null = null;
@@ -233,8 +234,36 @@ class BitcoinApi implements AbstractBitcoinApi {
 
   /** @asyncUnsafe */
   async $getOutspends(txId: string): Promise<IEsploraApi.Outspend[]> {
-    const outSpends: IEsploraApi.Outspend[] = [];
     const tx = await this.$getRawTransaction(txId, true, false);
+    if (indexer.isCoreIndexReady('txospenderindex')) {
+      const outputs = tx.vout.map((_, vout) => ({ txid: txId, vout }));
+      if (!outputs.length) {
+        return [];
+      }
+
+      try {
+        const spendingPrevouts: IBitcoinApi.TxSpendingPrevout[] = await this.bitcoindClient.getTxSpendingPrevout(outputs, { mempool_only: false });
+        return spendingPrevouts.map((spendingPrevout): IEsploraApi.Outspend => {
+          if (!spendingPrevout.spendingtxid) {
+            return { spent: false };
+          }
+
+          return {
+            spent: true,
+            txid: spendingPrevout.spendingtxid,
+            status: spendingPrevout.blockhash ? { confirmed: true, block_hash: spendingPrevout.blockhash } : { confirmed: false },
+          };
+        });
+      } catch (e) {
+        const rpcError = e as { code?: number; message?: string };
+        // If txospenderindex is not available, fall back to gettxout for each output
+        if (rpcError.code !== -1 || !rpcError.message?.includes('txospenderindex is unavailable')) {
+          throw e;
+        }
+      }
+    }
+
+    const outSpends: IEsploraApi.Outspend[] = [];
     for (let i = 0; i < tx.vout.length; i++) {
       if (tx.status && tx.status.block_height === 0) {
         outSpends.push({

--- a/backend/src/rpc-api/commands.ts
+++ b/backend/src/rpc-api/commands.ts
@@ -52,6 +52,7 @@ module.exports = {
   getTxOut: 'gettxout', // bitcoind v0.7.0+
   getTxOutProof: 'gettxoutproof', // bitcoind v0.11.0+
   getTxOutSetInfo: 'gettxoutsetinfo', // bitcoind v0.7.0+
+  getTxSpendingPrevout: 'gettxspendingprevout',
   getUnconfirmedBalance: 'getunconfirmedbalance', // bitcoind v0.9.0+
   getWalletInfo: 'getwalletinfo', // bitcoind v0.9.2+
   help: 'help',

--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -404,7 +404,7 @@
                       <fa-icon [icon]="['fas', 'arrow-alt-circle-right']" [fixedWidth]="true"></fa-icon>
                     </span>
                     <ng-template #spent>
-                      <a *ngIf="tx._outspends[vindex].txid else outputNoTxId" [routerLink]="['/tx/' | relativeUrl, tx._outspends[vindex].txid]"  [fragment]="'vin=' + tx._outspends[vindex].vin" class="red">
+                      <a *ngIf="tx._outspends[vindex].txid else outputNoTxId" [routerLink]="['/tx/' | relativeUrl, tx._outspends[vindex].txid]"  [fragment]="tx._outspends[vindex].vin !== undefined ? 'vin=' + tx._outspends[vindex].vin : undefined" class="red">
                         <fa-icon [icon]="['fas', 'arrow-alt-circle-right']" [fixedWidth]="true"></fa-icon>
                       </a>
                       <ng-template #outputNoTxId>

--- a/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
+++ b/frontend/src/app/components/tx-bowtie-graph-tooltip/tx-bowtie-graph-tooltip.component.html
@@ -83,13 +83,18 @@
                 </ng-template>
               </ng-container>
             </p>
-            <p *ngSwitchCase="'output'"><span i18n="transaction.input">Input</span>&nbsp; #{{ line.vin }}
+            <p *ngSwitchCase="'output'">
+              @if (line.vin !== undefined) {
+                <span i18n="transaction.input">Input</span>&nbsp; #{{ line.vin }}
+              }
               <ng-container *ngIf="line.blockHeight">
                 <ng-container *ngIf="line?.status?.block_height; else noBlockHeight">
                   <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: line?.status?.block_height - line.blockHeight, connector: true}"></ng-container>
                 </ng-container>
                 <ng-template #noBlockHeight>
-                  <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: chainTip + 1 - line.blockHeight, connector: true}"></ng-container>
+                  @if (line?.status?.confirmed !== true) {
+                    <ng-container *ngTemplateOutlet="nBlocksLater; context:{n: chainTip + 1 - line.blockHeight, connector: true}"></ng-container>
+                  }
                 </ng-template>
               </ng-container>
             </p>

--- a/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
+++ b/frontend/src/app/components/tx-bowtie-graph/tx-bowtie-graph.component.ts
@@ -555,12 +555,13 @@ export class TxBowtieGraphComponent implements OnInit, OnChanges {
       const output = this.tx.vout[index];
       const outspend = this.outspends[index];
       if (side === 'output-connector' && output && outspend && outspend.spent && outspend.txid) {
+        const fragmentParams = new URLSearchParams({ flow: '' });
+        if (outspend.vin !== undefined) {
+          fragmentParams.set('vin', outspend.vin.toString());
+        }
         this.router.navigate([this.relativeUrlPipe.transform('/tx'), outspend.txid], {
           queryParamsHandling: 'merge',
-          fragment: (new URLSearchParams({
-            flow: '',
-            vin: outspend.vin.toString(),
-          })).toString(),
+          fragment: fragmentParams.toString(),
         });
       } else if (index != null) {
         this.router.navigate([this.relativeUrlPipe.transform('/tx'), this.tx.txid], {

--- a/frontend/src/app/interfaces/electrs.interface.ts
+++ b/frontend/src/app/interfaces/electrs.interface.ts
@@ -192,9 +192,9 @@ export interface MempoolStats {
 
 export interface Outspend {
   spent: boolean;
-  txid: string;
-  vin: number;
-  status: Status;
+  txid?: string;
+  vin?: number;
+  status?: Status;
 }
 
 export interface Asset {


### PR DESCRIPTION
On non-esplora backend, the transaction page currently shows whether an output is spent, but doesn't link to the transaction spending it. This PR adds that link by including the spending txid (and confirmation status) in the `/txs/outspends` response. This works by opportunistically using the `gettxspendingprevout` RPC (which relies on the index `txospenderindex` introduced in Bitcoin Core v31). Current behavior is kept when when `txospenderindex` in not enabled or unavailable.

Testing (on a non-esplora instance, with `txospenderindex` enabled on the bitcoin node): navigate to a transaction with an spent output, click on the red spent button, and check that it correctly navigate to the spending transaction.

https://github.com/user-attachments/assets/528d69c5-e49d-41dc-9947-fa7c0d862d6f

if `txospenderindex` is not enabled, the button should not be clickable like before.