### PR TITLE
Fix false stale block banner on latest blocks opened by height

### DIFF
--- a/frontend/src/app/components/block/block.component.ts
+++ b/frontend/src/app/components/block/block.component.ts
@@ -174,7 +174,7 @@ export class BlockComponent implements OnInit, OnDestroy {
                 this.fees = block.extras.reward / 100000000 - this.blockSubsidy;
               }
             }
-          } else if (block.height === this.block?.height) {
+          } else if (block.height === this.block?.height && block.id !== this.block?.id) {
             this.block.stale = true;
             this.block.canonical = block.id;
             this.fetchCanonicalBlock();
@@ -274,6 +274,7 @@ export class BlockComponent implements OnInit, OnDestroy {
         }
         this.updateAuditAvailableFromBlockHeight(block.height);
         this.block = block;
+        this.blockHash = block.id;
         if (block.extras) {
           block.extras.minFee = this.getMinBlockFee(block);
           block.extras.maxFee = this.getMaxBlockFee(block);


### PR DESCRIPTION
## What changed

Fixes stale-block detection when a recent block is opened by height.

- Keeps `this.blockHash` in sync with the loaded block id across all block-loading paths.
- Only treats a same-height websocket block as a replacement when its id differs from the currently displayed block.

## Why

Blocks loaded from `latestBlocks` by height did not update `this.blockHash`. On the next block update, the reorg detector could therefore compare against a stale or undefined hash and incorrectly mark the canonical block as stale.

This could also make the block height link reference a previously loaded block.


Closes #6768 