### PR TITLE
Backend: derive difficulty adjustment state from the chain, don't abort the block loop on an uncomputable retarget

### DIFF
--- a/backend/src/__tests__/api/difficulty-adjustment.test.ts
+++ b/backend/src/__tests__/api/difficulty-adjustment.test.ts
@@ -122,6 +122,52 @@ describe('Mempool Difficulty Adjustment', () => {
     }
   });
 
+  test('should not produce negative estimates from a stale last-retarget time', () => {
+    // last-retarget time one epoch behind, so the window start is newer than it
+    const DATime = 1786219932;
+    const quarterEpochTime = 1788276827;
+    const nowSeconds = 1788286900;
+    const blockHeight = 963648 + 436;
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, blockHeight, 0.99, 'mainnet', nowSeconds - 20);
+
+    // plain per-epoch average, not the window
+    expect(result.timeAvg).toEqual(4740752); // (nowSeconds - DATime) / 436 blocks
+    expect(result.adjustedTimeAvg).toEqual(4740752);
+    expect(result.remainingTime).toEqual(7490388160); // 1580 remaining blocks
+    expect(result.estimatedRetargetDate).toEqual(1795777288160);
+    expect(result.difficultyChange).toEqual(-75);
+  });
+
+  test('should keep the sliding window across a legitimate timestamp inversion', () => {
+    // mainnet epoch 812448: the window start (block 812447) is 43 s newer than the retarget block
+    const DATime = 1697455965; // block 812448
+    const quarterEpochTime = 1697456008; // block 812447
+    const latestBlockTimestamp = 1697743189; // block 812950
+    const nowSeconds = latestBlockTimestamp + 120;
+    const previousRetarget = calcBitsDifference(0x1704e90f, 0x17049ca9); // blocks 810432 -> 812448
+    expect(previousRetarget).toBeCloseTo(6.4708237, 6);
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, 812950, previousRetarget, 'mainnet', latestBlockTimestamp);
+
+    expect(result.timeAvg).toEqual(572398);
+    expect(result.adjustedTimeAvg).toEqual(571169); // the window, not the plain average
+    expect(result.remainingTime).toEqual(864749866);
+    expect(result.estimatedRetargetDate).toEqual(1698608058866);
+    expect(result.difficultyChange).toBeCloseTo(5.2564832, 6);
+  });
+
+  test('should not use the sliding window when the previous retarget is unknown', () => {
+    const DATime = 1660820820;
+    const quarterEpochTime = 1660619814;
+    const nowSeconds = 1660917833;
+    const result = calcDifficultyAdjustment(DATime, quarterEpochTime, nowSeconds, 750134, NaN, 'mainnet', 0);
+
+    expect(result.previousRetarget).toBeNaN();
+    for (const key of ['difficultyChange', 'estimatedRetargetDate', 'remainingTime', 'timeAvg', 'adjustedTimeAvg']) {
+      expect(Number.isFinite(result[key])).toBe(true);
+    }
+    expect(result.adjustedTimeAvg).toEqual(result.timeAvg);
+  });
+
   test('should calculate Difficulty change from bits fields of two blocks', () => {
     // Check same exponent + check min max for output
     expect(calcBitsDifference(0x1d000200, 0x1d000100)).toEqual(100);

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -1449,15 +1449,20 @@ class Blocks {
       }
 
       if (block.height % 2016 === 0 && Common.indexingEnabled()) {
-        await DifficultyAdjustmentsRepository.$saveAdjustments({
-          time: block.timestamp,
-          height: block.height,
-          difficulty: block.difficulty,
-          // previousDifficultyRetarget is a +- percentage, +100 returns to positive, /100 returns to ratio.
-          // Instead of actually doing /100, just reduce the multiplier.
-          adjustment: Math.round((this.previousDifficultyRetarget + 100) * 10000) / 1000000, // Remove float point noise
-        });
-        this.updateTimerProgress(timer, `saved difficulty adjustment for ${this.currentBlockHeight}`);
+        if (Number.isFinite(this.previousDifficultyRetarget)) {
+          await DifficultyAdjustmentsRepository.$saveAdjustments({
+            time: block.timestamp,
+            height: block.height,
+            difficulty: block.difficulty,
+            // previousDifficultyRetarget is a +- percentage, +100 returns to positive, /100 returns to ratio.
+            // Instead of actually doing /100, just reduce the multiplier.
+            adjustment: Math.round((this.previousDifficultyRetarget + 100) * 10000) / 1000000, // Remove float point noise
+          });
+          this.updateTimerProgress(timer, `saved difficulty adjustment for ${this.currentBlockHeight}`);
+        } else {
+          // the column is NOT NULL; the indexer fills the row from the difficulty ratio instead
+          logger.warn(`Not saving the difficulty adjustment at block #${block.height} (unknown change), the indexer will compute it from the difficulty ratio`, logger.tags.mining);
+        }
       }
 
       // skip updating the orphan block cache if we've fallen behind the chain tip
@@ -1536,6 +1541,22 @@ class Blocks {
   }
 
   /**
+   * Difficulty change (%) between two consecutive epoch-start blocks, or NaN when it can't be
+   * computed (Liquid, or an exponent gap of 2+: impossible on mainnet, routine on testnet3).
+   */
+  private calcPreviousRetarget(oldBits: number, newBits: number): number {
+    if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
+      return NaN;
+    }
+    try {
+      return calcBitsDifference(oldBits, newBits);
+    } catch (e) {
+      logger.warn(`Cannot compute the difficulty change from bits 0x${oldBits.toString(16)} to 0x${newBits.toString(16)}: ${e instanceof Error ? e.message : e}`);
+      return NaN;
+    }
+  }
+
+  /**
    * (Re)load the difficulty adjustment state for the epoch containing `height` from Core:
    * the epoch-start block (or `epochStartBlock` if the caller has it) and the one before it.
    *
@@ -1559,11 +1580,7 @@ class Blocks {
       this.updateTimerProgress(timer, `got block hash ${epochStartHeight - 2016} for difficulty adjustment`);
       const previousPeriodBlock: IEsploraApi.Block = await bitcoinCoreApi.$getBlock(previousPeriodBlockHash);
       this.updateTimerProgress(timer, `got block ${epochStartHeight - 2016} for difficulty adjustment`);
-      if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
-        previousRetarget = NaN;
-      } else {
-        previousRetarget = calcBitsDifference(previousPeriodBlock.bits, block.bits);
-      }
+      previousRetarget = this.calcPreviousRetarget(previousPeriodBlock.bits, block.bits);
     }
 
     this.lastDifficultyAdjustmentTime = block.timestamp;

--- a/backend/src/api/blocks.ts
+++ b/backend/src/api/blocks.ts
@@ -46,8 +46,8 @@ class Blocks {
   private blocks: BlockExtended[] = [];
   private blockSummaries: BlockSummary[] = [];
   private currentBlockHeight = 0;
-  private currentBits = 0;
   private lastDifficultyAdjustmentTime = 0;
+  private difficultyEpochStartHeight = -1; // epoch start the difficulty adjustment state was loaded from, -1 = stale
   private previousDifficultyRetarget = 0;
   private quarterEpochBlockTime: number | null = null;
   private newBlockCallbacks: ((block: BlockExtended, txIds: string[], transactions: TransactionExtended[]) => void)[] = [];
@@ -1337,32 +1337,16 @@ class Blocks {
       fastForwarded = true;
       logger.info(`Re-indexing skipped blocks and corresponding hashrates data`);
       indexer.reindex(); // Make sure to index the skipped blocks #1619
+      // the skipped blocks may include a retarget or a reorg of the epoch start
+      this.difficultyEpochStartHeight = -1;
     }
 
-    if (!this.lastDifficultyAdjustmentTime) {
+    // (re)load the difficulty adjustment state on startup or after a fast-forward
+    if (this.difficultyAdjustmentStateIsStale(this.currentBlockHeight)) {
       const blockchainInfo = await bitcoinClient.getBlockchainInfo();
-      this.updateTimerProgress(timer, 'got blockchain info for initial difficulty adjustment');
+      this.updateTimerProgress(timer, 'got blockchain info for difficulty adjustment');
       if (blockchainInfo.blocks === blockchainInfo.headers) {
-        const heightDiff = blockHeightTip % 2016;
-        const blockHash = await bitcoinApi.$getBlockHash(blockHeightTip - heightDiff);
-        this.updateTimerProgress(timer, 'got block hash for initial difficulty adjustment');
-        const block: IEsploraApi.Block = await bitcoinApi.$getBlock(blockHash);
-        this.updateTimerProgress(timer, 'got block for initial difficulty adjustment');
-        this.lastDifficultyAdjustmentTime = block.timestamp;
-        this.currentBits = block.bits;
-
-        if (blockHeightTip >= 2016) {
-          const previousPeriodBlockHash = await bitcoinApi.$getBlockHash(blockHeightTip - heightDiff - 2016);
-          this.updateTimerProgress(timer, 'got previous block hash for initial difficulty adjustment');
-          const previousPeriodBlock: IEsploraApi.Block = await bitcoinApi.$getBlock(previousPeriodBlockHash);
-          this.updateTimerProgress(timer, 'got previous block for initial difficulty adjustment');
-          if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
-            this.previousDifficultyRetarget = NaN;
-          } else {
-            this.previousDifficultyRetarget = calcBitsDifference(previousPeriodBlock.bits, block.bits);
-          }
-          logger.debug(`Initial difficulty adjustment data set.`);
-        }
+        await this.$updateDifficultyAdjustmentState(this.currentBlockHeight, timer);
       } else {
         logger.debug(`Blockchain headers (${blockchainInfo.headers}) and blocks (${blockchainInfo.blocks}) not in sync. Waiting...`);
       }
@@ -1428,6 +1412,17 @@ class Blocks {
         await this.$handleReorgs(blockExtended, timer);
       }
 
+      // a reorg not caught above (indexing disabled) shows as a gap in the block cache
+      const lastCachedBlock = this.blocks[this.blocks.length - 1];
+      if (lastCachedBlock && lastCachedBlock.height === block.height - 1 && lastCachedBlock.id !== block.previousblockhash) {
+        this.difficultyEpochStartHeight = -1;
+      }
+
+      // new epoch or invalidated state: reload before the websocket broadcast
+      if (this.difficultyAdjustmentStateIsStale(block.height)) {
+        await this.$updateDifficultyAdjustmentState(block.height, timer, block);
+      }
+
       await websocketHandler.handleNewBlock(blockExtended, txIds, cpfpSummary.transactions, rbfTransactions);
       this.updateTimerProgress(timer, `sent websocket updates for ${this.currentBlockHeight}`);
 
@@ -1453,35 +1448,16 @@ class Blocks {
         }
       }
 
-      if (block.height % 2016 === 0) {
-        if (Common.indexingEnabled()) {
-          let adjustment;
-          if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
-            adjustment = NaN;
-          } else {
-            adjustment = Math.round(
-              // calcBitsDifference returns +- percentage, +100 returns to positive, /100 returns to ratio.
-              // Instead of actually doing /100, just reduce the multiplier.
-              (calcBitsDifference(this.currentBits, block.bits) + 100) * 10000
-            ) / 1000000; // Remove float point noise
-          }
-
-          await DifficultyAdjustmentsRepository.$saveAdjustments({
-            time: block.timestamp,
-            height: block.height,
-            difficulty: block.difficulty,
-            adjustment,
-          });
-          this.updateTimerProgress(timer, `saved difficulty adjustment for ${this.currentBlockHeight}`);
-        }
-
-        if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
-          this.previousDifficultyRetarget = NaN;
-        } else {
-          this.previousDifficultyRetarget = calcBitsDifference(this.currentBits, block.bits);
-        }
-        this.lastDifficultyAdjustmentTime = block.timestamp;
-        this.currentBits = block.bits;
+      if (block.height % 2016 === 0 && Common.indexingEnabled()) {
+        await DifficultyAdjustmentsRepository.$saveAdjustments({
+          time: block.timestamp,
+          height: block.height,
+          difficulty: block.difficulty,
+          // previousDifficultyRetarget is a +- percentage, +100 returns to positive, /100 returns to ratio.
+          // Instead of actually doing /100, just reduce the multiplier.
+          adjustment: Math.round((this.previousDifficultyRetarget + 100) * 10000) / 1000000, // Remove float point noise
+        });
+        this.updateTimerProgress(timer, `saved difficulty adjustment for ${this.currentBlockHeight}`);
       }
 
       // skip updating the orphan block cache if we've fallen behind the chain tip
@@ -1549,6 +1525,53 @@ class Blocks {
     }
   }
 
+  private getDifficultyEpochStartHeight(height: number): number {
+    const h = Math.max(0, height);
+    return h - (h % 2016);
+  }
+
+  /** true if `height` is in a different epoch than the loaded difficulty adjustment state */
+  private difficultyAdjustmentStateIsStale(height: number): boolean {
+    return this.difficultyEpochStartHeight !== this.getDifficultyEpochStartHeight(height);
+  }
+
+  /**
+   * (Re)load the difficulty adjustment state for the epoch containing `height` from Core:
+   * the epoch-start block (or `epochStartBlock` if the caller has it) and the one before it.
+   *
+   * @asyncUnsafe
+   */
+  private async $updateDifficultyAdjustmentState(height: number, timer: any, epochStartBlock?: IEsploraApi.Block): Promise<void> {
+    const epochStartHeight = this.getDifficultyEpochStartHeight(height);
+    let block: IEsploraApi.Block;
+    if (epochStartBlock && epochStartBlock.height === epochStartHeight) {
+      block = epochStartBlock;
+    } else {
+      const blockHash = await bitcoinCoreApi.$getBlockHash(epochStartHeight);
+      this.updateTimerProgress(timer, `got block hash ${epochStartHeight} for difficulty adjustment`);
+      block = await bitcoinCoreApi.$getBlock(blockHash);
+      this.updateTimerProgress(timer, `got block ${epochStartHeight} for difficulty adjustment`);
+    }
+
+    let previousRetarget = this.previousDifficultyRetarget;
+    if (epochStartHeight >= 2016) {
+      const previousPeriodBlockHash = await bitcoinCoreApi.$getBlockHash(epochStartHeight - 2016);
+      this.updateTimerProgress(timer, `got block hash ${epochStartHeight - 2016} for difficulty adjustment`);
+      const previousPeriodBlock: IEsploraApi.Block = await bitcoinCoreApi.$getBlock(previousPeriodBlockHash);
+      this.updateTimerProgress(timer, `got block ${epochStartHeight - 2016} for difficulty adjustment`);
+      if (['liquid', 'liquidtestnet'].includes(config.MEMPOOL.NETWORK)) {
+        previousRetarget = NaN;
+      } else {
+        previousRetarget = calcBitsDifference(previousPeriodBlock.bits, block.bits);
+      }
+    }
+
+    this.lastDifficultyAdjustmentTime = block.timestamp;
+    this.previousDifficultyRetarget = previousRetarget;
+    this.difficultyEpochStartHeight = epochStartHeight;
+    logger.debug(`Difficulty adjustment state set from block #${epochStartHeight} (previous retarget: ${previousRetarget.toFixed(2)}%)`);
+  }
+
   /** @asyncUnsafe */
   private async updateQuarterEpochBlockTime(): Promise<void> {
     if (this.currentBlockHeight >= 503) {
@@ -1588,6 +1611,8 @@ class Blocks {
     // previous blockhash is not what we expected: there has been a reorg
     if (currentlyIndexed !== null && forkTail.previousblockhash !== currentlyIndexed.id) {
       logger.warn(`Chain divergence detected at block ${blockExtended.height}, re-indexing most recent data`, logger.tags.mining);
+      // the reorg may replace the epoch start: invalidate now so the loop reloads even if the repair fails
+      this.difficultyEpochStartHeight = -1;
       this.updateTimerProgress(timer, `reconnecting diverged chain from ${this.currentBlockHeight}`);
       const newBlocks: BlockExtended[] = [];
     // walk back along the chain until we reach the fork point
@@ -1646,6 +1671,14 @@ class Blocks {
       this.updateTimerProgress(timer, `reindexed difficulty adjustments`);
       logger.info(`Re-indexed ${this.currentBlockHeight - forkTail.height} blocks and summaries. Also re-indexed the last difficulty adjustments. Will re-index latest hashrates in a few seconds.`, logger.tags.mining);
       indexer.reindex();
+
+      // reload before clients hear about the reorg; not fatal, the loop retries a failed reload
+      try {
+        await this.$updateDifficultyAdjustmentState(blockExtended.height, timer, blockExtended);
+        this.updateTimerProgress(timer, `reloaded difficulty adjustment state`);
+      } catch (e) {
+        logger.warn(`Failed to reload the difficulty adjustment state after the reorg at block #${blockExtended.height}, will retry: ${e instanceof Error ? e.message : e}`, logger.tags.mining);
+      }
 
       websocketHandler.handleReorg();
     }

--- a/backend/src/api/difficulty-adjustment.ts
+++ b/backend/src/api/difficulty-adjustment.ts
@@ -91,6 +91,7 @@ export function calcDifficultyAdjustment(
   const EPOCH_BLOCK_LENGTH = 2016; // Bitcoin mainnet
   const BLOCK_SECONDS_TARGET = 600; // Bitcoin mainnet
   const TESTNET_MAX_BLOCK_SECONDS = 1200; // Bitcoin testnet
+  const MAX_TIMESTAMP_INVERSION = 2 * 60 * 60; // normal block timestamp jitter (seconds)
 
   const diffSeconds = Math.max(0, nowSeconds - DATime);
   const blocksInEpoch = (blockHeight >= 0) ? blockHeight % EPOCH_BLOCK_LENGTH : 0;
@@ -105,10 +106,12 @@ export function calcDifficultyAdjustment(
   let adjustedTimeAvgSecs = timeAvgSecs;
 
   // for the first 504 blocks of the epoch, calculate the expected avg block interval
-  // from a sliding window over the last 504 blocks
-  if (quarterEpochTime && blocksInEpoch < 503) {
-    const timeLastEpoch = DATime - quarterEpochTime;
-    const adjustedTimeLastEpoch = timeLastEpoch * (1 + (previousRetarget / 100));
+  // from a sliding window over the last 504 blocks, unless the inputs are unusable:
+  // a window start newer than the last retarget (beyond timestamp jitter) means the
+  // retarget time is stale, and a NaN previous retarget can't scale the window
+  const windowStartLag = quarterEpochTime ? DATime - quarterEpochTime : 0;
+  if (quarterEpochTime && windowStartLag >= -MAX_TIMESTAMP_INVERSION && Number.isFinite(previousRetarget) && blocksInEpoch < 503) {
+    const adjustedTimeLastEpoch = windowStartLag * (1 + (previousRetarget / 100));
     const adjustedTimeSpan = diffSeconds + adjustedTimeLastEpoch;
     adjustedTimeAvgSecs = adjustedTimeSpan / 503;
     difficultyChange = (BLOCK_SECONDS_TARGET / (adjustedTimeSpan / 504) - 1) * 100;
@@ -140,7 +143,7 @@ export function calcDifficultyAdjustment(
   }
 
   const timeAvg = Math.floor(timeAvgSecs * 1000);
-  const adjustedTimeAvg = Math.floor(adjustedTimeAvgSecs * 1000);
+  const adjustedTimeAvg = Math.max(0, Math.floor(adjustedTimeAvgSecs * 1000));
   const remainingTime = remainingBlocks * adjustedTimeAvg;
   const estimatedRetargetDate = remainingTime + nowSeconds * 1000;
 


### PR DESCRIPTION
Stacked on #6733 (its commit is the first one here); the changes of this PR are the last two commits. I'll rebase once #6733 merges.

**Problem.** The difficulty-adjustment state (last retarget time, bits, previous retarget) is cached from the block loop and goes stale whenever the loop misses the retarget block: a fast-forward across a retarget height (bitcoind unreachable for more than 16 blocks), a reorg of the epoch-start block, or a restart within 8 blocks after a retarget (which records the retarget as 0%). On testnet3, `calcBitsDifference` throws on the exponent gap a min-difficulty reset produces at a retarget height (17 to 20 times in the past year, last at 5106528); the loop then retries that block every second, replaying the mempool update and the websocket broadcast, until the fast-forward skips it. Either way the estimate is wrong for the rest of the epoch, first negative and then far too long.

**Solution.** Derive the state from the chain instead of caching it from the loop: whenever the epoch of the last processed block changes, reload it from the epoch-start block and the one 2016 blocks before it, fetched from Core. Invalidate it on fast-forward and on reorg detection. Compute the previous retarget through a helper that returns NaN instead of throwing, and skip the `difficulty_adjustments` row when it is NaN; the indexer backfills that row from the difficulty ratio.

**Details**

- Commit 1, `$updateDifficultyAdjustmentState(height)`: runs on startup keyed to the resumed height rather than the tip (fixes the 0% case), and on the retarget block before the websocket broadcast so that block's `da` payload is already correct. Fetching from Core keeps it coherent with the loop when Esplora lags. A fast-forward invalidates the state; a reorg invalidates it at detection and reloads it before notifying clients; with indexing disabled, a discontinuity in the block cache triggers the same invalidation. `currentBits` is removed. Cost: two Core block fetches per epoch change, fast-forward or reorg, none per ordinary block.
- Commit 2, `calcPreviousRetarget`: logs and returns NaN on an uncomputable change. The row is skipped rather than written as NaN because the column is `float NOT NULL`, mysql2 escapes NaN as the bare literal `NaN`, and the repository rethrows non-duplicate errors, which would stall the loop again.
