### PR TITLE
Hide liquid incident alert when network restarts

### DIFF
--- a/frontend/src/app/shared/components/liquid-incident-alert/liquid-incident-alert.component.html
+++ b/frontend/src/app/shared/components/liquid-incident-alert/liquid-incident-alert.component.html
@@ -1,4 +1,4 @@
-<div class="container p-lg-0 pb-0" style="max-width: 100%; margin-top: 7px" *ngIf="storageService.getValue('hideLiquidIncidentWarning') !== 'hidden'">
+<div class="container p-lg-0 pb-0" style="max-width: 100%; margin-top: 7px" *ngIf="(showWarning$ | async) && storageService.getValue('hideLiquidIncidentWarning') !== 'hidden'">
   <div class="alert alert-danger alert-dismissible mb-0 text-center" role="alert">
     <div class="message-container">
       <span i18n="liquid-incident-warning">Liquid Network activity is currently paused due to a security incident. For more updates follow <a href="https://x.com/Liquid_BTC" target="_blank" rel="noopener">@Liquid_BTC</a>.</span>

--- a/frontend/src/app/shared/components/liquid-incident-alert/liquid-incident-alert.component.ts
+++ b/frontend/src/app/shared/components/liquid-incident-alert/liquid-incident-alert.component.ts
@@ -1,4 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { map } from 'rxjs';
+import { StateService } from '@app/services/state.service';
 import { StorageService } from '@app/services/storage.service';
 
 @Component({
@@ -9,8 +11,9 @@ import { StorageService } from '@app/services/storage.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LiquidIncidentAlertComponent {
+  showWarning$ = this.stateService.chainTip$.pipe(map(height => height >= 0 && height <= 4050335));
 
-  constructor(public storageService: StorageService) { }
+  constructor(public storageService: StorageService, private stateService: StateService) { }
 
   dismissWarning(): void {
     this.storageService.setValue('hideLiquidIncidentWarning', 'hidden');


### PR DESCRIPTION
This PR hides the Liquid incident banner once the tip is > 4050335 and the network resumes.