### PR TITLE
Fix OP_RETURN toggle on address page

### DIFF
--- a/frontend/src/app/components/transactions-list/transactions-list.component.html
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.html
@@ -362,13 +362,13 @@
                         } @else {
                           <a placement="bottom" style="cursor: pointer;">
                             @if ((vout.scriptpubkey_asm | hex2ascii).length > 200) {
-                              <span *ngIf="vout.scriptpubkey_asm !== 'OP_RETURN'" class="badge bg-secondary scriptmessage opreturn-msg" (click)="toggleShowFullOpReturnPreview(vindex)">{{ vout.scriptpubkey_asm | hex2ascii | slice:0:200 }}</span>
+                              <span *ngIf="vout.scriptpubkey_asm !== 'OP_RETURN'" class="badge bg-secondary scriptmessage opreturn-msg" (click)="toggleShowFullOpReturnPreview(tx.txid, vindex)">{{ vout.scriptpubkey_asm | hex2ascii | slice:0:200 }}</span>
                               <ng-container *ngIf="(showDetails$ | async) === false">
                                 @if ((vout.scriptpubkey_asm | hex2ascii).length > 200) {
-                                  @if (!showFullOpReturnPreview[vindex]) {
-                                    <span class="badge bg-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show more</span>
+                                  @if (!showFullOpReturnPreview[tx.txid + '-vout-' + vindex]) {
+                                    <span class="badge bg-primary" (click)="toggleShowFullOpReturnPreview(tx.txid, vindex)">Show more</span>
                                   } @else {
-                                    <span class="badge bg-primary" (click)="toggleShowFullOpReturnPreview(vindex)">Show less</span>
+                                    <span class="badge bg-primary" (click)="toggleShowFullOpReturnPreview(tx.txid, vindex)">Show less</span>
                                   }
                                 }
                               </ng-container>
@@ -426,7 +426,7 @@
                     <app-ord-data [runestone]="showOrdData[tx.txid + '-vout-' + vindex]['runestone']" [runeInfo]="showOrdData[tx.txid + '-vout-' + vindex]['runeInfo']" [type]="'vout'"></app-ord-data>
                 </td>
               </tr>
-              <tr *ngIf="vout.scriptpubkey_type === 'op_return' && showFullOpReturnPreview[vindex]" [ngClass]="{
+              <tr *ngIf="vout.scriptpubkey_type === 'op_return' && showFullOpReturnPreview[tx.txid + '-vout-' + vindex]" [ngClass]="{
                 'assetBox': assetsMinimal && assetsMinimal[vout.asset] && vout.scriptpubkey_address && tx.vin && !tx.vin[0].is_coinbase && tx._unblinded || outputIndex === vindex,
                 'highlight': addresses?.length && (addresses.includes(vout.scriptpubkey_address)),
                 'sigged': selectedSig && selectedSig.txIndex === i && sigHighlights.vout[vindex],
@@ -472,16 +472,16 @@
                       <tr *ngIf="vout.scriptpubkey_type == 'op_return'">
                         <td>OP_RETURN <span>data</span></td>
                         <td style="text-align: left; word-break: break-word; white-space: pre-line;">
-                          @if (!showFullOpReturnData[vindex]) {
+                          @if (!showFullOpReturnData[tx.txid + '-vout-' + vindex]) {
                             {{ (vout.scriptpubkey_asm | hex2ascii | slice:0:1000) }}
                           } @else {
                             {{ vout.scriptpubkey_asm | hex2ascii }}
                           }
                           <div *ngIf="(vout.scriptpubkey_asm | hex2ascii).length > 1000" style="display: flex;">
-                            <span *ngIf="!showFullOpReturnData[vindex]">...</span>
-                            <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullOpReturnData(vindex)" style="margin-left: auto;">
-                              <span *ngIf="!showFullOpReturnData[vindex]" i18n="show-all">Show all</span>
-                              <span *ngIf="showFullOpReturnData[vindex]" i18n="show-less">Show less</span>
+                            <span *ngIf="!showFullOpReturnData[tx.txid + '-vout-' + vindex]">...</span>
+                            <label class="btn btn-sm btn-primary mt-2" (click)="toggleShowFullOpReturnData(tx.txid, vindex)" style="margin-left: auto;">
+                              <span *ngIf="!showFullOpReturnData[tx.txid + '-vout-' + vindex]" i18n="show-all">Show all</span>
+                              <span *ngIf="showFullOpReturnData[tx.txid + '-vout-' + vindex]" i18n="show-less">Show less</span>
                             </label>
                           </div>
                         </td>

--- a/frontend/src/app/components/transactions-list/transactions-list.component.ts
+++ b/frontend/src/app/components/transactions-list/transactions-list.component.ts
@@ -67,8 +67,8 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
   showFullWitness: { [vinIndex: number]: { [witnessIndex: number]: boolean } } = {};
   showFullScriptPubkeyAsm: { [voutIndex: number]: boolean } = {};
   showFullScriptPubkeyHex: { [voutIndex: number]: boolean } = {};
-  showFullOpReturnData: { [voutIndex: number]: boolean } = {};
-  showFullOpReturnPreview: { [voutIndex: number]: boolean } = {};
+  showFullOpReturnData: { [key: string]: boolean } = {};
+  showFullOpReturnPreview: { [key: string]: boolean } = {};
   showTaprootControlBlock: { [vinIndex: number]: boolean } = {};
   showOrdData: { [key: string]: { show: boolean; inscriptions?: Inscription[]; runestone?: Runestone, runeInfo?: { [id: string]: { etching: Etching; txid: string; } }; } } = {};
   similarityMatches: Map<string, Map<string, { score: number, match: AddressMatch, group: number }>> = new Map();
@@ -614,12 +614,14 @@ export class TransactionsListComponent implements OnInit, OnChanges, OnDestroy {
     this.showFullScriptPubkeyHex[voutIndex] = !this.showFullScriptPubkeyHex[voutIndex];
   }
 
-  toggleShowFullOpReturnData(voutIndex: number): void {
-    this.showFullOpReturnData[voutIndex] = !this.showFullOpReturnData[voutIndex];
+  toggleShowFullOpReturnData(txid: string, voutIndex: number): void {
+    const key = txid + '-vout-' + voutIndex;
+    this.showFullOpReturnData[key] = !this.showFullOpReturnData[key];
   }
 
-  toggleShowFullOpReturnPreview(voutIndex: number): void {
-    this.showFullOpReturnPreview[voutIndex] = !this.showFullOpReturnPreview[voutIndex];
+  toggleShowFullOpReturnPreview(txid: string, voutIndex: number): void {
+    const key = txid + '-vout-' + voutIndex;
+    this.showFullOpReturnPreview[key] = !this.showFullOpReturnPreview[key];
   }
 
   toggleTaprootControlBlock(vinIndex: number): void {


### PR DESCRIPTION
On the address page, expanding an OP_RETURN also expands OP_RETURNs at the same output index in other transactions:

https://github.com/user-attachments/assets/9202ad36-0604-4bcc-a845-3476833f3763

This PR fixes this by using the same approach as inscriptions and runestones (include the txid in the toggle key).