### PR TITLE
Fix: Loading indicators in simpleproof cubo

### DIFF
--- a/frontend/src/app/components/simpleproof-widget/simpleproof-cubo-widget.component.html
+++ b/frontend/src/app/components/simpleproof-widget/simpleproof-cubo-widget.component.html
@@ -4,31 +4,26 @@
       <img src="/resources/cubo.svg" style="width: 1.1em; height: 1.1em; margin-right: 0.1em; transform: translateY(-0.1em);">
       {{ label }}
     </h1>
-    <div *ngIf="!widget && isLoading" class="spinner-border" role="status"></div>
   </div>
-
   <div class="clearfix"></div>
 
-  @if (isLoading) {
-    loading!
-    <div class="spinner-wrapper">
-      <div class="ms-2 spinner-border text-light" style="width: 25px; height: 25px"></div>
+  <div style="min-height: 295px">
+    <div *ngIf="!widget" class="search-container mb-3">
+      <input
+        type="text"
+        class="form-control"
+        (input)="applyFilter($event)"
+        placeholder="Search by student name or ID..."
+        i18n-placeholder="simpleproof.search_placeholder"
+        [class.disabled]="isLoading"
+      >
     </div>
-  } @else if (error || !verified.length) {
+
+  @if (!isLoading && (error || !verified.length)) {
     <div class="error-wrapper">
       <span>temporarily unavailable</span>
     </div>
   } @else {
-    <div style="min-height: 295px">
-      <div *ngIf="!widget" class="search-container mb-3">
-        <input
-          type="text"
-          class="form-control"
-          (input)="applyFilter($event)"
-          placeholder="Search by student name or ID..."
-          i18n-placeholder="simpleproof.search_placeholder"
-        >
-      </div>
       <table class="table table-borderless table-fixed">
         <thead>
           <tr>
@@ -49,7 +44,7 @@
             <th class="proof text-end" [ngClass]="{'widget': widget}" i18n="simpleproof.proof">Proof</th>
           </tr>
         </thead>
-        <tbody *ngIf="verifiedPage; else skeleton" [style]="isLoading ? 'opacity: 0.75' : ''">
+        <tbody>
           <tr *ngIf="widget" class="search-row">
             <td colspan="3" class="p-0" style="padding: 0 0 6px !important;">
               <div class="search-container">
@@ -59,63 +54,66 @@
                   (input)="applyFilter($event)"
                   placeholder="Search by student name or ID..."
                   i18n-placeholder="simpleproof.search_placeholder"
+                  [class.disabled]="isLoading"
                 >
               </div>
             </td>
           </tr>
-          <tr *ngFor="let item of verifiedPage">
-            @if (widget) {
-              <td class="student text-start" [class]="widget ? 'widget' : ''">
-                @if (item.sanitized_download_url) {
-                  <a [href]="item.sanitized_download_url" target="_blank">
-                    <span>{{ item.student_name }}</span>
-                    <span class="icon ms-2">
-                      <fa-icon [icon]="['fas', 'file-pdf']" [fixedWidth]="true"></fa-icon>
-                    </span>
-                  </a>
-                } @else {
-                  {{ item.student_name }}
-                }
-              </td>
-            } @else {
-              <td class="student text-start" [class]="widget ? 'widget' : ''">{{ item.student_name }}</td>
-              <td class="id text-start" [class]="widget ? 'widget' : ''">
-                @if (item.sanitized_download_url) {
-                  <a [href]="item.sanitized_download_url" target="_blank">
-                    <span>{{ item.id_code }}</span>
-                    <span class="icon ms-2">
-                      <fa-icon [icon]="['fas', 'file-pdf']" [fixedWidth]="true"></fa-icon>
-                    </span>
-                  </a>
-                } @else {
-                  {{ item.id_code }}
-                }
-              </td>
-            }
-            <td class="proof text-end" [class]="widget ? 'widget' : ''">
-              <a [href]="item.sanitized_simpleproof_url" target="_blank" class="badge badge-verify" style="font-size: 1.035em;">
-                <span class="icon">
-                  <img class="icon-img" src="/resources/sp.svg">
-                </span>
-                <span i18n="simpleproof.verify">Verify</span>
-              </a>
-            </td>
-          </tr>
-        </tbody>
-        <ng-template #skeleton>
-          <tbody>
-            <tr *ngFor="let item of [].constructor(itemsPerPage)">
-              <td class="filename text-start" [ngClass]="{'widget': widget}">
-                <span class="skeleton-loader" style="max-width: 75px"></span>
-              </td>
-              <td class="id text-start" [ngClass]="{'widget': widget}">
-                <span class="skeleton-loader" style="max-width: 75px"></span>
-              </td>
-              <td class="proof text-end" [ngClass]="{'widget': widget}">
-                <span class="skeleton-loader" style="max-width: 75px"></span>
+          @if (verifiedPage && !isLoading) {
+            <tr *ngFor="let item of verifiedPage">
+              @if (widget) {
+                <td class="student text-start" [class]="widget ? 'widget' : ''">
+                  @if (item.sanitized_download_url) {
+                    <a [href]="item.sanitized_download_url" target="_blank">
+                      <span>{{ item.student_name }}</span>
+                      <span class="icon ms-2">
+                        <fa-icon [icon]="['fas', 'file-pdf']" [fixedWidth]="true"></fa-icon>
+                      </span>
+                    </a>
+                  } @else {
+                    {{ item.student_name }}
+                  }
+                </td>
+              } @else {
+                <td class="student text-start" [class]="widget ? 'widget' : ''">{{ item.student_name }}</td>
+                <td class="id text-start" [class]="widget ? 'widget' : ''">
+                  @if (item.sanitized_download_url) {
+                    <a [href]="item.sanitized_download_url" target="_blank">
+                      <span>{{ item.id_code }}</span>
+                      <span class="icon ms-2">
+                        <fa-icon [icon]="['fas', 'file-pdf']" [fixedWidth]="true"></fa-icon>
+                      </span>
+                    </a>
+                  } @else {
+                    {{ item.id_code }}
+                  }
+                </td>
+              }
+              <td class="proof text-end" [class]="widget ? 'widget' : ''">
+                <a [href]="item.sanitized_simpleproof_url" target="_blank" class="badge badge-verify" style="font-size: 1.035em;">
+                  <span class="icon">
+                    <img class="icon-img" src="/resources/sp.svg">
+                  </span>
+                  <span i18n="simpleproof.verify">Verify</span>
+                </a>
               </td>
             </tr>
-          </tbody>
+          } @else {
+            <ng-container *ngTemplateOutlet="skeleton"></ng-container>
+          }
+        </tbody>
+        <ng-template #skeleton>
+          <tr *ngFor="let item of [].constructor(itemsPerPage)">
+            <td class="filename text-start" [ngClass]="{'widget': widget}">
+              <span class="skeleton-loader" style="max-width: 250px"></span>
+            </td>
+            <td class="id text-start" [ngClass]="{'widget': widget}">
+              <span class="skeleton-loader" style="max-width: 150px"></span>
+            </td>
+            <td class="proof text-end" [ngClass]="{'widget': widget}">
+              <span class="skeleton-loader" style="max-width: 125px"></span>
+            </td>
+          </tr>
         </ng-template>
       </table>
 
@@ -128,6 +126,6 @@
         <div class="clearfix"></div>
         <br>
       </ng-template>
-    </div>
   }
+  </div>
 </div>


### PR DESCRIPTION
closes #6698 

This PR implements skeleton loaders in https://bitcoin.gob.sv/sp/cubo in both widget and full page

https://github.com/user-attachments/assets/4f3b526b-38bb-47c6-aa3d-b91773cc312a
