### PR TITLE
fix: skip fee calculation for coinbase txs in $convertTransaction

### DIFF
--- a/backend/src/api/bitcoin/bitcoin-api.ts
+++ b/backend/src/api/bitcoin/bitcoin-api.ts
@@ -367,6 +367,10 @@ class BitcoinApi implements AbstractBitcoinApi {
       };
     }
 
+    if (esploraTransaction.vin[0].is_coinbase) {
+      return esploraTransaction;
+    }
+
     if (addPrevout) {
       try {
         esploraTransaction = await this.$calculateFeeFromInputs(esploraTransaction, false, lazyPrevouts);


### PR DESCRIPTION
closes #6706 

In #6648 I tried to use bitcoinCoreApi to get the coinbaseTx of a stale block, which bitcoin core does recognize, but `$convertTransaction` fee calculation failed on `getMempoolEntry` from `appendMempoolFeeData` since the tx is not confirmed nor in mempool ofc, so if the transaction is coinbase we skip the fee calculation at all.