### PR TITLE
Backend: guard the difficulty estimator against stale or unknown inputs

### DIFF
--- a/backend/src/__tests__/api/difficulty-adjustment.test.ts
+++ b/backend/src/__tests__/api/difficulty-adjustment.test.ts
@@ -122,6 +122,52 @@ describe('Mempool Difficulty Adjustment', () => {
     }
   });
 
+  test('should not produce negative estimates from a stale last-retarget time', () => {
+    // last-retarget time one epoch behind, so the window start is newer than it
+    const DATime = 1786219932;
+    const quarterEpochTime = 1788276827;
+    const nowSeconds = 1788286900;
+    const blockHeight = 963648 + 436;
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, blockHeight, 0.99, 'mainnet', nowSeconds - 20);
+
+    // plain per-epoch average, not the window
+    expect(result.timeAvg).toEqual(4740752); // (nowSeconds - DATime) / 436 blocks
+    expect(result.adjustedTimeAvg).toEqual(4740752);
+    expect(result.remainingTime).toEqual(7490388160); // 1580 remaining blocks
+    expect(result.estimatedRetargetDate).toEqual(1795777288160);
+    expect(result.difficultyChange).toEqual(-75);
+  });
+
+  test('should keep the sliding window across a legitimate timestamp inversion', () => {
+    // mainnet epoch 812448: the window start (block 812447) is 43 s newer than the retarget block
+    const DATime = 1697455965; // block 812448
+    const quarterEpochTime = 1697456008; // block 812447
+    const latestBlockTimestamp = 1697743189; // block 812950
+    const nowSeconds = latestBlockTimestamp + 120;
+    const previousRetarget = calcBitsDifference(0x1704e90f, 0x17049ca9); // blocks 810432 -> 812448
+    expect(previousRetarget).toBeCloseTo(6.4708237, 6);
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, 812950, previousRetarget, 'mainnet', latestBlockTimestamp);
+
+    expect(result.timeAvg).toEqual(572398);
+    expect(result.adjustedTimeAvg).toEqual(571169); // the window, not the plain average
+    expect(result.remainingTime).toEqual(864749866);
+    expect(result.estimatedRetargetDate).toEqual(1698608058866);
+    expect(result.difficultyChange).toBeCloseTo(5.2564832, 6);
+  });
+
+  test('should not use the sliding window when the previous retarget is unknown', () => {
+    const DATime = 1660820820;
+    const quarterEpochTime = 1660619814;
+    const nowSeconds = 1660917833;
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, 750134, NaN, 'mainnet', 0);
+
+    expect(result.previousRetarget).toBeNaN();
+    for (const key of ['difficultyChange', 'estimatedRetargetDate', 'remainingTime', 'timeAvg', 'adjustedTimeAvg']) {
+      expect(Number.isFinite(result[key])).toBe(true);
+    }
+    expect(result.adjustedTimeAvg).toEqual(result.timeAvg);
+  });
+
   test('should calculate Difficulty change from bits fields of two blocks', () => {
     // Check same exponent + check min max for output
     expect(calcBitsDifference(0x1d000200, 0x1d000100)).toEqual(100);

--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -91,6 +91,7 @@ export function calcDifficultyAdjustment(
   const EPOCH_BLOCK_LENGTH = 2016; // Bitcoin mainnet
   const BLOCK_SECONDS_TARGET = 600; // Bitcoin mainnet
   const TESTNET_MAX_BLOCK_SECONDS = 1200; // Bitcoin testnet
+  const MAX_TIMESTAMP_INVERSION = 2 * 60 * 60; // normal block timestamp jitter (seconds)
 
   const diffSeconds = Math.max(0, nowSeconds - DATime);
   const blocksInEpoch = (blockHeight >= 0) ? blockHeight % EPOCH_BLOCK_LENGTH : 0;
@@ -105,10 +106,12 @@ export function calcDifficultyAdjustment(
   let adjustedTimeAvgSecs = timeAvgSecs;
 
   // for the first 504 blocks of the epoch, calculate the expected avg block interval
-  // from a sliding window over the last 504 blocks
-  if (quarterEpochTime && blocksInEpoch < 503) {
-    const timeLastEpoch = DATime - quarterEpochTime;
-    const adjustedTimeLastEpoch = timeLastEpoch * (1 + (previousRetarget / 100));
+  // from a sliding window over the last 504 blocks, unless the inputs are unusable:
+  // a window start newer than the last retarget (beyond timestamp jitter) means the
+  // retarget time is stale, and a NaN previous retarget can't scale the window
+  const windowStartLag = quarterEpochTime ? DATime - quarterEpochTime : 0;
+  if (quarterEpochTime && windowStartLag >= -MAX_TIMESTAMP_INVERSION && Number.isFinite(previousRetarget) && blocksInEpoch < 503) {
+    const adjustedTimeLastEpoch = windowStartLag * (1 + (previousRetarget / 100));
     const adjustedTimeSpan = diffSeconds + adjustedTimeLastEpoch;
     adjustedTimeAvgSecs = adjustedTimeSpan / 503;
     difficultyChange = (BLOCK_SECONDS_TARGET / (adjustedTimeSpan / 504) - 1) * 100;
@@ -140,7 +143,7 @@ export function calcDifficultyAdjustment(
   }
 
   const timeAvg = Math.floor(timeAvgSecs * 1000);
-  const adjustedTimeAvg = Math.floor(adjustedTimeAvgSecs * 1000);
+  const adjustedTimeAvg = Math.max(0, Math.floor(adjustedTimeAvgSecs * 1000));
   const remainingTime = remainingBlocks * adjustedTimeAvg;
   const estimatedRetargetDate = remainingTime + nowSeconds * 1000;
 


### PR DESCRIPTION
**Problem.** When the cached last-retarget time is stale, or the previous retarget is NaN, `calcDifficultyAdjustment` publishes negative `adjustedTimeAvg` / `remainingTime` and a retarget date in the past, or all-null fields that the frontend renders as 1 Jan 1970.

**Solution.** Use the sliding window only when its inputs are usable: the window-start timestamp is not more than 2 hours newer than the last retarget, and the previous retarget is finite. Otherwise fall back to the plain per-epoch average. Floor `adjustedTimeAvg` at 0.

**Details**

- Stale anchor: the block loop can leave the last-retarget time an epoch behind (fast-forward or reorg across a retarget height, fixed in #6734). The window's previous-epoch span then goes negative. This guard is the backstop; with a stale anchor the estimate is bounded but still wrong.
- NaN previous retarget: Liquid today, bitcoin networks after #6734 when the bits change is uncomputable. Liquid already gets finite figures from the plain branch for blocks 503+ of every epoch; this makes the first 503 consistent rather than null.
- The 2-hour tolerance exists because block timestamps are not monotonic. Mainnet epoch 812448 starts with a 43 s inversion; it is the only affected epoch since January 2022 and keeps using the window.
- Tests: the live stale numbers must give the hard-coded fallback values; the real epoch 812448 data must give the window values (adjustedTimeAvg 571169 vs plain 572398); a NaN previous retarget must give finite fields. Expected values were computed independently of the TypeScript. The existing four vectors are unchanged.
