### PR TITLE
Backend: run the pools migration on a single database connection

### DIFF
--- a/backend/src/__tests__/database.test.ts
+++ b/backend/src/__tests__/database.test.ts
@@ -1,0 +1,108 @@
+import config from '../config';
+
+jest.mock('mysql2/promise', () => {
+  const state = { log: [] as string[], connections: 0 };
+  const record = (who: string, sql: any): void => { state.log.push(`${who}: ${typeof sql === 'string' ? sql : sql.sql}`); };
+  const fakeConnection = (name: string) => ({
+    query: jest.fn(async (sql) => { record(name, sql); return [[], []]; }),
+    beginTransaction: jest.fn(async () => { state.log.push(`${name}: begin`); }),
+    commit: jest.fn(async () => { state.log.push(`${name}: commit`); }),
+    rollback: jest.fn(async () => { state.log.push(`${name}: rollback`); }),
+    release: jest.fn(() => { state.log.push(`${name}: release`); }),
+  });
+  return {
+    __state: state,
+    createPool: () => ({
+      on: jest.fn(),
+      query: jest.fn(async (sql) => { record('pool', sql); return [[], []]; }),
+      getConnection: jest.fn(async () => fakeConnection(`conn${++state.connections}`)),
+    }),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __state: state } = require('mysql2/promise');
+import DB from '../database';
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 1));
+
+describe('DB.$transaction', () => {
+  beforeAll(() => {
+    config.DATABASE.ENABLED = true;
+  });
+  beforeEach(() => {
+    state.log.length = 0;
+  });
+
+  test('queries outside a transaction go to the pool', async () => {
+    await DB.query('SELECT 1');
+    expect(state.log).toEqual(['pool: SELECT 1']);
+  });
+
+  test('every query issued while the callback runs uses the transaction connection, then commits', async () => {
+    const deep = async (): Promise<void> => {
+      await tick();
+      await DB.query('UPDATE a');
+      await DB.query({ sql: 'UPDATE b', timeout: 1000 });
+    };
+    const result = await DB.$transaction(async () => {
+      await DB.query('DELETE FROM x');
+      await deep();
+      return 'done';
+    });
+    expect(result).toEqual('done');
+    expect(state.log).toEqual([
+      'conn1: begin',
+      'conn1: DELETE FROM x',
+      'conn1: UPDATE a',
+      'conn1: UPDATE b',
+      'conn1: commit',
+      'conn1: release',
+    ]);
+  });
+
+  test('a concurrent query started outside the transaction does not join it', async () => {
+    let releaseTransaction: () => void = () => {};
+    const gate = new Promise<void>((resolve) => { releaseTransaction = resolve; });
+    const transaction = DB.$transaction(async () => {
+      await DB.query('UPDATE inside');
+      await gate;
+    });
+    await tick();
+    await DB.query('SELECT outside');
+    releaseTransaction();
+    await transaction;
+    expect(state.log).toEqual([
+      'conn2: begin',
+      'conn2: UPDATE inside',
+      'pool: SELECT outside',
+      'conn2: commit',
+      'conn2: release',
+    ]);
+  });
+
+  test('an exception rolls back, releases, and propagates', async () => {
+    await expect(DB.$transaction(async () => {
+      await DB.query('UPDATE y');
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+    expect(state.log).toEqual(['conn3: begin', 'conn3: UPDATE y', 'conn3: rollback', 'conn3: release']);
+  });
+
+  test('a nested transaction and $atomicQuery join the enclosing one', async () => {
+    await DB.$transaction(async () => {
+      await DB.$transaction(async () => {
+        await DB.query('UPDATE nested');
+      });
+      await DB.$atomicQuery([{ query: 'INSERT 1', params: [] }, { query: 'INSERT 2', params: [] }]);
+    });
+    expect(state.log).toEqual([
+      'conn4: begin',
+      'conn4: UPDATE nested',
+      'conn4: INSERT 1',
+      'conn4: INSERT 2',
+      'conn4: commit',
+      'conn4: release',
+    ]);
+  });
+});

--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -1361,13 +1361,13 @@ class DatabaseMigration {
     transactionQueries.push(this.getUpdateToLatestSchemaVersionQuery());
 
     try {
-      await this.$executeQuery('START TRANSACTION;');
-      for (const query of transactionQueries) {
-        await this.$executeQuery(query);
-      }
-      await this.$executeQuery('COMMIT;');
+      await DB.$transaction(async () => {
+        for (const query of transactionQueries) {
+          await this.$executeQuery(query);
+        }
+      });
     } catch (e) {
-      await this.$executeQuery('ROLLBACK;');
+      logger.err(`MIGRATIONS: schema update to version ${DatabaseMigration.currentVersion} failed and was rolled back`);
       throw e;
     }
   }

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import config from './config';
 import { createPool, Pool, PoolConnection } from 'mysql2/promise';
+import { AsyncLocalStorage } from 'async_hooks';
 import logger, { LogLevel } from './logger';
 import { FieldPacket, OkPacket, PoolOptions, ResultSetHeader, RowDataPacket } from 'mysql2/typings/mysql';
 import { execSync } from 'child_process';
@@ -15,6 +16,7 @@ import { execSync } from 'child_process';
     }
   }
   private pool: Pool | null = null;
+  private transactionContext = new AsyncLocalStorage<PoolConnection>();
   private poolConfig: PoolOptions = {
     port: config.DATABASE.PORT,
     database: config.DATABASE.DATABASE,
@@ -51,8 +53,9 @@ import { execSync } from 'child_process';
           reject(new Error(`DB query failed to return, reject or time out within ${hardTimeout / 1000}s - ${query?.sql?.slice(0, 160) || (typeof(query) === 'string' || query instanceof String ? query?.slice(0, 160) : 'unknown query')}`));
         }, hardTimeout);
 
