### PR TITLE
fix: address treemap shrink

### DIFF
--- a/frontend/src/app/components/wallet/wallet.component.scss
+++ b/frontend/src/app/components/wallet/wallet.component.scss
@@ -6,8 +6,13 @@
 }
 
 .treemap-col {
-  width: 45%;
+  width: 100%;
   height: 300px;
+  margin-top: 1em;
+  @media (min-width: 768px){
+    width: 45%;
+    margin-top: 0px;
+  }
 }
 
 .fiat {


### PR DESCRIPTION
closes #6707 

<img width="422" height="772" alt="Screenshot 2026-09-03 at 2 50 45 AM" src="https://github.com/user-attachments/assets/76f05616-93a4-43b5-859b-ce398649c90f" />

