### PR TITLE
optimize liquid audit

### DIFF
--- a/backend/src/api/liquid/elements-parser.ts
+++ b/backend/src/api/liquid/elements-parser.ts
@@ -18,6 +18,18 @@ interface FederationAddress {
   blocknumber: number;
 }
 
+interface AuditUtxo {
+  unspent: number;
+  txid: string;
+  txindex: number;
+  bitcoinaddress: string;
+  amount: number;
+  blocknumber: number;
+  timelock: number;
+  expiredAt: number;
+  lastblockupdate: number;
+}
+
 class ElementsParser {
   private isRunning = false;
   private federationPegScripts: FederationAddress[] = [];
@@ -115,7 +127,8 @@ class ElementsParser {
       const params_utxos: (string | number)[] = [bitcointxid, bitcoinindex, bitcoinaddress, amount, bitcoinblock, bitcoinBlockTime, 1, bitcoinblock - 1, 0, pegInTimelock, 0, 0, txid, txindex, blockTime];
       await DB.query(query_utxos, params_utxos);
       const [minBlockUpdate] = await DB.query(`SELECT MIN(lastblockupdate) AS lastblockupdate FROM federation_txos WHERE unspent = 1`);
-      await this.$saveLastBlockAuditToDatabase(minBlockUpdate[0]['lastblockupdate']);
+      const heightToAudit = minBlockUpdate[0]['lastblockupdate'];
+      await DB.query(`UPDATE state SET number = ? WHERE name = 'last_bitcoin_block_audit' AND (number IS NULL OR number = 0 OR number > ?)`, [heightToAudit, heightToAudit]);
       logger.debug(`Saved new Federation UTXO ${bitcointxid}:${bitcoinindex} belonging to ${bitcoinaddress} to federation txos`);
 
     }
@@ -259,7 +272,7 @@ class ElementsParser {
 
   public async $updateFederationUtxos(stopAt: number) {
     try {
-      let auditProgress = await this.$getAuditProgress();
+      const auditProgress = await this.$getAuditProgress();
       if (!auditProgress.lastBlockAudit && !auditProgress.lastBlockScanned) {
         logger.debug(`No Federation UTXOs found in the database. Waiting for some to be confirmed before starting the Federation UTXOs audit`);
         return;
@@ -274,9 +287,35 @@ class ElementsParser {
 
       if (!auditProgress.lastBlockScanned) {
         auditProgress.lastBlockScanned = auditProgress.lastBlockAudit;
-        await this.$saveLastBlockScannedToDatabase(auditProgress.lastBlockScanned);
       }
       let height = Math.min(auditProgress.lastBlockAudit || auditProgress.lastBlockScanned, auditProgress.lastBlockScanned) + 1;
+      if (height > auditProgress.confirmedTip) {
+        return;
+      }
+
+      // Keep the unspent UTXOs in memory, bucketed by the last block they were updated in
+      const utxosByHeight = new Map<number, AuditUtxo[]>();
+      for (const utxo of await this.$getFederationUtxosToScan(height)) {
+        // Replay persisted spends and outputs inserted before an interrupted block finished
+        if (utxo.unspent === 0 || (utxo.lastblockupdate === utxo.blocknumber && utxo.blocknumber >= height)) {
+          utxo.lastblockupdate--;
+        }
+        this.bucketFederationUtxo(utxosByHeight, utxo);
+      }
+      let checkpointBlocks = 0;
+      let checkpointTime = Date.now();
+
+      // Get the peg-out addresses that need to be scanned
+      const redeemAddresses = await this.$getRedeemAddressesToScan();
+      const redeemAddressesByAddress = new Map<string, any[]>();
+      for (const redeemAddress of redeemAddresses) {
+        const entries = redeemAddressesByAddress.get(redeemAddress.bitcoinaddress);
+        if (entries) {
+          entries.push(redeemAddress);
+        } else {
+          redeemAddressesByAddress.set(redeemAddress.bitcoinaddress, [redeemAddress]);
+        }
+      }
 
       // Logging
       let indexedThisRun = 0;
@@ -288,30 +327,19 @@ class ElementsParser {
         const forceFullBlockScan = height > auditProgress.lastBlockScanned;
 
         // First, get the current UTXOs that need to be scanned in the block
-        const utxos = await this.$getFederationUtxosToScan(height);
-
-        // Get the peg-out addresses that need to be scanned
-        const redeemAddresses = await this.$getRedeemAddressesToScan();
-        const redeemAddressesByAddress = new Map<string, any[]>();
-        for (const redeemAddress of redeemAddresses) {
-          const entries = redeemAddressesByAddress.get(redeemAddress.bitcoinaddress);
-          if (entries) {
-            entries.push(redeemAddress);
-          } else {
-            redeemAddressesByAddress.set(redeemAddress.bitcoinaddress, [redeemAddress]);
-          }
-        }
+        const utxos = utxosByHeight.get(height - 1) || [];
+        utxosByHeight.delete(height - 1);
 
         // The fast way: check if these UTXOs are still unspent as of the current block with gettxout
         let spentAsTip: Map<string, any>;
         let unspentAsTip: Map<string, any>;
-        if (!forceFullBlockScan || auditProgress.confirmedTip - height <= 150) { // If the audit status is not too far in the past, we can use gettxout (fast way)
+        if (!forceFullBlockScan) {
           const utxosToParse = await this.$getFederationUtxosToParse(utxos);
           spentAsTip = utxosToParse.spentAsTip;
           unspentAsTip = utxosToParse.unspentAsTip;
           logger.debug(`Found ${utxos.length} Federation UTXOs and ${redeemAddresses.length} Peg-Out Addresses to scan in Bitcoin block height #${height} / #${auditProgress.confirmedTip}`);
           logger.debug(`${unspentAsTip.size} / ${utxos.length} Federation UTXOs are unspent as of tip`);
-        } else { // If the audit status is too far in the past, it is useless and wasteful to look for still unspent txos since they will all be spent as of the tip
+        } else { // Unscanned blocks are parsed in full anyway, so every UTXO can be checked against the block instead of gettxout
           spentAsTip = new Map<string, any>(utxos.map(utxo => [`${utxo.txid}:${utxo.txindex}`, utxo]));
           unspentAsTip = new Map<string, any>();
 
@@ -340,20 +368,24 @@ class ElementsParser {
         } else {
           block = await bitcoinSecondClient.getBlockHeader(blockHash, true);
         }
-        await this.$updateFederationUtxoProgress(block, spentAsTip, unspentAsTip, auditProgress.confirmedTip);
+        await this.$updateFederationUtxoProgress(block, spentAsTip, unspentAsTip, auditProgress.confirmedTip, utxosByHeight);
         if (forceFullBlockScan) {
-          await this.$saveLastBlockScannedToDatabase(height);
+          auditProgress.lastBlockScanned = height;
         }
 
-        // Finally, update the lastblockupdate of the remaining UTXOs and save to the database
-        const [minBlockUpdate] = await DB.query(`SELECT MIN(lastblockupdate) AS lastblockupdate FROM federation_txos WHERE unspent = 1`);
-        await this.$saveLastBlockAuditToDatabase(minBlockUpdate[0]['lastblockupdate'] ?? auditProgress.confirmedTip);
-
-        auditProgress = await this.$getAuditProgress();
+        auditProgress.lastBlockAudit = Math.min(auditProgress.confirmedTip, ...utxosByHeight.keys());
         height = Math.min(auditProgress.lastBlockAudit, auditProgress.lastBlockScanned) + 1;
         indexedThisRun++;
+        checkpointBlocks++;
+        const stopping = (Date.now() / 1000) >= stopAt;
 
-        if ((Date.now() / 1000) >= stopAt) {
+        if (checkpointBlocks >= 25 || Date.now() - checkpointTime >= 5000 || stopping || height > auditProgress.confirmedTip) {
+          await this.$saveAuditCheckpoint(auditProgress);
+          checkpointBlocks = 0;
+          checkpointTime = Date.now();
+        }
+
+        if (stopping) {
           logger.debug(`Reached max federation audit runtime, pausing audit to let Liquid parsing run and resuming later`);
           break;
         }
@@ -364,12 +396,21 @@ class ElementsParser {
     }
   }
 
-  // Get the UTXOs that need to be scanned in block height (UTXOs that were last updated in the block height - 1)
+  // Include spent outputs from the interval that may need replay after an interrupted run
   /** @asyncUnsafe */
-  protected async $getFederationUtxosToScan(height: number) {
-    const query = `SELECT txid, txindex, bitcoinaddress, amount, blocknumber, timelock, expiredAt FROM federation_txos WHERE lastblockupdate = ? AND unspent = 1`;
-    const [rows] = await DB.query(query, [height - 1]);
-    return rows as any[];
+  protected async $getFederationUtxosToScan(height: number): Promise<AuditUtxo[]> {
+    const query = `SELECT txid, txindex, bitcoinaddress, amount, blocknumber, timelock, expiredAt, lastblockupdate, unspent FROM federation_txos WHERE unspent = 1 OR (unspent = 0 AND lastblockupdate >= ?)`;
+    const [rows] = await DB.query(query, [height]);
+    return rows as AuditUtxo[];
+  }
+
+  protected bucketFederationUtxo(utxosByHeight: Map<number, AuditUtxo[]>, utxo: AuditUtxo): void {
+    const bucket = utxosByHeight.get(utxo.lastblockupdate);
+    if (bucket) {
+      bucket.push(utxo);
+    } else {
+      utxosByHeight.set(utxo.lastblockupdate, [utxo]);
+    }
   }
 
   // Returns the UTXOs that are spent as of tip and need to be scanned
@@ -448,6 +489,10 @@ class ElementsParser {
           // Find the number of times output.scriptPubKey.address appears in the candidates. There can be address reuse for peg-outs...
           const matchingAddress: any[] = redeemCandidates.filter(redeemAddress => -redeemAddress.amount === Math.round(output.value * 100000000));
           if (matchingAddress.length > 0) {
+            const [redeemed] = await DB.query(`SELECT 1 FROM elements_pegs WHERE bitcointxid = ? AND bitcoinindex = ? AND amount < 0 LIMIT 1`, [tx.txid, output.n]) as any[];
+            if (redeemed.length > 0) {
+              continue;
+            }
             if (matchingAddress.length > 1) {
               // If there are more than one peg out address with the same amount, we can't know which one redeemed the UTXO: we take the oldest one
               matchingAddress.sort((a, b) => a.datetime - b.datetime);
@@ -455,7 +500,7 @@ class ElementsParser {
             } else {
               logger.debug(`Found redeem txid ${tx.txid}:${output.n} to peg-out address ${matchingAddress[0].bitcoinaddress}, amount ${matchingAddress[0].amount}`);
             }
-            const query_add_redeem = `UPDATE elements_pegs SET bitcointxid = ?, bitcoinindex = ? WHERE bitcoinaddress = ? AND amount = ? AND datetime = ?`;
+            const query_add_redeem = `UPDATE elements_pegs SET bitcointxid = ?, bitcoinindex = ? WHERE bitcoinaddress = ? AND amount = ? AND datetime = ? AND bitcointxid = ''`;
             const params_add_redeem: (string | number)[] = [tx.txid, output.n, matchingAddress[0].bitcoinaddress, matchingAddress[0].amount, matchingAddress[0].datetime];
             await DB.query(query_add_redeem, params_add_redeem);
             const index = redeemCandidates.indexOf(matchingAddress[0]);
@@ -474,24 +519,41 @@ class ElementsParser {
   }
 
   /** @asyncUnsafe */
-  protected async $updateFederationUtxoProgress(block: Pick<IBitcoinApi.Block, 'height' | 'time'>, spentAsTip: Map<string, any>, unspentAsTip: Map<string, any>, confirmedTip: number) {
+  protected async $updateFederationUtxoProgress(block: Pick<IBitcoinApi.Block, 'height' | 'time'>, spentAsTip: Map<string, AuditUtxo>, unspentAsTip: Map<string, AuditUtxo>, confirmedTip: number, utxosByHeight: Map<number, AuditUtxo[]>) {
+    // UTXOs that keep walking block by block all share the same lastblockupdate, which is only saved at the next checkpoint
     for (const utxo of spentAsTip.values()) {
+      utxo.lastblockupdate = block.height;
       if (utxo.expiredAt === 0 && block.height >= utxo.blocknumber + utxo.timelock) { // The UTXO is expiring in this block
+        utxo.expiredAt = block.time;
         await DB.query(`UPDATE federation_txos SET lastblockupdate = ?, expiredAt = ? WHERE txid = ? AND txindex = ?`, [block.height, block.time, utxo.txid, utxo.txindex]);
-      } else {
-        await DB.query(`UPDATE federation_txos SET lastblockupdate = ? WHERE txid = ? AND txindex = ?`, [block.height, utxo.txid, utxo.txindex]);
       }
     }
 
     for (const utxo of unspentAsTip.values()) {
+      utxo.lastblockupdate = confirmedTip;
       if (utxo.expiredAt === 0 && block.height >= utxo.blocknumber + utxo.timelock) { // The UTXO is expiring in this block
+        utxo.expiredAt = block.time;
         await DB.query(`UPDATE federation_txos SET lastblockupdate = ?, expiredAt = ? WHERE txid = ? AND txindex = ?`, [confirmedTip, block.time, utxo.txid, utxo.txindex]);
       } else if (utxo.expiredAt === 0 && confirmedTip >= utxo.blocknumber + utxo.timelock) { // The UTXO is expiring before the tip: we need to keep track of it
+        utxo.lastblockupdate = utxo.blocknumber + utxo.timelock - 1;
         await DB.query(`UPDATE federation_txos SET lastblockupdate = ? WHERE txid = ? AND txindex = ?`, [utxo.blocknumber + utxo.timelock - 1, utxo.txid, utxo.txindex]);
       } else {
       await DB.query(`UPDATE federation_txos SET lastblockupdate = ? WHERE txid = ? AND txindex = ?`, [confirmedTip, utxo.txid, utxo.txindex]);
       }
     }
+
+    for (const utxo of [...spentAsTip.values(), ...unspentAsTip.values()]) {
+      this.bucketFederationUtxo(utxosByHeight, utxo);
+    }
+  }
+
+  // Every unspent UTXO still behind the scan height has been walked up to it since the last checkpoint
+  /** @asyncUnsafe */
+  protected async $saveAuditCheckpoint(auditProgress: { lastBlockAudit: number; lastBlockScanned: number }): Promise<void> {
+    const height = Math.min(auditProgress.lastBlockAudit, auditProgress.lastBlockScanned);
+    await DB.query(`UPDATE federation_txos SET lastblockupdate = ? WHERE unspent = 1 AND lastblockupdate < ?`, [height, height]);
+    await this.$saveLastBlockAuditToDatabase(auditProgress.lastBlockAudit);
+    await this.$saveLastBlockScannedToDatabase(auditProgress.lastBlockScanned);
   }
 
   /** @asyncUnsafe */


### PR DESCRIPTION
significantly speeds up the bulk phase of the liquid federation audit by writing a single UPDATE at periodic checkpoints instead of updating every tracked UTXO separately on every block, and holding tracked UTXOs in memory instead of querying everything again on every block.