-        // Use a specific connection if provided, otherwise delegate to the pool
-        const connectionPromise = connection ? Promise.resolve(connection) : this.getPool();
+        // Use a specific connection if provided, else the enclosing $transaction's, else the pool
+        const boundConnection = connection ?? this.transactionContext.getStore();
+        const connectionPromise = boundConnection ? Promise.resolve(boundConnection) : this.getPool();
         connectionPromise.then((pool: PoolConnection | Pool) => {
           return pool.query(query, params) as Promise<[T, FieldPacket[]]>;
         }).then(result => {
@@ -68,7 +71,7 @@ import { execSync } from 'child_process';
       });
     } else {
       try {
-        const pool = await this.getPool();
+        const pool = connection ?? this.transactionContext.getStore() ?? await this.getPool();
         return pool.query(query, params);
       } catch (e) {
         if (errorLogLevel !== 'silent') {
@@ -93,6 +96,20 @@ import { execSync } from 'child_process';
   public async $atomicQuery<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket |
     OkPacket[] | ResultSetHeader>(queries: { query, params }[], errorLogLevel: LogLevel | 'silent' = 'debug'): Promise<[T, FieldPacket[]][]>
   {
+    if (this.transactionContext.getStore()) {
+      // inside a $transaction: run on its connection, it commits or rolls back as a whole
+      try {
+        const results: [T, FieldPacket[]][] = [];
+        for (const query of queries) {
+          results.push(await this.query(query.query, query.params, errorLogLevel) as [T, FieldPacket[]]);
+        }
+        return results;
+      } catch (e) {
+        logger.warn('Could not complete db queries, the enclosing transaction will roll back: ' + (e instanceof Error ? e.message : e));
+        throw e;
+      }
+    }
+
     const pool = await this.getPool();
     let connection;
     try {
@@ -121,6 +138,37 @@ import { execSync } from 'child_process';
     }
   }
 
+
+  /**
+   * Run `fn` inside a database transaction on a dedicated connection. Every DB.query issued
+   * while `fn` runs, directly or through any call chain, uses that connection, so the
+   * transaction, its statements and the commit or rollback can't land on different pooled
+   * connections. Nested calls join the enclosing transaction.
+   *
+   * @asyncUnsafe
+   */
+  public async $transaction<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.transactionContext.getStore()) {
+      return fn();
+    }
+    const pool = await this.getPool();
+    const connection = await pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const result = await this.transactionContext.run(connection, fn);
+      await connection.commit();
+      return result;
+    } catch (e) {
+      try {
+        await connection.rollback();
+      } catch (rollbackError) {
+        logger.warn('Failed to rollback db transaction: ' + (rollbackError instanceof Error ? rollbackError.message : rollbackError));
+      }
+      throw e;
+    } finally {
+      connection.release();
+    }
+  }
 
   /** @asyncSafe */
   public async checkDbConnection() {

--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -89,13 +89,12 @@ class PoolsUpdater {
       }
 
       try {
-        await DB.query('START TRANSACTION;');
-        await this.updateDBSha(githubSha);
-        await poolsParser.migratePoolsJson();
-        await DB.query('COMMIT;');
+        await DB.$transaction(async () => {
+          await this.updateDBSha(githubSha);
+          await poolsParser.migratePoolsJson();
+        });
       } catch (e) {
-        logger.err(`Could not migrate mining pools, rolling back. Exception: ${JSON.stringify(e)}`, this.tag);
-        await DB.query('ROLLBACK;');
+        logger.err(`Could not migrate mining pools, rolled back. Exception: ${JSON.stringify(e)}`, this.tag);
       }
       logger.info(`Mining pools-v2.json (${githubSha}) import completed`, this.tag);
 


### PR DESCRIPTION
**Problem.** `pools-updater.ts` wraps the mining pools migration in `START TRANSACTION` and `COMMIT` sent through `DB.query`, which is `pool.query` and uses whichever pooled connection is free. When the two land on different connections (observed on a regtest backend with the default `POOL_SIZE`: `START TRANSACTION` on connection 21, `COMMIT` on 22), the transaction never commits. It keeps its row locks, so every block insert waits on the "Unknown" pool row through the `pool_id` foreign key and dies with "Lock wait timeout exceeded", and any write that later happens to go through that connection is invisible to other connections and rolled back on exit. `database-migration.ts` uses the same pattern for schema migrations.

**Solution.** Add `DB.$transaction(fn)`: it takes a dedicated connection, begins, runs `fn` with the connection bound to the async context (`AsyncLocalStorage`), commits, or rolls back and rethrows. Every `DB.query` issued while `fn` runs, at any call depth, uses that connection; queries outside it are unaffected; a nested `$transaction` or `$atomicQuery` joins the enclosing one. The pools migration and the schema migrations use it.

**Details**

- No call signatures change: the pools migration reaches `blocks.$indexBlock` through the block reindex, so threading a connection parameter was not a contained fix.
- Unit test (`database.test.ts`, mocked pool): queries outside a transaction go to the pool; queries inside, including through nested async calls, use the transaction's connection and commit in order; a concurrent query started outside does not join; an exception rolls back, releases and propagates; nested `$transaction` and `$atomicQuery` join.
- Live check on regtest with a fresh database and `POOL_SIZE` 100, the configuration that failed before: the pools import's begin and commit share a connection, blocks inserted while the indexer runs are visible from a separate client and survive a restart, no lock waits.
- Because the transaction now actually holds until commit, a pools update that re-tags many blocks holds row locks on the updated `pools` rows for its duration; a block insert referencing one of them waits until the commit. That was the intended behaviour all along and is rare (a pools.json change), but moving the block reindex out of the transaction would shorten it if it ever matters.
