### PR TITLE
[accelerator] fix pro "Pay" button logo color

### DIFF
--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.html
@@ -420,7 +420,7 @@
                 </p>
                 <div class="d-flex justify-content-center" [class.disabled]="quoteError || accelerateError || showSuccess || calculating || processing">
                   <div class="paymentMethod mx-2 d-flex justify-content-center align-items-center" style="width: 200px; height: 55px; font-size: 30px" (click)="accelerateWithMempoolAccount()">
-                    <img class="me-2 purple-filter" src="/resources/mempool-accelerator-sparkles-light.svg" height="30">
+                    <div class="me-2 purple-icon" style="width: 40px; height: 40px;"></div>
                     <span i18n="transaction.pay|Pay button label">Pay</span>
                   </div>
                 </div>

--- a/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
+++ b/frontend/src/app/components/accelerate-checkout/accelerate-checkout.component.scss
@@ -26,8 +26,18 @@ hr {
   cursor: pointer;
 }
 
-.purple-filter {
-  filter: brightness(0) saturate(100%) invert(30%) sepia(90%) saturate(5000%) hue-rotate(260deg);
+.purple-icon {
+  display: inline-block;
+  background-color: var(--tertiary);
+  filter: brightness(1.3);
+  -webkit-mask-image: url(/resources/mempool-accelerator-sparkles-light.svg);
+  mask-image: url(/resources/mempool-accelerator-sparkles-light.svg);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 .default-slot:not(:only-child) {


### PR DESCRIPTION
On mobile, the pay button logo is pink due to the css hack I was using. So this PR properly renders it in purple again (using the `tertiary`)

## Currently

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3601ea90-8eaa-48f4-a860-4ff70a3b69bb" />

## Fixed

<img width="300" alt="IMG_0131" src="https://github.com/user-attachments/assets/f7670f0f-6ee6-4444-ba4d-5b7a01bf43c0" />

