### PR TITLE
Add time indication to OP_CSV in script

### DIFF
--- a/frontend/src/app/shared/components/asm/asm.component.html
+++ b/frontend/src/app/shared/components/asm/asm.component.html
@@ -2,8 +2,8 @@
   @for (instruction of instructions; track instruction.instruction; let i = $index) {
     <span [class]='opcodeStyles.get(instruction.instruction)'>OP_{{instruction.instruction}}</span>
     @for (arg of instruction.args; track arg; let j = $index) {
-      @if (j === 0 && arg && instruction.cltvTimestamp !== undefined) {
-        <span class="cltv" [ngbTooltip]="formatTimestamp(instruction.cltvTimestamp)">
+      @if (j === 0 && arg && instruction.timelockTooltip !== undefined) {
+        <span class="timelock" [ngbTooltip]="instruction.timelockTooltip">
           <fa-icon [icon]="['fas', 'clock']" [fixedWidth]="true"></fa-icon>
         </span>
         {{ arg }}

--- a/frontend/src/app/shared/components/asm/asm.component.scss
+++ b/frontend/src/app/shared/components/asm/asm.component.scss
@@ -57,7 +57,7 @@
 	margin-right: -4px;
 }
 
-.cltv {
+.timelock {
 	margin-left: 4px;
 	margin-right: -4px;
 }

--- a/frontend/src/app/shared/components/asm/asm.component.ts
+++ b/frontend/src/app/shared/components/asm/asm.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/core';
 import { SigInfo, SighashLabels } from '@app/shared/transaction.utils';
-import { detectCltvTimestamps, formatCltvTimestamp } from '@app/shared/script.utils';
+import { detectTimelockTooltips } from '@app/shared/script.utils';
 
 @Component({
   selector: 'app-asm',
@@ -24,7 +24,7 @@ export class AsmComponent {
   @Output() showSigInfo = new EventEmitter<SigInfo>();
   @Output() hideSigInfo = new EventEmitter<void>();
 
-  instructions: { instruction: string, args: string[], cltvTimestamp?: number }[] = [];
+  instructions: { instruction: string, args: string[], timelockTooltip?: string }[] = [];
   sighashLabels: Record<number, string> = SighashLabels;
 
   ngOnInit(): void {
@@ -40,7 +40,7 @@ export class AsmComponent {
   parseASM(): void {
     const allInstructions = this.asm.split('OP_').filter(instruction => instruction.trim() !== '');
 
-    const cltvTimestamps = detectCltvTimestamps(allInstructions);
+    const timelockTooltips = detectTimelockTooltips(allInstructions);
 
     let instructions = allInstructions;
     // trim instructions to a whole number of instructions with at most `crop` characters total
@@ -84,7 +84,7 @@ export class AsmComponent {
       return {
         instruction: instructionName,
         args: args,
-        cltvTimestamp: cltvTimestamps.get(index)
+        timelockTooltip: timelockTooltips.get(index)
       };
     });
   }
@@ -96,8 +96,6 @@ export class AsmComponent {
   doHideSigInfo(): void {
     this.hideSigInfo.emit();
   }
-
-  readonly formatTimestamp = formatCltvTimestamp;
 
   readonly opcodeStyles: Map<string, string> = new Map([
     // Constants

--- a/frontend/src/app/shared/script.utils.ts
+++ b/frontend/src/app/shared/script.utils.ts
@@ -1,5 +1,4 @@
-import { Vin } from '../interfaces/electrs.interface';
-import { AddressType, detectAddressType } from './address-utils';
+import { dates } from './i18n/dates';
 import { ParsedTaproot } from './transaction.utils';
 
 const opcodes = {
@@ -561,9 +560,9 @@ export function isPoint(pointHex: string): boolean {
 export const LOCKTIME_THRESHOLD = 500000000;
 
 /**
- * Detects OP_CLTV operands in an ASM instruction list.
+ * Detects OP_CLTV and OP_CSV operands in an ASM instruction list.
  *
- * Returns a map of instruction index -> locktime value, keyed on the push that
+ * Returns a map of instruction index -> tooltip, keyed on the push that
  * carries the operand.
  *
  * Assumes the standard pattern of a 1-5 byte data push immediately followed by
@@ -573,10 +572,14 @@ export const LOCKTIME_THRESHOLD = 500000000;
  * as an unsigned little-endian integer; this is purely a display hint, not
  * consensus validation.
  *
+ * For OP_CSV: the highest bit of the last byte is the sign, negative values display as invalid.
+ * Bit 31 disables the check, the low 16 bits give the delay in blocks
+ * or in 512-second units if bit 22 is set.
+ *
  * @param instructions ASM instructions (already split on 'OP_')
  */
-export function detectCltvTimestamps(instructions: string[]): Map<number, number> {
-  const cltvTimestamps: Map<number, number> = new Map();
+export function detectTimelockTooltips(instructions: string[]): Map<number, string> {
+  const timelockTooltips: Map<number, string> = new Map();
   for (let i = 0; i < instructions.length; i++) {
     const instruction = instructions[i];
     const parts = instruction.split(' ');
@@ -591,17 +594,53 @@ export function detectCltvTimestamps(instructions: string[]): Map<number, number
       if (args[0].length === expectedLength && /^[0-9a-fA-F]+$/.test(args[0])) {
         if (i + 1 < instructions.length) {
           const nextOpcode = instructions[i + 1].split(' ')[0];
-          if (nextOpcode === 'CLTV') {
+          if (nextOpcode === 'CLTV' || nextOpcode === 'CSV') {
             const bytes = args[0].match(/.{2}/g) || [];
             const littleEndianValue = bytes.reverse().join('');
-            const timestamp = parseInt(littleEndianValue, 16);
-            cltvTimestamps.set(i, timestamp);
+            const value = parseInt(littleEndianValue, 16);
+            if (nextOpcode === 'CSV') {
+              const signBit = 2 ** (byteCount * 8 - 1);
+              const sequence = value >= signBit ? -(value - signBit) : value;
+              timelockTooltips.set(i, formatCsvSequence(sequence));
+            } else {
+              timelockTooltips.set(i, formatCltvTimestamp(value));
+            }
           }
         }
       }
     }
   }
-  return cltvTimestamps;
+  return timelockTooltips;
+}
+
+/** Formats a BIP68/112 operand as a relative block count or time interval */
+export function formatCsvSequence(sequence: number): string {
+  if (!Number.isInteger(sequence) || sequence < 0 || sequence > 0x7fffffffff) {
+    return 'Invalid relative locktime';
+  }
+  if (sequence & 0x80000000) {
+    return 'Relative locktime disabled (CSV acts as NOP)';
+  }
+  const value = sequence & 0xffff;
+  if (!(sequence & 0x00400000)) {
+    return `Relative locktime: ${value} block${value === 1 ? '' : 's'}`;
+  }
+  let seconds = value * 512;
+  const duration: string[] = [];
+  for (const [size, singular, plural] of [
+    [86400, 'i18nDay', 'i18nDays'],
+    [3600, 'i18nHour', 'i18nHours'],
+    [60, 'i18nMinute', 'i18nMinutes'],
+    [1, 'i18nSecond', 'i18nSeconds'],
+  ] as const) {
+    const count = Math.floor(seconds / size);
+    if (count) {
+      const dateStrings = dates(count);
+      duration.push(dateStrings[count === 1 ? singular : plural]);
+      seconds %= size;
+    }
+  }
+  return `Relative locktime: ${duration.join(' ') || dates(0).i18nSeconds}`;
 }
 
 /** Formats a BIP65 locktime value as a human-readable block height or UTC timestamp */


### PR DESCRIPTION
This PR extends the OP_CLTV tooltip feature to also display the relative timelock on OP_CSV in the script:

https://mempool.space/tx/0be2b9a3a6a9dc99443d6ce7bd3beaf33c713a4938af3bf0fec1e918257bbd32 :

<img width="500" alt="Screenshot 2026-09-11 at 10 13 32" src="https://github.com/user-attachments/assets/0e6a9698-24fd-44a9-a83d-ad640b7fd095" />

https://mempool.space/testnet/tx/a68a821e06c1156d5fe80f3662c941142ed2ce1a57e597ce05bf167bce21fe2d : 

<img width="505" height="547" alt="Screenshot 2026-09-11 at 10 14 46" src="https://github.com/user-attachments/assets/9a771c53-881a-46ed-8407-e62f9b8ccf00" />
